### PR TITLE
fix(#3921): 补回 EngineService.get() 意外删除的查询行

### DIFF
--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -76,6 +76,7 @@ class EngineService(BaseService):
             filters['is_del'] = False
 
             # Execute query - always return ModelList
+            result = self._crud_repo.find(filters=filters)
 
             return ServiceResult.success(result, f"Successfully retrieved engine data")
 


### PR DESCRIPTION
## Summary

- `EngineService.get()` 方法在 c16fbb7e 重构时误删了 `result = self._crud_repo.find(...)` 查询行，导致 `result` 未定义、运行时始终 NameError
- 补回查询行（不带已废弃的 `as_dataframe` 参数）

## Test plan

- [x] `tests/unit/data/services/test_engine_service_mock.py` 40 个测试全部通过
- [ ] `test_get_exception` 断言 `"query failed" in result.error` 现在能正确匹配异常消息

Closes #3921

🤖 Generated with [Claude Code](https://claude.com/claude-code)