### PR TITLE
fix: send_to_group/send_template_to_group 支持 group_uuid

### DIFF
--- a/src/ginkgo/notifier/core/notification_service.py
+++ b/src/ginkgo/notifier/core/notification_service.py
@@ -740,8 +740,9 @@ class NotificationDeliveryService:
     @retry(max_try=3)
     def send_to_group(
         self,
-        group_name: str,
         content: str,
+        group_uuid: Optional[str] = None,
+        group_name: Optional[str] = None,
         title: Optional[str] = None,
         content_type: str = "text",
         priority: int = 1,
@@ -751,8 +752,9 @@ class NotificationDeliveryService:
         向用户组发送通知
 
         Args:
-            group_name: 用户组名称 (业务层面，如 "traders")
             content: 通知内容
+            group_uuid: 用户组 UUID（优先）
+            group_name: 用户组名称（便捷入口，自动解析为 uuid）
             title: 通知标题（可选）
             content_type: 内容类型
             priority: 优先级
@@ -762,17 +764,23 @@ class NotificationDeliveryService:
             ServiceResult: 包含发送结果
         """
         try:
-            # 根据 name 获取 group
-            _group_result = self.user_group_service.get_group_by_name(group_name)
+            # 解析 group_uuid
+            if group_uuid:
+                _group_result = self.user_group_service.get_group_by_uuid(group_uuid)
+            elif group_name:
+                _group_result = self.user_group_service.get_group_by_name(group_name)
+            else:
+                return ServiceResult.error("Either group_uuid or group_name is required")
+
             if not _group_result.success or not _group_result.data:
-                return ServiceResult.error(f"Group not found: {group_name}")
+                return ServiceResult.error(f"Group not found: {group_uuid or group_name}")
             group = _group_result.data
 
             # 获取组内所有用户
             _members_result = self.user_group_service.get_group_member_uuids(group.uuid)
             user_uuids = _members_result.data if _members_result.success else []
             if not user_uuids:
-                return ServiceResult.error(f"No users found in group: {group_name}")
+                return ServiceResult.error(f"No users found in group: {group.name}")
 
             # 向所有用户发送通知
             results = []
@@ -797,11 +805,11 @@ class NotificationDeliveryService:
                 if result.is_success:
                     success_count += 1
 
-            GLOG.INFO(f"Group notification sent: {success_count}/{len(user_uuids)} users in group '{group_name}'")
+            GLOG.INFO(f"Group notification sent: {success_count}/{len(user_uuids)} users in group '{group.name}'")
 
             return ServiceResult.success(
                 data={
-                    "group_name": group_name,
+                    "group_name": group.name,
                     "total_users": len(user_uuids),
                     "success_count": success_count,
                     "results": results
@@ -817,9 +825,10 @@ class NotificationDeliveryService:
     @retry(max_try=3)
     def send_template_to_group(
         self,
-        group_name: str,
         template_id: str,
         context: Dict[str, Any],
+        group_uuid: Optional[str] = None,
+        group_name: Optional[str] = None,
         priority: int = 1,
         **kwargs
     ) -> ServiceResult:
@@ -827,9 +836,10 @@ class NotificationDeliveryService:
         使用模板向用户组发送通知
 
         Args:
-            group_name: 用户组名称
             template_id: 模板 ID
             context: 模板变量上下文
+            group_uuid: 用户组 UUID（优先）
+            group_name: 用户组名称（便捷入口，自动解析为 uuid）
             priority: 优先级
             **kwargs: 其他参数
 
@@ -837,17 +847,23 @@ class NotificationDeliveryService:
             ServiceResult: 包含发送结果
         """
         try:
-            # 根据 name 获取 group
-            _group_result = self.user_group_service.get_group_by_name(group_name)
+            # 解析 group_uuid
+            if group_uuid:
+                _group_result = self.user_group_service.get_group_by_uuid(group_uuid)
+            elif group_name:
+                _group_result = self.user_group_service.get_group_by_name(group_name)
+            else:
+                return ServiceResult.error("Either group_uuid or group_name is required")
+
             if not _group_result.success or not _group_result.data:
-                return ServiceResult.error(f"Group not found: {group_name}")
+                return ServiceResult.error(f"Group not found: {group_uuid or group_name}")
             group = _group_result.data
 
             # 获取组内所有用户
             _members_result = self.user_group_service.get_group_member_uuids(group.uuid)
             user_uuids = _members_result.data if _members_result.success else []
             if not user_uuids:
-                return ServiceResult.error(f"No users found in group: {group_name}")
+                return ServiceResult.error(f"No users found in group: {group.name}")
 
             # 向所有用户发送模板通知
             results = []
@@ -871,11 +887,11 @@ class NotificationDeliveryService:
                 if result.is_success:
                     success_count += 1
 
-            GLOG.INFO(f"Group template notification sent: {success_count}/{len(user_uuids)} users in group '{group_name}'")
+            GLOG.INFO(f"Group template notification sent: {success_count}/{len(user_uuids)} users in group '{group.name}'")
 
             return ServiceResult.success(
                 data={
-                    "group_name": group_name,
+                    "group_name": group.name,
                     "template_id": template_id,
                     "total_users": len(user_uuids),
                     "success_count": success_count,

--- a/src/ginkgo/notifier/core/webhook_dispatcher.py
+++ b/src/ginkgo/notifier/core/webhook_dispatcher.py
@@ -508,25 +508,12 @@ class WebhookDispatcher:
                     priority=priority,
                     **kwargs
                 )
-            elif group_name:
+            elif group_name or group_uuid:
                 return self._service.send_template_to_group(
+                    template_id="simple_signal",
+                    context=context,
+                    group_uuid=group_uuid,
                     group_name=group_name,
-                    template_id="simple_signal",
-                    context=context,
-                    priority=priority,
-                    **kwargs
-                )
-            elif group_uuid:
-                # 如果提供的是 group_uuid，需要先查找 group_name
-                _group_result = self._service.user_group_service.get_group_by_uuid(group_uuid)
-                if not _group_result.success or not _group_result.data:
-                    return ServiceResult.error(f"Group not found: {group_uuid}")
-                group = _group_result.data
-
-                return self._service.send_template_to_group(
-                    group_name=group.name,
-                    template_id="simple_signal",
-                    context=context,
                     priority=priority,
                     **kwargs
                 )

--- a/src/ginkgo/notifier/workers/notification_worker.py
+++ b/src/ginkgo/notifier/workers/notification_worker.py
@@ -367,19 +367,11 @@ class NotificationWorker:
                 channels=channels,
                 priority=priority
             )
-        elif group_name:
+        elif group_name or group_uuid:
             result = self.notification_service.send_to_group(
-                group_name=group_name,
                 content=content,
-                title=title,
-                channels=channels,
-                priority=priority
-            )
-        elif group_uuid:
-            # 需要先查找 group_name
-            result = self.notification_service.send_to_group(
                 group_uuid=group_uuid,
-                content=content,
+                group_name=group_name,
                 title=title,
                 channels=channels,
                 priority=priority
@@ -428,18 +420,12 @@ class NotificationWorker:
                 context=context,
                 priority=priority
             )
-        elif group_name:
+        elif group_name or group_uuid:
             result = self.notification_service.send_template_to_group(
-                group_name=group_name,
                 template_id=template_id,
                 context=context,
-                priority=priority
-            )
-        elif group_uuid:
-            result = self.notification_service.send_template_to_group(
                 group_uuid=group_uuid,
-                template_id=template_id,
-                context=context,
+                group_name=group_name,
                 priority=priority
             )
         else:

--- a/tests/unit/test_send_to_group_uuid.py
+++ b/tests/unit/test_send_to_group_uuid.py
@@ -1,0 +1,173 @@
+"""
+Tests for NotificationDeliveryService.send_to_group / send_template_to_group
+group_uuid support.
+
+Verifies that these methods accept group_uuid as the primary identifier,
+with group_name as a convenience wrapper that resolves to uuid.
+
+Issue: #3445
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_service():
+    """Create NotificationDeliveryService with mocked dependencies."""
+    from ginkgo.notifier.core.webhook_dispatcher import WebhookDispatcher
+    with patch.object(WebhookDispatcher, "__init__", lambda self, svc: None):
+        from ginkgo.notifier.core.notification_service import NotificationDeliveryService
+
+        mock_notification_svc = MagicMock()
+        mock_user_svc = MagicMock()
+        mock_group_svc = MagicMock()
+
+        # Default: group found by uuid
+        mock_group = MagicMock()
+        mock_group.uuid = "group-uuid-1"
+        mock_group.name = "traders"
+        mock_group_svc.get_group_by_uuid.return_value = ServiceResult.success(
+            data=mock_group, message="ok"
+        )
+        mock_group_svc.get_group_by_name.return_value = ServiceResult.success(
+            data=mock_group, message="ok"
+        )
+        mock_group_svc.get_group_member_uuids.return_value = ServiceResult.success(
+            data=["user-1", "user-2"], message="ok"
+        )
+
+        service = NotificationDeliveryService(
+            notification_service=mock_notification_svc,
+            template_engine=MagicMock(),
+            user_service=mock_user_svc,
+            user_group_service=mock_group_svc,
+        )
+
+    # Mock send_to_user to avoid deep recursion
+    service.send_to_user = MagicMock(return_value=ServiceResult.success(data={"message_id": "msg-1"}))
+    service.send_template_to_user = MagicMock(return_value=ServiceResult.success(data={"message_id": "msg-1"}))
+
+    return service
+
+
+class TestSendToGroupByUuid:
+    """send_to_group(group_uuid=...) sends to all group members."""
+
+    def test_resolves_uuid_and_sends_to_members(self):
+        service = _make_service()
+        result = service.send_to_group(
+            content="hello",
+            group_uuid="group-uuid-1",
+        )
+
+        assert result.success is True
+        # Should resolve group by uuid
+        service.user_group_service.get_group_by_uuid.assert_called_once_with("group-uuid-1")
+        # Should get members
+        service.user_group_service.get_group_member_uuids.assert_called_once()
+        # Should send to each member
+        assert service.send_to_user.call_count == 2
+
+
+class TestSendToGroupByName:
+    """send_to_group(group_name=...) resolves name→uuid then sends."""
+
+    def test_resolves_name_to_uuid_and_sends(self):
+        service = _make_service()
+        result = service.send_to_group(
+            content="hello",
+            group_name="traders",
+        )
+
+        assert result.success is True
+        # Should resolve group by name
+        service.user_group_service.get_group_by_name.assert_called_once_with("traders")
+        # Should then get members and send
+        service.user_group_service.get_group_member_uuids.assert_called_once()
+        assert service.send_to_user.call_count == 2
+
+
+class TestSendTemplateToGroupByUuid:
+    """send_template_to_group(group_uuid=...) sends template to group members."""
+
+    def test_resolves_uuid_and_sends_template(self):
+        service = _make_service()
+        result = service.send_template_to_group(
+            template_id="trading_signal",
+            context={"symbol": "AAPL"},
+            group_uuid="group-uuid-1",
+        )
+
+        assert result.success is True
+        service.user_group_service.get_group_by_uuid.assert_called_once_with("group-uuid-1")
+        service.user_group_service.get_group_member_uuids.assert_called_once()
+        assert service.send_template_to_user.call_count == 2
+
+
+class TestSendTemplateToGroupByName:
+    """send_template_to_group(group_name=...) resolves name→uuid then sends template."""
+
+    def test_resolves_name_to_uuid_and_sends_template(self):
+        service = _make_service()
+        result = service.send_template_to_group(
+            template_id="trading_signal",
+            context={"symbol": "AAPL"},
+            group_name="traders",
+        )
+
+        assert result.success is True
+        service.user_group_service.get_group_by_name.assert_called_once_with("traders")
+        service.user_group_service.get_group_member_uuids.assert_called_once()
+        assert service.send_template_to_user.call_count == 2
+
+
+class TestGroupNotFound:
+    """When group cannot be resolved, returns error."""
+
+    def test_send_to_group_uuid_not_found(self):
+        service = _make_service()
+        service.user_group_service.get_group_by_uuid.return_value = ServiceResult.error("not found")
+
+        result = service.send_to_group(content="hello", group_uuid="missing")
+        assert result.success is False
+
+    def test_send_to_group_name_not_found(self):
+        service = _make_service()
+        service.user_group_service.get_group_by_name.return_value = ServiceResult.error("not found")
+
+        result = service.send_to_group(content="hello", group_name="missing")
+        assert result.success is False
+
+    def test_send_template_to_group_uuid_not_found(self):
+        service = _make_service()
+        service.user_group_service.get_group_by_uuid.return_value = ServiceResult.error("not found")
+
+        result = service.send_template_to_group(
+            template_id="tpl", context={}, group_uuid="missing"
+        )
+        assert result.success is False
+
+    def test_send_template_to_group_name_not_found(self):
+        service = _make_service()
+        service.user_group_service.get_group_by_name.return_value = ServiceResult.error("not found")
+
+        result = service.send_template_to_group(
+            template_id="tpl", context={}, group_name="missing"
+        )
+        assert result.success is False
+
+
+class TestNeitherUuidNorName:
+    """When neither group_uuid nor group_name is provided, returns error."""
+
+    def test_send_to_group_requires_identifier(self):
+        service = _make_service()
+        result = service.send_to_group(content="hello")
+        assert result.success is False
+
+    def test_send_template_to_group_requires_identifier(self):
+        service = _make_service()
+        result = service.send_template_to_group(template_id="tpl", context={})
+        assert result.success is False


### PR DESCRIPTION
## Summary
- `send_to_group` / `send_template_to_group` 签名改为 `group_uuid` 优先，`group_name` 作为便捷入口自动解析
- Worker 的 `_process_simple_message` / `_process_template_message` 合并 group_name 和 group_uuid 为统一调用
- `WebhookDispatcher.send_trading_signal` 简化，移除手动 uuid→name 解析，直接透传给 service

Closes #3445

## Test plan
- [x] `tests/unit/test_send_to_group_uuid.py` — 10 个测试覆盖 uuid/name/not-found/missing 场景
- [x] 已有 35 个相关单元测试全部通过

🤖 Generated with [Claude Code](https://claude.ai/code)