### PR TITLE
test: supplement core service smoke tests

### DIFF
--- a/tests/integration/data/services/test_backtest_task_service_smoke.py
+++ b/tests/integration/data/services/test_backtest_task_service_smoke.py
@@ -1,0 +1,97 @@
+"""
+BacktestTaskService smoke test.
+
+Verifies the core task lifecycle through real services:
+create → get → update → delete
+
+Run: pytest tests/integration/data/services/test_backtest_task_service_smoke.py -v -s
+"""
+
+import time
+
+import pytest
+
+from ginkgo.data.containers import container
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_debug():
+    GCONF.set_debug(True)
+
+
+@pytest.fixture(scope="module")
+def task_svc():
+    return container.backtest_task_service()
+
+
+@pytest.fixture(scope="module")
+def sample_task(task_svc):
+    """Create a backtest task, yield uuid, cleanup after."""
+    ts = int(time.time())
+    result = task_svc.create(
+        name=f"smoke_task_{ts}",
+        engine_id="smoke-engine",
+        portfolio_id="smoke-portfolio",
+    )
+    assert result.is_success(), f"Create task failed: {result.error}"
+    task_id = result.data.uuid
+
+    yield task_id
+
+    try:
+        task_svc.delete(uuid=task_id)
+    except Exception:
+        pass
+
+
+class TestBacktestTaskServiceSmoke:
+    """Core BacktestTaskService lifecycle smoke test."""
+
+    def test_health_check(self, task_svc):
+        result = task_svc.health_check()
+        assert result.is_success()
+        assert result.data["status"] == "healthy"
+
+    def test_create_and_get(self, task_svc, sample_task):
+        result = task_svc.get_by_id(sample_task)
+        assert result.is_success()
+        assert result.data.uuid == sample_task
+        assert result.data.status == "created"
+
+    def test_list_includes_task(self, task_svc, sample_task):
+        result = task_svc.list(status="created", page_size=100)
+        assert result.is_success()
+        uuids = [t.uuid for t in result.data["data"]]
+        assert sample_task in uuids
+
+    def test_update_name(self, task_svc, sample_task):
+        result = task_svc.update(uuid=sample_task, name="renamed_smoke")
+        assert result.is_success()
+        assert "name" in result.data["updated_fields"]
+
+        verify = task_svc.get_by_id(sample_task)
+        assert verify.data.name == "renamed_smoke"
+
+    def test_statistics_counts_task(self, task_svc, sample_task):
+        result = task_svc.get_statistics()
+        assert result.is_success()
+        assert result.data["total"] > 0
+
+    def test_delete_task(self, task_svc):
+        # Create a separate task for deletion
+        ts = int(time.time())
+        create_result = task_svc.create(
+            name=f"smoke_del_{ts}",
+            engine_id="smoke-engine",
+            portfolio_id="smoke-portfolio",
+        )
+        assert create_result.is_success()
+        task_id = create_result.data.uuid
+
+        del_result = task_svc.delete(uuid=task_id)
+        assert del_result.is_success()
+
+        exists_result = task_svc.exists(uuid=task_id)
+        assert exists_result.is_success()
+        assert exists_result.data["exists"] is False

--- a/tests/integration/data/services/test_file_service_smoke.py
+++ b/tests/integration/data/services/test_file_service_smoke.py
@@ -1,0 +1,70 @@
+"""
+FileService smoke test.
+
+Verifies the core file lifecycle through real services:
+query existing → count → type listing
+
+Run: pytest tests/integration/data/services/test_file_service_smoke.py -v -s
+"""
+
+import pytest
+
+from ginkgo.data.containers import container
+from ginkgo.enums import FILE_TYPES
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_debug():
+    GCONF.set_debug(True)
+
+
+@pytest.fixture(scope="module")
+def file_svc():
+    return container.file_service()
+
+
+class TestFileServiceSmoke:
+    """Core FileService query smoke test."""
+
+    def test_get_strategies(self, file_svc):
+        result = file_svc.get(file_type=FILE_TYPES.STRATEGY)
+        assert result.is_success()
+        assert "files" in result.data
+        assert result.data["count"] >= 0
+
+    def test_get_by_name(self, file_svc):
+        result = file_svc.get_by_name("random_signal_strategy", FILE_TYPES.STRATEGY)
+        assert result.is_success()
+        files = result.data["files"]
+        assert len(files) > 0
+        assert files[0].name == "random_signal_strategy"
+
+    def test_count(self, file_svc):
+        result = file_svc.count()
+        assert result.is_success()
+        assert result.data["count"] >= 0
+
+    def test_get_available_types(self, file_svc):
+        result = file_svc.get_available_types()
+        assert result.is_success()
+        assert result.data["count"] > 0
+
+    def test_get_content(self, file_svc):
+        # Get a known strategy, then fetch its content
+        get_result = file_svc.get_by_name("no_risk", FILE_TYPES.RISKMANAGER)
+        assert get_result.is_success()
+        files = get_result.data["files"]
+        if not files:
+            pytest.skip("no_risk not found in database")
+        file_id = files[0].uuid
+
+        content_result = file_svc.get_content(file_id)
+        assert content_result.is_success()
+        assert content_result.data is not None
+        assert len(content_result.data) > 0
+
+    def test_exists_known_file(self, file_svc):
+        result = file_svc.exists(name="random_signal_strategy")
+        assert result.is_success()
+        assert result.data is True

--- a/tests/integration/data/services/test_portfolio_service_smoke.py
+++ b/tests/integration/data/services/test_portfolio_service_smoke.py
@@ -1,0 +1,116 @@
+"""
+PortfolioService smoke test.
+
+Verifies the core portfolio lifecycle through real services:
+create → bind components → get with details → delete
+
+Run: pytest tests/integration/data/services/test_portfolio_service_smoke.py -v -s
+"""
+
+import time
+
+import pytest
+
+from ginkgo.data.containers import container
+from ginkgo.enums import FILE_TYPES
+from ginkgo.libs import GCONF, GLOG
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_debug():
+    GCONF.set_debug(True)
+
+
+@pytest.fixture(scope="module")
+def portfolio_with_components():
+    """Create portfolio, bind components, yield UUID, cleanup."""
+    portfolio_svc = container.portfolio_service()
+    file_svc = container.file_service()
+    mapping_svc = container.mapping_service()
+
+    # Find component files
+    def _find_file(name, file_type):
+        result = file_svc.get(name=name, file_type=file_type)
+        if result.is_success() and result.data:
+            files = result.data.get("files", [])
+            for f in files:
+                if getattr(f, 'name', '') == name:
+                    return f.uuid, f.name
+        return None, None
+
+    strategy_id, strategy_name = _find_file("random_signal_strategy", FILE_TYPES.STRATEGY)
+    selector_id, selector_name = _find_file("fixed_selector", FILE_TYPES.SELECTOR)
+    risk_id, risk_name = _find_file("no_risk", FILE_TYPES.RISKMANAGER)
+
+    assert strategy_id, "Strategy not found"
+
+    # Create portfolio
+    ts = int(time.time())
+    result = portfolio_svc.add(
+        name=f"smoke_port_{ts}",
+        initial_capital=100000.0,
+        mode="BACKTEST",
+    )
+    assert result.is_success(), f"Create failed: {result.error}"
+    portfolio_id = result.data["uuid"]
+
+    # Bind components
+    for file_id, file_name, comp_type in [
+        (strategy_id, strategy_name, FILE_TYPES.STRATEGY),
+        (selector_id, selector_name, FILE_TYPES.SELECTOR) if selector_id else None,
+        (risk_id, risk_name, FILE_TYPES.RISKMANAGER) if risk_id else None,
+    ]:
+        if file_id is None:
+            continue
+        bind_result = mapping_svc.create_portfolio_file_binding(
+            portfolio_uuid=portfolio_id,
+            file_uuid=file_id,
+            file_name=file_name,
+            file_type=comp_type,
+        )
+        assert bind_result.is_success(), f"Bind {comp_type} failed: {bind_result.error}"
+
+    GLOG.INFO(f"[SMOKE] Portfolio ready: {portfolio_id}")
+    yield portfolio_id
+
+    try:
+        portfolio_svc.delete(portfolio_id=portfolio_id)
+    except Exception:
+        pass
+
+
+class TestPortfolioServiceSmoke:
+    """Core portfolio lifecycle smoke test."""
+
+    def test_create_and_get(self, portfolio_with_components):
+        portfolio_svc = container.portfolio_service()
+        result = portfolio_svc.get(portfolio_id=portfolio_with_components)
+        assert result.is_success()
+        data = result.data[0] if isinstance(result.data, list) else result.data
+        assert data.uuid == portfolio_with_components
+
+    def test_components_bound(self, portfolio_with_components):
+        result = container.portfolio_service().get_components(
+            portfolio_id=portfolio_with_components
+        )
+        assert result.is_success()
+        components = result.data
+        assert len(components) > 0
+        types = [c.get("component_type") for c in components]
+        assert "STRATEGY" in types or 6 in types or "6" in types
+
+    def test_delete_portfolio(self, portfolio_with_components):
+        portfolio_svc = container.portfolio_service()
+        portfolio_id = portfolio_with_components
+
+        # Verify exists
+        result = portfolio_svc.get(portfolio_id=portfolio_id)
+        assert result.is_success()
+
+        # Delete
+        del_result = portfolio_svc.delete(portfolio_id=portfolio_id)
+        assert del_result.is_success()
+
+        # Verify gone
+        result = portfolio_svc.get(portfolio_id=portfolio_id)
+        assert not result.is_success() or not result.data

--- a/tests/integration/data/services/test_signal_service.py
+++ b/tests/integration/data/services/test_signal_service.py
@@ -1,0 +1,113 @@
+"""
+SignalService smoke test.
+
+Verifies the core business methods of SignalService against real database:
+- delete_signals_by_portfolio
+- delete_signals_by_portfolio_and_date_range
+
+Run: pytest tests/integration/data/services/test_signal_service.py -v -s
+"""
+
+import pytest
+
+from ginkgo.data.containers import container
+from ginkgo.enums import SOURCE_TYPES
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(scope="module", autouse=True)
+def ensure_debug():
+    GCONF.set_debug(True)
+
+
+@pytest.fixture(scope="module")
+def signal_service():
+    return container.signal_service()
+
+
+@pytest.fixture(scope="module")
+def sample_signal_data(signal_service):
+    """Create a test signal, yield (portfolio_id, task_id), cleanup after."""
+    signal_crud = container.cruds.signal()
+    portfolio_id = "SMOKE_TEST_SIGNAL_SVC"
+    task_id = "smoke-task-signal-svc"
+
+    # Insert a test signal via CRUD
+    signal_crud.create(
+        portfolio_id=portfolio_id,
+        engine_id="smoke-engine",
+        task_id=task_id,
+        code="000001.SZ",
+        direction=1,
+        reason="smoke test",
+        source=SOURCE_TYPES.TEST.value,
+        timestamp="2025-05-01",
+    )
+
+    yield portfolio_id, task_id
+
+    # Cleanup
+    try:
+        signal_crud.remove(filters={"portfolio_id": portfolio_id})
+    except Exception:
+        pass
+
+
+class TestSignalServiceSmoke:
+    """Core business methods of SignalService."""
+
+    def test_delete_signals_by_portfolio(self, signal_service, sample_signal_data):
+        portfolio_id, task_id = sample_signal_data
+
+        # Verify signal exists
+        signal_crud = container.cruds.signal()
+        found = signal_crud.find(filters={"portfolio_id": portfolio_id})
+        assert len(found) > 0
+
+        # Delete via service
+        result = signal_service.delete_signals_by_portfolio(portfolio_id)
+        assert result.is_success()
+
+        # Verify deleted
+        found = signal_crud.find(filters={"portfolio_id": portfolio_id})
+        assert len(found) == 0
+
+    def test_delete_by_portfolio_rejects_empty_id(self, signal_service):
+        result = signal_service.delete_signals_by_portfolio("")
+        assert not result.is_success()
+
+    def test_delete_by_date_range(self, signal_service):
+        """Insert two signals, delete only one by date range."""
+        signal_crud = container.cruds.signal()
+        portfolio_id = "SMOKE_TEST_DATE_RANGE"
+        from datetime import datetime
+
+        # Two signals with different dates
+        signal_crud.create(
+            portfolio_id=portfolio_id, engine_id="e", task_id="t",
+            code="000001.SZ", direction=1, reason="old",
+            source=SOURCE_TYPES.TEST.value,
+            timestamp=datetime(2025, 1, 1),
+        )
+        signal_crud.create(
+            portfolio_id=portfolio_id, engine_id="e", task_id="t",
+            code="000002.SZ", direction=2, reason="new",
+            source=SOURCE_TYPES.TEST.value,
+            timestamp=datetime(2025, 6, 1),
+        )
+
+        # Delete only signals before 2025-03-01
+        result = signal_service.delete_signals_by_portfolio_and_date_range(
+            portfolio_id=portfolio_id,
+            start_date="2025-01-01",
+            end_date="2025-03-01",
+        )
+        assert result.is_success()
+
+        # Only the newer signal should remain
+        remaining = signal_crud.find(filters={"portfolio_id": portfolio_id})
+        assert len(remaining) == 1
+        assert remaining[0].code == "000002.SZ"
+
+        # Cleanup
+        signal_crud.remove(filters={"portfolio_id": portfolio_id})


### PR DESCRIPTION
## Summary
- Add smoke tests for 4 core services: PortfolioService (3), SignalService (3), BacktestTaskService (6), FileService (6)
- Together with existing BacktestOrchestrator smoke test (4), total 22 integration tests covering core pipelines

## Test plan
- [x] All 22 smoke tests pass against real database
- [x] No regressions in existing integration tests (344 passed)

Closes #2206

🤖 Generated with [Claude Code](https://claude.com/claude-code)