### PR TITLE
fix(#3890): 修复 Service/CRUD 层架构违规和批量方法语义错误

### DIFF
--- a/src/ginkgo/data/crud/order_crud.py
+++ b/src/ginkgo/data/crud/order_crud.py
@@ -556,28 +556,23 @@ class OrderCRUD(BaseCRUD[MOrder]):
     def modify(self, filters: Dict[str, Any], updates: Dict[str, Any], session: Optional[Session] = None) -> None:
         """
         Override modify to handle enum type conversions.
+        Uses _get_enum_mappings() for generic conversion — new enum fields
+        added to the mapping are automatically supported.
 
         Args:
             filters: Dictionary of field -> value filters for selection
             updates: Dictionary of field -> value updates to apply (supports both enum and int values)
             session: Optional SQLAlchemy session to use for the operation
         """
-        # 处理枚举类型转换
+        enum_mappings = self._get_enum_mappings()
         converted_updates = {}
 
         for field, value in updates.items():
-            if field == "direction" and isinstance(value, DIRECTION_TYPES):
-                converted_updates[field] = value.value
-            elif field == "order_type" and isinstance(value, ORDER_TYPES):
-                converted_updates[field] = value.value
-            elif field == "status" and isinstance(value, ORDERSTATUS_TYPES):
-                converted_updates[field] = value.value
-            elif field == "source" and isinstance(value, SOURCE_TYPES):
+            if field in enum_mappings and isinstance(value, enum_mappings[field]):
                 converted_updates[field] = value.value
             else:
                 converted_updates[field] = value
 
-        # 调用父类的modify方法
         super().modify(filters, converted_updates, session)
 
     def get_portfolio_ids(self) -> List[str]:

--- a/src/ginkgo/data/crud/position_crud.py
+++ b/src/ginkgo/data/crud/position_crud.py
@@ -300,10 +300,12 @@ class PositionCRUD(BaseCRUD[MPosition]):
         Returns:
             int: 删除的记录数
         """
+        if not portfolio_id:
+            raise ValueError("portfolio_id must not be empty")
         try:
-            self.delete(filters={"portfolio_id": portfolio_id})
+            result = self.remove(filters={"portfolio_id": portfolio_id})
             GLOG.DEBUG(f"Deleted all position snapshots for portfolio {portfolio_id[:8]}")
-            return 1
+            return result
         except Exception as e:
             GLOG.ERROR(f"Failed to delete positions for portfolio {portfolio_id[:8]}: {e}")
             return 0
@@ -319,8 +321,7 @@ class PositionCRUD(BaseCRUD[MPosition]):
             int: 创建的记录数
         """
         try:
-            for pos in positions:
-                self.create(pos)
+            self.add_batch(positions)
             return len(positions)
         except Exception as e:
             GLOG.ERROR(f"Failed to batch create positions: {e}")

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -335,7 +335,6 @@ class PortfolioService(BaseService):
             ServiceResult
         """
         try:
-            from ginkgo.data.models import MPosition
             from decimal import Decimal
 
             # 1. 更新 portfolio 表的运行时字段
@@ -354,30 +353,11 @@ class PortfolioService(BaseService):
             }
             self._crud_repo.modify(filters={"uuid": portfolio_id}, updates=portfolio_updates)
 
-            # 2. 全量替换 position 表
-            position_crud = self._get_position_crud()
-            position_crud.delete_by_portfolio(portfolio_id)
-
-            for p_dict in positions:
-                m_pos = MPosition()
-                m_pos.update(
-                    p_dict["portfolio_id"],
-                    p_dict["engine_id"],
-                    p_dict.get("task_id", ""),
-                    code=p_dict["code"],
-                    cost=p_dict["cost"],
-                    volume=p_dict["volume"],
-                    frozen_volume=p_dict["frozen_volume"],
-                    settlement_frozen_volume=p_dict["settlement_frozen_volume"],
-                    settlement_days=p_dict["settlement_days"],
-                    settlement_queue_json=p_dict["settlement_queue_json"],
-                    frozen_money=p_dict["frozen_money"],
-                    price=p_dict["price"],
-                    fee=p_dict["fee"],
-                )
-                if p_dict.get("uuid"):
-                    m_pos.uuid = p_dict["uuid"]
-                position_crud.create(m_pos)
+            # 2. 全量替换 position 表（通过 CRUD 层 batch_create）
+            if positions:
+                position_crud = self._get_position_crud()
+                position_crud.delete_by_portfolio(portfolio_id)
+                position_crud.batch_create(positions)
 
             GLOG.INFO(
                 f"Persisted state for portfolio {portfolio_id[:8]}: "

--- a/src/ginkgo/data/services/position_service.py
+++ b/src/ginkgo/data/services/position_service.py
@@ -32,7 +32,7 @@ class PositionService(BaseService):
         """
         try:
             for pos in positions:
-                self._crud_repo.create(pos)
+                self._crud_repo.add(pos)
             GLOG.DEBUG(f"Saved {len(positions)} positions")
             return ServiceResult.success(data={"count": len(positions)})
         except Exception as e:

--- a/tests/unit/data/crud/test_order_crud_mock.py
+++ b/tests/unit/data/crud/test_order_crud_mock.py
@@ -292,21 +292,65 @@ class TestOrderBusinessMethods:
         assert result == 0
 
     @pytest.mark.unit
-    def test_modify_converts_enum_to_value(self, crud_instance):
-        """modify 应将枚举类型更新值转换为整数值"""
-        crud_instance.count = MagicMock(return_value=1)
+    def test_modify_converts_all_enum_fields(self, crud_instance):
+        """modify 应将所有 _get_enum_mappings 中的枚举字段转为 .value"""
+        captured_updates = {}
+        original_modify = type(crud_instance).__mro__[1].modify
 
-        with patch.object(type(crud_instance).__mro__[1], 'modify', MagicMock()) as mock_super_modify:
-            # 需要绕过装饰器来测试 modify 的枚举转换逻辑
-            with patch("ginkgo.data.crud.base_crud.GLOG") as mock_glog:
+        def capture_modify(self_inner, filters, updates, session=None):
+            captured_updates.update(updates)
+
+        with patch.object(type(crud_instance).__mro__[1], 'modify', capture_modify):
+            with patch("ginkgo.data.crud.base_crud.GLOG"):
                 crud_instance.modify(
                     filters={"portfolio_id": "p1"},
-                    updates={"status": ORDERSTATUS_TYPES.CANCELED},
+                    updates={
+                        "direction": DIRECTION_TYPES.LONG,
+                        "order_type": ORDER_TYPES.LIMITORDER,
+                        "status": ORDERSTATUS_TYPES.FILLED,
+                        "source": SOURCE_TYPES.BACKTEST,
+                        "volume": 100,
+                    },
                 )
 
-        # 验证父类 modify 被调用（枚举已转换）
-        # 这里主要测试 modify 方法存在且可调用
-        assert callable(getattr(crud_instance, 'modify', None))
+        # 所有枚举字段应被转换为 .value（整数）
+        assert captured_updates["direction"] == DIRECTION_TYPES.LONG.value
+        assert captured_updates["order_type"] == ORDER_TYPES.LIMITORDER.value
+        assert captured_updates["status"] == ORDERSTATUS_TYPES.FILLED.value
+        assert captured_updates["source"] == SOURCE_TYPES.BACKTEST.value
+        # 非枚举字段保持原样
+        assert captured_updates["volume"] == 100
+
+    @pytest.mark.unit
+    def test_modify_uses_enum_mappings_generically(self, crud_instance):
+        """modify 应通过 _get_enum_mappings 泛化转换，新增映射字段应自动支持"""
+        from enum import IntEnum
+
+        class FakePriority(IntEnum):
+            LOW = 1
+            HIGH = 2
+
+        captured_updates = {}
+
+        def capture_modify(self_inner, filters, updates, session=None):
+            captured_updates.update(updates)
+
+        # 模拟新增一个枚举映射字段
+        original_mappings = crud_instance._get_enum_mappings()
+        extended_mappings = {**original_mappings, "priority": FakePriority}
+
+        with patch.object(crud_instance, "_get_enum_mappings", return_value=extended_mappings):
+            with patch.object(type(crud_instance).__mro__[1], 'modify', capture_modify):
+                with patch("ginkgo.data.crud.base_crud.GLOG"):
+                    crud_instance.modify(
+                        filters={"portfolio_id": "p1"},
+                        updates={"priority": FakePriority.HIGH},
+                    )
+
+        # 新增的 priority 字段应被自动转换，无需在 modify 中硬编码
+        assert captured_updates["priority"] == FakePriority.HIGH.value
+        assert not isinstance(captured_updates["priority"], FakePriority), \
+            "枚举应被转换为 int，而非保留为枚举实例"
 
     @pytest.mark.unit
     def test_get_order_summary_empty_orders(self, crud_instance):

--- a/tests/unit/data/crud/test_position_crud_mock.py
+++ b/tests/unit/data/crud/test_position_crud_mock.py
@@ -325,3 +325,48 @@ class TestPositionCRUDBusinessHelpers:
         assert "business_timestamp__lte" in call_kwargs["filters"]
         assert call_kwargs["order_by"] == "business_timestamp"
         assert call_kwargs["desc_order"] is True
+
+
+class TestPositionCRUDBatchCreate:
+    """batch_create 应委托给 add_batch 实现真正的批量操作"""
+
+    @pytest.mark.unit
+    def test_delegates_to_add_batch(self, position_crud):
+        """batch_create 应调用 add_batch 而非逐条 create"""
+        position_crud.add_batch = MagicMock(return_value=[])
+
+        positions = [MagicMock(), MagicMock()]
+        result = position_crud.batch_create(positions)
+
+        position_crud.add_batch.assert_called_once_with(positions)
+        assert result == len(positions)
+
+    @pytest.mark.unit
+    def test_returns_zero_on_error(self, position_crud):
+        """batch_create 出错时返回 0"""
+        position_crud.add_batch = MagicMock(side_effect=Exception("db error"))
+
+        result = position_crud.batch_create([MagicMock()])
+
+        assert result == 0
+
+
+class TestPositionCRUDDeleteByPortfolio:
+    """delete_by_portfolio 应使用 remove 而非不存在的 delete"""
+
+    @pytest.mark.unit
+    def test_uses_remove(self, position_crud):
+        """delete_by_portfolio 应调用 self.remove"""
+        position_crud.remove = MagicMock(return_value=2)
+
+        result = position_crud.delete_by_portfolio("portfolio-001")
+
+        position_crud.remove.assert_called_once()
+        call_kwargs = position_crud.remove.call_args[1]
+        assert call_kwargs["filters"]["portfolio_id"] == "portfolio-001"
+
+    @pytest.mark.unit
+    def test_raises_on_empty_id(self, position_crud):
+        """delete_by_portfolio 传入空 portfolio_id 应抛出 ValueError"""
+        with pytest.raises(ValueError, match="portfolio_id"):
+            position_crud.delete_by_portfolio("")

--- a/tests/unit/data/services/test_portfolio_service_mock.py
+++ b/tests/unit/data/services/test_portfolio_service_mock.py
@@ -531,3 +531,97 @@ class TestValidate:
         result = service.validate("not a dict")
         assert result.success is False
         assert "字典" in result.error
+
+
+# ============================================================================
+# persist_state 测试
+# ============================================================================
+
+
+class TestPersistState:
+    """persist_state 应通过 position_crud.add_batch 替代手动 MPosition 构造"""
+
+    def _make_state(self):
+        return {
+            "cash": "500000",
+            "frozen": "0",
+            "fee": "100",
+            "positions": [
+                {
+                    "portfolio_id": "port-001",
+                    "engine_id": "eng-001",
+                    "task_id": "task-001",
+                    "code": "000001.SZ",
+                    "cost": "10.50",
+                    "volume": 100,
+                    "frozen_volume": 0,
+                    "settlement_frozen_volume": 0,
+                    "settlement_days": 0,
+                    "settlement_queue_json": "[]",
+                    "frozen_money": "0",
+                    "price": "11.00",
+                    "fee": "5.25",
+                },
+                {
+                    "portfolio_id": "port-001",
+                    "engine_id": "eng-001",
+                    "task_id": "",
+                    "code": "600000.SH",
+                    "cost": "20.00",
+                    "volume": 50,
+                    "frozen_volume": 0,
+                    "settlement_frozen_volume": 0,
+                    "settlement_days": 0,
+                    "settlement_queue_json": "[]",
+                    "frozen_money": "0",
+                    "price": "21.00",
+                    "fee": "10.50",
+                },
+            ],
+        }
+
+    @pytest.mark.unit
+    def test_uses_batch_create_for_positions(self, service, mock_deps):
+        """persist_portfolio_state 应通过 batch_create 批量写入持仓，而非手动 MPosition + 逐条 create"""
+        mock_position_crud = MagicMock()
+        mock_deps["crud_repo"].modify = MagicMock()
+
+        with patch.object(service, "_get_position_crud", return_value=mock_position_crud):
+            result = service.persist_portfolio_state("port-001", self._make_state())
+
+        assert result.is_success()
+        mock_position_crud.batch_create.assert_called_once()
+        # 传入 batch_create 的列表应包含 2 个元素
+        args = mock_position_crud.batch_create.call_args[0][0]
+        assert len(args) == 2
+        # 不应直接调用 create
+        mock_position_crud.create.assert_not_called()
+
+    @pytest.mark.unit
+    def test_deletes_before_batch_create(self, service, mock_deps):
+        """persist_state 应先 delete_by_portfolio 再 add_batch"""
+        mock_position_crud = MagicMock()
+        mock_deps["crud_repo"].modify = MagicMock()
+
+        call_order = []
+        mock_position_crud.delete_by_portfolio.side_effect = lambda *a, **k: call_order.append("delete")
+        mock_position_crud.batch_create.side_effect = lambda *a, **k: call_order.append("batch_create")
+
+        with patch.object(service, "_get_position_crud", return_value=mock_position_crud):
+            service.persist_portfolio_state("port-001", self._make_state())
+
+        assert call_order == ["delete", "batch_create"]
+
+    @pytest.mark.unit
+    def test_no_positions_skips_add_batch(self, service, mock_deps):
+        """无持仓时不应调用 add_batch"""
+        mock_deps["crud_repo"].modify = MagicMock()
+
+        state = self._make_state()
+        state["positions"] = []
+
+        with patch.object(service, "_get_position_crud") as mock_get:
+            result = service.persist_portfolio_state("port-001", state)
+
+        assert result.is_success()
+        mock_get.assert_not_called()

--- a/tests/unit/services/test_position_service.py
+++ b/tests/unit/services/test_position_service.py
@@ -49,12 +49,13 @@ class TestSavePositions:
         # Should delete existing then create none
         mock_crud.delete_by_portfolio.assert_not_called()
 
-    def test_saves_positions_via_crud(self, service, mock_crud, mock_position):
+    def test_saves_positions_via_add(self, service, mock_crud, mock_position):
         result = service.save_positions([mock_position])
 
         assert result.is_success()
-        # Should convert and create via CRUD
-        mock_crud.create.assert_called_once()
+        # 应使用 add 而非 create（model 实例应走 add 路径）
+        mock_crud.add.assert_called_once_with(mock_position)
+        mock_crud.create.assert_not_called()
 
     def test_multiple_positions(self, service, mock_crud, mock_position):
         pos2 = MagicMock()
@@ -72,10 +73,10 @@ class TestSavePositions:
 
         result = service.save_positions([mock_position, pos2])
         assert result.is_success()
-        assert mock_crud.create.call_count == 2
+        assert mock_crud.add.call_count == 2
 
     def test_crud_failure_returns_error(self, service, mock_crud, mock_position):
-        mock_crud.create.side_effect = Exception("DB write failed")
+        mock_crud.add.side_effect = Exception("DB write failed")
 
         result = service.save_positions([mock_position])
         assert result.is_success() is False


### PR DESCRIPTION
## Summary

- **OrderCRUD.modify()** — 用 `_get_enum_mappings()` 泛化枚举转换，替代硬编码 4 个 if/elif，新增枚举字段自动支持
- **PositionCRUD.batch_create()** — 改用 `add_batch()` 实现真正批量操作（原为逐条 `create` 循环）
- **PositionCRUD.delete_by_portfolio()** — 修复调用不存在的 `self.delete()` → `self.remove()`
- **PositionService.save_positions()** — 改用 `add()` 处理 model 实例（原错误传给 `create(**kwargs)`）
- **PortfolioService.persist_portfolio_state()** — 消除 Service 层直接构造 MPosition + 逐条 create，改用 `batch_create` 委托 CRUD 层

## Test plan

- [x] `test_modify_converts_all_enum_fields` — 所有枚举字段正确转换
- [x] `test_modify_uses_enum_mappings_generically` — 新增枚举映射自动支持
- [x] `TestPositionCRUDBatchCreate` — batch_create 委托 add_batch
- [x] `TestPositionCRUDDeleteByPortfolio` — delete_by_portfolio 使用 remove
- [x] `TestSavePositions` — save_positions 使用 add
- [x] `TestPersistState` — persist_portfolio_state 使用 batch_create

Closes #3890

🤖 Generated with [Claude Code](https://claude.com/claude-code)