### PR TITLE
Strategy/Risk parameter validation and dual mechanism docs

### DIFF
--- a/src/ginkgo/trading/bases/risk_base.py
+++ b/src/ginkgo/trading/bases/risk_base.py
@@ -36,6 +36,19 @@ class RiskBase(TimeMixin, ContextMixin, EngineBindableMixin, NamedMixin, Base):
     - 引擎绑定 (bind_engine, engine_put)
     - 名称管理 (name)
     - 组件基础功能 (uuid, component_type, dataframe转换)
+
+    双重风控机制：
+    - cal(): 被动拦截。Portfolio 收到 Strategy 的订单后，依次通过每个
+      RiskManager.cal()，风控可调整 volume、拒绝订单或放行。数据流：
+      Strategy → Signal → Order → Risk.cal() → 调整后 Order
+    - generate_signals(): 主动信号。每次价格事件到达时，Portfolio 调用
+      每个 RiskManager.generate_signals()，风控可主动生成平仓信号（如
+      止损、止盈）。数据流：EventPriceUpdate → Risk.generate_signals() → Signal
+
+    与 Strategy 的区别：
+    - Strategy.cal() 根据行情决定"买什么"，输出信号
+    - Risk.cal() 根据已有订单决定"能不能买"，调整或拦截
+    - Risk.generate_signals() 根据行情决定"要不要卖"，输出风控信号
     """
 
     def __init__(self, name: str = "risk", engine=None, **kwargs):

--- a/src/ginkgo/trading/strategies/random_signal_strategy.py
+++ b/src/ginkgo/trading/strategies/random_signal_strategy.py
@@ -106,6 +106,21 @@ class RandomSignalStrategy(BaseStrategy):
         self.random_seed = seed
         random.seed(seed)
 
+    # See #24: validate strategy parameters at binding time
+    def validate_parameters(self, params: Dict[str, Any]) -> bool:
+        """Validate strategy parameters: probabilities must be numeric and in [0, 1]."""
+        for key in ("buy_probability", "sell_probability"):
+            if key not in params:
+                continue
+            val = params[key]
+            try:
+                val = float(val)
+            except (ValueError, TypeError):
+                return False
+            if val < 0.0 or val > 1.0:
+                return False
+        return True
+
     def cal(self, portfolio_info: Dict[str, Any], event: EventPriceUpdate, *args, **kwargs) -> List[Signal]:
         """
         策略主要计算逻辑

--- a/tests/unit/trading/strategies/test_parameter_validation.py
+++ b/tests/unit/trading/strategies/test_parameter_validation.py
@@ -1,0 +1,90 @@
+"""
+Tests for strategy parameter validation.
+
+Verifies that validate_parameters catches invalid params at binding time
+instead of silently accepting them and failing at runtime.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.trading.strategies.random_signal_strategy import RandomSignalStrategy
+
+
+# ===========================================================================
+# Tracer bullet: RandomSignalStrategy parameter validation
+# ===========================================================================
+
+
+class TestRandomSignalValidation:
+    """Verify RandomSignalStrategy.validate_parameters rejects invalid inputs."""
+
+    def test_rejects_negative_buy_probability(self):
+        strategy = RandomSignalStrategy()
+        result = strategy.validate_parameters({
+            "buy_probability": -0.5,
+            "sell_probability": 0.3,
+        })
+        assert result is False
+
+    def test_rejects_buy_probability_above_one(self):
+        strategy = RandomSignalStrategy()
+        result = strategy.validate_parameters({
+            "buy_probability": 1.5,
+            "sell_probability": 0.3,
+        })
+        assert result is False
+
+    def test_rejects_negative_sell_probability(self):
+        strategy = RandomSignalStrategy()
+        result = strategy.validate_parameters({
+            "buy_probability": 0.3,
+            "sell_probability": -0.1,
+        })
+        assert result is False
+
+    def test_accepts_valid_probabilities(self):
+        strategy = RandomSignalStrategy()
+        result = strategy.validate_parameters({
+            "buy_probability": 0.3,
+            "sell_probability": 0.3,
+        })
+        assert result is True
+
+    def test_accepts_default_params(self):
+        strategy = RandomSignalStrategy()
+        result = strategy.validate_parameters({})
+        assert result is True
+
+    def test_rejects_non_numeric_probability(self):
+        strategy = RandomSignalStrategy()
+        result = strategy.validate_parameters({
+            "buy_probability": "not_a_number",
+        })
+        assert result is False
+
+
+# ===========================================================================
+# Binding-time validation: ComponentLoader calls validate_parameters
+# ===========================================================================
+
+
+class TestBindingTimeValidation:
+    """Verify validate_parameters is callable and usable for pre-instantiation checks."""
+
+    def test_validate_before_instantiate_rejects_invalid(self):
+        """Caller can use validate_parameters to check params before constructing."""
+        strategy = RandomSignalStrategy()
+        raw_params = {"buy_probability": "not_a_number", "sell_probability": 0.3}
+        assert strategy.validate_parameters(raw_params) is False
+
+    def test_validate_before_instantiate_accepts_valid(self):
+        strategy = RandomSignalStrategy()
+        raw_params = {"buy_probability": 0.5, "sell_probability": 0.2}
+        assert strategy.validate_parameters(raw_params) is True
+
+    def test_validate_with_string_numeric(self):
+        """String numerics like '0.3' should be accepted (DB stores as strings)."""
+        strategy = RandomSignalStrategy()
+        raw_params = {"buy_probability": "0.3", "sell_probability": "0.2"}
+        assert strategy.validate_parameters(raw_params) is True


### PR DESCRIPTION
## Summary
- Add `validate_parameters` to `RandomSignalStrategy` that validates probability values (range [0,1], numeric including string numerics from DB)
- Document RiskBase dual mechanism in docstring: `cal()` (passive order interception) vs `generate_signals()` (active risk signals)
- Add 9 unit tests covering parameter validation and pre-instantiation checks

## Test plan
- [x] `pytest tests/unit/trading/strategies/test_parameter_validation.py` — 9 passed
- [ ] Smoke test: verify backtest still works end-to-end

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)