### PR TITLE
fix(#3844): mixin 链统一以 Base 结尾兜底，修复 ContextMixin TypeError

### DIFF
--- a/src/ginkgo/trading/bases/base_broker.py
+++ b/src/ginkgo/trading/bases/base_broker.py
@@ -19,12 +19,13 @@ from typing import Optional, Dict, Any
 
 from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
+from ginkgo.entities.base import Base
 from ginkgo.entities import Position
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.libs import GLOG
 
 
-class BaseBroker(TimeMixin, ContextMixin):
+class BaseBroker(TimeMixin, ContextMixin, Base):
     """
     Broker基础类
 
@@ -39,14 +40,14 @@ class BaseBroker(TimeMixin, ContextMixin):
     - LiveBroker: SDK管理订单状态，不需要本地队列
     """
 
-    def __init__(self, name: str = "BaseBroker"):
+    def __init__(self, name: str = "BaseBroker", *args, **kwargs):
         """
         初始化Broker基础功能
 
         Args:
             name: Broker名称
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         # 设置名称
         self._broker_name = name

--- a/src/ginkgo/trading/bases/base_trade_gateway.py
+++ b/src/ginkgo/trading/bases/base_trade_gateway.py
@@ -18,10 +18,11 @@ from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
 from ginkgo.trading.mixins.order_management_mixin import OrderManagementMixin
 from ginkgo.entities.mixins import EngineBindableMixin
+from ginkgo.entities.base import Base
 from ginkgo.libs import GLOG
 
 
-class BaseTradeGateway(TimeMixin, ContextMixin, OrderManagementMixin, EngineBindableMixin):
+class BaseTradeGateway(TimeMixin, ContextMixin, OrderManagementMixin, EngineBindableMixin, Base):
     """
     TradeGateway基础类
 
@@ -33,14 +34,14 @@ class BaseTradeGateway(TimeMixin, ContextMixin, OrderManagementMixin, EngineBind
     子类继承后只需要专注于具体的路由逻辑。
     """
 
-    def __init__(self, name: str = "BaseTradeGateway"):
+    def __init__(self, name: str = "BaseTradeGateway", *args, **kwargs):
         """
         初始化TradeGateway基础功能
 
         Args:
             name: TradeGateway名称
         """
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         # 设置名称
         self._gateway_name = name

--- a/src/ginkgo/trading/events/base_event.py
+++ b/src/ginkgo/trading/events/base_event.py
@@ -22,9 +22,10 @@ from ginkgo.enums import EVENT_TYPES, SOURCE_TYPES
 from ginkgo.libs import base_repr, datetime_normalize
 from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
+from ginkgo.entities.base import Base
 
 
-class EventBase(TimeMixin, ContextMixin, metaclass=ABCMeta):
+class EventBase(TimeMixin, ContextMixin, Base, metaclass=ABCMeta):
     """
     事件基类
 

--- a/src/ginkgo/trading/mixins/order_management_mixin.py
+++ b/src/ginkgo/trading/mixins/order_management_mixin.py
@@ -29,9 +29,9 @@ class OrderManagementMixin:
     不涉及任何数据库操作，纯内存操作以保证性能。
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         """初始化订单管理数据结构"""
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
         # 待处理订单队列 - 按照FIFO顺序处理
         self._pending_orders: List[Order] = []

--- a/tests/unit/core/test_mixin_chain_sink.py
+++ b/tests/unit/core/test_mixin_chain_sink.py
@@ -1,0 +1,53 @@
+# #3844: ContextMixin.__init__ 调用签名错误导致 TypeError
+# 验证所有 mixin 链末端都有 Base 兜底，未知 kwargs 不会导致 object.__init__() 报错
+import pytest
+
+from ginkgo.trading.events.base_event import EventBase
+from ginkgo.trading.events.price_update import EventPriceUpdate
+from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.bases.base_trade_gateway import BaseTradeGateway
+from ginkgo.entities.base import Base
+
+
+class TestMixinChainSink:
+    """Mixin 链末端兜底：所有使用 mixin 的类都应以 Base 结尾，不让 mixin 直接碰到 object"""
+
+    def test_eventbase_has_base_in_mro(self):
+        """EventBase 的 MRO 中应包含 Base"""
+        assert Base in EventBase.__mro__
+
+    def test_base_broker_has_base_in_mro(self):
+        """BaseBroker 的 MRO 中应包含 Base"""
+        assert Base in BaseBroker.__mro__
+
+    def test_base_trade_gateway_has_base_in_mro(self):
+        """BaseTradeGateway 的 MRO 中应包含 Base"""
+        assert Base in BaseTradeGateway.__mro__
+
+    def test_eventbase_with_unknown_kwargs_no_error(self):
+        """EventBase 子类传入未知 kwargs 不应 TypeError"""
+        # timestamp 是 TimeMixin 的 property，不是 __init__ 参数
+        # 以前会流到 object.__init__() 导致 TypeError
+        e = EventPriceUpdate(timestamp="2024-01-01")
+        assert e is not None
+
+    def test_eventbase_with_multiple_unknown_kwargs(self):
+        """多个未知 kwargs 也不报错"""
+        e = EventPriceUpdate(timestamp="2024-01-01", code="000001.SZ", extra=42)
+        assert e is not None
+
+    def test_base_broker_with_unknown_kwargs(self):
+        """BaseBroker 传入未知 kwargs 不应 TypeError"""
+        b = BaseBroker(name="test", extra_param="value")
+        assert b is not None
+
+    def test_base_trade_gateway_with_unknown_kwargs(self):
+        """BaseTradeGateway 传入未知 kwargs 不应 TypeError"""
+        g = BaseTradeGateway(name="test", extra_param="value")
+        assert g is not None
+
+    def test_eventbase_normal_init_still_works(self):
+        """EventBase 正常初始化仍可用"""
+        e = EventPriceUpdate()
+        assert e._uuid is not None
+        assert isinstance(e._uuid, str)


### PR DESCRIPTION
## Summary

- EventBase/BaseBroker/BaseTradeGateway 的 mixin 链末端直接是 `object`，未消费的 kwargs（如 `timestamp=`）流到 `object.__init__()` 导致 TypeError（约 120+ 测试失败）
- 在三个类的继承链末尾加 `Base` 作为 sink，`Base.__init__` 调用 `super().__init__()` 不转发 kwargs，吸收所有残余参数
- 统一 `BaseBroker`、`BaseTradeGateway`、`OrderManagementMixin` 的 `__init__` 签名接受 `*args/**kwargs`，支持协作继承转发

## 架构原则

所有 mixin 链都以 `Base` 结尾，不让任何 mixin 直接碰到 `object`。每个 `__init__` 接受并转发 `*args/**kwargs`，由 `Base` 做最终兜底。

## 变更文件

| 文件 | 改动 |
|------|------|
| `trading/events/base_event.py` | `EventBase(TimeMixin, ContextMixin, Base, metaclass=ABCMeta)` |
| `trading/bases/base_broker.py` | `BaseBroker(TimeMixin, ContextMixin, Base)` + `*args, **kwargs` |
| `trading/bases/base_trade_gateway.py` | `BaseTradeGateway(..., Base)` + `*args, **kwargs` |
| `trading/mixins/order_management_mixin.py` | `__init__` 加 `*args, **kwargs` |

## Test plan

- [x] 新增 `tests/unit/core/test_mixin_chain_sink.py`：8 个测试覆盖 MRO 检查和未知 kwargs
- [x] 原始 issue 中 41 个失败测试全部通过（`test_engine_mode_management.py`）
- [ ] 运行更广范围的测试确认无回归

Closes #3844

🤖 Generated with [Claude Code](https://claude.com/claude-code)