### PR TITLE
feat: portfolio list metrics & architecture improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -851,3 +851,17 @@ Rules:
 - Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
 - If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
 - After modifying code files in this session, run `graphify update .` to keep the graph current (AST-only, no API cost)
+
+## Agent skills
+
+### Issue tracker
+
+Issues tracked in GitHub Issues (Kaoruha/GinkGO). See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five-label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout. See `docs/agents/domain.md`.

--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -47,6 +47,117 @@ def _map_state(state_value) -> str:
     return str(state_value)
 
 
+def _map_mode(mode_value) -> str:
+    """将 mode 数值映射为字符串"""
+    from ginkgo.enums import PORTFOLIO_MODE_TYPES
+    if isinstance(mode_value, int):
+        if mode_value == PORTFOLIO_MODE_TYPES.BACKTEST.value:
+            return "BACKTEST"
+        elif mode_value == PORTFOLIO_MODE_TYPES.PAPER.value:
+            return "PAPER"
+        else:
+            return "LIVE"
+    return str(mode_value)
+
+
+def _get_latest_backtest_metrics(portfolio_id: str) -> dict:
+    """获取 portfolio 最新已完成回测的绩效指标"""
+    try:
+        from ginkgo.data.containers import container
+        task_crud = container.cruds.backtest_task()
+        tasks = task_crud.find(
+            filters={"portfolio_id": portfolio_id, "status": "completed", "is_del": False},
+            order_by="create_at",
+            desc_order=True,
+            page_size=1,
+        )
+        if tasks and len(tasks) > 0:
+            t = tasks[0]
+            return {
+                "annual_return": float(getattr(t, "annual_return", 0) or 0),
+                "sharpe_ratio": float(getattr(t, "sharpe_ratio", 0) or 0),
+                "max_drawdown": float(getattr(t, "max_drawdown", 0) or 0),
+                "win_rate": float(getattr(t, "win_rate", 0) or 0),
+                "last_backtest_date": t.create_at.isoformat() if hasattr(t, "create_at") and t.create_at else None,
+            }
+    except Exception:
+        pass
+    return {}
+
+
+def _count_backtests(portfolio_id: str) -> int:
+    """统计 portfolio 的回测次数"""
+    try:
+        from ginkgo.data.containers import container
+        task_crud = container.cruds.backtest_task()
+        return task_crud.count(filters={"portfolio_id": portfolio_id, "is_del": False}) or 0
+    except Exception:
+        return 0
+
+
+def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
+    """获取关联组合摘要"""
+    try:
+        from ginkgo.data.containers import container
+        deployment_crud = container.cruds.deployment()
+        related = []
+
+        if mode_int == 0:  # BACKTEST: find deployed PAPER/LIVE
+            deployments = deployment_crud.find(filters={"source_portfolio_id": portfolio_id})
+            if deployments:
+                portfolio_svc = get_portfolio_service()
+                for dep in deployments:
+                    target_list = portfolio_svc.get(portfolio_id=dep.target_portfolio_id)
+                    if target_list and target_list.data:
+                        t = target_list.data[0]
+                        mode_str = "PAPER" if t.mode == 1 else "LIVE"
+                        metrics = {
+                            "annual_return": float(getattr(t, "annual_return", 0) or 0),
+                            "max_drawdown": float(getattr(t, "max_drawdown", 0) or 0),
+                        }
+                        related.append({
+                            "uuid": t.uuid,
+                            "name": t.name,
+                            "mode": mode_str,
+                            "state": _map_state(t.state),
+                            **metrics,
+                        })
+        else:  # PAPER/LIVE: find source BACKTEST
+            deployments = deployment_crud.find(filters={"target_portfolio_id": portfolio_id})
+            if deployments:
+                portfolio_svc = get_portfolio_service()
+                source_id = deployments[0].source_portfolio_id
+                source_list = portfolio_svc.get(portfolio_id=source_id)
+                if source_list and source_list.data:
+                    s = source_list.data[0]
+                    bt_metrics = _get_latest_backtest_metrics(source_id)
+                    related.append({
+                        "uuid": s.uuid,
+                        "name": s.name,
+                        "mode": "BACKTEST",
+                        "state": _map_state(s.state),
+                        "relation": "source",
+                        **bt_metrics,
+                    })
+                # Other deployments from same source
+                for dep in deployments:
+                    if dep.target_portfolio_id != portfolio_id:
+                        other_list = portfolio_svc.get(portfolio_id=dep.target_portfolio_id)
+                        if other_list and other_list.data:
+                            o = other_list.data[0]
+                            related.append({
+                                "uuid": o.uuid,
+                                "name": o.name,
+                                "mode": "PAPER" if o.mode == 1 else "LIVE",
+                                "state": _map_state(o.state),
+                                "annual_return": float(getattr(o, "annual_return", 0) or 0),
+                                "max_drawdown": float(getattr(o, "max_drawdown", 0) or 0),
+                            })
+        return related
+    except Exception:
+        return []
+
+
 def get_file_service():
     """获取FileService实例"""
     from ginkgo.data.containers import container
@@ -97,15 +208,41 @@ async def list_portfolios(
 
         portfolios = []
         for p in result.data or []:
-            mode_val = "BACKTEST" if p.mode == PORTFOLIO_MODE_TYPES.BACKTEST.value else ("PAPER" if p.mode == PORTFOLIO_MODE_TYPES.PAPER.value else "LIVE")
+            mode_int = p.mode
+
+            # Performance metrics
+            if mode_int == PORTFOLIO_MODE_TYPES.BACKTEST.value:
+                metrics = _get_latest_backtest_metrics(p.uuid)
+                backtest_count = _count_backtests(p.uuid)
+            else:  # PAPER/LIVE - read from MPortfolio fields
+                metrics = {
+                    "annual_return": float(getattr(p, "annual_return", 0) or 0),
+                    "sharpe_ratio": float(getattr(p, "sharpe_ratio", 0) or 0),
+                    "max_drawdown": float(getattr(p, "max_drawdown", 0) or 0),
+                    "win_rate": float(getattr(p, "win_rate", 0) or 0),
+                }
+                backtest_count = 0
+
+            # Related portfolios
+            related = _get_related_portfolios(p.uuid, mode_int)
+
             portfolios.append({
                 "uuid": p.uuid,
                 "name": p.name,
-                "mode": mode_val,
+                "mode": _map_mode(p.mode),
                 "state": _map_state(p.state),
                 "config_locked": _check_frozen(p.uuid),
-                "net_value": 1.0,
-                "created_at": p.create_at.isoformat() if hasattr(p, 'create_at') and p.create_at else None
+                # Performance metrics
+                "annual_return": metrics.get("annual_return"),
+                "sharpe_ratio": metrics.get("sharpe_ratio"),
+                "max_drawdown": metrics.get("max_drawdown"),
+                "win_rate": metrics.get("win_rate"),
+                # Meta info
+                "backtest_count": backtest_count,
+                "last_backtest_date": metrics.get("last_backtest_date"),
+                # Related portfolios
+                "related": related,
+                "created_at": p.create_at.isoformat() if hasattr(p, 'create_at') and p.create_at else None,
             })
 
         return ok(data=portfolios, message="Portfolios retrieved successfully")

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/superpowers/plans/2026-05-13-portfolio-list-metrics.md
+++ b/docs/superpowers/plans/2026-05-13-portfolio-list-metrics.md
@@ -1,0 +1,680 @@
+# Portfolio 列表绩效展示 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在组合列表页卡片上直接展示绩效指标（年化收益/Sharpe/最大回撤/胜率）和关联组合摘要，无需点进详情页。
+
+**Architecture:** 后端三层改动——aggregator 写回 Portfolio → service 新增 update_performance → API 返回指标+关联。前端卡片 body 替换为 2x2 绩效网格，底部增加关联摘要条。
+
+**Tech Stack:** Python/FastAPI (后端), Vue 3 + TypeScript (前端), MySQL (MPortfolio), SQLAlchemy (ORM)
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/ginkgo/data/services/portfolio_service.py` | Modify | 新增 `update_performance()` 方法 |
+| `src/ginkgo/trading/analysis/backtest_result_aggregator.py` | Modify | 回测完成时调用 `update_performance()` |
+| `api/api/portfolio.py` | Modify | 列表 API 返回绩效指标 + 关联摘要 |
+| `api/api/deployment.py` | Read | 参考部署 API 获取关联关系 |
+| `web-ui/src/api/modules/portfolio.ts` | Modify | Portfolio 类型增加绩效+关联字段 |
+| `web-ui/src/views/portfolio/PortfolioList.vue` | Modify | 卡片绩效网格 + 关联摘要条 |
+
+---
+
+### Task 1: PortfolioService 新增 update_performance 方法
+
+**Files:**
+- Modify: `src/ginkgo/data/services/portfolio_service.py`
+
+- [ ] **Step 1: 在 PortfolioService 中新增 update_performance 方法**
+
+在 `update()` 方法之后（约 line 280）添加：
+
+```python
+def update_performance(
+    self,
+    portfolio_id: str,
+    annual_return: float = None,
+    sharpe_ratio: float = None,
+    max_drawdown: float = None,
+    win_rate: float = None,
+    total_trades: int = None,
+    winning_trades: int = None,
+) -> ServiceResult:
+    """更新 Portfolio 绩效指标字段"""
+    try:
+        updates = {}
+        if annual_return is not None:
+            updates["total_profit"] = annual_return  # annual_return 存入 total_profit 字段
+        if sharpe_ratio is not None:
+            updates["sharpe_ratio"] = sharpe_ratio
+        if max_drawdown is not None:
+            updates["max_drawdown"] = max_drawdown
+        if win_rate is not None:
+            updates["win_rate"] = win_rate
+        if total_trades is not None:
+            updates["total_trades"] = total_trades
+        if winning_trades is not None:
+            updates["winning_trades"] = winning_trades
+
+        if not updates:
+            return ServiceResult.success(data=None, message="No fields to update")
+
+        result = self._crud_repo.modify(uuid=portfolio_id, **updates)
+        if result:
+            return ServiceResult.success(data=result, message="Performance updated")
+        return ServiceResult.error("Portfolio not found")
+    except Exception as e:
+        return ServiceResult.error(f"Failed to update performance: {e}")
+```
+
+注意：MPortfolio 模型没有 `annual_return` 字段，需检查是否需要新增字段或复用 `total_profit`。
+
+- [ ] **Step 2: 确认 MPortfolio 模型是否有 annual_return 字段**
+
+运行: `grep -n "annual_return" src/ginkgo/data/models/model_portfolio.py`
+
+如果没有 `annual_return` 字段，需要在 model 中新增：
+
+在 `model_portfolio.py` 的性能指标区域（`win_rate` 之后）添加：
+
+```python
+annual_return: Mapped[DECIMAL] = mapped_column(DECIMAL(10, 4), default=0.00)
+```
+
+同时在该文件的 `update()` 方法的 `str` dispatch 中增加：
+
+```python
+if annual_return is not None:
+    self.annual_return = annual_return
+```
+
+- [ ] **Step 3: 修正 update_performance 方法**
+
+如果 Step 2 新增了 `annual_return` 字段，修正 Step 1 的方法，将 `annual_return` 直接写入对应字段而非 `total_profit`：
+
+```python
+if annual_return is not None:
+    updates["annual_return"] = annual_return
+```
+
+- [ ] **Step 4: 运行数据库迁移**
+
+由于新增了模型字段，需要重新 init 表：
+
+```bash
+ginkgo system config set --debug on
+ginkgo data init
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ginkgo/data/services/portfolio_service.py src/ginkgo/data/models/model_portfolio.py
+git commit -m "feat: add update_performance to PortfolioService + annual_return field"
+```
+
+---
+
+### Task 2: 回测完成时同步写 Portfolio
+
+**Files:**
+- Modify: `src/ginkgo/trading/analysis/backtest_result_aggregator.py`
+
+- [ ] **Step 1: 在 aggregate_and_save 末尾添加 Portfolio 同步逻辑**
+
+在 `aggregate_and_save` 方法中，`GLOG.INFO(f"Backtest results saved for task: {task_id}")` （约 line 143）之前插入：
+
+```python
+# 同步绩效指标到 MPortfolio
+try:
+    from ginkgo.data.containers import container as data_container
+    portfolio_svc = data_container.services.portfolio()
+    perf_result = portfolio_svc.update_performance(
+        portfolio_id=portfolio_id,
+        annual_return=metrics.get("annual_return", 0.0),
+        sharpe_ratio=metrics.get("sharpe_ratio", 0.0),
+        max_drawdown=metrics.get("max_drawdown", 0.0),
+        win_rate=metrics.get("trade_win_rate", metrics.get("win_rate", 0.0)),
+        total_trades=stats.get("total_orders", 0),
+        winning_trades=None,  # 暂无 winning_trades 统计
+    )
+    if not perf_result.is_success():
+        GLOG.WARN(f"Failed to sync performance to portfolio {portfolio_id}: {perf_result.error}")
+except Exception as e:
+    GLOG.WARN(f"Failed to sync performance to portfolio {portfolio_id}: {e}")
+```
+
+用 try/except 包裹，失败不影响主流程。
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/ginkgo/trading/analysis/backtest_result_aggregator.py
+git commit -m "feat: sync backtest metrics to MPortfolio on completion"
+```
+
+---
+
+### Task 3: API 列表接口返回绩效指标
+
+**Files:**
+- Modify: `api/api/portfolio.py`
+
+- [ ] **Step 1: 导入依赖并新增辅助函数**
+
+在 `api/api/portfolio.py` 顶部导入区域添加：
+
+```python
+from ginkgo.data.cruds.backtest_task_crud import BacktestTaskCRUD
+from ginkgo.data.cruds.deployment_crud import DeploymentCRUD
+```
+
+在文件中添加辅助函数：
+
+```python
+def _get_latest_backtest_metrics(portfolio_id: str) -> dict:
+    """获取 portfolio 最新已完成回测的绩效指标"""
+    try:
+        from ginkgo.data.containers import container
+        task_crud = container.cruds.backtest_task()
+        tasks = task_crud.find(
+            filters={"portfolio_id": portfolio_id, "status": "completed"},
+            order_by="create_at",
+            desc_order=True,
+            page_size=1,
+        )
+        if tasks and len(tasks) > 0:
+            t = tasks[0]
+            return {
+                "annual_return": getattr(t, "annual_return", None),
+                "sharpe_ratio": getattr(t, "sharpe_ratio", None),
+                "max_drawdown": getattr(t, "max_drawdown", None),
+                "win_rate": getattr(t, "win_rate", None),
+                "backtest_count": 1,  # will be overwritten
+                "last_backtest_date": t.create_at.isoformat() if hasattr(t, "create_at") else None,
+            }
+    except Exception:
+        pass
+    return {}
+
+
+def _count_backtests(portfolio_id: str) -> int:
+    """统计 portfolio 的回测次数"""
+    try:
+        from ginkgo.data.containers import container
+        task_crud = container.cruds.backtest_task()
+        return task_crud.count(filters={"portfolio_id": portfolio_id}) or 0
+    except Exception:
+        return 0
+
+
+def _get_related_portfolios(portfolio_id: str, mode: int) -> list:
+    """获取关联组合摘要"""
+    try:
+        from ginkgo.data.containers import container
+        deployment_crud = container.cruds.deployment()
+        related = []
+
+        if mode == 0:  # BACKTEST: 查找部署出去的 PAPER/LIVE
+            deployments = deployment_crud.find(filters={"source_portfolio_id": portfolio_id})
+            if deployments:
+                portfolio_svc = get_portfolio_service()
+                for dep in deployments:
+                    target_id = dep.target_portfolio_id
+                    target_list = portfolio_svc.get(portfolio_id=target_id)
+                    if target_list and target_list.data:
+                        t = target_list.data[0]
+                        related.append({
+                            "uuid": t.uuid,
+                            "name": t.name,
+                            "mode": "PAPER" if t.mode == 1 else "LIVE",
+                            "state": _map_state(t.state),
+                            "annual_return": float(getattr(t, "annual_return", 0) or 0),
+                            "max_drawdown": float(getattr(t, "max_drawdown", 0) or 0),
+                        })
+        else:  # PAPER/LIVE: 查找来源回测
+            deployments = deployment_crud.find(filters={"target_portfolio_id": portfolio_id})
+            if deployments:
+                portfolio_svc = get_portfolio_service()
+                source_id = deployments[0].source_portfolio_id
+                source_list = portfolio_svc.get(portfolio_id=source_id)
+                if source_list and source_list.data:
+                    s = source_list.data[0]
+                    # 获取回测指标
+                    bt_metrics = _get_latest_backtest_metrics(source_id)
+                    related.append({
+                        "uuid": s.uuid,
+                        "name": s.name,
+                        "mode": "BACKTEST",
+                        "state": _map_state(s.state),
+                        "annual_return": bt_metrics.get("annual_return", 0),
+                        "max_drawdown": bt_metrics.get("max_drawdown", 0),
+                        "relation": "source",
+                    })
+                # 同组其他部署
+                for dep in deployments:
+                    if dep.target_portfolio_id != portfolio_id:
+                        other_list = portfolio_svc.get(portfolio_id=dep.target_portfolio_id)
+                        if other_list and other_list.data:
+                            o = other_list.data[0]
+                            if o.uuid != portfolio_id:
+                                related.append({
+                                    "uuid": o.uuid,
+                                    "name": o.name,
+                                    "mode": "PAPER" if o.mode == 1 else "LIVE",
+                                    "state": _map_state(o.state),
+                                    "annual_return": float(getattr(o, "annual_return", 0) or 0),
+                                    "max_drawdown": float(getattr(o, "max_drawdown", 0) or 0),
+                                })
+        return related
+    except Exception:
+        return []
+```
+
+- [ ] **Step 2: 修改 list_portfolios 响应序列化**
+
+在 `list_portfolios` 函数中，替换响应构建部分（约 lines 98-109）：
+
+```python
+portfolios_data = []
+for p in result.data:
+    mode_val = _map_mode(p.mode)
+    mode_int = p.mode
+
+    # 绩效指标
+    metrics = {}
+    if mode_int == 0:  # BACKTEST
+        metrics = _get_latest_backtest_metrics(p.uuid)
+        metrics["backtest_count"] = _count_backtests(p.uuid)
+    else:  # PAPER/LIVE
+        metrics = {
+            "annual_return": float(getattr(p, "annual_return", 0) or 0),
+            "sharpe_ratio": float(getattr(p, "sharpe_ratio", 0) or 0),
+            "max_drawdown": float(getattr(p, "max_drawdown", 0) or 0),
+            "win_rate": float(getattr(p, "win_rate", 0) or 0),
+        }
+
+    # 关联组合
+    related = _get_related_portfolios(p.uuid, mode_int)
+
+    portfolios_data.append({
+        "uuid": p.uuid,
+        "name": p.name,
+        "mode": mode_val,
+        "state": _map_state(p.state),
+        "config_locked": _check_frozen(p.uuid),
+        # 绩效指标
+        "annual_return": metrics.get("annual_return"),
+        "sharpe_ratio": metrics.get("sharpe_ratio"),
+        "max_drawdown": metrics.get("max_drawdown"),
+        "win_rate": metrics.get("win_rate"),
+        # 元信息
+        "backtest_count": metrics.get("backtest_count", 0),
+        "last_backtest_date": metrics.get("last_backtest_date"),
+        # 关联
+        "related": related,
+        "created_at": p.create_at.isoformat(),
+    })
+```
+
+- [ ] **Step 3: 验证 API 响应**
+
+启动 API 服务器并请求列表接口：
+
+```bash
+ginkgo serve api 2>&1 | tee /tmp/ginkgo-api.log &
+curl -s http://localhost:8000/api/v1/portfolios/ | python -m json.tool | head -40
+```
+
+确认响应包含 `annual_return`、`sharpe_ratio`、`max_drawdown`、`win_rate`、`related` 字段。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/api/portfolio.py
+git commit -m "feat: return performance metrics and related portfolios in list API"
+```
+
+---
+
+### Task 4: 前端 Portfolio 类型更新
+
+**Files:**
+- Modify: `web-ui/src/api/modules/portfolio.ts`
+
+- [ ] **Step 1: 更新 Portfolio 接口**
+
+在 `portfolio.ts` 的 `Portfolio` 接口中增加字段：
+
+```typescript
+export interface RelatedPortfolio {
+  uuid: string
+  name: string
+  mode: string
+  state: string
+  annual_return?: number | null
+  max_drawdown?: number | null
+  relation?: string
+}
+
+export interface Portfolio {
+  uuid: string
+  name: string
+  desc?: string
+  mode: number | string
+  state: number | string
+  initial_cash?: number
+  current_cash?: number
+  net_value?: number
+  config_locked?: boolean
+  // 绩效指标
+  annual_return?: number | null
+  sharpe_ratio?: number | null
+  max_drawdown?: number | null
+  win_rate?: number | null
+  // 元信息
+  backtest_count?: number
+  last_backtest_date?: string | null
+  // 关联组合
+  related?: RelatedPortfolio[]
+  // 原有字段
+  positions?: any
+  risk_alerts?: any
+  components?: any
+  created_at?: string
+  updated_at?: string
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add web-ui/src/api/modules/portfolio.ts
+git commit -m "feat: add performance metrics types to Portfolio interface"
+```
+
+---
+
+### Task 5: 前端卡片绩效网格 + 关联摘要条
+
+**Files:**
+- Modify: `web-ui/src/views/portfolio/PortfolioList.vue`
+
+- [ ] **Step 1: 替换卡片 body 为绩效网格**
+
+将 `<div class="card-body">` 区域（约 lines 116-129）替换为：
+
+```html
+<div class="card-body">
+  <div class="metrics-grid">
+    <div class="metric">
+      <span class="label">{{ getReturnLabel(portfolio.mode) }}</span>
+      <span class="value" :class="getValueClass(portfolio.annual_return)">
+        {{ formatPercent(portfolio.annual_return) }}
+      </span>
+    </div>
+    <div class="metric">
+      <span class="label">Sharpe</span>
+      <span class="value" :class="getSharpeClass(portfolio.sharpe_ratio)">
+        {{ formatDecimal(portfolio.sharpe_ratio) }}
+      </span>
+    </div>
+    <div class="metric">
+      <span class="label">最大回撤</span>
+      <span class="value negative">
+        {{ formatDrawdown(portfolio.max_drawdown) }}
+      </span>
+    </div>
+    <div class="metric">
+      <span class="label">胜率</span>
+      <span class="value" :class="getWinRateClass(portfolio.win_rate)">
+        {{ formatPercent(portfolio.win_rate) }}
+      </span>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: 替换卡片 footer 并增加关联摘要条**
+
+将 `<div class="card-footer">` 区域（约 lines 130-138）替换为：
+
+```html
+<!-- 底部信息栏 -->
+<div class="card-footer">
+  <span class="footer-tag" :class="`tag-${getModeColorClass(portfolio.mode)}`">
+    {{ formatMode(portfolio.mode) }}
+  </span>
+  <span class="footer-tag" :class="`tag-${getStateColorClass(portfolio.state)}`">
+    {{ formatState(portfolio.state) }}
+  </span>
+  <span class="date">{{ formatShortDate(portfolio.created_at) }}</span>
+</div>
+<!-- 关联摘要条 -->
+<div v-if="portfolio.related && portfolio.related.length > 0" class="related-bar">
+  <div
+    v-for="rel in portfolio.related"
+    :key="rel.uuid"
+    class="related-card"
+    :class="`related-${rel.mode.toLowerCase()}`"
+    @click.stop="viewDetail({ uuid: rel.uuid })"
+  >
+    <div class="related-header">
+      <span class="related-mode">{{ formatRelatedMode(rel.mode) }}</span>
+      <span v-if="rel.state" class="related-state">{{ rel.state }}</span>
+    </div>
+    <div class="related-metrics">
+      <span>收益 <strong :class="getValueClass(rel.annual_return)">{{ formatPercent(rel.annual_return) }}</strong></span>
+      <span>回撤 <strong class="negative">{{ formatDrawdown(rel.max_drawdown) }}</strong></span>
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 3: 添加格式化辅助函数**
+
+在 `<script setup>` 中添加：
+
+```typescript
+const getReturnLabel = (mode: any) => {
+  const m = typeof mode === 'string' ? mode.toUpperCase() : mode
+  return m === 'BACKTEST' || m === 0 ? '年化收益' : '累计收益'
+}
+
+const formatPercent = (val: any) => {
+  if (val === null || val === undefined || val === 0) return '--'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n)) return '--'
+  const sign = n > 0 ? '+' : ''
+  return `${sign}${(n * 100).toFixed(2)}%`
+}
+
+const formatDecimal = (val: any) => {
+  if (val === null || val === undefined || val === 0) return '--'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n)) return '--'
+  return n.toFixed(2)
+}
+
+const formatDrawdown = (val: any) => {
+  if (val === null || val === undefined || val === 0) return '--'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n)) return '--'
+  return `-${(Math.abs(n) * 100).toFixed(1)}%`
+}
+
+const getValueClass = (val: any) => {
+  if (val === null || val === undefined) return 'neutral'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n) || n === 0) return 'neutral'
+  return n > 0 ? 'positive' : 'negative'
+}
+
+const getSharpeClass = (val: any) => {
+  if (val === null || val === undefined) return 'neutral'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n) || n === 0) return 'neutral'
+  if (n < 0.5) return 'warning'
+  return n > 0 ? 'positive' : 'negative'
+}
+
+const getWinRateClass = (val: any) => {
+  if (val === null || val === undefined) return 'neutral'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n) || n === 0) return 'neutral'
+  return n >= 0.5 ? 'positive' : 'warning'
+}
+
+const formatRelatedMode = (mode: string) => {
+  const map: Record<string, string> = {
+    'BACKTEST': '来源回测',
+    'PAPER': '模拟',
+    'LIVE': '实盘',
+  }
+  return map[mode] || mode
+}
+```
+
+注意：检查后端返回的 `annual_return` 等值是小数（0.1617）还是百分比（16.17）。如果是小数，`formatPercent` 需要乘 100（如上代码）。如果是百分比数值，去掉 `* 100`。
+
+- [ ] **Step 4: 添加 CSS 样式**
+
+在 `<style scoped>` 中添加：
+
+```css
+.metrics-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
+  padding: 10px;
+  background: var(--bg-card-inner, #12122a);
+  border-radius: 6px;
+}
+
+.metrics-grid .metric .label {
+  font-size: 10px;
+  color: #888;
+}
+
+.metrics-grid .metric .value {
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.value.positive { color: #4caf50; }
+.value.negative { color: #f44336; }
+.value.warning { color: #ff9800; }
+.value.neutral { color: #555; }
+
+/* 关联摘要条 */
+.related-bar {
+  display: flex;
+  gap: 8px;
+  padding: 10px 0 0;
+  border-top: 1px solid #252540;
+  margin-top: 10px;
+}
+
+.related-card {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.related-card:hover { opacity: 0.8; }
+
+.related-backtest {
+  background: #0f0f2a;
+  border: 1px solid #20203a;
+}
+
+.related-paper {
+  background: #1e1e0a;
+  border: 1px solid #3a3520;
+}
+
+.related-live {
+  background: #0a1e1a;
+  border: 1px solid #203a2a;
+}
+
+.related-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.related-mode { font-size: 10px; font-weight: 600; }
+.related-backtest .related-mode { color: #7c8aff; }
+.related-paper .related-mode { color: #ff9800; }
+.related-live .related-mode { color: #4caf50; }
+
+.related-state { font-size: 9px; color: #4caf50; }
+
+.related-metrics {
+  display: flex;
+  gap: 10px;
+  font-size: 9px;
+  color: #888;
+}
+
+.related-metrics strong { font-size: 11px; }
+```
+
+- [ ] **Step 5: 验证前端效果**
+
+启动 WebUI 开发服务器，在浏览器中查看组合列表页：
+
+```bash
+ginkgo serve webui 2>&1 | tee /tmp/webui.log &
+```
+
+确认：
+1. 绩效指标 2x2 网格正确显示
+2. 无数据时显示灰色 `--`
+3. 关联摘要条正确显示（有 deploy 关系的卡片）
+4. Mode 颜色区分正确
+5. 摘要条可点击跳转
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web-ui/src/views/portfolio/PortfolioList.vue web-ui/src/api/modules/portfolio.ts
+git commit -m "feat: portfolio list card with performance metrics and related summary"
+```
+
+---
+
+### Task 6: 集成验证
+
+- [ ] **Step 1: 端到端验证**
+
+1. 运行一次回测，确认 `MPortfolio` 的绩效字段被更新：
+```bash
+# 用 ginkgo CLI 运行回测
+ginkgo backtest run <backtest_id>
+# 检查数据库
+python -c "
+from ginkgo.data.containers import container
+svc = container.services.portfolio()
+r = svc.get(portfolio_id='<portfolio_uuid>')
+p = r.data[0]
+print(f'annual_return={p.annual_return}, sharpe={p.sharpe_ratio}, drawdown={p.max_drawdown}, win_rate={p.win_rate}')
+"
+```
+
+2. 打开 WebUI 组合列表页，确认回测组合卡片显示绩效指标
+
+3. 如有 deploy 关系，确认关联摘要条显示正确
+
+- [ ] **Step 2: 最终 Commit & Push**
+
+```bash
+git push all master
+```

--- a/docs/superpowers/specs/2026-05-13-portfolio-list-metrics-design.md
+++ b/docs/superpowers/specs/2026-05-13-portfolio-list-metrics-design.md
@@ -1,0 +1,164 @@
+# Portfolio 列表绩效展示设计
+
+> 日期: 2026-05-13
+> 状态: 已确认
+
+## 目标
+
+在组合列表页一眼看到每个组合的回测/模拟/实盘表现，并能对比关联组合的指标偏差。
+
+## 现状问题
+
+1. 列表卡片只显示"净值"（hardcoded 1.0）和"初始资金"，无任何绩效指标
+2. 必须点进详情页 → 查看回测才能知道表现
+3. deploy 出的模拟/实盘组合与源回测组合之间在列表页无任何关联展示
+
+## 设计决策
+
+### 1. 每个卡片独立，关系用摘要条展示
+
+Portfolio 之间是平级关联关系，不是树形上下游。列表保持一维平铺，关联信息通过底部摘要条展示。
+
+### 2. 指标按 Mode 区分数据来源
+
+| Mode | 数据来源 | 主指标名 |
+|------|---------|---------|
+| BACKTEST | `backtest_task` 最新 completed 记录 | 年化收益 |
+| PAPER | `MPortfolio` 自身字段（Worker 实时更新） | 累计收益 |
+| LIVE | `MPortfolio` 自身字段（实盘交易实时更新） | 累计收益 |
+
+### 3. 回测完成时同步写 Portfolio
+
+当前 `aggregate_and_save()` 只写 `BacktestTask`，不写 `MPortfolio`。在末尾新增一步，将绩效指标同步写入 `MPortfolio`，使列表 API 无需额外查询即可返回指标。
+
+## 卡片 UI
+
+### 主指标区（2x2 网格）
+
+替换现有"净值/初始资金"，显示：
+
+| 位置 | 指标 | 颜色规则 |
+|------|------|---------|
+| 左上 | 年化收益(BACKTEST) / 累计收益(PAPER/LIVE) | 正值绿，负值红 |
+| 右上 | Sharpe 比率 | 正值绿，负值红，<0.5 橙 |
+| 左下 | 最大回撤 | 始终红色（取绝对值） |
+| 右下 | 胜率 | >50% 绿，<50% 橙 |
+
+无数据时显示灰色 `--`。
+
+### 底部信息栏
+
+| Mode | 显示内容 |
+|------|---------|
+| BACKTEST | 最近回测日期 · 回测次数 |
+| PAPER | 运行天数 |
+| LIVE | 运行天数 · 交易所/环境 |
+
+### 关联摘要条
+
+有 deploy 关系的卡片底部显示关联组合的紧凑指标（2 个核心指标：收益 + 回撤）。
+
+**方向规则：**
+- BACKTEST 卡片：并排显示已部署的 PAPER / LIVE 摘要
+- PAPER/LIVE 卡片：显示来源 BACKTEST 摘要 + 同组其他关联组合
+
+**摘要条样式：** 按 Mode 颜色区分边框和标签（蓝=回测，橙=模拟，绿=实盘），可点击跳转到对应 portfolio 详情。
+
+无关联的卡片底部不显示摘要条区域。
+
+## 筛选
+
+保持现有 Mode filter + 关键词搜索，行为不变：
+- Mode 筛选：简单过滤，只显示对应 mode 的卡片
+- 关键词搜索：按名称匹配
+- 两者叠加取交集
+
+摘要条始终显示（不受筛选影响），提供完整的关联上下文。
+
+## 后端改动
+
+### 1. API 列表接口返回绩效指标
+
+**文件:** `api/api/portfolio.py` — `GET /api/v1/portfolios/`
+
+响应增加字段：
+```python
+{
+    "uuid": str,
+    "name": str,
+    "mode": str,
+    "state": str,
+    # 新增绩效指标
+    "annual_return": float | None,
+    "sharpe_ratio": float | None,
+    "max_drawdown": float | None,
+    "win_rate": float | None,
+    # 新增关联信息
+    "related": [
+        {"uuid": str, "name": str, "mode": str, "state": str,
+         "annual_return": float | None, "max_drawdown": float | None,
+         "relation": "source" | "deploy_paper" | "deploy_live"}
+    ],
+    # 新增元信息
+    "backtest_count": int,       # BACKTEST mode: 回测次数
+    "last_backtest_date": str,   # BACKTEST mode: 最近回测日期
+    "running_days": int,         # PAPER/LIVE mode: 运行天数
+}
+```
+
+**实现逻辑：**
+- BACKTEST mode：查 `backtest_task` 表取最新 completed 记录的指标
+- PAPER/LIVE mode：直接读 `MPortfolio` 字段
+- 关联信息：通过 `deployment` 表或 `source_portfolio_id` 查找关联组合，取其指标
+
+### 2. 回测完成时同步写 Portfolio
+
+**文件:** `src/ginkgo/trading/analysis/backtest_result_aggregator.py`
+
+在 `aggregate_and_save()` 方法末尾新增：
+```python
+# 同步指标到 MPortfolio
+portfolio_service = container.services.portfolio()
+portfolio_service.update_performance(
+    portfolio_id=portfolio_id,
+    annual_return=metrics.get("annual_return", 0.0),
+    sharpe_ratio=metrics.get("sharpe_ratio", 0.0),
+    max_drawdown=metrics.get("max_drawdown", 0.0),
+    win_rate=metrics.get("trade_win_rate", metrics.get("win_rate", 0.0)),
+)
+```
+
+### 3. Portfolio Service 新增 update_performance 方法
+
+**文件:** `src/ginkgo/data/services/portfolio_service.py`
+
+新增方法，接收绩效指标并更新 `MPortfolio` 记录。
+
+## 前端改动
+
+### 文件: `web-ui/src/views/portfolio/PortfolioList.vue`
+
+1. 卡片 body 替换为 2x2 绩效网格
+2. 卡片底部新增关联摘要条区域
+3. 颜色规则：正值绿 / 负值红 / 中性橙 / 无数据灰
+
+### 文件: `web-ui/src/stores/portfolio.ts`
+
+处理列表 API 返回的新字段（绩效指标 + 关联信息）。
+
+## 涉及文件
+
+| 文件 | 改动 |
+|------|------|
+| `api/api/portfolio.py` | 列表 API 返回绩效指标 + 关联摘要 |
+| `src/ginkgo/trading/analysis/backtest_result_aggregator.py` | 回测完成时同步写 Portfolio |
+| `src/ginkgo/data/services/portfolio_service.py` | 新增 `update_performance()` |
+| `web-ui/src/views/portfolio/PortfolioList.vue` | 卡片绩效网格 + 关联摘要条 |
+| `web-ui/src/stores/portfolio.ts` | 处理新字段 |
+
+## 不做的事
+
+- 不做树形/分组布局
+- 不做 tab 切换
+- 不修改 MPortfolio 模型（字段已存在）
+- 不改变筛选逻辑（保持现有行为）

--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -75,6 +75,7 @@ from ginkgo.data.services.mapping_service import MappingService
 from ginkgo.data.services.encryption_service import EncryptionService, get_encryption_service
 from ginkgo.data.services.live_account_service import LiveAccountService
 from ginkgo.data.services.api_key_service import ApiKeyService
+from ginkgo.data.services.position_service import PositionService
 from ginkgo.data.services.validation_service import ValidationService
 
 # Live trading CRUDs
@@ -224,6 +225,11 @@ class Container(containers.DeclarativeContainer):
     )
 
     redis_service = providers.Singleton(RedisService, redis_crud=redis_crud)
+
+    position_service = providers.Singleton(
+        PositionService,
+        crud_repo=providers.Singleton(get_crud, "position"),
+    )
 
     kafka_service = providers.Singleton(KafkaService, kafka_crud=kafka_crud)
 

--- a/src/ginkgo/data/crud/order_crud.py
+++ b/src/ginkgo/data/crud/order_crud.py
@@ -541,48 +541,6 @@ class OrderCRUD(BaseCRUD[MOrder]):
             filters["portfolio_id"] = portfolio_id
         return self.count(filters)
 
-    def get_order_summary(self, portfolio_id: str, start_date: Optional[Any] = None, end_date: Optional[Any] = None) -> dict:
-        """
-        Business helper: Get order summary statistics for a portfolio.
-        """
-        filters = {"portfolio_id": portfolio_id}
-        
-        if start_date:
-            filters["timestamp__gte"] = datetime_normalize(start_date)
-        if end_date:
-            filters["timestamp__lte"] = datetime_normalize(end_date)
-        
-        
-        if not orders:
-            return {
-                "total_orders": 0,
-                "pending_orders": 0,
-                "filled_orders": 0,
-                "cancelled_orders": 0,
-                "total_volume": 0,
-                "avg_price": 0,
-                "total_fees": 0,
-            }
-        
-        summary = {
-            "total_orders": len(orders),
-            "pending_orders": sum(1 for o in orders if o.status == ORDERSTATUS_TYPES.NEW),
-            "filled_orders": sum(1 for o in orders if o.status == ORDERSTATUS_TYPES.FILLED),
-            "cancelled_orders": sum(1 for o in orders if o.status == ORDERSTATUS_TYPES.CANCELED),
-            "total_volume": sum(o.volume for o in orders if o.volume),
-            "total_fees": sum(float(o.fee) for o in orders if o.fee),
-        }
-        
-        filled_orders = [o for o in orders if o.status == ORDERSTATUS_TYPES.FILLED and o.transaction_price]
-        if filled_orders:
-            total_amount = sum(float(o.transaction_price) * o.volume for o in filled_orders)
-            total_volume = sum(o.volume for o in filled_orders)
-            summary["avg_price"] = total_amount / total_volume if total_volume > 0 else 0
-        else:
-            summary["avg_price"] = 0
-        
-        return summary
-
     def get_all_codes(self) -> List[str]:
         """
         Business helper: Get all distinct stock codes with orders.

--- a/src/ginkgo/data/crud/portfolio_crud.py
+++ b/src/ginkgo/data/crud/portfolio_crud.py
@@ -132,40 +132,8 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
         }
 
     def _convert_models_to_business_objects(self, models: List[MPortfolio]) -> List[Any]:
-        """
-        🎯 Convert MPortfolio models to business objects.
-
-        Args:
-            models: List of MPortfolio models with enum fields already fixed
-
-        Returns:
-            List of PortfolioBase business objects
-        """
-        from ginkgo.trading.bases.portfolio_base import PortfolioBase
-
-        business_objects = []
-        for model in models:
-            try:
-                # Create PortfolioBase from MPortfolio model
-                portfolio = PortfolioBase(
-                    name=model.name,
-                    timestamp=model.create_at
-                )
-                # Set the portfolio properties from the model
-                portfolio._uuid = model.uuid
-                portfolio._name = model.name
-                portfolio._mode = PORTFOLIO_MODE_TYPES.from_int(model.mode) or PORTFOLIO_MODE_TYPES.BACKTEST
-                portfolio._state = PORTFOLIO_RUNSTATE_TYPES.from_int(model.state) or PORTFOLIO_RUNSTATE_TYPES.INITIALIZED
-                portfolio._create_at = model.create_at
-                portfolio._update_at = model.update_at
-
-                business_objects.append(portfolio)
-            except Exception as e:
-                GLOG.ERROR(f"Failed to convert MPortfolio to PortfolioBase: {e}")
-                # Fallback: return original model
-                business_objects.append(model)
-
-        return business_objects
+        # TODO: 创建 entities.Portfolio 后在此做 MPortfolio → Portfolio 转换
+        return models
 
     def _convert_output_items(self, items: List[MPortfolio], output_type: str = "model") -> List[Any]:
         """Hook method: Convert MPortfolio objects for business layer."""
@@ -222,19 +190,6 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
         GLOG.WARN(f"删除组合 {uuid}")
         return self.remove({"uuid": uuid})
 
-    def update_mode(self, uuid: str, mode: PORTFOLIO_MODE_TYPES) -> None:
-        """Update portfolio mode.
-
-        .. deprecated::
-            mode 只能通过 DeploymentService.deploy() 或 PortfolioService.add() 设置。
-            直接修改 mode 已废弃。
-        """
-        raise DeprecationWarning(
-            "update_mode is deprecated. "
-            "Use DeploymentService.deploy() to create deployed portfolios, "
-            "or PortfolioService.add() for new portfolios."
-        )
-
     def update_state(self, uuid: str, state: PORTFOLIO_RUNSTATE_TYPES) -> None:
         """Update portfolio state."""
         state_value = PORTFOLIO_RUNSTATE_TYPES.validate_input(state)
@@ -283,23 +238,4 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
         GLOG.WARN("find_by_live_status is deprecated, use find_by_mode instead")
         mode = PORTFOLIO_MODE_TYPES.LIVE if is_live else PORTFOLIO_MODE_TYPES.BACKTEST
         return self.find_by_mode(mode)
-
-    def update_live_status(self, uuid: str, is_live: bool) -> None:
-        """
-        [已废弃] 更新投资组合实盘状态
-
-        .. deprecated::
-            此方法已废弃，请使用 update_mode() 替代。
-
-            迁移示例:
-                旧: update_live_status(uuid, is_live=True)
-                新: update_mode(uuid, PORTFOLIO_MODE_TYPES.LIVE)
-
-        Args:
-            uuid: 投资组合UUID
-            is_live: True=实盘, False=回测
-        """
-        GLOG.WARN("update_live_status is deprecated, use update_mode instead")
-        mode = PORTFOLIO_MODE_TYPES.LIVE if is_live else PORTFOLIO_MODE_TYPES.BACKTEST
-        return self.update_mode(uuid, mode)
 

--- a/src/ginkgo/data/models/model_portfolio.py
+++ b/src/ginkgo/data/models/model_portfolio.py
@@ -56,6 +56,7 @@ class MPortfolio(MMysqlBase):
     max_drawdown: Mapped[DECIMAL] = mapped_column(DECIMAL(20, 8), default=0.00)
     sharpe_ratio: Mapped[DECIMAL] = mapped_column(DECIMAL(10, 4), default=0.00)
     win_rate: Mapped[DECIMAL] = mapped_column(DECIMAL(5, 4), default=0.00)
+    annual_return: Mapped[DECIMAL] = mapped_column(DECIMAL(10, 4), default=0.00)
     total_trades: Mapped[int] = mapped_column(default=0)
     winning_trades: Mapped[int] = mapped_column(default=0)
 
@@ -81,6 +82,7 @@ class MPortfolio(MMysqlBase):
         max_drawdown: Optional[float] = None,
         sharpe_ratio: Optional[float] = None,
         win_rate: Optional[float] = None,
+        annual_return: Optional[float] = None,
         total_trades: Optional[int] = None,
         winning_trades: Optional[int] = None,
         *args,
@@ -119,6 +121,8 @@ class MPortfolio(MMysqlBase):
             self.sharpe_ratio = sharpe_ratio
         if win_rate is not None:
             self.win_rate = win_rate
+        if annual_return is not None:
+            self.annual_return = annual_return
         if total_trades is not None:
             self.total_trades = total_trades
         if winning_trades is not None:

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -263,6 +263,63 @@ class PortfolioService(BaseService):
         }
         return ServiceResult.success(result_data, f"Portfolio updated successfully")
 
+    def update_performance(
+        self,
+        portfolio_id: str,
+        annual_return: float = None,
+        sharpe_ratio: float = None,
+        max_drawdown: float = None,
+        win_rate: float = None,
+        total_trades: int = None,
+        winning_trades: int = None,
+    ) -> ServiceResult:
+        """更新 Portfolio 绩效指标字段
+
+        回测完成后由结果聚合器调用，批量更新组合的绩效指标。
+
+        Args:
+            portfolio_id: 投资组合UUID
+            annual_return: 年化收益率
+            sharpe_ratio: 夏普比率
+            max_drawdown: 最大回撤
+            win_rate: 胜率
+            total_trades: 总交易次数
+            winning_trades: 盈利交易次数
+
+        Returns:
+            ServiceResult: 更新结果
+        """
+        try:
+            if not portfolio_id or not portfolio_id.strip():
+                return ServiceResult.error("Portfolio ID cannot be empty")
+
+            updates = {}
+            if annual_return is not None:
+                updates["annual_return"] = annual_return
+            if sharpe_ratio is not None:
+                updates["sharpe_ratio"] = sharpe_ratio
+            if max_drawdown is not None:
+                updates["max_drawdown"] = max_drawdown
+            if win_rate is not None:
+                updates["win_rate"] = win_rate
+            if total_trades is not None:
+                updates["total_trades"] = total_trades
+            if winning_trades is not None:
+                updates["winning_trades"] = winning_trades
+
+            if not updates:
+                return ServiceResult.success(data=None, message="No fields to update")
+
+            self._crud_repo.modify(filters={"uuid": portfolio_id}, updates=updates)
+            GLOG.INFO(f"Updated performance for portfolio {portfolio_id[:8]}: {list(updates.keys())}")
+            return ServiceResult.success(
+                data={"portfolio_id": portfolio_id, "updated_fields": list(updates.keys())},
+                message="Performance updated",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"Failed to update performance for portfolio {portfolio_id}: {e}")
+            return ServiceResult.error(f"Failed to update performance: {e}")
+
     def persist_portfolio_state(self, portfolio_id: str, state: dict) -> ServiceResult:
         """
         将 Portfolio 运行时状态持久化到 MySQL

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -1160,7 +1160,9 @@ class PortfolioService(BaseService):
 
             portfolio = PortfolioLive(
                 uuid=portfolio_model.uuid,  # 使用数据库UUID
-                name=portfolio_model.name
+                name=portfolio_model.name,
+                position_writer=self._build_position_writer(),
+                redis_writer=self._build_redis_writer(),
             )
 
             # 设置初始资金
@@ -1459,3 +1461,15 @@ class PortfolioService(BaseService):
 
         else:
             return None
+
+    def _build_position_writer(self):
+        """构建持仓持久化 writer（委托给 PositionService）。"""
+        from ginkgo.data.containers import container
+        from ginkgo.data.services.position_service import PositionService
+        position_crud = container.cruds.position()
+        return PositionService(crud_repo=position_crud)
+
+    def _build_redis_writer(self):
+        """构建 Redis 状态 writer（委托给 RedisService）。"""
+        from ginkgo.data.containers import container
+        return container.redis_service()

--- a/src/ginkgo/data/services/position_service.py
+++ b/src/ginkgo/data/services/position_service.py
@@ -1,0 +1,62 @@
+# Upstream: PortfolioLive (构造函数注入的 position_writer)
+# Downstream: PositionCRUD (持仓持久化)、GLOG (日志)
+# Role: 持仓业务服务，提供 save_positions / get_positions 等接口
+
+
+from typing import List, Optional, Any
+
+from ginkgo.data.services.base_service import BaseService, ServiceResult
+from ginkgo.libs import GLOG, to_decimal
+
+
+class PositionService(BaseService):
+    """
+    持仓业务服务层。
+
+    编排 PositionCRUD 的数据访问操作，提供业务语义化的接口。
+    作为 PortfolioLive 的 position_writer 注入。
+    """
+
+    def __init__(self, crud_repo=None, **kwargs):
+        super().__init__(crud_repo=crud_repo, **kwargs)
+
+    def save_positions(self, positions: list) -> ServiceResult:
+        """
+        持久化持仓列表（逐条写入）。
+
+        Args:
+            positions: 持仓实体列表（Position 或 duck-typed 对象）
+
+        Returns:
+            ServiceResult
+        """
+        try:
+            for pos in positions:
+                self._crud_repo.create(pos)
+            GLOG.DEBUG(f"Saved {len(positions)} positions")
+            return ServiceResult.success(data={"count": len(positions)})
+        except Exception as e:
+            GLOG.ERROR(f"save_positions failed: {e}")
+            return ServiceResult.error(str(e))
+
+    def get_positions(self, portfolio_id: str) -> ServiceResult:
+        """
+        查询指定 portfolio 的持仓。
+        """
+        try:
+            result = self._crud_repo.find_by_portfolio(portfolio_id)
+            return ServiceResult.success(data=result)
+        except Exception as e:
+            GLOG.ERROR(f"get_positions failed: {e}")
+            return ServiceResult.error(str(e))
+
+    def get_portfolio_value(self, portfolio_id: str) -> ServiceResult:
+        """
+        获取 portfolio 持仓总市值。
+        """
+        try:
+            result = self._crud_repo.get_portfolio_value(portfolio_id)
+            return ServiceResult.success(data=result)
+        except Exception as e:
+            GLOG.ERROR(f"get_portfolio_value failed: {e}")
+            return ServiceResult.error(str(e))

--- a/src/ginkgo/trading/analysis/backtest_result_aggregator.py
+++ b/src/ginkgo/trading/analysis/backtest_result_aggregator.py
@@ -140,6 +140,23 @@ class BacktestResultAggregator:
                     # 不返回错误，允许汇总继续完成（任务可能未预先创建）
                     GLOG.WARN(f"Backtest task may not exist. Create it before running backtest.")
 
+            # 同步绩效指标到 MPortfolio
+            try:
+                from ginkgo.data.containers import container as data_container
+                portfolio_svc = data_container.services.portfolio()
+                perf_result = portfolio_svc.update_performance(
+                    portfolio_id=portfolio_id,
+                    annual_return=metrics.get("annual_return", 0.0),
+                    sharpe_ratio=metrics.get("sharpe_ratio", 0.0),
+                    max_drawdown=metrics.get("max_drawdown", 0.0),
+                    win_rate=metrics.get("trade_win_rate", metrics.get("win_rate", 0.0)),
+                    total_trades=stats.get("total_orders", 0),
+                )
+                if not perf_result.is_success():
+                    GLOG.WARN(f"Failed to sync performance to portfolio {portfolio_id}: {perf_result.error}")
+            except Exception as e:
+                GLOG.WARN(f"Failed to sync performance to portfolio {portfolio_id}: {e}")
+
             GLOG.INFO(f"Backtest results saved for task: {task_id}")
             return ServiceResult.success({
                 "task_id": task_id,

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -37,8 +37,6 @@ from ginkgo.enums import (
     RECORDSTAGE_TYPES,
     PORTFOLIO_RUNSTATE_TYPES,
 )
-from ginkgo.data.models import MOrder
-from ginkgo.data.drivers import add
 
 from ginkgo.libs import datetime_normalize, to_decimal, GLOG
 from ginkgo.libs.core.config import GCONF
@@ -59,10 +57,15 @@ class PortfolioLive(PortfolioBase):
     # If not run time function will pass the class.
     __abstract__ = False
 
-    def __init__(self, notification_service: INotificationService = None, *args, **kwargs):
+    def __init__(self, notification_service: INotificationService = None,
+                 position_writer=None, redis_writer=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # 使用依赖注入的通知服务，如果没有提供则自动创建
         self._notification_service = notification_service or NotificationServiceFactory.create_service()
+
+        # 注入的持久化服务
+        self._position_writer = position_writer
+        self._redis_writer = redis_writer
 
         # 设置日志分类
         GLOG.set_log_category("backtest")
@@ -400,47 +403,14 @@ class PortfolioLive(PortfolioBase):
 
         Returns:
             bool: 同步成功返回True
-
-        同步内容：
-            1. 所有持仓数据（Position）写入ClickHouse
-            2. Portfolio现金和元数据更新到MySQL
         """
+        if self._position_writer is None:
+            GLOG.ERROR("sync_state_to_db: no position_writer injected")
+            return False
+
         try:
-            from ginkgo.data.drivers import add
-            from ginkgo.data.models.model_position import MPosition
-            from ginkgo.data.crud.position_crud import PositionCRUD
-
-            # 1. 同步所有持仓到ClickHouse
-            position_crud = PositionCRUD()
-            for code, position in self._positions.items():
-                try:
-                    # 创建MPosition模型
-                    m_position = MPosition()
-                    m_position.set(
-                        portfolio_id=self.portfolio_id,
-                        engine_id=self.engine_id,
-                        task_id=self.task_id,
-                        code=position.code,
-                        direction=position.direction,
-                        volume=position.volume,
-                        frozen=position.frozen,
-                        cost=position.cost,
-                        price=position.price,
-                        fee=position.fee,
-                        timestamp=self.get_time_provider().now() if self.get_time_provider() else None
-                    )
-
-                    # 写入ClickHouse
-                    add(m_position)
-                    GLOG.DEBUG(f"Position {code} synced to database")
-
-                except Exception as e:
-                    GLOG.ERROR(f"Failed to sync position {code} to database: {e}")
-                    return False
-
-            # 2. 更新Portfolio元数据到MySQL（TODO: Phase 4实现）
-            # MVP阶段：暂不实现Portfolio状态更新
-            # Phase 4：通过PortfolioService更新Portfolio的current_cash, current_worth等字段
+            positions = list(self._positions.values())
+            self._position_writer.save_positions(positions)
 
             GLOG.INFO(f"Portfolio state synced to database: {len(self._positions)} positions")
             return True
@@ -490,13 +460,12 @@ class PortfolioLive(PortfolioBase):
             status: 状态枚举
         """
         try:
-            from ginkgo.data.crud import RedisCRUD
-            redis_crud = RedisCRUD()
-            redis_client = redis_crud.redis
+            if self._redis_writer is None:
+                GLOG.WARN("sync_status_to_redis: no redis_writer injected")
+                return
 
-            # Redis key: portfolio:{portfolio_id}:status
             status_key = f"portfolio:{self.portfolio_id}:status"
-            redis_client.set(status_key, status.value)
+            self._redis_writer.set(status_key, status.value)
 
             GLOG.DEBUG(f"Status synced to Redis: {status_key} = {status.value}")
 

--- a/src/ginkgo/trading/sizers/fixed_sizer.py
+++ b/src/ginkgo/trading/sizers/fixed_sizer.py
@@ -1,5 +1,5 @@
 # Upstream: PortfolioBase, ComponentFactoryService
-# Downstream: BaseSizer, Signal, Order, DIRECTION_TYPES, container, to_decimal
+# Downstream: BaseSizer, Signal, Order, DIRECTION_TYPES, to_decimal
 # Role: 固定仓位管理器，按固定数量下单并自动根据可用资金调整
 
 
@@ -16,7 +16,6 @@ from ginkgo.trading.bases.sizer_base import SizerBase as BaseSizer
 from ginkgo.entities import Order, Signal
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.libs import to_decimal, GLOG
-from ginkgo.data.containers import container
 
 
 class FixedSizer(BaseSizer):
@@ -96,18 +95,18 @@ class FixedSizer(BaseSizer):
         try:
             current_time = self.get_time_provider().now()
             if signal.direction == DIRECTION_TYPES.LONG:
+                if self._data_feeder is None:
+                    GLOG.ERROR(f"Sizer:{self.name} has no data_feeder bound")
+                    return None
                 # If LONG, get the price info of last month, in case the data is not available, use yesterday's price
                 last_month_day = current_time + datetime.timedelta(days=-30)
                 yester_day = current_time + datetime.timedelta(days=-1)
-                # 使用BarService的get方法
-                result = container.bar_service().get(code=code, start_date=last_month_day, end_date=yester_day)
-                if not result.success or len(result.data) == 0:
-                    GLOG.CRITICAL(f"{code} has no data from {last_month_day} to {yester_day}.It should not happened. {current_time}",
-                    )
-                    return None
-                # 转换为DataFrame
-                past_price = result.data.to_dataframe()
-                if past_price.shape[0] == 0:
+                past_price = self._data_feeder.get_historical_data(
+                    symbols=[code],
+                    start_time=last_month_day,
+                    end_time=yester_day,
+                )
+                if past_price is None or past_price.shape[0] == 0:
                     GLOG.CRITICAL(f"{code} has no data from {last_month_day} to {yester_day}.It should not happened. {current_time}")
                     return None
                 last_price = past_price.iloc[-1]["close"]

--- a/tests/unit/services/test_portfolio_service_performance.py
+++ b/tests/unit/services/test_portfolio_service_performance.py
@@ -1,0 +1,190 @@
+# tests/unit/services/test_portfolio_service_performance.py
+"""
+Unit tests for PortfolioService.update_performance() and MPortfolio.annual_return.
+
+Covers:
+- Full and partial performance field updates via the service layer
+- Empty / no-op update
+- Error on nonexistent portfolio
+- MPortfolio.update(str) dispatch correctly sets annual_return
+"""
+import pytest
+from unittest.mock import MagicMock, call
+
+from ginkgo.data.models.model_portfolio import MPortfolio
+from ginkgo.data.services.portfolio_service import PortfolioService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_service():
+    """PortfolioService with mocked dependencies (same pattern as lifecycle tests)."""
+    service = PortfolioService.__new__(PortfolioService)
+    service._crud_repo = MagicMock()
+    service._portfolio_file_mapping_crud = MagicMock()
+    service._deployment_crud = MagicMock()
+    service._param_crud = MagicMock()
+    return service
+
+
+# ===========================================================================
+# update_performance service tests
+# ===========================================================================
+
+
+class TestUpdatePerformanceSetsFields:
+    """All performance fields should be forwarded to _crud_repo.modify."""
+
+    def test_all_fields(self, mock_service):
+        result = mock_service.update_performance(
+            portfolio_id="p-001",
+            annual_return=0.145,
+            sharpe_ratio=1.23,
+            max_drawdown=0.08,
+            win_rate=0.62,
+            total_trades=100,
+            winning_trades=62,
+        )
+
+        assert result.is_success()
+        mock_service._crud_repo.modify.assert_called_once_with(
+            filters={"uuid": "p-001"},
+            updates={
+                "annual_return": 0.145,
+                "sharpe_ratio": 1.23,
+                "max_drawdown": 0.08,
+                "win_rate": 0.62,
+                "total_trades": 100,
+                "winning_trades": 62,
+            },
+        )
+
+    def test_result_data_contains_updated_fields(self, mock_service):
+        result = mock_service.update_performance(
+            portfolio_id="p-002",
+            annual_return=0.10,
+        )
+
+        assert result.is_success()
+        assert "annual_return" in result.data["updated_fields"]
+        assert result.data["portfolio_id"] == "p-002"
+
+
+class TestUpdatePerformancePartialUpdate:
+    """Only supplied fields should appear in the updates dict."""
+
+    def test_sharpe_ratio_and_win_rate_only(self, mock_service):
+        result = mock_service.update_performance(
+            portfolio_id="p-003",
+            sharpe_ratio=2.5,
+            win_rate=0.55,
+        )
+
+        assert result.is_success()
+        mock_service._crud_repo.modify.assert_called_once_with(
+            filters={"uuid": "p-003"},
+            updates={"sharpe_ratio": 2.5, "win_rate": 0.55},
+        )
+
+    def test_single_field(self, mock_service):
+        result = mock_service.update_performance(
+            portfolio_id="p-004",
+            total_trades=42,
+        )
+
+        assert result.is_success()
+        mock_service._crud_repo.modify.assert_called_once_with(
+            filters={"uuid": "p-004"},
+            updates={"total_trades": 42},
+        )
+
+
+class TestUpdatePerformanceEmptyUpdate:
+    """Calling with no optional args should succeed without calling modify."""
+
+    def test_no_fields(self, mock_service):
+        result = mock_service.update_performance(portfolio_id="p-005")
+
+        assert result.is_success()
+        mock_service._crud_repo.modify.assert_not_called()
+
+
+class TestUpdatePerformanceNonexistentPortfolio:
+    """modify() raising should produce an error ServiceResult."""
+
+    def test_modify_raises(self, mock_service):
+        mock_service._crud_repo.modify.side_effect = Exception("row not found")
+
+        result = mock_service.update_performance(
+            portfolio_id="nonexistent-uuid",
+            annual_return=0.05,
+        )
+
+        assert result.is_success() is False
+        assert "Failed to update performance" in result.error
+
+    def test_empty_portfolio_id(self, mock_service):
+        result = mock_service.update_performance(portfolio_id="")
+
+        assert result.is_success() is False
+        mock_service._crud_repo.modify.assert_not_called()
+
+    def test_whitespace_portfolio_id(self, mock_service):
+        result = mock_service.update_performance(portfolio_id="   ")
+
+        assert result.is_success() is False
+        mock_service._crud_repo.modify.assert_not_called()
+
+
+# ===========================================================================
+# MPortfolio.annual_return model tests
+# ===========================================================================
+
+
+class TestMPortfolioAnnualReturnInModelUpdate:
+    """MPortfolio.update(str) should correctly set annual_return."""
+
+    def test_annual_return_set_via_str_dispatch(self):
+        model = MPortfolio()
+        model.update(
+            "test_portfolio",
+            annual_return=0.1543,
+        )
+
+        assert float(model.annual_return) == pytest.approx(0.1543)
+
+    def test_annual_return_default_is_none_before_persist(self):
+        model = MPortfolio()
+        # SQLAlchemy column default only applies on DB INSERT; in-memory is None
+        assert model.annual_return is None
+
+    def test_annual_return_not_set_when_none(self):
+        model = MPortfolio()
+        model.update("test_portfolio", annual_return=0.20)
+
+        # Update again without annual_return -- value should stay unchanged
+        model.update("test_portfolio")
+        assert float(model.annual_return) == pytest.approx(0.20)
+
+    def test_annual_return_alongside_other_performance_fields(self):
+        model = MPortfolio()
+        model.update(
+            "test_portfolio",
+            annual_return=0.12,
+            sharpe_ratio=1.5,
+            max_drawdown=0.08,
+            win_rate=0.60,
+            total_trades=50,
+            winning_trades=30,
+        )
+
+        assert float(model.annual_return) == pytest.approx(0.12)
+        assert float(model.sharpe_ratio) == pytest.approx(1.5)
+        assert float(model.max_drawdown) == pytest.approx(0.08)
+        assert float(model.win_rate) == pytest.approx(0.60)
+        assert model.total_trades == 50
+        assert model.winning_trades == 30

--- a/tests/unit/services/test_position_service.py
+++ b/tests/unit/services/test_position_service.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for PositionService.
+
+Verifies that PositionService orchestrates position persistence
+through PositionCRUD, providing the `save_positions` interface
+that PortfolioLive depends on.
+"""
+import pytest
+from unittest.mock import MagicMock, call
+
+from ginkgo.data.services.position_service import PositionService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+@pytest.fixture
+def mock_crud():
+    return MagicMock()
+
+
+@pytest.fixture
+def service(mock_crud):
+    return PositionService(crud_repo=mock_crud)
+
+
+@pytest.fixture
+def mock_position():
+    """A duck-typed position object matching what PortfolioLive passes."""
+    pos = MagicMock()
+    pos.portfolio_id = "p-001"
+    pos.engine_id = "e-001"
+    pos.task_id = "t-001"
+    pos.code = "000001.SZ"
+    pos.direction = "LONG"
+    pos.volume = 100
+    pos.frozen = 0
+    pos.cost = 10.5
+    pos.price = 11.0
+    pos.fee = 0.5
+    pos.timestamp = None
+    return pos
+
+
+class TestSavePositions:
+    """save_positions is the primary interface used by PortfolioLive."""
+
+    def test_empty_list(self, service, mock_crud):
+        result = service.save_positions([])
+        assert result.is_success()
+        # Should delete existing then create none
+        mock_crud.delete_by_portfolio.assert_not_called()
+
+    def test_saves_positions_via_crud(self, service, mock_crud, mock_position):
+        result = service.save_positions([mock_position])
+
+        assert result.is_success()
+        # Should convert and create via CRUD
+        mock_crud.create.assert_called_once()
+
+    def test_multiple_positions(self, service, mock_crud, mock_position):
+        pos2 = MagicMock()
+        pos2.portfolio_id = "p-001"
+        pos2.engine_id = "e-001"
+        pos2.task_id = "t-001"
+        pos2.code = "600000.SH"
+        pos2.direction = "LONG"
+        pos2.volume = 200
+        pos2.frozen = 0
+        pos2.cost = 20.0
+        pos2.price = 21.0
+        pos2.fee = 1.0
+        pos2.timestamp = None
+
+        result = service.save_positions([mock_position, pos2])
+        assert result.is_success()
+        assert mock_crud.create.call_count == 2
+
+    def test_crud_failure_returns_error(self, service, mock_crud, mock_position):
+        mock_crud.create.side_effect = Exception("DB write failed")
+
+        result = service.save_positions([mock_position])
+        assert result.is_success() is False
+        assert "DB write failed" in result.error
+
+
+class TestGetPositions:
+    """Query positions by portfolio."""
+
+    def test_find_by_portfolio(self, service, mock_crud):
+        mock_crud.find_by_portfolio.return_value = []
+
+        result = service.get_positions("p-001")
+        assert result.is_success()
+        mock_crud.find_by_portfolio.assert_called_once_with("p-001")
+
+    def test_get_portfolio_value(self, service, mock_crud):
+        mock_crud.get_portfolio_value.return_value = {
+            "total_market_value": 10000,
+            "total_cost": 9000,
+        }
+
+        result = service.get_portfolio_value("p-001")
+        assert result.is_success()
+        assert result.data["total_market_value"] == 10000

--- a/tests/unit/trading/portfolios/test_portfolio_live.py
+++ b/tests/unit/trading/portfolios/test_portfolio_live.py
@@ -1,0 +1,159 @@
+"""
+Tests for PortfolioLive constructor injection of position_writer and redis_writer.
+
+Verifies that PortfolioLive no longer imports CRUDs directly,
+and delegates state persistence to injected services.
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+from ginkgo.trading.portfolios.portfolio_live import PortfolioLive
+
+
+@pytest.fixture
+def mock_position_writer():
+    """Mock for the injected position persistence service."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_redis_writer():
+    """Mock for the injected Redis status service (duck-typed: has set(key, value))."""
+    return MagicMock()
+
+
+@pytest.fixture
+def portfolio(mock_position_writer, mock_redis_writer):
+    """PortfolioLive with injected dependencies."""
+    p = PortfolioLive(
+        position_writer=mock_position_writer,
+        redis_writer=mock_redis_writer,
+        uuid="test-portfolio-001",
+        name="TestLive",
+    )
+    # minimal setup
+    p.add_cash(100000)
+    return p
+
+
+class TestConstructorInjection:
+    """PortfolioLive accepts services via constructor, not imports."""
+
+    def test_position_writer_stored(self, mock_position_writer, mock_redis_writer):
+        p = PortfolioLive(
+            position_writer=mock_position_writer,
+            redis_writer=mock_redis_writer,
+        )
+        assert p._position_writer is mock_position_writer
+
+    def test_redis_writer_stored(self, mock_position_writer, mock_redis_writer):
+        p = PortfolioLive(
+            position_writer=mock_position_writer,
+            redis_writer=mock_redis_writer,
+        )
+        assert p._redis_writer is mock_redis_writer
+
+    def test_no_crud_imports_in_module(self):
+        """Module source should not import PositionCRUD or RedisCRUD."""
+        import ginkgo.trading.portfolios.portfolio_live as mod
+        import importlib
+
+        importlib.reload(mod)
+        source = open(mod.__file__).read()
+        assert "PositionCRUD" not in source
+        assert "RedisCRUD" not in source
+
+
+class TestSyncStateToDb:
+    """sync_state_to_db delegates to injected position_writer."""
+
+    def test_delegates_to_position_writer(self, portfolio, mock_position_writer):
+        from ginkgo.entities import Position
+
+        pos = Position(
+            portfolio_id=portfolio.uuid,
+            engine_id="test-engine",
+            task_id="test-task",
+            code="000001.SZ",
+            cost=Decimal("10.5"),
+            volume=100,
+            price=Decimal("11.0"),
+        )
+        portfolio.add_position(pos)
+
+        result = portfolio.sync_state_to_db()
+
+        assert result is True
+        mock_position_writer.save_positions.assert_called_once()
+        # Verify positions data passed
+        args = mock_position_writer.save_positions.call_args
+        assert len(args[0][0]) == 1  # list of positions
+        assert args[0][0][0].code == "000001.SZ"
+
+    def test_no_positions_still_succeeds(self, portfolio, mock_position_writer):
+        result = portfolio.sync_state_to_db()
+        assert result is True
+        mock_position_writer.save_positions.assert_called_once_with([])
+
+    def test_writer_failure_returns_false(self, portfolio, mock_position_writer):
+        from ginkgo.entities import Position
+
+        pos = Position(
+            portfolio_id=portfolio.uuid,
+            engine_id="test-engine",
+            task_id="test-task",
+            code="000001.SZ",
+            cost=Decimal("10"),
+            volume=100,
+            price=Decimal("10"),
+        )
+        portfolio.add_position(pos)
+
+        mock_position_writer.save_positions.side_effect = Exception("DB error")
+        result = portfolio.sync_state_to_db()
+        assert result is False
+
+
+class TestSyncStatusToRedis:
+    """_sync_status_to_redis delegates to injected redis_writer."""
+
+    def test_delegates_to_redis_writer(self, portfolio, mock_redis_writer):
+        portfolio._sync_status_to_redis(PORTFOLIO_RUNSTATE_TYPES.STOPPING)
+
+        mock_redis_writer.set.assert_called_once()
+        args = mock_redis_writer.set.call_args
+        assert "portfolio:test-portfolio-001:status" == args[0][0]
+        assert args[0][1] == PORTFOLIO_RUNSTATE_TYPES.STOPPING.value
+
+    def test_redis_failure_handled(self, portfolio, mock_redis_writer):
+        mock_redis_writer.set.side_effect = Exception("Redis down")
+
+        # Should not raise
+        portfolio._sync_status_to_redis(PORTFOLIO_RUNSTATE_TYPES.STOPPING)
+
+
+class TestNoPositionWriter:
+    """Without position_writer, sync_state_to_db gracefully handles."""
+
+    def test_sync_without_writer(self, mock_redis_writer):
+        p = PortfolioLive(
+            redis_writer=mock_redis_writer,
+            uuid="test-no-writer",
+        )
+        p.add_cash(50000)
+
+        result = p.sync_state_to_db()
+        # Should gracefully return False or log warning, not crash
+        assert result is False
+
+    def test_status_without_redis_writer(self, mock_position_writer):
+        p = PortfolioLive(
+            position_writer=mock_position_writer,
+            uuid="test-no-redis",
+        )
+        # Should not raise
+        p._sync_status_to_redis(PORTFOLIO_RUNSTATE_TYPES.RUNNING)

--- a/tests/unit/trading/sizers/test_fixed_sizer.py
+++ b/tests/unit/trading/sizers/test_fixed_sizer.py
@@ -1,0 +1,124 @@
+"""
+Unit tests for FixedSizer using data_feeder instead of DI container.
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.entities import Signal
+from ginkgo.trading.sizers.fixed_sizer import FixedSizer
+
+
+@pytest.fixture
+def sizer():
+    s = FixedSizer(name="TestSizer", volume="100")
+    # mock time provider
+    tp = MagicMock()
+    tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+    s._time_provider = tp
+    return s
+
+
+@pytest.fixture
+def mock_feeder():
+    feeder = MagicMock()
+    return feeder
+
+
+def _make_signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG):
+    s = Signal(code=code, direction=direction)
+    s._portfolio_id = "test-portfolio"
+    s._engine_id = "test-engine"
+    return s
+
+
+def _make_portfolio_info(cash=Decimal("500000"), positions=None):
+    return {
+        "cash": cash,
+        "positions": positions or {},
+    }
+
+
+class TestFixedSizerUsesDataFeeder:
+    """FixedSizer should get price data via _data_feeder, not container."""
+
+    def test_long_uses_data_feeder(self, sizer, mock_feeder):
+        """LONG order fetches price via data_feeder.get_historical_data."""
+        df = pd.DataFrame({"close": [10.0, 10.5, 11.0]})
+        mock_feeder.get_historical_data.return_value = df
+        sizer._data_feeder = mock_feeder
+
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=Decimal("500000"))
+
+        order = sizer.cal(info, signal)
+
+        mock_feeder.get_historical_data.assert_called_once()
+        # should NOT import container
+        assert order is not None
+        assert order.code == "000001.SZ"
+
+    def test_no_data_feeder_returns_none(self, sizer):
+        """Without data_feeder, LONG signal cannot get price → None."""
+        sizer._data_feeder = None
+
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info()
+
+        order = sizer.cal(info, signal)
+        assert order is None
+
+    def test_empty_dataframe_returns_none(self, sizer, mock_feeder):
+        """data_feeder returns empty DataFrame → no order."""
+        mock_feeder.get_historical_data.return_value = pd.DataFrame()
+        sizer._data_feeder = mock_feeder
+
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info()
+
+        order = sizer.cal(info, signal)
+        assert order is None
+
+    def test_short_does_not_call_data_feeder(self, sizer, mock_feeder):
+        """SHORT order uses existing position, no price lookup needed."""
+        sizer._data_feeder = mock_feeder
+
+        pos = MagicMock()
+        pos.volume = 200
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.SHORT)
+        info = _make_portfolio_info(positions={"000001.SZ": pos})
+
+        order = sizer.cal(info, signal)
+
+        mock_feeder.get_historical_data.assert_not_called()
+        assert order is not None
+        assert order.volume == 200
+
+    def test_get_historical_data_args(self, sizer, mock_feeder):
+        """Verify correct date range passed to get_historical_data."""
+        df = pd.DataFrame({"close": [10.0, 11.0]})
+        mock_feeder.get_historical_data.return_value = df
+        sizer._data_feeder = mock_feeder
+
+        signal = _make_signal("600000.SH", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info()
+
+        sizer.cal(info, signal)
+
+        call_args = mock_feeder.get_historical_data.call_args
+        assert call_args.kwargs["symbols"] == ["600000.SH"]
+        assert call_args.kwargs["start_time"].date() == datetime.date(2025, 12, 16)
+        assert call_args.kwargs["end_time"].date() == datetime.date(2026, 1, 14)
+
+    def test_no_container_import(self):
+        """FixedSizer module should not import container."""
+        import importlib
+        import ginkgo.trading.sizers.fixed_sizer as mod
+
+        importlib.reload(mod)
+        source = open(mod.__file__).read()
+        assert "container" not in source

--- a/web-ui/src/api/modules/portfolio.ts
+++ b/web-ui/src/api/modules/portfolio.ts
@@ -15,6 +15,16 @@ export interface PortfolioComponents {
   analyzers: PortfolioComponent[]
 }
 
+export interface RelatedPortfolio {
+  uuid: string
+  name: string
+  mode: string
+  state: string
+  annual_return?: number | null
+  max_drawdown?: number | null
+  relation?: string
+}
+
 export interface Portfolio {
   uuid: string
   name: string
@@ -30,6 +40,16 @@ export interface Portfolio {
   components?: PortfolioComponents
   created_at: string
   updated_at: string
+  // 绩效指标
+  annual_return?: number | null
+  sharpe_ratio?: number | null
+  max_drawdown?: number | null
+  win_rate?: number | null
+  // 元信息
+  backtest_count?: number
+  last_backtest_date?: string | null
+  // 关联组合
+  related?: RelatedPortfolio[]
 }
 
 export interface PortfolioCreateRequest {

--- a/web-ui/src/views/portfolio/PortfolioList.vue
+++ b/web-ui/src/views/portfolio/PortfolioList.vue
@@ -114,16 +114,30 @@
             </div>
 
             <div class="card-body">
-              <div class="metrics">
+              <div class="metrics-grid">
                 <div class="metric">
-                  <span class="label">净值</span>
-                  <span class="value" :class="{ positive: (portfolio.net_value || 1) >= 1, negative: (portfolio.net_value || 1) < 1 }">
-                    {{ (portfolio.net_value || 1).toFixed(4) }}
+                  <span class="label">{{ getReturnLabel(portfolio.mode) }}</span>
+                  <span class="value" :class="getValueClass(portfolio.annual_return)">
+                    {{ formatPercent(portfolio.annual_return) }}
                   </span>
                 </div>
                 <div class="metric">
-                  <span class="label">初始资金</span>
-                  <span class="value">{{ formatMoney(portfolio.initial_cash) }}</span>
+                  <span class="label">Sharpe</span>
+                  <span class="value" :class="getSharpeClass(portfolio.sharpe_ratio)">
+                    {{ formatDecimal(portfolio.sharpe_ratio) }}
+                  </span>
+                </div>
+                <div class="metric">
+                  <span class="label">最大回撤</span>
+                  <span class="value negative">
+                    {{ formatDrawdown(portfolio.max_drawdown) }}
+                  </span>
+                </div>
+                <div class="metric">
+                  <span class="label">胜率</span>
+                  <span class="value" :class="getWinRateClass(portfolio.win_rate)">
+                    {{ formatPercent(portfolio.win_rate) }}
+                  </span>
                 </div>
               </div>
             </div>
@@ -135,6 +149,24 @@
                 {{ formatState(portfolio.state) }}
               </span>
               <span class="date">{{ formatShortDate(portfolio.created_at) }}</span>
+            </div>
+            <div v-if="portfolio.related && portfolio.related.length > 0" class="related-bar">
+              <div
+                v-for="rel in portfolio.related"
+                :key="rel.uuid"
+                class="related-card"
+                :class="`related-${rel.mode.toLowerCase()}`"
+                @click.stop="viewDetail({ uuid: rel.uuid })"
+              >
+                <div class="related-header">
+                  <span class="related-mode">{{ formatRelatedMode(rel.mode) }}</span>
+                  <span v-if="rel.state" class="related-state">{{ rel.state }}</span>
+                </div>
+                <div class="related-metrics">
+                  <span>收益 <strong :class="getValueClass(rel.annual_return)">{{ formatPercent(rel.annual_return) }}</strong></span>
+                  <span>回撤 <strong class="negative">{{ formatDrawdown(rel.max_drawdown) }}</strong></span>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -304,6 +336,64 @@ const formatShortDate = (dateStr: string) => {
   if (!dateStr) return ''
   const d = new Date(dateStr)
   return `${d.getMonth() + 1}/${d.getDate()} ${d.getHours()}:${String(d.getMinutes()).padStart(2, '0')}`
+}
+
+const getReturnLabel = (mode: any) => {
+  const m = typeof mode === 'string' ? mode.toUpperCase() : mode
+  return m === 'BACKTEST' || m === 0 || m === '0' ? '年化收益' : '累计收益'
+}
+
+const formatPercent = (val: any) => {
+  if (val === null || val === undefined || val === 0) return '--'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n)) return '--'
+  const sign = n > 0 ? '+' : ''
+  return `${sign}${(n * 100).toFixed(2)}%`
+}
+
+const formatDecimal = (val: any) => {
+  if (val === null || val === undefined || val === 0) return '--'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n)) return '--'
+  return n.toFixed(2)
+}
+
+const formatDrawdown = (val: any) => {
+  if (val === null || val === undefined || val === 0) return '--'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n)) return '--'
+  return `-${(Math.abs(n) * 100).toFixed(1)}%`
+}
+
+const getValueClass = (val: any) => {
+  if (val === null || val === undefined) return 'neutral'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n) || n === 0) return 'neutral'
+  return n > 0 ? 'positive' : 'negative'
+}
+
+const getSharpeClass = (val: any) => {
+  if (val === null || val === undefined) return 'neutral'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n) || n === 0) return 'neutral'
+  if (n < 0.5) return 'warning'
+  return n > 0 ? 'positive' : 'negative'
+}
+
+const getWinRateClass = (val: any) => {
+  if (val === null || val === undefined) return 'neutral'
+  const n = typeof val === 'string' ? parseFloat(val) : val
+  if (isNaN(n) || n === 0) return 'neutral'
+  return n >= 0.5 ? 'positive' : 'warning'
+}
+
+const formatRelatedMode = (mode: string) => {
+  const map: Record<string, string> = {
+    'BACKTEST': '来源回测',
+    'PAPER': '模拟',
+    'LIVE': '实盘',
+  }
+  return map[mode] || mode
 }
 
 const setFilterMode = (value: string) => { filterMode.value = value }
@@ -537,12 +627,22 @@ onUnmounted(() => {
 
 .card-body { display: flex; flex-direction: column; gap: 12px; flex: 1; }
 
-.metrics { display: flex; gap: 24px; }
-.metric { display: flex; flex-direction: column; gap: 2px; }
-.metric .label { font-size: 11px; color: #6a6a7a; }
-.metric .value { font-size: 18px; font-weight: 600; color: #fff; }
-.metric .value.positive { color: #52c41a; }
-.metric .value.negative { color: #f5222d; }
+.metrics-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px 16px;
+  padding: 10px;
+  background: #12122a;
+  border-radius: 6px;
+}
+
+.metrics-grid .metric .label { font-size: 10px; color: #888; }
+.metrics-grid .metric .value { font-size: 16px; font-weight: 700; }
+
+.value.positive { color: #4caf50; }
+.value.negative { color: #f44336; }
+.value.warning { color: #ff9800; }
+.value.neutral { color: #555; }
 
 .card-footer {
   display: flex;
@@ -559,6 +659,51 @@ onUnmounted(() => {
 }
 
 .card-footer .date { font-size: 12px; color: #6a6a7a; margin-left: auto; }
+
+.related-bar {
+  display: flex;
+  gap: 8px;
+  padding: 10px 0 0;
+  border-top: 1px solid #252540;
+  margin-top: 10px;
+}
+
+.related-card {
+  flex: 1;
+  padding: 8px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.related-card:hover { opacity: 0.8; }
+
+.related-backtest { background: #0f0f2a; border: 1px solid #20203a; }
+.related-paper { background: #1e1e0a; border: 1px solid #3a3520; }
+.related-live { background: #0a1e1a; border: 1px solid #203a2a; }
+
+.related-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.related-mode { font-size: 10px; font-weight: 600; }
+.related-backtest .related-mode { color: #7c8aff; }
+.related-paper .related-mode { color: #ff9800; }
+.related-live .related-mode { color: #4caf50; }
+
+.related-state { font-size: 9px; color: #4caf50; }
+
+.related-metrics {
+  display: flex;
+  gap: 10px;
+  font-size: 9px;
+  color: #888;
+}
+
+.related-metrics strong { font-size: 11px; }
 
 /* Empty */
 .empty-state {


### PR DESCRIPTION
## Summary

- Portfolio list API 返回 performance 指标（annual_return, sharpe_ratio 等）和关联 portfolio
- WebUI PortfolioList 卡片展示 performance 指标
- 回测完成时同步指标到 MPortfolio
- 架构改进：解耦 trading 与 data 层
  - FixedSizer 改用 data_feeder
  - PortfolioLive 构造函数注入 + 新建 PositionService
  - PortfolioCRUD 移除 trading 反向依赖
  - OrderCRUD 删除死代码 get_order_summary
  - PortfolioCRUD 删除废弃方法
- Scaffold agent skills config (issue tracker, triage labels, domain docs)

## Test plan

- [x] 34 个单元测试全部通过（portfolio_service_performance, fixed_sizer, portfolio_live, position_service）

🤖 Generated with [Claude Code](https://claude.com/claude-code)