### PR TITLE
refactor: remove dead CredentialService

### DIFF
--- a/src/ginkgo/data/services/__init__.py
+++ b/src/ginkgo/data/services/__init__.py
@@ -38,7 +38,7 @@ from ginkgo.data.services.factor_service import FactorService
 from ginkgo.data.services.result_service import ResultService
 from ginkgo.data.services.signal_tracking_service import SignalTrackingService
 from ginkgo.data.services.order_service import OrderService  # order_service 懒加载，按需获取
-from ginkgo.data.services.credential_service import CredentialService
+# See #22: CredentialService removed — UserService already handles credential CRUD directly
 from ginkgo.data.services.user_service import UserService
 from ginkgo.data.services.user_group_service import UserGroupService
 from ginkgo.data.services.notification_service import NotificationService


### PR DESCRIPTION
## Summary
- Remove CredentialService — zero callers, UserService already handles credential CRUD directly
- AnalyzerService and NotificationService remain (per discussion on #22)

## Test plan
- [x] Verified no remaining references to CredentialService
- [x] `grep -rn CredentialService src/` returns only the removal comment

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)