### PR TITLE
fix(#3886): 创建缺失的 MUserCredential model/CRUD，修复 NotificationWorker 测试

### DIFF
--- a/src/ginkgo/data/crud/user_credential_crud.py
+++ b/src/ginkgo/data/crud/user_credential_crud.py
@@ -1,0 +1,70 @@
+# Upstream: UserService (用户管理业务服务)
+# Downstream: BaseCRUD (继承提供标准CRUD能力和装饰器)、MUserCredential (MySQL凭据模型)
+# Role: UserCredentialCRUD凭据CRUD操作继承BaseCRUD提供用户凭据管理功能
+
+
+from typing import List, Optional, Any, Dict
+
+from ginkgo.data.crud.base_crud import BaseCRUD
+from ginkgo.data.models import MUserCredential
+from ginkgo.enums import SOURCE_TYPES
+from ginkgo.data.access_control import restrict_crud_access
+
+
+@restrict_crud_access
+class UserCredentialCRUD(BaseCRUD[MUserCredential]):
+
+    _model_class = MUserCredential
+
+    def __init__(self):
+        super().__init__(MUserCredential)
+
+    def _get_enum_mappings(self) -> Dict[str, Any]:
+        return {
+            'source': SOURCE_TYPES,
+        }
+
+    def _get_field_config(self) -> dict:
+        return {
+            'user_id': {
+                'type': 'string',
+                'min': 1,
+                'max': 32
+            },
+            'password_hash': {
+                'type': 'string',
+                'min': 0,
+                'max': 256
+            },
+            'is_active': {
+                'type': 'boolean'
+            },
+            'is_admin': {
+                'type': 'boolean'
+            }
+        }
+
+    def _create_from_params(self, **kwargs) -> MUserCredential:
+        if 'user_id' not in kwargs:
+            raise ValueError("user_id 是必填参数")
+
+        return MUserCredential(
+            user_id=kwargs["user_id"],
+            password_hash=kwargs.get("password_hash", ""),
+            is_active=kwargs.get("is_active", True),
+            is_admin=kwargs.get("is_admin", False),
+            source=SOURCE_TYPES.validate_input(kwargs.get("source", SOURCE_TYPES.OTHER)),
+        )
+
+    def _convert_input_item(self, item: Any) -> Optional[MUserCredential]:
+        return None
+
+    def _convert_models_to_business_objects(self, models: List) -> List:
+        return models
+
+    def _convert_output_items(self, items: List[MUserCredential], output_type: str = "model") -> List[Any]:
+        return items
+
+    def get_by_user_id(self, user_id: str) -> Optional[MUserCredential]:
+        results = self.find(filters={"user_id": user_id})
+        return results[0] if results else None

--- a/src/ginkgo/data/models/model_user_credential.py
+++ b/src/ginkgo/data/models/model_user_credential.py
@@ -1,0 +1,69 @@
+# Upstream: UserService (用户管理业务逻辑)、UserCredentialCRUD (凭据数据CRUD操作)
+# Downstream: MMysqlBase (继承提供MySQL ORM能力)、ModelConversion (提供实体转换能力)
+# Role: MUserCredential用户凭据模型继承MMysqlBase定义凭据核心字段(user_id/password_hash/is_active/is_admin)支持用户认证功能
+
+
+import datetime
+
+from typing import Optional
+from sqlalchemy import String, Boolean, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ginkgo.data.models.model_mysqlbase import MMysqlBase
+from ginkgo.data.crud.model_conversion import ModelConversion
+from ginkgo.enums import SOURCE_TYPES
+
+
+class MUserCredential(MMysqlBase, ModelConversion):
+    """
+    用户凭据模型
+
+    存储用户登录凭证（密码哈希等），与 MUser 一对一关系。
+
+    Attributes:
+        uuid: 凭据唯一标识
+        user_id: 关联的用户UUID（外键）
+        password_hash: 密码哈希值
+        is_active: 凭据是否启用
+        is_admin: 是否管理员
+    """
+    __abstract__ = False
+    __tablename__ = "user_credentials"
+
+    # 外键和核心字段
+    user_id: Mapped[str] = mapped_column(String(32), ForeignKey("users.uuid"), nullable=False, unique=True, index=True)
+    password_hash: Mapped[str] = mapped_column(String(256), nullable=False, default="")
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    is_admin: Mapped[bool] = mapped_column(Boolean, default=False)
+
+    # 关系映射
+    user = relationship("MUser", back_populates="credential")
+
+    def __init__(
+        self,
+        user_id: Optional[str] = None,
+        password_hash: Optional[str] = None,
+        is_active: Optional[bool] = None,
+        is_admin: Optional[bool] = None,
+        source=None,
+        **kwargs
+    ):
+        super().__init__(**kwargs)
+
+        if user_id is None:
+            raise ValueError("user_id is required")
+
+        self.user_id = user_id
+        self.password_hash = password_hash or ""
+        self.is_active = is_active if is_active is not None else True
+        self.is_admin = is_admin if is_admin is not None else False
+
+        if source is not None:
+            self.source = SOURCE_TYPES.validate_input(source) or SOURCE_TYPES.OTHER.value
+        else:
+            self.source = SOURCE_TYPES.OTHER.value
+
+    def __repr__(self) -> str:
+        status = "Active" if self.is_active else "Disabled"
+        role = "Admin" if self.is_admin else "User"
+        return f"<MUserCredential(uuid={self.uuid[:8]}..., user_id={self.user_id[:8]}..., {status}, {role})>"

--- a/tests/unit/notifier/workers/test_notification_worker.py
+++ b/tests/unit/notifier/workers/test_notification_worker.py
@@ -35,15 +35,12 @@ class TestNotificationWorkerInit:
     def test_init_default(self):
         """测试默认初始化"""
         notification_service = Mock()
-        record_crud = Mock()
 
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         assert worker.notification_service == notification_service
-        assert worker.record_crud == record_crud
         assert worker._group_id == "notification_worker_group"
         assert worker.status == WorkerStatus.STOPPED
         assert worker.is_running is False
@@ -51,11 +48,9 @@ class TestNotificationWorkerInit:
     def test_init_with_group_id(self):
         """测试使用自定义 group_id"""
         notification_service = Mock()
-        record_crud = Mock()
 
         worker = NotificationWorker(
             notification_service=notification_service,
-            record_crud=record_crud,
             group_id="custom_group"
         )
 
@@ -64,10 +59,8 @@ class TestNotificationWorkerInit:
     def test_stats_initial(self):
         """测试初始统计信息"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         stats = worker.stats
@@ -86,7 +79,6 @@ class TestNotificationWorkerLifecycle:
     def test_start_success(self, mock_consumer_class):
         """测试成功启动 Worker"""
         notification_service = Mock()
-        record_crud = Mock()
 
         # Mock consumer
         mock_consumer = Mock()
@@ -95,8 +87,7 @@ class TestNotificationWorkerLifecycle:
         mock_consumer_class.return_value = mock_consumer
 
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         result = worker.start()
@@ -112,10 +103,8 @@ class TestNotificationWorkerLifecycle:
     def test_start_when_running(self):
         """测试重复启动"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         # 模拟正在运行
@@ -129,7 +118,6 @@ class TestNotificationWorkerLifecycle:
     def test_stop_success(self, mock_consumer_class):
         """测试成功停止 Worker"""
         notification_service = Mock()
-        record_crud = Mock()
 
         # Mock consumer
         mock_consumer = Mock()
@@ -138,8 +126,7 @@ class TestNotificationWorkerLifecycle:
         mock_consumer_class.return_value = mock_consumer
 
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
         worker.start()
 
@@ -154,10 +141,8 @@ class TestNotificationWorkerLifecycle:
     def test_stop_when_not_running(self):
         """测试停止未运行的 Worker"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         result = worker.stop()
@@ -172,10 +157,8 @@ class TestNotificationWorkerProcessMessage:
     def test_process_message_simple_success(self):
         """测试处理 simple 消息成功"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         message = {
@@ -203,10 +186,8 @@ class TestNotificationWorkerProcessMessage:
     def test_process_message_template_success(self):
         """测试处理 template 消息成功"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         message = {
@@ -233,10 +214,8 @@ class TestNotificationWorkerProcessMessage:
     def test_process_message_trading_signal(self):
         """测试处理交易信号消息"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         message = {
@@ -260,10 +239,8 @@ class TestNotificationWorkerProcessMessage:
     def test_process_message_system_notification(self):
         """测试处理系统通知消息"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         message = {
@@ -285,10 +262,8 @@ class TestNotificationWorkerProcessMessage:
     def test_process_message_invalid(self):
         """测试处理无效消息"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         message = {
@@ -308,10 +283,8 @@ class TestNotificationWorkerGroupMessaging:
     def test_process_simple_message_to_group(self):
         """测试发送 simple 消息到用户组"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         message = {
@@ -329,6 +302,7 @@ class TestNotificationWorkerGroupMessaging:
         assert result is True
         notification_service.send_to_group.assert_called_once_with(
             group_name="test_group",
+            group_uuid=None,
             content="Group test message",
             title=None,
             channels=None,
@@ -343,10 +317,8 @@ class TestNotificationWorkerHealthStatus:
     def test_get_health_status_stopped(self):
         """测试获取健康状态（已停止）"""
         notification_service = Mock()
-        record_crud = Mock()
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         status = worker.get_health_status()
@@ -359,7 +331,6 @@ class TestNotificationWorkerHealthStatus:
     def test_get_health_status_running(self, mock_consumer_class):
         """测试获取健康状态（运行中）"""
         notification_service = Mock()
-        record_crud = Mock()
 
         # Mock consumer
         mock_consumer = Mock()
@@ -368,8 +339,7 @@ class TestNotificationWorkerHealthStatus:
         mock_consumer_class.return_value = mock_consumer
 
         worker = NotificationWorker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
         worker.start()
 
@@ -392,25 +362,20 @@ class TestConvenienceFunctions:
     def test_create_notification_worker(self):
         """测试创建 Worker 便捷函数"""
         notification_service = Mock()
-        record_crud = Mock()
 
         worker = create_notification_worker(
-            notification_service=notification_service,
-            record_crud=record_crud
+            notification_service=notification_service
         )
 
         assert isinstance(worker, NotificationWorker)
         assert worker.notification_service == notification_service
-        assert worker.record_crud == record_crud
 
     def test_create_notification_worker_with_group_id(self):
         """测试创建 Worker 便捷函数（带 group_id）"""
         notification_service = Mock()
-        record_crud = Mock()
 
         worker = create_notification_worker(
             notification_service=notification_service,
-            record_crud=record_crud,
             group_id="custom_group"
         )
 


### PR DESCRIPTION
## Summary
- 创建 `model_user_credential.py`：用户凭据 Model（user_id/password_hash/is_admin），与 MUser 一对一关系
- 创建 `user_credential_crud.py`：凭据 CRUD 操作（get_by_user_id/add/modify）
- 移除测试中已废弃的 `record_crud` 参数，对齐 `NotificationWorker` 当前 `__init__` 签名
- 修复 `send_to_group` 断言新增的 `group_uuid` 参数

## 根因
巨型 commit `274b0c07` 在 `model_user.py`（relationship）和 `models/__init__.py`（import）中引用了 `MUserCredential`，但从未创建对应的 model 文件。PEP 562 lazy loading 隐藏了这个问题，PR #3825 切换 eager import 后暴露。

## Test plan
- [x] `pytest tests/unit/notifier/workers/test_notification_worker.py` — 17 passed
- [ ] 验证 `from ginkgo.data.models import MUserCredential` 可正常导入
- [ ] 验证 `from ginkgo.data.crud.user_credential_crud import UserCredentialCRUD` 可正常导入

🤖 Generated with [Claude Code](https://claude.com/claude-code)