### PR TITLE
fix: models eager import 解决 SQLAlchemy mapper 初始化失败 (#3614)

### DIFF
--- a/src/ginkgo/data/models/__init__.py
+++ b/src/ginkgo/data/models/__init__.py
@@ -2,70 +2,57 @@
 # Downstream: 全部ORM模型类(MBar/MTick/MOrder/MPosition等)
 # Role: 数据模型包入口，统一导出所有ClickHouse/MySQL/MongoDB ORM模型类
 
-# See #2715: PEP 562 懒加载
-_LAZY_IMPORTS = {
-    "MAdjustfactor": ("ginkgo.data.models.model_adjustfactor", "MAdjustfactor"),
-    "MAnalyzerRecord": ("ginkgo.data.models.model_analyzer_record", "MAnalyzerRecord"),
-    "MBacktestRecordBase": ("ginkgo.data.models.model_backtest_record_base", "MBacktestRecordBase"),
-    "MBacktestTask": ("ginkgo.data.models.model_backtest_task", "MBacktestTask"),
-    "MBar": ("ginkgo.data.models.model_bar", "MBar"),
-    "MCapitalAdjustment": ("ginkgo.data.models.model_capital_adjustment", "MCapitalAdjustment"),
-    "MClickBase": ("ginkgo.data.models.model_clickbase", "MClickBase"),
-    "MEngine": ("ginkgo.data.models.model_engine", "MEngine"),
-    "MEngineHandlerMapping": ("ginkgo.data.models.model_engine_handler_mapping", "MEngineHandlerMapping"),
-    "MEnginePortfolioMapping": ("ginkgo.data.models.model_engine_portfolio_mapping", "MEnginePortfolioMapping"),
-    "MFactor": ("ginkgo.data.models.model_factor", "MFactor"),
-    "MFile": ("ginkgo.data.models.model_file", "MFile"),
-    "MHandler": ("ginkgo.data.models.model_handler", "MHandler"),
-    "MParam": ("ginkgo.data.models.model_param", "MParam"),
-    "MMysqlBase": ("ginkgo.data.models.model_mysqlbase", "MMysqlBase"),
-    "MMongoBase": ("ginkgo.data.models.model_mongobase", "MMongoBase"),
-    "MOrder": ("ginkgo.data.models.model_order", "MOrder"),
-    "MOrderRecord": ("ginkgo.data.models.model_order_record", "MOrderRecord"),
-    "MPortfolio": ("ginkgo.data.models.model_portfolio", "MPortfolio"),
-    "MPortfolioFileMapping": ("ginkgo.data.models.model_portfolio_file_mapping", "MPortfolioFileMapping"),
-    "MPosition": ("ginkgo.data.models.model_position", "MPosition"),
-    "MPositionRecord": ("ginkgo.data.models.model_position_record", "MPositionRecord"),
-    "MSignal": ("ginkgo.data.models.model_signal", "MSignal"),
-    "MStockInfo": ("ginkgo.data.models.model_stock_info", "MStockInfo"),
-    "MLiveAccount": ("ginkgo.data.models.model_live_account", "MLiveAccount"),
-    "MBrokerInstance": ("ginkgo.data.models.model_broker_instance", "MBrokerInstance"),
-    "MTradeRecord": ("ginkgo.data.models.model_trade_record", "MTradeRecord"),
-    "MTick": ("ginkgo.data.models.model_tick", "MTick"),
-    "MTickSummary": ("ginkgo.data.models.model_tick_summary", "MTickSummary"),
-    "MTradeDay": ("ginkgo.data.models.model_trade_day", "MTradeDay"),
-    "MTransfer": ("ginkgo.data.models.model_transfer", "MTransfer"),
-    "MTransferRecord": ("ginkgo.data.models.model_transfer_record", "MTransferRecord"),
-    "MRunRecord": ("ginkgo.data.models.model_run_record", "MRunRecord"),
-    "MUser": ("ginkgo.data.models.model_user", "MUser"),
-    "MUserContact": ("ginkgo.data.models.model_user_contact", "MUserContact"),
-    "MDeployment": ("ginkgo.data.models.model_deployment", "MDeployment"),
-    "MUserCredential": ("ginkgo.data.models.model_user_credential", "MUserCredential"),
-    "MUserGroup": ("ginkgo.data.models.model_user_group", "MUserGroup"),
-    "MUserGroupMapping": ("ginkgo.data.models.model_user_group_mapping", "MUserGroupMapping"),
-    "MNotificationTemplate": ("ginkgo.data.models.model_notification_template", "MNotificationTemplate"),
-    "MNotificationRecord": ("ginkgo.data.models.model_notification_record", "MNotificationRecord"),
-    "MNotificationRecipient": ("ginkgo.data.models.model_notification_recipient", "MNotificationRecipient"),
-    "MBacktestLog": ("ginkgo.data.models.model_logs", "MBacktestLog"),
-    "MComponentLog": ("ginkgo.data.models.model_logs", "MComponentLog"),
-    "MPerformanceLog": ("ginkgo.data.models.model_logs", "MPerformanceLog"),
-    "MValidationResult": ("ginkgo.data.models.model_validation_result", "MValidationResult"),
-}
+# 注意：这里使用 eager import 而非框架其他地方采用的懒加载（PEP 562）。
+# 原因：SQLAlchemy 的 relationship() 使用字符串引用目标类（如 "MUserCredential"），
+# 在 mapper 配置阶段需要所有引用的类已在同一个 registry 中。
+# 懒加载会导致只加载单个模型时，其 relationship 目标类不在 registry 中，
+# 从而抛出 InvalidRequestError。
+# ORM 模型类只是声明式定义，import 时不连接数据库，开销可忽略。
 
-
-def __getattr__(name):
-    if name in _LAZY_IMPORTS:
-        import importlib
-
-        module_path, attr_name = _LAZY_IMPORTS[name]
-        module = importlib.import_module(module_path)
-        return getattr(module, attr_name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(_LAZY_IMPORTS.keys() | set(globals().keys()))
-
+from ginkgo.data.models.model_adjustfactor import MAdjustfactor
+from ginkgo.data.models.model_analyzer_record import MAnalyzerRecord
+from ginkgo.data.models.model_backtest_record_base import MBacktestRecordBase
+from ginkgo.data.models.model_backtest_task import MBacktestTask
+from ginkgo.data.models.model_bar import MBar
+from ginkgo.data.models.model_capital_adjustment import MCapitalAdjustment
+from ginkgo.data.models.model_clickbase import MClickBase
+from ginkgo.data.models.model_engine import MEngine
+from ginkgo.data.models.model_engine_handler_mapping import MEngineHandlerMapping
+from ginkgo.data.models.model_engine_portfolio_mapping import MEnginePortfolioMapping
+from ginkgo.data.models.model_factor import MFactor
+from ginkgo.data.models.model_file import MFile
+from ginkgo.data.models.model_handler import MHandler
+from ginkgo.data.models.model_param import MParam
+from ginkgo.data.models.model_mysqlbase import MMysqlBase
+from ginkgo.data.models.model_mongobase import MMongoBase
+from ginkgo.data.models.model_order import MOrder
+from ginkgo.data.models.model_order_record import MOrderRecord
+from ginkgo.data.models.model_portfolio import MPortfolio
+from ginkgo.data.models.model_portfolio_file_mapping import MPortfolioFileMapping
+from ginkgo.data.models.model_position import MPosition
+from ginkgo.data.models.model_position_record import MPositionRecord
+from ginkgo.data.models.model_signal import MSignal
+from ginkgo.data.models.model_stock_info import MStockInfo
+from ginkgo.data.models.model_live_account import MLiveAccount
+from ginkgo.data.models.model_broker_instance import MBrokerInstance
+from ginkgo.data.models.model_trade_record import MTradeRecord
+from ginkgo.data.models.model_tick import MTick
+from ginkgo.data.models.model_tick_summary import MTickSummary
+from ginkgo.data.models.model_trade_day import MTradeDay
+from ginkgo.data.models.model_transfer import MTransfer
+from ginkgo.data.models.model_transfer_record import MTransferRecord
+from ginkgo.data.models.model_run_record import MRunRecord
+from ginkgo.data.models.model_user import MUser
+from ginkgo.data.models.model_user_contact import MUserContact
+from ginkgo.data.models.model_deployment import MDeployment
+from ginkgo.data.models.model_user_credential import MUserCredential
+from ginkgo.data.models.model_user_group import MUserGroup
+from ginkgo.data.models.model_user_group_mapping import MUserGroupMapping
+from ginkgo.data.models.model_notification_template import MNotificationTemplate
+from ginkgo.data.models.model_notification_record import MNotificationRecord
+from ginkgo.data.models.model_notification_recipient import MNotificationRecipient
+from ginkgo.data.models.model_logs import MBacktestLog, MComponentLog, MPerformanceLog
+from ginkgo.data.models.model_validation_result import MValidationResult
 
 __all__ = [
     "MAdjustfactor",
@@ -110,10 +97,8 @@ __all__ = [
     "MNotificationTemplate",
     "MNotificationRecord",
     "MNotificationRecipient",
-    # 日志系统模型 (011-distributed-logging)
     "MBacktestLog",
     "MComponentLog",
     "MPerformanceLog",
-    # 验证系统模型
     "MValidationResult",
 ]


### PR DESCRIPTION
## Summary
- `models/__init__.py` 懒加载导致 SQLAlchemy `relationship()` 字符串引用的目标类不在 registry，触发 `InvalidRequestError`
- 改为 eager import，注释说明原因

## Before / After
```
Before: ginkgo portfolio list → InvalidRequestError: MUserCredential failed to locate
After:  ginkgo portfolio list → 正常输出
```

## Test plan
- [x] `ginkgo portfolio list` 正常
- [x] mapper relationship 解析通过

Closes #3614, #3626

🤖 Generated with [Claude Code](https://claude.com/claude-code)