### PR TITLE
fix(#3847): rate_limit.py 内存泄漏修复

### DIFF
--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -5,10 +5,13 @@
 from fastapi import Request, HTTPException, status
 from starlette.middleware.base import BaseHTTPMiddleware
 from typing import Dict
-from collections import defaultdict
 import time
 
 from core.logging import logger
+
+# Issue #3847: 防止 IP 记录无限累积
+_MAX_IPS = 10000
+_FULL_CLEANUP_INTERVAL = 1000
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
@@ -18,14 +21,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.max_requests = max_requests
         self.window_seconds = window_seconds
-        # 存储每个IP的请求记录 {ip: [(timestamp, count), ...]}
-        self.requests: Dict[str, list] = defaultdict(list)
+        self.requests: Dict[str, list] = {}
+        self._request_count = 0
 
     async def dispatch(self, request: Request, call_next):
-        # 获取客户端IP
         client_ip = self.get_client_ip(request)
 
-        # 检查是否超过限制
         if self.is_rate_limited(client_ip):
             logger.warning(f"Rate limit exceeded for {client_ip}")
             raise HTTPException(
@@ -33,60 +34,61 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 detail="Too many requests"
             )
 
-        # 记录请求
         self.record_request(client_ip)
+        self._cleanup_current_ip(client_ip)
 
-        # 清理过期记录
-        self.cleanup_old_requests()
+        self._request_count += 1
+        if self._request_count % _FULL_CLEANUP_INTERVAL == 0:
+            self._full_cleanup()
 
         return await call_next(request)
 
     def get_client_ip(self, request: Request) -> str:
-        """获取客户端IP"""
-        # 尝试从 X-Forwarded-For 获取
         forwarded = request.headers.get("X-Forwarded-For")
         if forwarded:
             return forwarded.split(",")[0].strip()
 
-        # 尝试从 X-Real-IP 获取
         real_ip = request.headers.get("X-Real-IP")
         if real_ip:
             return real_ip
 
-        # 使用客户端地址
         if request.client:
             return request.client.host
 
         return "unknown"
 
     def is_rate_limited(self, client_ip: str) -> bool:
-        """检查是否超过限流"""
         now = time.time()
         window_start = now - self.window_seconds
-
-        # 获取时间窗口内的请求数
-        requests_in_window = [
-            ts for ts in self.requests[client_ip]
-            if ts > window_start
-        ]
-
-        return len(requests_in_window) >= self.max_requests
+        records = self.requests.get(client_ip)
+        if not records:
+            return False
+        return sum(1 for ts in records if ts > window_start) >= self.max_requests
 
     def record_request(self, client_ip: str):
-        """记录请求"""
+        if client_ip not in self.requests:
+            if len(self.requests) >= _MAX_IPS:
+                self._full_cleanup()
+            self.requests[client_ip] = []
         self.requests[client_ip].append(time.time())
 
-    def cleanup_old_requests(self):
-        """清理过期请求记录"""
+    def _cleanup_current_ip(self, client_ip: str):
+        """清理当前 IP 的过期记录"""
+        records = self.requests.get(client_ip)
+        if not records:
+            return
+        window_start = time.time() - self.window_seconds
+        self.requests[client_ip] = [ts for ts in records if ts > window_start]
+        if not self.requests[client_ip]:
+            del self.requests[client_ip]
+
+    def _full_cleanup(self):
+        """全量清理所有 IP 的过期记录"""
         now = time.time()
         window_start = now - self.window_seconds
-
-        for ip in list(self.requests.keys()):
-            self.requests[ip] = [
-                ts for ts in self.requests[ip]
-                if ts > window_start
-            ]
-
-            # 如果没有记录了，删除该IP
-            if not self.requests[ip]:
-                del self.requests[ip]
+        expired = [
+            ip for ip, records in self.requests.items()
+            if not any(ts > window_start for ts in records)
+        ]
+        for ip in expired:
+            del self.requests[ip]


### PR DESCRIPTION
## Summary
- 每次请求只清理当前 IP 的过期记录，避免 O(N*M) 全量遍历
- 每 1000 次请求触发一次全量清理，移除所有过期 IP
- 新增 `max_ips=10000` 上限，超限时强制全量清理后再插入
- 移除 `defaultdict` 依赖，改用普通 dict 精确控制生命周期

Closes #3847

## Test plan
- [ ] 高并发场景下 `self.requests` 内存不再无限增长
- [ ] 限流功能正常（单 IP 窗口内超限返回 429）
- [ ] 过期 IP 被正确清理

🤖 Generated with [Claude Code](https://claude.com/claude-code)