### PR TITLE
docs: 补充 models 包 eager import 例外说明 (#3830)

### DIFF
--- a/src/ginkgo/data/__init__.py
+++ b/src/ginkgo/data/__init__.py
@@ -2,6 +2,7 @@
 # Downstream: containers(Container), seeding(数据初始化), utils(get_crud)
 # Role: 数据层包入口，暴露依赖注入容器container和工具函数，统一数据访问入口
 # See #2715: 聚合导入改为 __getattr__ 懒加载，打断全量模块加载链
+# 注意: models/ 包因 SQLAlchemy relationship() 要求使用 eager import，是唯一的例外
 
 
 
@@ -26,7 +27,7 @@ Available services:
 - container.component_service() - 组件实例化服务
 """
 
-# See #2715: 懒加载注册表，避免 import 时触发全量加载
+# See #2715: 懒加载注册表，避免 import 时触发全量加载（models/ 包除外，见该目录注释）
 _LAZY_IMPORTS = {
     "container": ("ginkgo.data.containers", "container"),
     "seeding": ("ginkgo.data.seeding", None),

--- a/src/ginkgo/data/crud/__init__.py
+++ b/src/ginkgo/data/crud/__init__.py
@@ -2,7 +2,7 @@
 # Downstream: BaseCRUD, ClickHouse/MySQL/MongoDB/Redis数据库模型
 # Role: CRUD包入口，统一导出全部CRUD类(BarCRUD、OrderCRUD、PortfolioCRUD等40+个)，供服务层和容器注册使用
 
-# See #2715: PEP 562 懒加载
+# See #2715: PEP 562 懒加载（models/ 包除外，见该目录注释）
 _LAZY_IMPORTS = {
     "AdjustfactorCRUD": ("ginkgo.data.crud.adjustfactor_crud", "AdjustfactorCRUD"),
     "AnalyzerRecordCRUD": ("ginkgo.data.crud.analyzer_record_crud", "AnalyzerRecordCRUD"),

--- a/src/ginkgo/data/drivers/__init__.py
+++ b/src/ginkgo/data/drivers/__init__.py
@@ -2,6 +2,7 @@
 # Downstream: GinkgoClickhouse, GinkgoMysql, GinkgoMongo, GinkgoRedis, DatabaseDriverBase
 # Role: 数据库驱动包入口，导出四大驱动类并定义熔断器(CircuitBreaker)防止级联故障
 # See #2715: 聚合导入改为 __getattr__ 懒加载，打断全量模块加载链
+# 注意: models/ 包因 SQLAlchemy relationship() 要求使用 eager import，是唯一的例外
 
 
 
@@ -21,7 +22,7 @@ from ginkgo.data.drivers.ginkgo_mysql import GinkgoMysql
 from ginkgo.data.drivers.ginkgo_redis import GinkgoRedis
 from ginkgo.libs import GLOG
 
-# See #2715: PEP 562 懒加载 — 只在访问时才导入这些重量级模块
+# See #2715: PEP 562 懒加载 — 只在访问时才导入这些重量级模块（models/ 包除外）
 def __getattr__(name):
     _lazy = {
         "GinkgoProducer": ("ginkgo.data.drivers.ginkgo_kafka", "GinkgoProducer"),

--- a/src/ginkgo/data/services/__init__.py
+++ b/src/ginkgo/data/services/__init__.py
@@ -17,7 +17,7 @@ Architecture:
 # Core classes — kept as direct imports (lightweight base classes used everywhere)
 from ginkgo.data.services.base_service import BaseService, ServiceResult
 
-# See #2715: PEP 562 懒加载
+# See #2715: PEP 562 懒加载（models/ 包除外，见该目录注释）
 _LAZY_IMPORTS = {
     "AdjustfactorService": ("ginkgo.data.services.adjustfactor_service", "AdjustfactorService"),
     "BacktestTaskService": ("ginkgo.data.services.backtest_task_service", "BacktestTaskService"),

--- a/src/ginkgo/data/sources/__init__.py
+++ b/src/ginkgo/data/sources/__init__.py
@@ -2,7 +2,7 @@
 # Downstream: GinkgoTushare, GinkgoAkShare, GinkgoBaoStock, GinkgoTDX, GinkgoYahoo
 # Role: 数据源包入口，统一导出所有外部数据源适配器(Tushare/AKShare/BaoStock/TDX/Yahoo)
 
-# See #2715: PEP 562 懒加载
+# See #2715: PEP 562 懒加载（models/ 包除外，见该目录注释）
 _LAZY_IMPORTS = {
     "GinkgoAkShare": ("ginkgo.data.sources.ginkgo_akshare", "GinkgoAkShare"),
     "GinkgoBaoStock": ("ginkgo.data.sources.ginkgo_baostock", "GinkgoBaoStock"),


### PR DESCRIPTION
## Summary
在 5 个文件的 #2715 懒加载注释旁补充 models 包例外说明，避免后续开发者误以为所有包都应使用懒加载。

## Changes
- src/ginkgo/data/__init__.py (2处)
- src/ginkgo/data/services/__init__.py
- src/ginkgo/data/drivers/__init__.py (2处)
- src/ginkgo/data/sources/__init__.py
- src/ginkgo/data/crud/__init__.py

Closes #3830

🤖 Generated with [Claude Code](https://claude.com/claude-code)