### PR TITLE
refactor: PEP 562 lazy loading for data layer __init__.py modules

### DIFF
--- a/src/ginkgo/data/__init__.py
+++ b/src/ginkgo/data/__init__.py
@@ -1,6 +1,9 @@
 # Upstream: 回测引擎, 策略模块, 分析器模块, CLI命令, Web UI, Worker系统
 # Downstream: containers(Container), seeding(数据初始化), utils(get_crud)
 # Role: 数据层包入口，暴露依赖注入容器container和工具函数，统一数据访问入口
+# See #2715: 聚合导入改为 __getattr__ 懒加载，打断全量模块加载链
+
+
 
 
 """
@@ -23,14 +26,27 @@ Available services:
 - container.component_service() - 组件实例化服务
 """
 
-# Import the dependency injection container
-from ginkgo.data.containers import container
+# See #2715: 懒加载注册表，避免 import 时触发全量加载
+_LAZY_IMPORTS = {
+    "container": ("ginkgo.data.containers", "container"),
+    "seeding": ("ginkgo.data.seeding", None),
+    "get_crud": ("ginkgo.data.utils", "get_crud"),
+}
 
-# Import seeding module for data initialization
-from ginkgo.data import seeding
 
-# Import CRUD utility for direct CRUD access
-from ginkgo.data.utils import get_crud
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        import importlib
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        if attr_name is None:
+            return module
+        return getattr(module, attr_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return list(_LAZY_IMPORTS.keys()) + list(globals().keys())
+
 
 __all__ = ["container", "seeding", "get_crud"]
-

--- a/src/ginkgo/data/crud/__init__.py
+++ b/src/ginkgo/data/crud/__init__.py
@@ -2,58 +2,69 @@
 # Downstream: BaseCRUD, ClickHouse/MySQL/MongoDB/Redis数据库模型
 # Role: CRUD包入口，统一导出全部CRUD类(BarCRUD、OrderCRUD、PortfolioCRUD等40+个)，供服务层和容器注册使用
 
+# See #2715: PEP 562 懒加载
+_LAZY_IMPORTS = {
+    "AdjustfactorCRUD": ("ginkgo.data.crud.adjustfactor_crud", "AdjustfactorCRUD"),
+    "AnalyzerRecordCRUD": ("ginkgo.data.crud.analyzer_record_crud", "AnalyzerRecordCRUD"),
+    "BacktestTaskCRUD": ("ginkgo.data.crud.backtest_task_crud", "BacktestTaskCRUD"),
+    "BarCRUD": ("ginkgo.data.crud.bar_crud", "BarCRUD"),
+    "BaseCRUD": ("ginkgo.data.crud.base_crud", "BaseCRUD"),
+    "BaseMongoCRUD": ("ginkgo.data.crud.base_mongo_crud", "BaseMongoCRUD"),
+    "CapitalAdjustmentCRUD": ("ginkgo.data.crud.capital_adjustment_crud", "CapitalAdjustmentCRUD"),
+    "EngineCRUD": ("ginkgo.data.crud.engine_crud", "EngineCRUD"),
+    "EngineHandlerMappingCRUD": ("ginkgo.data.crud.engine_handler_mapping_crud", "EngineHandlerMappingCRUD"),
+    "EnginePortfolioMappingCRUD": ("ginkgo.data.crud.engine_portfolio_mapping_crud", "EnginePortfolioMappingCRUD"),
+    "FactorCRUD": ("ginkgo.data.crud.factor_crud", "FactorCRUD"),
+    "FileCRUD": ("ginkgo.data.crud.file_crud", "FileCRUD"),
+    "HandlerCRUD": ("ginkgo.data.crud.handler_crud", "HandlerCRUD"),
+    "KafkaCRUD": ("ginkgo.data.crud.kafka_crud", "KafkaCRUD"),
+    "OrderCRUD": ("ginkgo.data.crud.order_crud", "OrderCRUD"),
+    "OrderRecordCRUD": ("ginkgo.data.crud.order_record_crud", "OrderRecordCRUD"),
+    "ParamCRUD": ("ginkgo.data.crud.param_crud", "ParamCRUD"),
+    "PortfolioCRUD": ("ginkgo.data.crud.portfolio_crud", "PortfolioCRUD"),
+    "PortfolioFileMappingCRUD": ("ginkgo.data.crud.portfolio_file_mapping_crud", "PortfolioFileMappingCRUD"),
+    "PositionCRUD": ("ginkgo.data.crud.position_crud", "PositionCRUD"),
+    "PositionRecordCRUD": ("ginkgo.data.crud.position_record_crud", "PositionRecordCRUD"),
+    "RedisCRUD": ("ginkgo.data.crud.redis_crud", "RedisCRUD"),
+    "SignalCRUD": ("ginkgo.data.crud.signal_crud", "SignalCRUD"),
+    "SignalTrackerCRUD": ("ginkgo.data.crud.signal_tracker_crud", "SignalTrackerCRUD"),
+    "StockInfoCRUD": ("ginkgo.data.crud.stock_info_crud", "StockInfoCRUD"),
+    "TickCRUD": ("ginkgo.data.crud.tick_crud", "TickCRUD"),
+    "TickSummaryCRUD": ("ginkgo.data.crud.tick_summary_crud", "TickSummaryCRUD"),
+    "TradeDayCRUD": ("ginkgo.data.crud.trade_day_crud", "TradeDayCRUD"),
+    "TransferCRUD": ("ginkgo.data.crud.transfer_crud", "TransferCRUD"),
+    "TransferRecordCRUD": ("ginkgo.data.crud.transfer_record_crud", "TransferRecordCRUD"),
+    "UserCRUD": ("ginkgo.data.crud.user_crud", "UserCRUD"),
+    "UserContactCRUD": ("ginkgo.data.crud.user_contact_crud", "UserContactCRUD"),
+    "DeploymentCRUD": ("ginkgo.data.crud.deployment_crud", "DeploymentCRUD"),
+    "UserCredentialCRUD": ("ginkgo.data.crud.user_credential_crud", "UserCredentialCRUD"),
+    "UserGroupCRUD": ("ginkgo.data.crud.user_group_crud", "UserGroupCRUD"),
+    "UserGroupMappingCRUD": ("ginkgo.data.crud.user_group_mapping_crud", "UserGroupMappingCRUD"),
+    "LiveAccountCRUD": ("ginkgo.data.crud.live_account_crud", "LiveAccountCRUD"),
+    "BrokerInstanceCRUD": ("ginkgo.data.crud.broker_instance_crud", "BrokerInstanceCRUD"),
+    "TradeRecordCRUD": ("ginkgo.data.crud.trade_record_crud", "TradeRecordCRUD"),
+    "NotificationTemplateCRUD": ("ginkgo.data.crud.notification_template_crud", "NotificationTemplateCRUD"),
+    "NotificationRecordCRUD": ("ginkgo.data.crud.notification_record_crud", "NotificationRecordCRUD"),
+    "NotificationRecipientCRUD": ("ginkgo.data.crud.notification_recipient_crud", "NotificationRecipientCRUD"),
+    "MarketSubscriptionCRUD": ("ginkgo.data.crud.market_subscription_crud", "MarketSubscriptionCRUD"),
+    "ApiKeyCRUD": ("ginkgo.data.crud.api_key_crud", "ApiKeyCRUD"),
+    "ValidationError": ("ginkgo.data.crud.validation", "ValidationError"),
+}
 
 
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        return getattr(module, attr_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def __dir__():
+    return sorted(_LAZY_IMPORTS.keys() | set(globals().keys()))
 
-
-from ginkgo.data.crud.adjustfactor_crud import AdjustfactorCRUD
-from ginkgo.data.crud.analyzer_record_crud import AnalyzerRecordCRUD
-from ginkgo.data.crud.backtest_task_crud import BacktestTaskCRUD
-from ginkgo.data.crud.bar_crud import BarCRUD
-from ginkgo.data.crud.backtest_task_crud import BacktestTaskCRUD
-from ginkgo.data.crud.base_crud import BaseCRUD
-from ginkgo.data.crud.base_mongo_crud import BaseMongoCRUD
-from ginkgo.data.crud.capital_adjustment_crud import CapitalAdjustmentCRUD
-from ginkgo.data.crud.engine_crud import EngineCRUD
-from ginkgo.data.crud.engine_handler_mapping_crud import EngineHandlerMappingCRUD
-from ginkgo.data.crud.engine_portfolio_mapping_crud import EnginePortfolioMappingCRUD
-from ginkgo.data.crud.factor_crud import FactorCRUD
-from ginkgo.data.crud.file_crud import FileCRUD
-from ginkgo.data.crud.handler_crud import HandlerCRUD
-from ginkgo.data.crud.kafka_crud import KafkaCRUD
-from ginkgo.data.crud.order_crud import OrderCRUD
-from ginkgo.data.crud.order_record_crud import OrderRecordCRUD
-from ginkgo.data.crud.param_crud import ParamCRUD
-from ginkgo.data.crud.portfolio_crud import PortfolioCRUD
-from ginkgo.data.crud.portfolio_file_mapping_crud import PortfolioFileMappingCRUD
-from ginkgo.data.crud.position_crud import PositionCRUD
-from ginkgo.data.crud.position_record_crud import PositionRecordCRUD
-from ginkgo.data.crud.redis_crud import RedisCRUD
-from ginkgo.data.crud.signal_crud import SignalCRUD
-from ginkgo.data.crud.signal_tracker_crud import SignalTrackerCRUD
-from ginkgo.data.crud.stock_info_crud import StockInfoCRUD
-from ginkgo.data.crud.tick_crud import TickCRUD
-from ginkgo.data.crud.tick_summary_crud import TickSummaryCRUD
-from ginkgo.data.crud.trade_day_crud import TradeDayCRUD
-from ginkgo.data.crud.transfer_crud import TransferCRUD
-from ginkgo.data.crud.transfer_record_crud import TransferRecordCRUD
-from ginkgo.data.crud.user_crud import UserCRUD
-from ginkgo.data.crud.user_contact_crud import UserContactCRUD
-from ginkgo.data.crud.deployment_crud import DeploymentCRUD
-from ginkgo.data.crud.user_credential_crud import UserCredentialCRUD
-from ginkgo.data.crud.user_group_crud import UserGroupCRUD
-from ginkgo.data.crud.user_group_mapping_crud import UserGroupMappingCRUD
-from ginkgo.data.crud.live_account_crud import LiveAccountCRUD
-from ginkgo.data.crud.broker_instance_crud import BrokerInstanceCRUD
-from ginkgo.data.crud.trade_record_crud import TradeRecordCRUD
-from ginkgo.data.crud.notification_template_crud import NotificationTemplateCRUD
-from ginkgo.data.crud.notification_record_crud import NotificationRecordCRUD
-from ginkgo.data.crud.notification_recipient_crud import NotificationRecipientCRUD
-from ginkgo.data.crud.market_subscription_crud import MarketSubscriptionCRUD
-from ginkgo.data.crud.api_key_crud import ApiKeyCRUD
-from ginkgo.data.crud.validation import ValidationError
 
 __all__ = [
     "AdjustfactorCRUD",

--- a/src/ginkgo/data/drivers/__init__.py
+++ b/src/ginkgo/data/drivers/__init__.py
@@ -1,6 +1,7 @@
 # Upstream: 数据层容器(containers.py), CRUD层, 服务层
 # Downstream: GinkgoClickhouse, GinkgoMysql, GinkgoMongo, GinkgoRedis, DatabaseDriverBase
 # Role: 数据库驱动包入口，导出四大驱动类并定义熔断器(CircuitBreaker)防止级联故障
+# See #2715: 聚合导入改为 __getattr__ 懒加载，打断全量模块加载链
 
 
 
@@ -19,6 +20,22 @@ from ginkgo.data.drivers.ginkgo_mongo import GinkgoMongo
 from ginkgo.data.drivers.ginkgo_mysql import GinkgoMysql
 from ginkgo.data.drivers.ginkgo_redis import GinkgoRedis
 from ginkgo.libs import GLOG
+
+# See #2715: PEP 562 懒加载 — 只在访问时才导入这些重量级模块
+def __getattr__(name):
+    _lazy = {
+        "GinkgoProducer": ("ginkgo.data.drivers.ginkgo_kafka", "GinkgoProducer"),
+        "GinkgoConsumer": ("ginkgo.data.drivers.ginkgo_kafka", "GinkgoConsumer"),
+        "kafka_topic_llen": ("ginkgo.data.drivers.ginkgo_kafka", "kafka_topic_llen"),
+        "MClickBase": ("ginkgo.data.models", "MClickBase"),
+        "MMysqlBase": ("ginkgo.data.models", "MMysqlBase"),
+        "MMongoBase": ("ginkgo.data.models", "MMongoBase"),
+    }
+    if name in _lazy:
+        import importlib
+        module_path, attr_name = _lazy[name]
+        return getattr(importlib.import_module(module_path), attr_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class CircuitBreaker:
@@ -127,13 +144,8 @@ class CircuitBreaker:
             self._failure_count = 0
             self._last_failure_time = None
             GLOG.INFO("Circuit breaker manually reset")
-from ginkgo.data.drivers.ginkgo_kafka import (
-    GinkgoProducer,
-    GinkgoConsumer,
-    kafka_topic_llen,
-)
-from ginkgo.data.models import MClickBase, MMysqlBase, MMongoBase
-from ginkgo.libs import try_wait_counter, GLOG, GCONF, time_logger, retry, skip_if_ran, cache_with_expiration
+# See #2715: kafka/models 改为 __getattr__ 懒加载和函数内局部导入
+from ginkgo.libs import try_wait_counter, GCONF, time_logger, retry, skip_if_ran, cache_with_expiration
 
 max_try = 5
 
@@ -346,6 +358,7 @@ def create_mongo_connection() -> GinkgoMongo:
 
 
 def get_db_connection(value):
+    from ginkgo.data.models import MClickBase, MMysqlBase, MMongoBase
     if isinstance(value, type):
         if issubclass(value, MClickBase):
             return get_click_connection()
@@ -378,6 +391,7 @@ def add(value, *args, **kwargs) -> any:
     Returns:
         Added model with updated fields
     """
+    from ginkgo.data.models import MClickBase, MMysqlBase
     if not isinstance(value, (MClickBase, MMysqlBase)):
         GLOG.ERROR(f"Can not add {value} to database.")
         return
@@ -411,6 +425,7 @@ def add_all(values: List[Any], *args, **kwargs) -> None:
     """
     GLOG.DEBUG(f"Try add {len(values)} multi data to session.")
 
+    from ginkgo.data.models import MClickBase, MMysqlBase
     click_list = []
     click_count = 0
     mysql_list = []
@@ -584,6 +599,7 @@ def create_all_tables() -> None:
     """
     # 导入 models 包，触发所有子模块的导入，使模型类注册到 metadata
     import ginkgo.data.models
+    from ginkgo.data.models import MClickBase, MMysqlBase
 
     # Create Tables in clickhouse
     MClickBase.metadata.create_all(get_click_connection().engine)
@@ -613,6 +629,7 @@ def _create_mongo_collections() -> None:
         # 导入所有模型以触发模型注册
         import ginkgo.data.models as models_module
         import inspect
+        from ginkgo.data.models import MMongoBase
 
         created_collections = []
         created_indexes = []
@@ -679,6 +696,7 @@ def drop_all_tables() -> None:
     Returns:
         None
     """
+    from ginkgo.data.models import MClickBase, MMysqlBase
     # Drop Tables in clickhouse
     MClickBase.metadata.reflect(get_click_connection().engine)
     MClickBase.metadata.drop_all(get_click_connection().engine)

--- a/src/ginkgo/data/models/__init__.py
+++ b/src/ginkgo/data/models/__init__.py
@@ -2,55 +2,69 @@
 # Downstream: 全部ORM模型类(MBar/MTick/MOrder/MPosition等)
 # Role: 数据模型包入口，统一导出所有ClickHouse/MySQL/MongoDB ORM模型类
 
+# See #2715: PEP 562 懒加载
+_LAZY_IMPORTS = {
+    "MAdjustfactor": ("ginkgo.data.models.model_adjustfactor", "MAdjustfactor"),
+    "MAnalyzerRecord": ("ginkgo.data.models.model_analyzer_record", "MAnalyzerRecord"),
+    "MBacktestRecordBase": ("ginkgo.data.models.model_backtest_record_base", "MBacktestRecordBase"),
+    "MBacktestTask": ("ginkgo.data.models.model_backtest_task", "MBacktestTask"),
+    "MBar": ("ginkgo.data.models.model_bar", "MBar"),
+    "MCapitalAdjustment": ("ginkgo.data.models.model_capital_adjustment", "MCapitalAdjustment"),
+    "MClickBase": ("ginkgo.data.models.model_clickbase", "MClickBase"),
+    "MEngine": ("ginkgo.data.models.model_engine", "MEngine"),
+    "MEngineHandlerMapping": ("ginkgo.data.models.model_engine_handler_mapping", "MEngineHandlerMapping"),
+    "MEnginePortfolioMapping": ("ginkgo.data.models.model_engine_portfolio_mapping", "MEnginePortfolioMapping"),
+    "MFactor": ("ginkgo.data.models.model_factor", "MFactor"),
+    "MFile": ("ginkgo.data.models.model_file", "MFile"),
+    "MHandler": ("ginkgo.data.models.model_handler", "MHandler"),
+    "MParam": ("ginkgo.data.models.model_param", "MParam"),
+    "MMysqlBase": ("ginkgo.data.models.model_mysqlbase", "MMysqlBase"),
+    "MMongoBase": ("ginkgo.data.models.model_mongobase", "MMongoBase"),
+    "MOrder": ("ginkgo.data.models.model_order", "MOrder"),
+    "MOrderRecord": ("ginkgo.data.models.model_order_record", "MOrderRecord"),
+    "MPortfolio": ("ginkgo.data.models.model_portfolio", "MPortfolio"),
+    "MPortfolioFileMapping": ("ginkgo.data.models.model_portfolio_file_mapping", "MPortfolioFileMapping"),
+    "MPosition": ("ginkgo.data.models.model_position", "MPosition"),
+    "MPositionRecord": ("ginkgo.data.models.model_position_record", "MPositionRecord"),
+    "MSignal": ("ginkgo.data.models.model_signal", "MSignal"),
+    "MStockInfo": ("ginkgo.data.models.model_stock_info", "MStockInfo"),
+    "MLiveAccount": ("ginkgo.data.models.model_live_account", "MLiveAccount"),
+    "MBrokerInstance": ("ginkgo.data.models.model_broker_instance", "MBrokerInstance"),
+    "MTradeRecord": ("ginkgo.data.models.model_trade_record", "MTradeRecord"),
+    "MTick": ("ginkgo.data.models.model_tick", "MTick"),
+    "MTickSummary": ("ginkgo.data.models.model_tick_summary", "MTickSummary"),
+    "MTradeDay": ("ginkgo.data.models.model_trade_day", "MTradeDay"),
+    "MTransfer": ("ginkgo.data.models.model_transfer", "MTransfer"),
+    "MTransferRecord": ("ginkgo.data.models.model_transfer_record", "MTransferRecord"),
+    "MRunRecord": ("ginkgo.data.models.model_run_record", "MRunRecord"),
+    "MUser": ("ginkgo.data.models.model_user", "MUser"),
+    "MUserContact": ("ginkgo.data.models.model_user_contact", "MUserContact"),
+    "MDeployment": ("ginkgo.data.models.model_deployment", "MDeployment"),
+    "MUserCredential": ("ginkgo.data.models.model_user_credential", "MUserCredential"),
+    "MUserGroup": ("ginkgo.data.models.model_user_group", "MUserGroup"),
+    "MUserGroupMapping": ("ginkgo.data.models.model_user_group_mapping", "MUserGroupMapping"),
+    "MNotificationTemplate": ("ginkgo.data.models.model_notification_template", "MNotificationTemplate"),
+    "MNotificationRecord": ("ginkgo.data.models.model_notification_record", "MNotificationRecord"),
+    "MNotificationRecipient": ("ginkgo.data.models.model_notification_recipient", "MNotificationRecipient"),
+    "MBacktestLog": ("ginkgo.data.models.model_logs", "MBacktestLog"),
+    "MComponentLog": ("ginkgo.data.models.model_logs", "MComponentLog"),
+    "MPerformanceLog": ("ginkgo.data.models.model_logs", "MPerformanceLog"),
+    "MValidationResult": ("ginkgo.data.models.model_validation_result", "MValidationResult"),
+}
 
 
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        return getattr(module, attr_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-
-from ginkgo.data.models.model_adjustfactor import MAdjustfactor
-from ginkgo.data.models.model_analyzer_record import MAnalyzerRecord
-from ginkgo.data.models.model_backtest_record_base import MBacktestRecordBase
-from ginkgo.data.models.model_backtest_task import MBacktestTask
-from ginkgo.data.models.model_bar import MBar
-from ginkgo.data.models.model_capital_adjustment import MCapitalAdjustment
-from ginkgo.data.models.model_clickbase import MClickBase
-from ginkgo.data.models.model_engine import MEngine
-from ginkgo.data.models.model_engine_handler_mapping import MEngineHandlerMapping
-from ginkgo.data.models.model_engine_portfolio_mapping import MEnginePortfolioMapping
-from ginkgo.data.models.model_factor import MFactor
-from ginkgo.data.models.model_file import MFile
-from ginkgo.data.models.model_handler import MHandler
-from ginkgo.data.models.model_param import MParam
-from ginkgo.data.models.model_mysqlbase import MMysqlBase
-from ginkgo.data.models.model_mongobase import MMongoBase
-from ginkgo.data.models.model_order import MOrder
-from ginkgo.data.models.model_order_record import MOrderRecord
-from ginkgo.data.models.model_portfolio import MPortfolio
-from ginkgo.data.models.model_portfolio_file_mapping import MPortfolioFileMapping
-from ginkgo.data.models.model_position import MPosition
-from ginkgo.data.models.model_position_record import MPositionRecord
-from ginkgo.data.models.model_signal import MSignal
-from ginkgo.data.models.model_stock_info import MStockInfo
-from ginkgo.data.models.model_live_account import MLiveAccount
-from ginkgo.data.models.model_broker_instance import MBrokerInstance
-from ginkgo.data.models.model_trade_record import MTradeRecord
-from ginkgo.data.models.model_tick import MTick
-from ginkgo.data.models.model_tick_summary import MTickSummary
-from ginkgo.data.models.model_trade_day import MTradeDay
-from ginkgo.data.models.model_transfer import MTransfer
-from ginkgo.data.models.model_transfer_record import MTransferRecord
-from ginkgo.data.models.model_run_record import MRunRecord
-from ginkgo.data.models.model_user import MUser
-from ginkgo.data.models.model_user_contact import MUserContact
-from ginkgo.data.models.model_deployment import MDeployment
-from ginkgo.data.models.model_user_credential import MUserCredential
-from ginkgo.data.models.model_user_group import MUserGroup
-from ginkgo.data.models.model_user_group_mapping import MUserGroupMapping
-from ginkgo.data.models.model_notification_template import MNotificationTemplate
-from ginkgo.data.models.model_notification_record import MNotificationRecord
-from ginkgo.data.models.model_notification_recipient import MNotificationRecipient
-from ginkgo.data.models.model_logs import MBacktestLog, MComponentLog, MPerformanceLog
-from ginkgo.data.models.model_validation_result import MValidationResult
+def __dir__():
+    return sorted(_LAZY_IMPORTS.keys() | set(globals().keys()))
 
 
 __all__ = [
@@ -103,4 +117,3 @@ __all__ = [
     # 验证系统模型
     "MValidationResult",
 ]
-

--- a/src/ginkgo/data/services/__init__.py
+++ b/src/ginkgo/data/services/__init__.py
@@ -2,11 +2,6 @@
 # Downstream: BaseService, 各CRUD类(BarCRUD, OrderCRUD等)
 # Role: 服务包入口，统一导出全部数据服务(BarService, EngineService, PortfolioService等)和ServiceResult
 
-
-
-
-
-
 """
 Services Package - Flat Architecture
 
@@ -19,29 +14,46 @@ Architecture:
     └── Legacy Aliases (Backward compatibility)
 """
 
-# Core classes
+# Core classes — kept as direct imports (lightweight base classes used everywhere)
 from ginkgo.data.services.base_service import BaseService, ServiceResult
 
-# Concrete service implementations
-from ginkgo.data.services.adjustfactor_service import AdjustfactorService
-from ginkgo.data.services.backtest_task_service import BacktestTaskService
-from ginkgo.data.services.stockinfo_service import StockinfoService
-from ginkgo.data.services.bar_service import BarService
-from ginkgo.data.services.tick_service import TickService
-from ginkgo.data.services.file_service import FileService
-from ginkgo.data.services.engine_service import EngineService
-from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
-from ginkgo.data.services.portfolio_service import PortfolioService
-from ginkgo.data.services.redis_service import RedisService
-from ginkgo.data.services.kafka_service import KafkaService
-from ginkgo.data.services.factor_service import FactorService
-from ginkgo.data.services.result_service import ResultService
-from ginkgo.data.services.signal_tracking_service import SignalTrackingService
-from ginkgo.data.services.order_service import OrderService  # order_service 懒加载，按需获取
-# See #22: CredentialService removed — dead code, zero callers
-from ginkgo.data.services.user_service import UserService
-from ginkgo.data.services.user_group_service import UserGroupService
-from ginkgo.data.services.notification_service import NotificationService
+# See #2715: PEP 562 懒加载
+_LAZY_IMPORTS = {
+    "AdjustfactorService": ("ginkgo.data.services.adjustfactor_service", "AdjustfactorService"),
+    "BacktestTaskService": ("ginkgo.data.services.backtest_task_service", "BacktestTaskService"),
+    "StockinfoService": ("ginkgo.data.services.stockinfo_service", "StockinfoService"),
+    "BarService": ("ginkgo.data.services.bar_service", "BarService"),
+    "TickService": ("ginkgo.data.services.tick_service", "TickService"),
+    "FileService": ("ginkgo.data.services.file_service", "FileService"),
+    "EngineService": ("ginkgo.data.services.engine_service", "EngineService"),
+    "PortfolioMappingService": ("ginkgo.data.services.portfolio_mapping_service", "PortfolioMappingService"),
+    "PortfolioService": ("ginkgo.data.services.portfolio_service", "PortfolioService"),
+    "RedisService": ("ginkgo.data.services.redis_service", "RedisService"),
+    "KafkaService": ("ginkgo.data.services.kafka_service", "KafkaService"),
+    "FactorService": ("ginkgo.data.services.factor_service", "FactorService"),
+    "ResultService": ("ginkgo.data.services.result_service", "ResultService"),
+    "SignalTrackingService": ("ginkgo.data.services.signal_tracking_service", "SignalTrackingService"),
+    "OrderService": ("ginkgo.data.services.order_service", "OrderService"),
+    # See #22: CredentialService removed — dead code, zero callers
+    "UserService": ("ginkgo.data.services.user_service", "UserService"),
+    "UserGroupService": ("ginkgo.data.services.user_group_service", "UserGroupService"),
+    "NotificationService": ("ginkgo.data.services.notification_service", "NotificationService"),
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        return getattr(module, attr_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(_LAZY_IMPORTS.keys() | set(globals().keys()))
+
 
 # Legacy aliases (Backward compatibility)
 DataService = BaseService

--- a/src/ginkgo/data/sources/__init__.py
+++ b/src/ginkgo/data/sources/__init__.py
@@ -2,15 +2,28 @@
 # Downstream: GinkgoTushare, GinkgoAkShare, GinkgoBaoStock, GinkgoTDX, GinkgoYahoo
 # Role: 数据源包入口，统一导出所有外部数据源适配器(Tushare/AKShare/BaoStock/TDX/Yahoo)
 
+# See #2715: PEP 562 懒加载
+_LAZY_IMPORTS = {
+    "GinkgoAkShare": ("ginkgo.data.sources.ginkgo_akshare", "GinkgoAkShare"),
+    "GinkgoBaoStock": ("ginkgo.data.sources.ginkgo_baostock", "GinkgoBaoStock"),
+    "GinkgoTDX": ("ginkgo.data.sources.ginkgo_tdx", "GinkgoTDX"),
+    "GinkgoTushare": ("ginkgo.data.sources.ginkgo_tushare", "GinkgoTushare"),
+    "GinkgoYahoo": ("ginkgo.data.sources.ginkgo_yahoo", "GinkgoYahoo"),
+}
 
 
+def __getattr__(name):
+    if name in _LAZY_IMPORTS:
+        import importlib
+
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        return getattr(module, attr_name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def __dir__():
+    return sorted(_LAZY_IMPORTS.keys() | set(globals().keys()))
 
-from ginkgo.data.sources.ginkgo_akshare import GinkgoAkShare
-from ginkgo.data.sources.ginkgo_baostock import GinkgoBaoStock
-from ginkgo.data.sources.ginkgo_tdx import GinkgoTDX
-from ginkgo.data.sources.ginkgo_tushare import GinkgoTushare
-from ginkgo.data.sources.ginkgo_yahoo import GinkgoYahoo
 
 __all__ = ["GinkgoAkShare", "GinkgoBaoStock", "GinkgoTDX", "GinkgoTushare", "GinkgoYahoo"]

--- a/tests/unit/test_drivers_lazy_import.py
+++ b/tests/unit/test_drivers_lazy_import.py
@@ -1,0 +1,134 @@
+"""
+#2715: drivers/__init__.py + data/__init__.py 懒加载改造
+
+验证 import ginkgo.data.drivers 不再触发全量模块加载，
+同时保持所有公开接口的向后兼容性。
+
+性能: ~1s, N tests [PASS]
+"""
+
+import subprocess
+import sys
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_MEASURE_SCRIPT = """
+import sys
+before = set(sys.modules.keys())
+import ginkgo.data.drivers
+after = set(sys.modules.keys())
+ginkgo_modules = sorted(m for m in (after - before) if m.startswith('ginkgo'))
+print(len(ginkgo_modules))
+"""
+
+
+def _run_subprocess(script):
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    return result.stdout.strip().split("\n")[-1]
+
+
+class TestDriversLazyImport:
+    """#2715: 验证 drivers 包懒加载减少导入足迹"""
+
+    def test_import_footprint_under_50(self):
+        """import ginkgo.data.drivers 应加载 < 50 个 ginkgo 模块（当前极限 ~39，含 libs 31 + 5 driver + 3 其他）
+
+        39 个模块是 PEP 562 + 保留业务逻辑在 __init__.py 的极限。
+        libs(31) 被 CircuitBreaker/装饰器顶层依赖，无法再降。
+        5 个 driver 被类型注解和 ConnectionManager 直接依赖，无法再降。
+        """
+        count = int(_run_subprocess(_MEASURE_SCRIPT))
+        assert count < 50, f"Expected < 50 ginkgo modules, got {count}"
+
+
+class TestLazyImportBackwardCompat:
+    """#2715: 验证懒加载后公开接口仍可正常使用"""
+
+    _IMPORT_COMPAT_SCRIPT = """
+import sys
+from ginkgo.data.drivers import {symbol}
+print(type({symbol}).__name__)
+"""
+
+    @pytest.mark.parametrize("symbol", [
+        "GinkgoClickhouse",
+        "GinkgoMysql",
+        "GinkgoMongo",
+        "GinkgoRedis",
+        "DatabaseDriverBase",
+        "GinkgoProducer",
+        "GinkgoConsumer",
+    ])
+    def test_class_import(self, symbol):
+        """from ginkgo.data.drivers import XxxClass 返回正确的类"""
+        output = _run_subprocess(self._IMPORT_COMPAT_SCRIPT.format(symbol=symbol))
+        assert output in ("type", "ABCMeta"), f"Expected class type, got {output}"
+
+    def test_function_import_get_db_connection(self):
+        """from ginkgo.data.drivers import get_db_connection 返回 callable"""
+        output = _run_subprocess("""
+from ginkgo.data.drivers import get_db_connection
+print(callable(get_db_connection))
+""")
+        assert output == "True"
+
+    def test_function_import_kafka_topic_llen(self):
+        """from ginkgo.data.drivers import kafka_topic_llen 返回 callable"""
+        output = _run_subprocess("""
+from ginkgo.data.drivers import kafka_topic_llen
+print(callable(kafka_topic_llen))
+""")
+        assert output == "True"
+
+
+class TestDataInitLazyImport:
+    """#2715: 验证 ginkgo.data 包的 container/seeding/get_crud 懒加载"""
+
+    _DATA_IMPORT_SCRIPT = """
+from ginkgo.data import {symbol}
+print(type({symbol}).__name__)
+"""
+
+    def test_container_import(self):
+        """from ginkgo.data import container 返回容器实例"""
+        output = _run_subprocess("""
+from ginkgo.data import container
+print(type(container).__name__)
+""")
+        assert output.endswith("Container"), f"Expected *Container, got {output}"
+
+    def test_get_crud_import(self):
+        """from ginkgo.data import get_crud 返回 callable"""
+        output = _run_subprocess("""
+from ginkgo.data import get_crud
+print(callable(get_crud))
+""")
+        assert output == "True"
+
+    def test_seeding_import(self):
+        """from ginkgo.data import seeding 返回模块"""
+        output = _run_subprocess("""
+from ginkgo.data import seeding
+print(type(seeding).__name__)
+""")
+        assert output == "module"
+
+
+class TestLazyImportPerformance:
+    """#2715: 前后性能对比"""
+
+    def test_before_after_comparison(self):
+        """打印改造前后 ginkgo 模块加载数对比"""
+        count = int(_run_subprocess(_MEASURE_SCRIPT))
+        # 改造前: 211, 改造后应 < 100
+        before = 211
+        reduction = (1 - count / before) * 100
+        print(f"\n  改造前: {before} ginkgo 模块")
+        print(f"  改造后: {count} ginkgo 模块")
+        print(f"  减少: {reduction:.0f}%")
+        assert count < before, f"No improvement: {count} >= {before}"


### PR DESCRIPTION
## Summary
- 对 `ginkgo/data/` 下 6 个子包的 `__init__.py` 实现 PEP 562 `__getattr__` 懒加载，避免 `import ginkgo.data` 时一次性加载所有子模块
- 新增 `test_drivers_lazy_import.py` 验证：import 占用模块数 < 50、向后兼容（所有类/函数仍可正常导入）、性能对比

## Test plan
- [x] `tests/unit/test_drivers_lazy_import.py` — 14 tests passed（import 占用、兼容性、性能）
- [x] `tests/unit/test_module_imports.py` — 46 tests passed（全量 __init__.py 冒烟测试）

🤖 Generated with [Claude Code](https://claude.com/claude-code)