### PR TITLE
fix: 修复 Momentum 策略测试与源码不匹配

### DIFF
--- a/tests/unit/trading/strategies/test_momentum.py
+++ b/tests/unit/trading/strategies/test_momentum.py
@@ -3,8 +3,10 @@ Momentum Strategy (动量因子策略) 单元测试
 
 覆盖范围:
 - TestMomentumConstruction: 默认参数、自定义参数、无效参数验证
-- TestMomentumCal: 事件过滤、数据不足、动量排名、再平衡逻辑
-- test_reset_state: 状态重置
+- TestMomentumCal: 事件过滤、数据不足、动量信号生成
+- TestResetState: 状态重置
+
+Related: #3620
 """
 
 import sys
@@ -19,26 +21,36 @@ from unittest.mock import MagicMock, patch
 from ginkgo.trading.strategies.momentum import Momentum
 from ginkgo.trading.events.price_update import EventPriceUpdate
 from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.entities import Bar
 
 
-def _make_bar(close: float, timestamp: datetime = None):
+def _make_bar(close: float, code: str = "000001.SZ", timestamp: datetime = None):
     """创建一个模拟的 bar 对象"""
     if timestamp is None:
         timestamp = datetime(2024, 1, 15, 10, 0, 0)
-    bar = MagicMock()
+    bar = MagicMock(spec=Bar)
     bar.close = close
+    bar.code = code
     bar.timestamp = timestamp
     return bar
 
 
-def _make_bars(closes: list, start: datetime = None):
+def _make_bars(closes: list, code: str = "000001.SZ", start: datetime = None):
     """创建一个 bar 列表，每条间隔一天"""
     if start is None:
         start = datetime(2024, 1, 1)
     bars = []
     for i, c in enumerate(closes):
-        bars.append(_make_bar(c, timestamp=start + timedelta(days=i)))
+        bars.append(_make_bar(c, code=code, timestamp=start + timedelta(days=i)))
     return bars
+
+
+def _make_price_event(code: str = "000001.SZ"):
+    """创建模拟的 EventPriceUpdate（绕过 Bar 构造复杂性）"""
+    event = MagicMock(spec=EventPriceUpdate)
+    event.code = code
+    event.__class__ = EventPriceUpdate
+    return event
 
 
 def _make_portfolio_info(now: datetime = None, interested_codes=None):
@@ -46,7 +58,7 @@ def _make_portfolio_info(now: datetime = None, interested_codes=None):
     if now is None:
         now = datetime(2024, 1, 20)
     if interested_codes is None:
-        interested_codes = ["000001.SZ", "000002.SZ", "000003.SZ"]
+        interested_codes = ["000001.SZ"]
     return {
         "uuid": "portfolio-001",
         "engine_id": "engine-001",
@@ -55,6 +67,18 @@ def _make_portfolio_info(now: datetime = None, interested_codes=None):
         "interested_codes": interested_codes,
         "positions": {},
     }
+
+
+@pytest.fixture
+def bound_strategy():
+    """创建并绑定上下文的 Momentum 策略实例"""
+    s = Momentum(lookback_period=5, momentum_threshold=0.02)
+    ctx = MagicMock()
+    ctx.portfolio_id = "portfolio-001"
+    ctx.engine_id = "engine-001"
+    ctx.task_id = "run-001"
+    s._context = ctx
+    return s
 
 
 # ──────────────────────────────────────────────
@@ -68,46 +92,26 @@ class TestMomentumConstruction:
         """默认参数初始化"""
         s = Momentum()
         assert s.lookback_period == 20
-        assert s.top_n == 5
-        assert s.rebalance_days == 5
+        assert s.momentum_threshold == 0.02
         assert s.frequency == "1d"
-        assert s._last_rebalance is None
-        assert s._current_holdings == set()
 
     def test_custom_params(self):
         """自定义参数初始化"""
         s = Momentum(
             name="MyMomentum",
             lookback_period=10,
-            top_n=3,
-            rebalance_days=3,
+            momentum_threshold=0.05,
             frequency="1h",
         )
         assert s.name == "MyMomentum"
         assert s.lookback_period == 10
-        assert s.top_n == 3
-        assert s.rebalance_days == 3
+        assert s.momentum_threshold == 0.05
         assert s.frequency == "1h"
-
-    def test_invalid_top_n_zero_raises(self):
-        """top_n=0 应该抛出 ValueError"""
-        with pytest.raises(ValueError, match="top_n"):
-            Momentum(top_n=0)
-
-    def test_invalid_top_n_negative_raises(self):
-        """top_n 为负数应该抛出 ValueError"""
-        with pytest.raises(ValueError, match="top_n"):
-            Momentum(top_n=-1)
 
     def test_invalid_lookback_period_raises(self):
         """lookback_period < 2 应该抛出 ValueError"""
         with pytest.raises(ValueError, match="lookback_period"):
             Momentum(lookback_period=1)
-
-    def test_invalid_rebalance_days_raises(self):
-        """rebalance_days < 1 应该抛出 ValueError"""
-        with pytest.raises(ValueError, match="rebalance_days"):
-            Momentum(rebalance_days=0)
 
 
 # ──────────────────────────────────────────────
@@ -126,142 +130,80 @@ class TestMomentumCal:
         assert result == []
 
     def test_returns_empty_when_insufficient_data(self):
-        """数据不足时返回空列表（首次再平衡应该尝试，但 get_bars_cached 返回空）"""
-        s = Momentum(lookback_period=20, top_n=2)
-        portfolio_info = _make_portfolio_info(
-            interested_codes=["000001.SZ", "000002.SZ"]
-        )
+        """数据不足时返回空列表"""
+        s = Momentum(lookback_period=20)
+        portfolio_info = _make_portfolio_info()
 
         with patch.object(s, "get_bars_cached", return_value=[]):
-            result = s.cal(portfolio_info, EventPriceUpdate())
+            result = s.cal(portfolio_info, _make_price_event("000001.SZ"))
             assert result == []
 
-    def test_ranks_and_picks_top_momentum_stocks(self):
-        """动量排名测试：3只股票取top 2，验证选中的是动量最高的"""
-        s = Momentum(lookback_period=5, top_n=2, rebalance_days=1)
+    def test_long_signal_when_momentum_exceeds_threshold(self, bound_strategy):
+        """动量超过正阈值且无持仓 → LONG 信号"""
+        s = bound_strategy
         now = datetime(2024, 1, 20)
-        portfolio_info = _make_portfolio_info(
-            now=now,
-            interested_codes=["000001.SZ", "000002.SZ", "000003.SZ"],
-        )
+        portfolio_info = _make_portfolio_info(now=now)
+        bars = _make_bars([100.0, 101.0, 103.0, 106.0, 108.0, 110.0])
 
-        # 000001.SZ: close 从 100 涨到 110 -> +10%
-        # 000002.SZ: close 从 100 涨到 115 -> +15%  (最高)
-        # 000003.SZ: close 从 100 涨到 95  -> -5%
-        start = datetime(2024, 1, 1)
+        with patch.object(s, "get_bars_cached", return_value=bars):
+            result = s.cal(portfolio_info, _make_price_event("000001.SZ"))
 
-        def mock_get_bars(symbol, count, frequency, use_cache=True):
-            if symbol == "000001.SZ":
-                closes = [100.0, 102.0, 103.0, 107.0, 108.0, 110.0]
-            elif symbol == "000002.SZ":
-                closes = [100.0, 103.0, 106.0, 110.0, 112.0, 115.0]
-            else:  # 000003.SZ
-                closes = [100.0, 99.0, 98.0, 97.0, 96.0, 95.0]
-            return _make_bars(closes, start)
+        assert len(result) == 1
+        assert result[0].direction == DIRECTION_TYPES.LONG
+        assert result[0].code == "000001.SZ"
 
-        with patch.object(s, "get_bars_cached", side_effect=mock_get_bars):
-            result = s.cal(portfolio_info, EventPriceUpdate())
-
-        # 应该产生 2 个 LONG 信号（top 2 动量最高的股票）
-        long_codes = {sig.code for sig in result if sig.direction == DIRECTION_TYPES.LONG}
-        assert len(long_codes) == 2
-        assert "000002.SZ" in long_codes  # +15% 最高动量
-        assert "000001.SZ" in long_codes  # +10% 第二高
-        assert "000003.SZ" not in long_codes  # -5% 不应该入选
-
-    def test_skips_rebalance_if_not_enough_days_passed(self):
-        """再平衡间隔未到时应返回空列表"""
-        s = Momentum(lookback_period=5, top_n=2, rebalance_days=5)
+    def test_short_signal_when_negative_momentum_with_position(self, bound_strategy):
+        """动量低于负阈值且有持仓 → SHORT 信号"""
+        s = bound_strategy
         now = datetime(2024, 1, 20)
-        portfolio_info = _make_portfolio_info(
-            now=now,
-            interested_codes=["000001.SZ", "000002.SZ"],
-        )
+        portfolio_info = _make_portfolio_info(now=now)
+        portfolio_info["positions"] = {"000001.SZ": {}}
+        bars = _make_bars([100.0, 98.0, 96.0, 93.0, 91.0, 90.0])
 
-        start = datetime(2024, 1, 1)
+        with patch.object(s, "get_bars_cached", return_value=bars):
+            result = s.cal(portfolio_info, _make_price_event("000001.SZ"))
 
-        def mock_get_bars(symbol, count, frequency, use_cache=True):
-            closes = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0]
-            return _make_bars(closes, start)
+        assert len(result) == 1
+        assert result[0].direction == DIRECTION_TYPES.SHORT
 
-        with patch.object(s, "get_bars_cached", side_effect=mock_get_bars):
-            # 第一次调用 - 应该再平衡
-            result1 = s.cal(portfolio_info, EventPriceUpdate())
-            assert len(result1) > 0
-
-            # 紧接着再调用（同一天）- 应该跳过
-            result2 = s.cal(portfolio_info, EventPriceUpdate())
-            assert result2 == []
-
-    def test_generates_short_signals_for_exits(self):
-        """持有股票跌出 top_n 时应生成 SHORT 信号"""
-        s = Momentum(lookback_period=5, top_n=2, rebalance_days=1)
+    def test_no_signal_within_threshold(self):
+        """动量在阈值范围内 → 无信号"""
+        s = Momentum(lookback_period=5, momentum_threshold=0.10)
         now = datetime(2024, 1, 20)
-        portfolio_info = _make_portfolio_info(
-            now=now,
-            interested_codes=["000001.SZ", "000002.SZ", "000003.SZ"],
-        )
+        portfolio_info = _make_portfolio_info(now=now)
+        bars = _make_bars([100.0, 101.0, 101.5, 102.0, 102.5, 103.0])
 
-        start = datetime(2024, 1, 1)
+        with patch.object(s, "get_bars_cached", return_value=bars):
+            result = s.cal(portfolio_info, _make_price_event("000001.SZ"))
 
-        def mock_get_bars_phase1(symbol, count, frequency, use_cache=True):
-            """第一阶段：000003.SZ 动量最高"""
-            if symbol == "000001.SZ":
-                closes = [100.0, 102.0, 103.0, 107.0, 108.0, 110.0]
-            elif symbol == "000002.SZ":
-                closes = [100.0, 103.0, 106.0, 110.0, 112.0, 115.0]
-            else:
-                closes = [100.0, 108.0, 112.0, 118.0, 122.0, 130.0]  # +30%
-            return _make_bars(closes, start)
+        assert result == []
 
-        # 第一次再平衡：选中 000003.SZ (+30%) 和 000002.SZ (+15%)
-        with patch.object(s, "get_bars_cached", side_effect=mock_get_bars_phase1):
-            result1 = s.cal(portfolio_info, EventPriceUpdate())
-            assert len(result1) == 2
-            long_codes_1 = {sig.code for sig in result1 if sig.direction == DIRECTION_TYPES.LONG}
-            assert "000003.SZ" in long_codes_1
+    def test_no_duplicate_buy_with_position(self):
+        """有持仓且动量超阈值 → 不重复买入"""
+        s = Momentum(lookback_period=5, momentum_threshold=0.02)
+        now = datetime(2024, 1, 20)
+        portfolio_info = _make_portfolio_info(now=now)
+        portfolio_info["positions"] = {"000001.SZ": {}}
+        bars = _make_bars([100.0, 101.0, 103.0, 106.0, 108.0, 110.0])
 
-        # 模拟时间推进，超过再平衡间隔
-        later_now = now + timedelta(days=s.rebalance_days + 1)
-        portfolio_info["now"] = later_now
+        with patch.object(s, "get_bars_cached", return_value=bars):
+            result = s.cal(portfolio_info, _make_price_event("000001.SZ"))
 
-        def mock_get_bars_phase2(symbol, count, frequency, use_cache=True):
-            """第二阶段：000003.SZ 动量暴跌"""
-            if symbol == "000001.SZ":
-                closes = [100.0, 102.0, 103.0, 107.0, 108.0, 120.0]  # +20%
-            elif symbol == "000002.SZ":
-                closes = [100.0, 103.0, 106.0, 110.0, 112.0, 125.0]  # +25%
-            else:
-                closes = [100.0, 98.0, 95.0, 92.0, 88.0, 85.0]  # -15%
-            return _make_bars(closes, start)
+        assert result == []
 
-        # 第二次再平衡：000003.SZ 跌出 top 2
-        with patch.object(s, "get_bars_cached", side_effect=mock_get_bars_phase2):
-            result2 = s.cal(portfolio_info, EventPriceUpdate())
-
-        # 应该有 SHORT 信号卖出 000003.SZ
-        short_codes = {sig.code for sig in result2 if sig.direction == DIRECTION_TYPES.SHORT}
-        assert "000003.SZ" in short_codes
-
-    def test_signals_contain_correct_portfolio_context(self):
+    def test_signals_contain_correct_portfolio_context(self, bound_strategy):
         """信号应包含正确的 portfolio_id、engine_id、business_timestamp"""
-        s = Momentum(lookback_period=5, top_n=1, rebalance_days=1)
+        s = bound_strategy
+        s._context.engine_id = "engine-xyz"
+        s._context.task_id = "run-abc"
         now = datetime(2024, 3, 15, 14, 30, 0)
-        portfolio_info = _make_portfolio_info(
-            now=now,
-            interested_codes=["000001.SZ"],
-        )
+        portfolio_info = _make_portfolio_info(now=now, interested_codes=["000001.SZ"])
         portfolio_info["engine_id"] = "engine-xyz"
         portfolio_info["task_id"] = "run-abc"
+        bars = _make_bars([100.0, 101.0, 102.0, 103.0, 104.0, 110.0])
 
-        start = datetime(2024, 3, 1)
-
-        def mock_get_bars(symbol, count, frequency, use_cache=True):
-            closes = [100.0, 101.0, 102.0, 103.0, 104.0, 110.0]
-            return _make_bars(closes, start)
-
-        with patch.object(s, "get_bars_cached", side_effect=mock_get_bars):
-            result = s.cal(portfolio_info, EventPriceUpdate())
+        with patch.object(s, "get_bars_cached", return_value=bars):
+            result = s.cal(portfolio_info, _make_price_event("000001.SZ"))
 
         assert len(result) == 1
         sig = result[0]
@@ -272,19 +214,20 @@ class TestMomentumCal:
 
 
 # ──────────────────────────────────────────────
-# test_reset_state
+# TestResetState
 # ──────────────────────────────────────────────
 
 class TestResetState:
     """状态重置测试"""
 
     def test_reset_state(self):
-        """重置后 _last_rebalance 和 _current_holdings 应清空"""
+        """重置后数据缓存应清空"""
         s = Momentum()
-        s._last_rebalance = datetime(2024, 1, 1)
-        s._current_holdings = {"000001.SZ", "000002.SZ"}
+        # 填充缓存
+        s._data_cache["000001.SZ"] = [MagicMock()]
+        s._cache_timestamps["000001.SZ"] = datetime(2024, 1, 1)
 
         s.reset_state()
 
-        assert s._last_rebalance is None
-        assert s._current_holdings == set()
+        assert len(s._data_cache) == 0
+        assert len(s._cache_timestamps) == 0


### PR DESCRIPTION
## Summary

- 修复 `test_momentum.py` 中测试期望与源码不匹配的问题 (#3620)
- 测试错误地期望 Momentum Strategy 有 `top_n`/`rebalance_days`（属于 MomentumSelector 职责），实际源码是单股阈值动量策略
- 重写测试匹配源码实际行为，11 个测试全部通过

## Changes

- 删除 `top_n`/`rebalance_days`/`_last_rebalance`/`_current_holdings` 相关测试（违反架构边界：选股属于 Selector）
- 新增单股阈值信号测试：LONG/SHORT/阈值内无信号/持仓不重复买入
- 使用 `@pytest.fixture bound_strategy` 管理策略 context 绑定
- 修复 `EventPriceUpdate` 构造方式（需要 Bar payload）

## Test plan

- [x] `pytest tests/unit/trading/strategies/test_momentum.py` — 11 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)