### PR TITLE
fix(#3849): 统一 tests/api/ 路径管理，消除 sys.path 冗余

### DIFF
--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Issue #3849: 统一管理 api/ 目录路径，避免各测试文件重复 sys.path.insert
+api_dir = Path(__file__).parent.parent.parent / "api"
+api_str = str(api_dir)
+if api_str not in sys.path:
+    sys.path.insert(0, api_str)

--- a/tests/api/test_deployment_api.py
+++ b/tests/api/test_deployment_api.py
@@ -1,11 +1,5 @@
 import pytest
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-# Add api directory to path for imports
-api_path = Path(__file__).parent.parent.parent / "api"
-sys.path.insert(0, str(api_path))
 
 
 def test_update_saga_rejects_frozen_portfolio():

--- a/tests/api/test_saga_integration.py
+++ b/tests/api/test_saga_integration.py
@@ -7,11 +7,11 @@ Saga 事务管理器集成测试
 import sys
 from pathlib import Path
 
-# 添加项目路径
-current_dir = Path(__file__).parent
-project_root = current_dir.parent
-sys.path.insert(0, str(current_dir))  # 添加 apiserver 目录
-sys.path.insert(0, str(project_root / "src"))  # 添加 ginkgo 源码目录
+# 添加 ginkgo 源码目录
+src_dir = Path(__file__).parent.parent.parent / "src"
+src_str = str(src_dir)
+if src_str not in sys.path:
+    sys.path.insert(0, src_str)
 
 
 def test_saga_step_creation():


### PR DESCRIPTION
## Summary
- 新增 `tests/api/conftest.py` 统一管理 `api/` 目录路径
- `test_deployment_api.py`: 移除重复的 `sys.path.insert`
- `test_saga_integration.py`: 移除 `api/` 的 `sys.path.insert`（改由 conftest 处理），保留 `src/` 路径
- `pyproject.toml` 中 `pythonpath = [".", "src"]` 不含 `"api"`，已无需修改

Closes #3849

## Test plan
- [ ] `pytest tests/api/ --co` 收集测试无导入错误
- [ ] `test_deployment_api.py` 和 `test_saga_transaction.py` 正常运行

🤖 Generated with [Claude Code](https://claude.com/claude-code)