### PR TITLE
fix(#3835): mypy python_version 3.8→3.12 与 requires-python 对齐

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ extend-exclude = '''
 '''
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true


### PR DESCRIPTION
## Summary
- `pyproject.toml` mypy `python_version` 从 `"3.8"` 改为 `"3.12"`，与 `requires-python = ">=3.11"` 对齐
- 修复 mypy 无法检查 3.9+ 类型特性（联合类型 `X|Y`、`match/case`、`ParamSpec` 等）导致的误报

Closes #3835

## Test plan
- [ ] 确认 `pyproject.toml` 中 `python_version` 为 `"3.12"`
- [ ] 运行 `mypy` 检查，确认不再对 3.10+ 语法产生版本相关误报

🤖 Generated with [Claude Code](https://claude.com/claude-code)