### PR TITLE
fix: MUserCredential 添加 update() 方法重写 (#3895)

### DIFF
--- a/src/ginkgo/data/models/model_user_credential.py
+++ b/src/ginkgo/data/models/model_user_credential.py
@@ -6,6 +6,8 @@
 import datetime
 
 from typing import Optional
+
+import pandas as pd
 from sqlalchemy import String, Boolean, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -62,6 +64,60 @@ class MUserCredential(MMysqlBase, ModelConversion):
             self.source = SOURCE_TYPES.validate_input(source) or SOURCE_TYPES.OTHER.value
         else:
             self.source = SOURCE_TYPES.OTHER.value
+
+    def update(self, *args, **kwargs) -> None:
+        """更新凭据信息 - 支持关键字参数、字符串位置参数和 pd.Series"""
+        if not args and kwargs:
+            self._update_from_kwargs(**kwargs)
+        elif args:
+            self._update_dispatch(args[0], *args[1:], **kwargs)
+        else:
+            raise NotImplementedError("Unsupported type for update")
+
+    def _update_dispatch(self, first_arg, *args, **kwargs) -> None:
+        if isinstance(first_arg, str):
+            self._update_from_str(first_arg, *args, **kwargs)
+        elif isinstance(first_arg, pd.Series):
+            self._update_from_series(first_arg, *args, **kwargs)
+        else:
+            raise NotImplementedError(f"Unsupported type for update: {type(first_arg)}")
+
+    def _update_from_kwargs(self, password_hash=None, is_active=None, is_admin=None, source=None, **kwargs) -> None:
+        if password_hash is not None:
+            self.password_hash = password_hash
+        if is_active is not None:
+            self.is_active = is_active
+        if is_admin is not None:
+            self.is_admin = is_admin
+        if source is not None:
+            validated = SOURCE_TYPES.validate_input(source)
+            self.source = validated if validated is not None else self.source
+        self.update_at = datetime.datetime.now()
+
+    def _update_from_str(self, password_hash=None, is_active=None, is_admin=None, source=None, *args, **kwargs) -> None:
+        if password_hash is not None:
+            self.password_hash = password_hash
+        if is_active is not None:
+            self.is_active = is_active
+        if is_admin is not None:
+            self.is_admin = is_admin
+        if source is not None:
+            validated = SOURCE_TYPES.validate_input(source)
+            self.source = validated if validated is not None else self.source
+        self.update_at = datetime.datetime.now()
+
+    def _update_from_series(self, series: pd.Series, *args, **kwargs) -> None:
+        if 'password_hash' in series.index and pd.notna(series['password_hash']):
+            self.password_hash = str(series['password_hash'])
+        if 'is_active' in series.index and pd.notna(series['is_active']):
+            self.is_active = bool(series['is_active'])
+        if 'is_admin' in series.index and pd.notna(series['is_admin']):
+            self.is_admin = bool(series['is_admin'])
+        if 'source' in series.index and pd.notna(series['source']):
+            validated = SOURCE_TYPES.validate_input(series['source'])
+            if validated is not None:
+                self.source = validated
+        self.update_at = datetime.datetime.now()
 
     def __repr__(self) -> str:
         status = "Active" if self.is_active else "Disabled"

--- a/tests/unit/data/models/test_user_credential_model.py
+++ b/tests/unit/data/models/test_user_credential_model.py
@@ -1,0 +1,75 @@
+# #3895 MUserCredential.update() TDD tests
+import datetime
+
+import pytest
+
+from ginkgo.data.models.model_user_credential import MUserCredential
+
+
+class TestMUserCredentialUpdate:
+    """MUserCredential.update() 行为测试 — #3895"""
+
+    def _make(self, **overrides):
+        defaults = dict(user_id="user-001", password_hash="h1")
+        defaults.update(overrides)
+        return MUserCredential(**defaults)
+
+    # --- kwargs 更新 ---
+
+    def test_update_password_hash_via_kwargs(self):
+        cred = self._make()
+        cred.update(password_hash="new_hash")
+        assert cred.password_hash == "new_hash"
+
+    def test_update_is_active_via_kwargs(self):
+        cred = self._make()
+        cred.update(is_active=False)
+        assert cred.is_active is False
+
+    def test_update_is_admin_via_kwargs(self):
+        cred = self._make()
+        cred.update(is_admin=True)
+        assert cred.is_admin is True
+
+    def test_update_multiple_fields_via_kwargs(self):
+        cred = self._make()
+        cred.update(password_hash="h2", is_active=False, is_admin=True)
+        assert cred.password_hash == "h2"
+        assert cred.is_active is False
+        assert cred.is_admin is True
+
+    # --- update_at 刷新 ---
+
+    def test_update_refreshes_update_at(self):
+        cred = self._make()
+        before = cred.update_at
+        cred.update(password_hash="h3")
+        assert cred.update_at > before
+
+    # --- pd.Series 更新 ---
+
+    def test_update_from_series(self):
+        import pandas as pd
+
+        cred = self._make()
+        series = pd.Series({
+            "password_hash": "series_hash",
+            "is_active": False,
+            "is_admin": True,
+        })
+        cred.update(series)
+        assert cred.password_hash == "series_hash"
+        assert cred.is_active is False
+        assert cred.is_admin is True
+
+    # --- 错误处理 ---
+
+    def test_update_no_args_raises(self):
+        cred = self._make()
+        with pytest.raises(NotImplementedError):
+            cred.update()
+
+    def test_update_unsupported_type_raises(self):
+        cred = self._make()
+        with pytest.raises(NotImplementedError):
+            cred.update(12345)


### PR DESCRIPTION
## Summary
- 为 `MUserCredential` 添加 `update()` 方法重写，修复调用时触发 `NotImplementedError` 的问题
- 参考 `MUser.update()` 模式，支持 kwargs、字符串位置参数、pd.Series 三种调用方式
- 可更新字段：`password_hash`、`is_active`、`is_admin`、`source`

## Test plan
- [x] 8 个单元测试全部通过（kwargs 更新、update_at 刷新、Series 更新、错误处理）
- [x] `pytest tests/unit/data/models/test_user_credential_model.py -v` → 8 passed

Closes #3895

🤖 Generated with [Claude Code](https://claude.com/claude-code)