### PR TITLE
fix(#3880): 数据库驱动层 models eager import guard

### DIFF
--- a/src/ginkgo/data/drivers/ginkgo_clickhouse.py
+++ b/src/ginkgo/data/drivers/ginkgo_clickhouse.py
@@ -14,6 +14,9 @@ from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.libs.utils.health_check import check_clickhouse_ready
 from ginkgo.data.drivers.base_driver import DatabaseDriverBase
 
+# 确保所有 ORM 模型在 mapper 配置前加载（#3880）
+import ginkgo.data.models  # noqa: F401
+
 
 class GinkgoClickhouse(DatabaseDriverBase):
     """ClickHouse数据库驱动 - 继承DatabaseDriverBase"""

--- a/src/ginkgo/data/drivers/ginkgo_mysql.py
+++ b/src/ginkgo/data/drivers/ginkgo_mysql.py
@@ -15,6 +15,11 @@ from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.libs.utils.health_check import check_mysql_ready
 from ginkgo.data.drivers.base_driver import DatabaseDriverBase
 
+# 确保所有 ORM 模型在 mapper 配置前加载（#3880）
+# SQLAlchemy 的 relationship() 使用字符串引用，mapper 配置时需要目标类已在 registry 中。
+# 此 import 触发 models/__init__.py 的 eager import，保证所有模型就绪。
+import ginkgo.data.models  # noqa: F401
+
 
 class GinkgoMysql(DatabaseDriverBase):
     """MySQL数据库驱动 - 继承DatabaseDriverBase"""


### PR DESCRIPTION
## Summary
- 在 MySQL/ClickHouse 驱动层顶部添加 `import ginkgo.data.models`，确保所有 ORM 模型在 SQLAlchemy mapper 配置前已加载
- 根因：117 处直接 import model 文件绕过 `models/__init__.py` 的 eager import，间歇性导致 `relationship("MUserCredential")` 找不到目标类

## Test plan
- [x] `ginkgo backtest list` 正常
- [x] `ginkgo portfolio list` 正常
- [x] User CRUD（涉及 MUser→MUserCredential relationship）正常
- [x] MUser mapper relationships 配置完整

🤖 Generated with [Claude Code](https://claude.com/claude-code)