### PR TITLE
fix: list_all() 消除 CRUD 直调

### DIFF
--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -289,6 +289,7 @@ class Container(containers.DeclarativeContainer):
             user_contact_crud=get_crud("user_contact"),
             user_group_mapping_crud=get_crud("user_group_mapping"),
             user_group_service=user_group_service(),
+            user_service=user_service(),
         )
     )
 

--- a/src/ginkgo/notifier/services/notification_recipient_service.py
+++ b/src/ginkgo/notifier/services/notification_recipient_service.py
@@ -34,6 +34,7 @@ class NotificationRecipientService(BaseService):
         user_contact_crud: UserContactCRUD,
         user_group_mapping_crud: UserGroupMappingCRUD,
         user_group_service=None,
+        user_service=None,
     ):
         """
         初始化 NotificationRecipientService
@@ -43,12 +44,14 @@ class NotificationRecipientService(BaseService):
             user_contact_crud: UserContactCRUD 实例
             user_group_mapping_crud: UserGroupMappingCRUD 实例
             user_group_service: UserGroupService 实例（可选，推荐）
+            user_service: UserService 实例（可选，推荐）
         """
         super().__init__(crud_repo=recipient_crud)
         self._recipient_crud = recipient_crud
         self._user_contact_crud = user_contact_crud
         self._user_group_mapping_crud = user_group_mapping_crud
         self.user_group_service = user_group_service
+        self.user_service = user_service
 
     @retry(max_try=3)
     def add_recipient(
@@ -428,27 +431,26 @@ class NotificationRecipientService(BaseService):
                     filters["recipient_type"] = recipient_type.value
 
             # 查询
+            recipients = self._recipient_crud.find(filters=filters)
 
             # 获取所有用户和用户组信息用于显示
             user_ids = list(set([r.user_id for r in recipients if r.user_id]))
             group_ids = list(set([r.user_group_id for r in recipients if r.user_group_id]))
 
             users_map = {}
-            if user_ids:
-                from ginkgo.data.containers import container
-                user_crud = container.user_crud()
+            if user_ids and self.user_service:
                 for user_id in user_ids:
-                    if user_list:
-                        u = user_list[0]
+                    _user_result = self.user_service.get_user(user_id)
+                    if _user_result.success and _user_result.data:
+                        u = _user_result.data
                         users_map[user_id] = {"uuid": u.uuid, "username": u.username, "display_name": u.display_name}
 
             groups_map = {}
-            if group_ids:
-                from ginkgo.data.containers import container
-                group_crud = container.user_group_crud()
+            if group_ids and self.user_group_service:
                 for group_id in group_ids:
-                    if group_list:
-                        g = group_list[0]
+                    _group_result = self.user_group_service.get_group_by_uuid(group_id)
+                    if _group_result.success and _group_result.data:
+                        g = _group_result.data
                         groups_map[group_id] = {"uuid": g.uuid, "name": g.name}
 
             result = []

--- a/tests/unit/test_list_all_crud_elimination.py
+++ b/tests/unit/test_list_all_crud_elimination.py
@@ -1,0 +1,124 @@
+"""
+Tests for NotificationRecipientService.list_all() CRUD elimination.
+
+Verifies that list_all() uses UserService/UserGroupService facades
+instead of direct CRUD access for user/group enrichment.
+
+Issue: #3443
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.enums import RECIPIENT_TYPES
+from ginkgo.notifier.services.notification_recipient_service import NotificationRecipientService
+
+
+def _make_recipient(user_id=None, user_group_id=None):
+    """Create a mock MNotificationRecipient."""
+    r = MagicMock()
+    r.uuid = "r-1"
+    r.name = "test-recipient"
+    r.user_id = user_id
+    r.user_group_id = user_group_id
+    r.is_default = True
+    r.description = "desc"
+    r.create_at = None
+    r.get_recipient_type_enum.return_value = RECIPIENT_TYPES.USER
+    return r
+
+
+def _make_service():
+    """Create NotificationRecipientService with mocked dependencies."""
+    recipient_crud = MagicMock()
+    user_contact_crud = MagicMock()
+    user_group_mapping_crud = MagicMock()
+
+    user_service = MagicMock()
+    group_service = MagicMock()
+
+    service = NotificationRecipientService(
+        recipient_crud=recipient_crud,
+        user_contact_crud=user_contact_crud,
+        user_group_mapping_crud=user_group_mapping_crud,
+        user_group_service=group_service,
+        user_service=user_service,
+    )
+    return service
+
+
+class TestListAllUserServiceEnrichment:
+    """list_all() should use UserService.get_user() for user enrichment."""
+
+    def test_calls_user_service_not_crud(self):
+        service = _make_service()
+        recipient = _make_recipient(user_id="user-1")
+        service._recipient_crud.find.return_value = [recipient]
+
+        mock_user = MagicMock()
+        mock_user.uuid = "user-1"
+        mock_user.username = "alice"
+        mock_user.display_name = "Alice"
+        service.user_service.get_user.return_value = ServiceResult.success(
+            data=mock_user, message="ok"
+        )
+
+        result = service.list_all()
+        assert result.success is True
+        service.user_service.get_user.assert_called_once_with("user-1")
+
+    def test_user_info_included_in_result(self):
+        service = _make_service()
+        recipient = _make_recipient(user_id="user-1")
+        service._recipient_crud.find.return_value = [recipient]
+
+        mock_user = MagicMock()
+        mock_user.uuid = "user-1"
+        mock_user.username = "alice"
+        mock_user.display_name = "Alice"
+        service.user_service.get_user.return_value = ServiceResult.success(
+            data=mock_user, message="ok"
+        )
+
+        result = service.list_all()
+        assert result.success is True
+        recipients = result.data["recipients"]
+        assert recipients[0]["user_info"]["username"] == "alice"
+
+
+class TestListAllGroupServiceEnrichment:
+    """list_all() should use UserGroupService for group enrichment."""
+
+    def test_calls_group_service_for_group_enrichment(self):
+        service = _make_service()
+        recipient = _make_recipient(user_group_id="group-1")
+        recipient.get_recipient_type_enum.return_value = RECIPIENT_TYPES.USER_GROUP
+        service._recipient_crud.find.return_value = [recipient]
+
+        mock_group = MagicMock()
+        mock_group.uuid = "group-1"
+        mock_group.name = "traders"
+        service.user_group_service.get_group_by_uuid.return_value = ServiceResult.success(
+            data=mock_group, message="ok"
+        )
+
+        result = service.list_all()
+        assert result.success is True
+        service.user_group_service.get_group_by_uuid.assert_called_once_with("group-1")
+        recipients = result.data["recipients"]
+        assert recipients[0]["user_group_info"]["name"] == "traders"
+
+
+class TestListAllNoDirectCRUDAccess:
+    """list_all() must not import or access data.containers."""
+
+    def test_no_container_import(self):
+        """list_all should not import from ginkgo.data.containers."""
+        import inspect
+        from ginkgo.notifier.services.notification_recipient_service import NotificationRecipientService
+
+        source = inspect.getsource(NotificationRecipientService.list_all)
+        assert "from ginkgo.data.containers" not in source
+        assert "container.user_crud" not in source
+        assert "container.user_group_crud" not in source


### PR DESCRIPTION
## Summary
- `NotificationRecipientService` 构造函数新增 `user_service` 参数
- `list_all()` 中 `container.user_crud()` / `container.user_group_crud()` 直调替换为 `user_service.get_user()` 和 `user_group_service.get_group_by_uuid()` facade
- 补全缺失的 `recipients` 查询（原始 #3429 bug 残留）
- data container 注入 `user_service`

Closes #3443

## Test plan
- [x] `tests/unit/test_list_all_crud_elimination.py` — 4 个测试覆盖 UserService/UserGroupService enrichment 和无 CRUD 直调验证
- [x] 49 个相关单元测试全部通过

🤖 Generated with [Claude Code](https://claude.ai/code)