### PR TITLE
fix: 更新过时的 BaseService 引用和 NotificationService 类名注释

### DIFF
--- a/src/ginkgo/notifier/channels/__init__.py
+++ b/src/ginkgo/notifier/channels/__init__.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务)
+# Upstream: NotificationDeliveryService (通知服务)
 # Downstream: WebhookChannel, EmailChannel, KafkaChannel
 # Role: 通知渠道模块提供各类通知渠道实现支持Webhook/Email/Kafka等通知方式支持通知系统功能
 

--- a/src/ginkgo/notifier/channels/base_channel.py
+++ b/src/ginkgo/notifier/channels/base_channel.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务业务逻辑)
+# Upstream: NotificationDeliveryService (通知服务业务逻辑)
 # Downstream: WebhookChannel, EmailChannel, KafkaChannel (具体渠道实现)
 # Role: BaseNotificationChannel通知渠道接口定义通知渠道的标准接口确保所有渠道实现一致性支持通知系统功能
 

--- a/src/ginkgo/notifier/channels/console_channel.py
+++ b/src/ginkgo/notifier/channels/console_channel.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务业务逻辑)、BaseNotificationChannel (渠道接口)
+# Upstream: NotificationDeliveryService (通知服务业务逻辑)、BaseNotificationChannel (渠道接口)
 # Downstream: Console (标准输出)
 # Role: ConsoleChannel控制台通知渠道实现向标准输出打印通知消息用于测试和调试支持通知系统功能
 

--- a/src/ginkgo/notifier/channels/email_channel.py
+++ b/src/ginkgo/notifier/channels/email_channel.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务业务逻辑)、BaseNotificationChannel (渠道接口)
+# Upstream: NotificationDeliveryService (通知服务业务逻辑)、BaseNotificationChannel (渠道接口)
 # Downstream: SMTP 邮件服务器 (外部服务)
 # Role: EmailChannel Email通知渠道实现通过SMTP协议发送邮件通知支持HTML格式和附件支持通知系统功能
 

--- a/src/ginkgo/notifier/channels/webhook_channel.py
+++ b/src/ginkgo/notifier/channels/webhook_channel.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务业务逻辑)、BaseNotificationChannel (渠道接口)
+# Upstream: NotificationDeliveryService (通知服务业务逻辑)、BaseNotificationChannel (渠道接口)
 # Downstream: Discord Webhook API (外部服务)
 # Role: WebhookChannel Webhook通知渠道实现通过Webhook发送消息到Discord/钉钉/企业微信等支持Markdown和嵌入消息支持通知系统功能
 

--- a/src/ginkgo/notifier/core/message_queue.py
+++ b/src/ginkgo/notifier/core/message_queue.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务业务逻辑)
+# Upstream: NotificationDeliveryService (通知服务业务逻辑)
 # Downstream: Kafka Producer (GinkgoProducer)、KafkaCRUD (Kafka CRUD操作)
 # Role: MessageQueue 消息队列封装封装Kafka发送通知消息支持异步通知处理支持通知系统功能
 

--- a/src/ginkgo/notifier/core/notification_constants.py
+++ b/src/ginkgo/notifier/core/notification_constants.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService, WebhookDispatcher (通知发送和Webhook调度)
+# Upstream: NotificationDeliveryService, WebhookDispatcher (通知发送和Webhook调度)
 # Downstream: 无（纯常量模块）
 # Role: 通知系统常量定义，包括 Discord 颜色方案和颜色映射表
 

--- a/src/ginkgo/notifier/core/notification_service.py
+++ b/src/ginkgo/notifier/core/notification_service.py
@@ -1,5 +1,5 @@
 # Upstream: CLI Commands (ginkgo notify 命令)、Kafka Worker (通知消费)
-# Downstream: BaseService (继承提供服务基础能力)、data.services.NotificationService (模板/记录Service)、BaseNotificationChannel (通知渠道接口)
+# Downstream: data.services.NotificationService (模板/记录Service)、BaseNotificationChannel (通知渠道接口)
 # Role: NotificationDeliveryService通知交付服务提供通知发送/模板渲染/渠道选择/记录管理等交付逻辑支持通知系统功能
 
 from __future__ import annotations  # 启用延迟注解评估，避免循环导入

--- a/src/ginkgo/notifier/core/notify.py
+++ b/src/ginkgo/notifier/core/notify.py
@@ -95,7 +95,7 @@ def notify(
     try:
         service = _get_notification_service()
         if service is None:
-            GLOG.ERROR("NotificationService not available")
+            GLOG.ERROR("NotificationDeliveryService not available")
             return False
 
         # 构建通知内容（不使用模板，直接发送）
@@ -241,7 +241,7 @@ def notify_with_fields(
     try:
         service = _get_notification_service()
         if service is None:
-            GLOG.ERROR(f"[{module}] NotificationService not available")
+            GLOG.ERROR(f"[{module}] NotificationDeliveryService not available")
             return False
 
         # 通过 service facade 解析接收人

--- a/src/ginkgo/notifier/core/template_engine.py
+++ b/src/ginkgo/notifier/core/template_engine.py
@@ -1,4 +1,4 @@
-# Upstream: NotificationService (通知服务业务逻辑)、NotifierCLI (命令行工具)
+# Upstream: NotificationDeliveryService (通知服务业务逻辑)、NotifierCLI (命令行工具)
 # Downstream: NotificationTemplateCRUD (模板CRUD操作)、Jinja2 (模板渲染库)
 # Role: TemplateEngine模板引擎提供模板渲染功能支持Jinja2语法和变量替换支持通知系统功能
 

--- a/src/ginkgo/notifier/core/webhook_dispatcher.py
+++ b/src/ginkgo/notifier/core/webhook_dispatcher.py
@@ -5,7 +5,7 @@
 """
 Webhook 调度器
 
-将 Webhook 相关的发送逻辑从 NotificationService 中分离，包括：
+将 Webhook 相关的发送逻辑从 NotificationDeliveryService 中分离，包括：
 - 直接 Webhook 发送（无需用户 UUID）
 - Discord Webhook 封装
 - 交易信号 Webhook 发送

--- a/src/ginkgo/notifier/workers/notification_worker.py
+++ b/src/ginkgo/notifier/workers/notification_worker.py
@@ -289,7 +289,7 @@ class NotificationWorker:
         """
         处理单条消息
 
-        根据 message_type 调用对应的 NotificationService 方法。
+        根据 message_type 调用对应的 NotificationDeliveryService 方法。
 
         Args:
             message: Kafka 消息（已反序列化）
@@ -358,7 +358,7 @@ class NotificationWorker:
             GLOG.ERROR("[ERROR] Simple message missing content")
             return False
 
-        # 调用 NotificationService
+        # 调用 NotificationDeliveryService
         if user_uuid:
             result = self.notification_service.send_to_user(
                 user_uuid=user_uuid,
@@ -420,7 +420,7 @@ class NotificationWorker:
             GLOG.ERROR("[ERROR] Template message missing template_id")
             return False
 
-        # 调用 NotificationService
+        # 调用 NotificationDeliveryService
         if user_uuid:
             result = self.notification_service.send_template_to_user(
                 user_uuid=user_uuid,
@@ -484,7 +484,7 @@ class NotificationWorker:
             GLOG.ERROR("[ERROR] Trading signal message missing required fields")
             return False
 
-        # 调用 NotificationService
+        # 调用 NotificationDeliveryService
         if user_uuid:
             result = self.notification_service.send_trading_signal(
                 user_uuid=user_uuid,
@@ -549,7 +549,7 @@ class NotificationWorker:
             GLOG.ERROR("[ERROR] System notification message missing content")
             return False
 
-        # 调用 NotificationService
+        # 调用 NotificationDeliveryService
         if user_uuid:
             result = self.notification_service.send_system_notification(
                 user_uuid=user_uuid,

--- a/src/ginkgo/notifier/workers/notification_worker.py
+++ b/src/ginkgo/notifier/workers/notification_worker.py
@@ -56,7 +56,7 @@ class NotificationWorker:
     """
     通知 Kafka Worker
 
-    从 `ginkgo.notifications` topic 消费消息并调用 NotificationService。
+    从 `ginkgo.notifications` topic 消费消息并调用 NotificationDeliveryService。
     """
 
     # Kafka topic 名称


### PR DESCRIPTION
## Summary
- 移除 `notification_service.py` 头注释中已失效的 `BaseService` 引用
- 更新 `notification_worker.py` 类 docstring 中的类名为 `NotificationDeliveryService`

Closes #3444

## Test plan
- [ ] 确认注释内容与实际类定义一致

🤖 Generated with [Claude Code](https://claude.ai/code)