### PR TITLE
fix: 空桩数据源改为显式 NotImplementedError (#3819)

### DIFF
--- a/src/ginkgo/data/sources/ginkgo_akshare.py
+++ b/src/ginkgo/data/sources/ginkgo_akshare.py
@@ -13,11 +13,11 @@ from ginkgo.data.sources.source_base import GinkgoSourceBase
 
 class GinkgoAkShare(GinkgoSourceBase):
     def connect(self, *args, **kwargs):
-        pass
+        raise NotImplementedError("GinkgoAkShare 尚未实现")
 
     def fetch_cn_stock_trade_day(self, *args, **kwargs) -> pd.DataFrame:
-        pass
+        raise NotImplementedError("GinkgoAkShare 尚未实现")
 
     def fetch_cn_stock_list(self, date: any, *args, **kwargs):
-        pass
+        raise NotImplementedError("GinkgoAkShare 尚未实现")
 

--- a/src/ginkgo/data/sources/ginkgo_tushare.py
+++ b/src/ginkgo/data/sources/ginkgo_tushare.py
@@ -189,7 +189,7 @@ class GinkgoTushare(GinkgoSourceBase):
     def fetch_cn_stock_min(
         self, code: str, start_date: any = GCONF.DEFAULTSTART, end_date: any = GCONF.DEFAULTEND, *args, **kwargs
     ) -> pd.DataFrame:
-        pass
+        raise NotImplementedError("fetch_cn_stock_min 尚未实现，请使用其他数据源获取分钟级数据")
 
     def _calculate_optimal_window_size(self, total_days: int) -> int:
         """

--- a/src/ginkgo/data/sources/ginkgo_yahoo.py
+++ b/src/ginkgo/data/sources/ginkgo_yahoo.py
@@ -11,5 +11,21 @@ from ginkgo.data.sources.source_base import GinkgoSourceBase
 
 
 class GinkgoYahoo(GinkgoSourceBase):
-    pass
+    def connect(self, *args, **kwargs):
+        raise NotImplementedError("GinkgoYahoo 尚未实现")
+
+    def fetch_cn_stock_trade_day(self, *args, **kwargs):
+        raise NotImplementedError("GinkgoYahoo 尚未实现")
+
+    def fetch_cn_stock_list(self, date: any, *args, **kwargs):
+        raise NotImplementedError("GinkgoYahoo 尚未实现")
+
+    def fetch_cn_stock_daybar(self, *args, **kwargs):
+        raise NotImplementedError("GinkgoYahoo 尚未实现")
+
+    def fetch_cn_stock_adjustfactor(self, *args, **kwargs):
+        raise NotImplementedError("GinkgoYahoo 尚未实现")
+
+    def fetch_cn_stockinfo(self, *args, **kwargs):
+        raise NotImplementedError("GinkgoYahoo 尚未实现")
 

--- a/tests/unit/data/test_source_akshare.py
+++ b/tests/unit/data/test_source_akshare.py
@@ -55,16 +55,13 @@ class AkShareTest(unittest.TestCase):
         """
         ak = GinkgoAkShare()
 
-        # 验证connect方法存在且已实现
+        # 验证connect方法存在且可调用
         self.assertTrue(hasattr(ak, "connect"), "必须有connect方法")
         self.assertTrue(callable(getattr(ak, "connect")), "connect必须可调用")
 
-        # 验证connect方法不抛出NotImplementedError
-        try:
+        # GinkgoAkShare 尚未实现，connect 应抛出 NotImplementedError
+        with self.assertRaises(NotImplementedError):
             ak.connect()
-            print(":white_check_mark: GinkgoAkShare.connect() 已正确实现")
-        except NotImplementedError:
-            self.fail("GinkgoAkShare.connect() 未实现，所有子类必须实现抽象方法")
 
         # 验证数据获取方法存在
         available_data_methods = [
@@ -90,23 +87,9 @@ class AkShareTest(unittest.TestCase):
         """
         ak = GinkgoAkShare()
 
-        try:
-            result = ak.connect()
-            # 如果connect成功执行，验证返回值和状态
-            if result is not None:
-                self.assertIsInstance(result, (bool, object), "connect返回值类型应该合理")
-
-            # 验证连接后状态
-            if hasattr(ak, "client"):
-                # client可以是None或者实际的客户端对象
-                pass  # 这里允许任何状态，因为具体实现可能不同
-
-        except NotImplementedError:
-            # 如果抛出NotImplementedError，说明还未实现
-            self.fail("AkShare的connect方法尚未实现。请实现connect方法后再运行测试。")
-        except Exception as e:
-            # 其他异常可能是实现错误
-            self.fail(f"connect方法实现有误，抛出异常: {type(e).__name__}: {e}")
+        # GinkgoAkShare.connect() 尚未实现，应抛出 NotImplementedError
+        with self.assertRaises(NotImplementedError):
+            ak.connect()
 
     def test_AkShare_DataMethodsImplementation(self):
         """测试数据获取方法实现


### PR DESCRIPTION
## Summary

将数据源模块中的空桩 `pass` 改为 `raise NotImplementedError`，调用方会收到明确错误而非静默返回空值。

- **ginkgo_tushare.py**: `fetch_cn_stock_min` — 1 个方法
- **ginkgo_akshare.py**: `connect`/`fetch_cn_stock_trade_day`/`fetch_cn_stock_list` — 3 个方法
- **ginkgo_yahoo.py**: 整个类从 `pass` 改为 6 个显式方法

## Test plan

- [x] `GinkgoAkShare().connect()` → raises `NotImplementedError`
- [x] `GinkgoYahoo().connect()` → raises `NotImplementedError`
- [x] `GinkgoTushare().fetch_cn_stock_min()` → raises `NotImplementedError`
- [x] 现有 Tushare 功能（daybar/adjustfactor/stockinfo）不受影响

Closes #3819

🤖 Generated with [Claude Code](https://claude.com/claude-code)