### PR TITLE
test(#3836): OKXBroker 单元测试 — 34 个测试 + 限价单校验 bug fix

### DIFF
--- a/src/ginkgo/trading/brokers/okx_broker.py
+++ b/src/ginkgo/trading/brokers/okx_broker.py
@@ -412,6 +412,11 @@ class OKXBroker(IBroker):
             GLOG.ERROR(f"Unsupported order type: {order.order_type}")
             return False
 
+        # 限价单必须有价格
+        if order.order_type == ORDER_TYPES.LIMITORDER and not order.price:
+            GLOG.ERROR("Limit order requires a price")
+            return False
+
         return True
 
     def submit_order_event(self, event) -> BrokerExecutionResult:

--- a/tests/unit/trading/brokers/test_okx_broker_unit.py
+++ b/tests/unit/trading/brokers/test_okx_broker_unit.py
@@ -1,0 +1,281 @@
+"""
+OKXBroker 单元测试 — 补充覆盖
+
+覆盖范围：
+- RetryConfig 配置
+- 网络错误分类 (_classify_network_error)
+- 重试判断 (_is_retryable_error)
+- 指数退避延迟 (_calculate_delay)
+- _execute_with_retry 重试逻辑
+- validate_order 订单校验
+- 错误统计 (_increment_error_count / get_error_stats)
+- WebSocket 消息处理 (_on_order_message)
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from ginkgo.trading.brokers.okx_broker import OKXBroker, RetryConfig, NetworkErrorType
+from ginkgo.trading.interfaces.broker_interface import BrokerExecutionResult
+from ginkgo.data.models.model_order import MOrder, DIRECTION_TYPES, ORDER_TYPES
+from ginkgo.enums import ORDERSTATUS_TYPES
+
+
+# ---- RetryConfig ----
+
+class TestRetryConfig:
+    def test_default_values(self):
+        config = RetryConfig()
+        assert config.max_retries == 3
+        assert config.base_delay == 1.0
+        assert config.max_delay == 60.0
+        assert config.exponential_base == 2.0
+        assert config.jitter is True
+
+    def test_custom_values(self):
+        config = RetryConfig(max_retries=5, base_delay=2.0, max_delay=30.0, exponential_base=3.0, jitter=False)
+        assert config.max_retries == 5
+        assert config.base_delay == 2.0
+        assert config.max_delay == 30.0
+        assert config.exponential_base == 3.0
+        assert config.jitter is False
+
+
+# ---- NetworkErrorType classification ----
+
+class TestClassifyNetworkError:
+    def test_ssl_handshake_timeout(self):
+        err = Exception("SSL handshake timeout")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.SSL_TIMEOUT
+
+    def test_ssl_eof(self):
+        err = Exception("SSL unexpected EOF")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.SSL_EOF
+
+    def test_connection_refused(self):
+        err = Exception("Connection refused by remote host")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.CONNECTION_REFUSED
+
+    def test_connection_reset(self):
+        err = Exception("Connection reset by peer")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.CONNECTION_RESET
+
+    def test_timeout(self):
+        err = Exception("Request timeout after 30s")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.TIMEOUT
+
+    def test_unknown_error(self):
+        err = Exception("Something unexpected happened")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.UNKNOWN
+
+    def test_case_insensitive(self):
+        err = Exception("CONNECTION REFUSED")
+        assert OKXBroker._classify_network_error(err) == NetworkErrorType.CONNECTION_REFUSED
+
+
+# ---- _is_retryable_error ----
+
+class TestIsRetryableError:
+    def test_ssl_error_retryable(self):
+        assert OKXBroker._is_retryable_error(Exception("SSL error")) is True
+
+    def test_timeout_retryable(self):
+        assert OKXBroker._is_retryable_error(Exception("Request timeout")) is True
+
+    def test_connection_error_type_retryable(self):
+        assert OKXBroker._is_retryable_error(ConnectionError("lost")) is True
+
+    def test_timeout_error_type_retryable(self):
+        assert OKXBroker._is_retryable_error(TimeoutError("timed out")) is True
+
+    def test_non_retryable(self):
+        assert OKXBroker._is_retryable_error(Exception("Invalid API key")) is False
+
+    def test_connection_reset_retryable(self):
+        assert OKXBroker._is_retryable_error(Exception("Connection reset")) is True
+
+
+# ---- _calculate_delay ----
+
+class TestCalculateDelay:
+    def test_first_attempt_no_jitter(self):
+        config = RetryConfig(base_delay=1.0, exponential_base=2.0, jitter=False)
+        delay = OKXBroker._calculate_delay(0, config)
+        assert delay == 1.0
+
+    def test_second_attempt_no_jitter(self):
+        config = RetryConfig(base_delay=1.0, exponential_base=2.0, jitter=False)
+        delay = OKXBroker._calculate_delay(1, config)
+        assert delay == 2.0
+
+    def test_third_attempt_no_jitter(self):
+        config = RetryConfig(base_delay=1.0, exponential_base=2.0, jitter=False)
+        delay = OKXBroker._calculate_delay(2, config)
+        assert delay == 4.0
+
+    def test_capped_at_max_delay(self):
+        config = RetryConfig(base_delay=1.0, exponential_base=10.0, max_delay=5.0, jitter=False)
+        delay = OKXBroker._calculate_delay(5, config)
+        assert delay == 5.0
+
+    def test_jitter_within_range(self):
+        config = RetryConfig(base_delay=1.0, exponential_base=2.0, jitter=True, max_delay=100.0)
+        delays = [OKXBroker._calculate_delay(0, config) for _ in range(100)]
+        for d in delays:
+            assert 0.8 <= d <= 1.2  # ±20% of 1.0
+
+
+# ---- _execute_with_retry ----
+
+@pytest.fixture
+def mock_encryption_service():
+    svc = Mock()
+    svc.decrypt.side_effect = lambda x: x.replace("encrypted-", "")
+    return svc
+
+
+@pytest.fixture
+def broker(mock_encryption_service):
+    with patch('ginkgo.trading.brokers.okx_broker.get_encryption_service', return_value=mock_encryption_service):
+        return OKXBroker(
+            broker_uuid="test-uuid",
+            portfolio_id="test-portfolio",
+            live_account_id="test-account",
+            api_key="encrypted-key",
+            api_secret="encrypted-secret",
+            passphrase="encrypted-pass",
+            environment="testnet",
+        )
+
+
+class TestExecuteWithRetry:
+    @patch('ginkgo.trading.brokers.okx_broker.time.sleep')
+    def test_success_first_attempt(self, mock_sleep, broker):
+        func = Mock(return_value="ok")
+        result = broker._execute_with_retry(func, operation_name="test")
+        assert result == "ok"
+        assert func.call_count == 1
+        mock_sleep.assert_not_called()
+
+    @patch('ginkgo.trading.brokers.okx_broker.time.sleep')
+    def test_retries_on_retryable_error(self, mock_sleep, broker):
+        func = Mock(side_effect=[Exception("SSL timeout"), "ok"])
+        result = broker._execute_with_retry(func, operation_name="test")
+        assert result == "ok"
+        assert func.call_count == 2
+
+    @patch('ginkgo.trading.brokers.okx_broker.time.sleep')
+    def test_raises_non_retryable_immediately(self, mock_sleep, broker):
+        func = Mock(side_effect=ValueError("bad input"))
+        with pytest.raises(ValueError, match="bad input"):
+            broker._execute_with_retry(func, operation_name="test")
+        assert func.call_count == 1
+
+    @patch('ginkgo.trading.brokers.okx_broker.time.sleep')
+    def test_raises_after_max_retries(self, mock_sleep, broker):
+        broker._retry_config = RetryConfig(max_retries=2, jitter=False)
+        func = Mock(side_effect=Exception("SSL timeout"))
+        with pytest.raises(Exception, match="SSL timeout"):
+            broker._execute_with_retry(func, operation_name="test")
+        assert func.call_count == 2
+
+
+# ---- validate_order ----
+
+class TestValidateOrder:
+    def test_reject_when_not_connected(self, broker):
+        order = Mock(spec=MOrder)
+        assert broker.validate_order(order) is False
+
+    @patch('ginkgo.trading.brokers.okx_broker.Account')
+    @patch('ginkgo.trading.brokers.okx_broker.Trade')
+    def test_accept_market_order_when_connected(self, mock_trade, mock_account, broker):
+        mock_account_inst = Mock()
+        mock_account_inst.get_account_balance.return_value = {'code': '0', 'data': []}
+        mock_account.AccountAPI.return_value = mock_account_inst
+        mock_trade.TradeAPI.return_value = Mock()
+        broker.connect()
+
+        order = Mock(spec=MOrder)
+        order.code = "BTC-USDT"
+        order.direction = DIRECTION_TYPES.LONG
+        order.volume = 0.01
+        order.order_type = ORDER_TYPES.MARKETORDER
+        assert broker.validate_order(order) is True
+
+    @patch('ginkgo.trading.brokers.okx_broker.Account')
+    @patch('ginkgo.trading.brokers.okx_broker.Trade')
+    def test_accept_limit_order_with_price(self, mock_trade, mock_account, broker):
+        mock_account_inst = Mock()
+        mock_account_inst.get_account_balance.return_value = {'code': '0', 'data': []}
+        mock_account.AccountAPI.return_value = mock_account_inst
+        mock_trade.TradeAPI.return_value = Mock()
+        broker.connect()
+
+        order = Mock(spec=MOrder)
+        order.code = "BTC-USDT"
+        order.direction = DIRECTION_TYPES.LONG
+        order.volume = 0.01
+        order.order_type = ORDER_TYPES.LIMITORDER
+        order.price = 50000.0
+        assert broker.validate_order(order) is True
+
+    @patch('ginkgo.trading.brokers.okx_broker.Account')
+    @patch('ginkgo.trading.brokers.okx_broker.Trade')
+    def test_reject_limit_order_without_price(self, mock_trade, mock_account, broker):
+        mock_account_inst = Mock()
+        mock_account_inst.get_account_balance.return_value = {'code': '0', 'data': []}
+        mock_account.AccountAPI.return_value = mock_account_inst
+        mock_trade.TradeAPI.return_value = Mock()
+        broker.connect()
+
+        order = Mock(spec=MOrder)
+        order.code = "BTC-USDT"
+        order.direction = DIRECTION_TYPES.LONG
+        order.volume = 0.01
+        order.order_type = ORDER_TYPES.LIMITORDER
+        order.price = None
+        assert broker.validate_order(order) is False
+
+
+# ---- Error stats ----
+
+class TestErrorStats:
+    def test_initial_stats_all_zero(self, broker):
+        stats = broker.get_error_stats()
+        assert all(v == 0 for v in stats.values())
+
+    def test_increment_counts(self, broker):
+        broker._increment_error_count(NetworkErrorType.SSL_TIMEOUT)
+        broker._increment_error_count(NetworkErrorType.SSL_TIMEOUT)
+        broker._increment_error_count(NetworkErrorType.TIMEOUT)
+        stats = broker.get_error_stats()
+        assert stats["ssl_timeout"] == 2
+        assert stats["timeout"] == 1
+
+    def test_get_error_stats_returns_copy(self, broker):
+        broker._increment_error_count(NetworkErrorType.CONNECTION_REFUSED)
+        stats1 = broker.get_error_stats()
+        stats1["connection_refused"] = 999
+        stats2 = broker.get_error_stats()
+        assert stats2["connection_refused"] == 1
+
+
+# ---- WebSocket message handling ----
+
+class TestOnOrderMessage:
+    def test_delegates_to_adapt_order(self, broker):
+        msg = {"arg": {"channel": "orders"}, "data": [{"ordId": "12345", "state": "filled"}]}
+        with patch('ginkgo.livecore.websocket_event_adapter.adapt_order') as mock_adapt:
+            mock_adapt.return_value = {"exchange_order_id": "12345", "status": "filled"}
+            broker._on_order_message(msg)
+            mock_adapt.assert_called_once_with(msg)
+
+    def test_returns_early_on_empty_adapt(self, broker):
+        msg = {"arg": {"channel": "orders"}, "data": []}
+        with patch('ginkgo.livecore.websocket_event_adapter.adapt_order', return_value=None):
+            broker._on_order_message(msg)
+
+    def test_handles_adapt_exception(self, broker):
+        msg = {"arg": {"channel": "orders"}, "data": [{}]}
+        with patch('ginkgo.livecore.websocket_event_adapter.adapt_order', side_effect=Exception("parse error")):
+            broker._on_order_message(msg)

--- a/tests/unit/trading/gateway/test_trade_gateway.py
+++ b/tests/unit/trading/gateway/test_trade_gateway.py
@@ -1,0 +1,314 @@
+"""
+TradeGateway 单元测试
+
+TDD 覆盖：初始化、订单路由、基础校验、同步/异步执行、超时检测
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime, timedelta
+
+from ginkgo.trading.gateway.trade_gateway import TradeGateway
+from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.entities import Order
+from ginkgo.enums import ORDERSTATUS_TYPES, DIRECTION_TYPES, ORDER_TYPES, EVENT_TYPES
+
+
+class StubBroker(BaseBroker):
+    """测试用 Broker 桩，满足 isinstance 检查"""
+    def __init__(self, market: str = "SIM"):
+        super().__init__()
+        self.market = market
+        self._result_callback = None
+        self._submit_calls = []
+        self._cancel_calls = []
+        self._connected = True
+        self._validate_ok = True
+        self._immediate = (market == "SIM")
+        self._manual_confirm = False
+
+    def set_result_callback(self, cb):
+        self._result_callback = cb
+
+    def supports_immediate_execution(self):
+        return self._immediate
+
+    def requires_manual_confirmation(self):
+        return self._manual_confirm
+
+    def validate_order(self, order):
+        return self._validate_ok
+
+    def is_connected(self):
+        return self._connected
+
+    def submit_order_event(self, event):
+        self._submit_calls.append(event)
+        return Mock(status=ORDERSTATUS_TYPES.SUBMITTED, broker_order_id="stub-123")
+
+    def cancel_order(self, broker_order_id):
+        self._cancel_calls.append(broker_order_id)
+        return Mock(status=ORDERSTATUS_TYPES.CANCELED)
+
+
+def make_mock_broker(market: str = "SIM", connected: bool = True) -> StubBroker:
+    return StubBroker(market=market)
+
+
+def make_order(code: str = "000001.SZ", direction=DIRECTION_TYPES.LONG, volume: int = 100) -> Order:
+    """创建测试订单"""
+    order = Mock(spec=Order)
+    order.uuid = "test-order-uuid-1234"
+    order.code = code
+    order.direction = direction
+    order.volume = volume
+    order.order_type = ORDER_TYPES.MARKETORDER
+    order.price = None
+    return order
+
+
+class TestTradeGatewayInit:
+    """初始化行为"""
+
+    def test_single_broker_wrapped_in_list(self):
+        broker = make_mock_broker("SIM")
+        gw = TradeGateway(brokers=broker, name="test-gw")
+        assert len(gw.brokers) == 1
+        assert gw.broker is broker
+
+    def test_multiple_brokers(self):
+        b1 = make_mock_broker("SIM")
+        b2 = make_mock_broker("A股")
+        gw = TradeGateway(brokers=[b1, b2], name="test-gw")
+        assert len(gw.brokers) == 2
+
+    def test_invalid_brokers_raises(self):
+        with pytest.raises(ValueError, match="brokers must be"):
+            TradeGateway(brokers="not_a_broker", name="test-gw")
+
+    def test_sim_broker_as_default_for_all_markets(self):
+        sim = make_mock_broker("SIM")
+        gw = TradeGateway(brokers=sim, name="test-gw")
+        assert gw._market_mapping.get("A股") is sim
+        assert gw._market_mapping.get("美股") is sim
+        assert gw._market_mapping.get("Crypto") is sim
+
+    def test_dedicated_market_takes_priority_over_sim(self):
+        sim = make_mock_broker("SIM")
+        a_stock = make_mock_broker("A股")
+        gw = TradeGateway(brokers=[sim, a_stock], name="test-gw")
+        assert gw._market_mapping["A股"] is a_stock
+        assert gw._market_mapping["美股"] is sim
+
+
+class TestGetMarketByCode:
+    """市场代码解析"""
+
+    @pytest.fixture
+    def gw(self):
+        return TradeGateway(brokers=make_mock_broker("SIM"), name="test")
+
+    def test_a_stock_sz(self, gw):
+        assert gw._get_market_by_code("000001.SZ") == "A股"
+
+    def test_a_stock_sh(self, gw):
+        assert gw._get_market_by_code("600000.SH") == "A股"
+
+    def test_hk_stock(self, gw):
+        assert gw._get_market_by_code("00700.HK") == "港股"
+
+    def test_us_stock(self, gw):
+        assert gw._get_market_by_code("AAPL") == "美股"
+
+    def test_crypto(self, gw):
+        assert gw._get_market_by_code("BTC/USDT") == "Crypto"
+
+    def test_futures(self, gw):
+        assert gw._get_market_by_code("IF2506") == "期货"
+
+    def test_empty_code_defaults_a_stock(self, gw):
+        assert gw._get_market_by_code("") == "A股"
+
+    def test_unknown_code_defaults_a_stock(self, gw):
+        assert gw._get_market_by_code("UNKNOWN") == "A股"
+
+
+class TestGetBrokerForOrder:
+    """订单路由"""
+
+    def test_routes_a_stock_to_correct_broker(self):
+        a_broker = make_mock_broker("A股")
+        gw = TradeGateway(brokers=a_broker, name="test")
+        order = make_order("000001.SZ")
+        assert gw.get_broker_for_order(order) is a_broker
+
+    def test_routes_crypto_to_correct_broker(self):
+        crypto_broker = make_mock_broker("Crypto")
+        gw = TradeGateway(brokers=crypto_broker, name="test")
+        order = make_order("BTC/USDT")
+        assert gw.get_broker_for_order(order) is crypto_broker
+
+    def test_falls_back_to_sim_broker(self):
+        sim = make_mock_broker("SIM")
+        gw = TradeGateway(brokers=sim, name="test")
+        order = make_order("000001.SZ")
+        assert gw.get_broker_for_order(order) is sim
+
+    def test_returns_none_when_no_broker_for_market(self):
+        """只有 A股 broker，但下单美股 → 无匹配"""
+        a_broker = make_mock_broker("A股")
+        gw = TradeGateway(brokers=a_broker, name="test")
+        order = make_order("AAPL")
+        assert gw.get_broker_for_order(order) is None
+
+
+class TestValidateOrderBasic:
+    """基础订单校验"""
+
+    @pytest.fixture
+    def gw(self):
+        return TradeGateway(brokers=make_mock_broker("SIM"), name="test")
+
+    def test_valid_order(self, gw):
+        order = make_order()
+        assert gw._validate_order_basic(order) is True
+
+    def test_reject_none_order(self, gw):
+        assert gw._validate_order_basic(None) is False
+
+    def test_reject_order_without_uuid(self, gw):
+        order = Mock(spec=Order)
+        del order.uuid
+        order.code = "000001.SZ"
+        order.volume = 100
+        assert gw._validate_order_basic(order) is False
+
+    def test_reject_empty_code(self, gw):
+        order = make_order()
+        order.code = ""
+        assert gw._validate_order_basic(order) is False
+
+    def test_reject_zero_volume(self, gw):
+        order = make_order()
+        order.volume = 0
+        assert gw._validate_order_basic(order) is False
+
+    def test_reject_negative_volume(self, gw):
+        order = make_order()
+        order.volume = -1
+        assert gw._validate_order_basic(order) is False
+
+
+class TestOnOrderAckSyncExecution:
+    """同步执行路径（回测模式）"""
+
+    @pytest.fixture
+    def gw(self):
+        broker = make_mock_broker("SIM")
+        gw = TradeGateway(brokers=broker, name="test")
+        gw.set_event_publisher(Mock())
+        return gw
+
+    def _make_ack_event(self, order):
+        event = Mock()
+        event.payload = order
+        event.broker_order_id = "broker-123"
+        event.ack_message = "ACK"
+        event.portfolio_id = "test-portfolio"
+        return event
+
+    def test_sync_submission_updates_order_status(self, gw):
+        order = make_order()
+        event = self._make_ack_event(order)
+        gw.on_order_ack(event)
+        assert len(gw.brokers[0]._submit_calls) == 1
+
+    def test_rejects_invalid_order(self, gw):
+        order = Mock(spec=Order)
+        order.code = ""
+        order.volume = 100
+        order.uuid = "bad-order"
+        event = self._make_ack_event(order)
+        gw.on_order_ack(event)
+        assert len(gw.brokers[0]._submit_calls) == 0
+
+    def test_rejects_when_no_broker_matches(self, gw):
+        """SIM broker 只覆盖默认市场，code 无法匹配时仍走 SIM"""
+        # 极端情况：去掉 SIM 的默认映射
+        gw._market_mapping.clear()
+        order = make_order("UNKNOWN.CODE")
+        event = self._make_ack_event(order)
+        gw.on_order_ack(event)
+        assert len(gw.brokers[0]._submit_calls) == 0
+
+
+class TestHandleAsyncResult:
+    """异步执行结果处理"""
+
+    @pytest.fixture
+    def gw(self):
+        broker = make_mock_broker("Crypto")
+        gw = TradeGateway(brokers=broker, name="test")
+        gw.set_event_publisher(Mock())
+        return gw
+
+    def test_ignores_unknown_order(self, gw):
+        result = Mock()
+        result.broker_order_id = "unknown-123"
+        result.status = ORDERSTATUS_TYPES.FILLED
+        gw._handle_async_result(result)
+        # 不应崩溃
+
+    def test_processes_filled_result(self, gw):
+        order = make_order("BTC/USDT")
+        broker = gw.brokers[0]
+        gw.track_order("broker-456", {
+            "order": order,
+            "broker": broker,
+            "submit_time": datetime.now(),
+            "execution_mode": "live",
+        })
+        result = Mock()
+        result.broker_order_id = "broker-456"
+        result.status = ORDERSTATUS_TYPES.FILLED
+        result.filled_volume = 0.01
+        result.filled_price = 50000.0
+        result.error_message = None
+        with patch.object(gw, '_handle_execution_result'):
+            gw._handle_async_result(result)
+        # 订单应从跟踪中移除
+        assert gw.get_tracked_order("broker-456") is None
+
+
+class TestCheckOrderTimeouts:
+    """超时检测"""
+
+    @pytest.fixture
+    def gw(self):
+        broker = make_mock_broker("SIM")
+        gw = TradeGateway(brokers=broker, name="test")
+        gw.set_event_publisher(Mock())
+        return gw
+
+    def test_detects_timed_out_order(self, gw):
+        order = make_order()
+        old_time = datetime.now() - timedelta(seconds=600)
+        gw.track_order("timeout-001", {
+            "order": order,
+            "broker": gw.brokers[0],
+            "submit_time": old_time,
+            "timeout_seconds": 300,
+        })
+        timed_out = gw.check_order_timeouts()
+        assert "timeout-001" in timed_out
+
+    def test_no_timeout_for_recent_order(self, gw):
+        order = make_order()
+        gw.track_order("fresh-001", {
+            "order": order,
+            "broker": gw.brokers[0],
+            "submit_time": datetime.now(),
+            "timeout_seconds": 300,
+        })
+        timed_out = gw.check_order_timeouts()
+        assert "fresh-001" not in timed_out


### PR DESCRIPTION
## Summary
- 新增 34 个 OKXBroker 单元测试，覆盖：RetryConfig、网络错误分类、重试判断、指数退避、`_execute_with_retry`、`validate_order`、错误统计、WebSocket 消息处理
- 修复 `validate_order` bug：限价单缺少价格时现在正确返回 False

## Test plan
- [x] 34 个新测试全部通过
- [x] 已有 12 个 OKXBroker 测试无回归
- [x] 全部 mock 隔离，不依赖真实 OKX API

Partially closes #3836（OKXBroker 部分）

🤖 Generated with [Claude Code](https://claude.com/claude-code)