### PR TITLE
fix: 重写 ML 策略测试适配当前源码接口

### DIFF
--- a/tests/unit/backtest/test_ml_strategy.py
+++ b/tests/unit/backtest/test_ml_strategy.py
@@ -1,8 +1,8 @@
 """
-性能: 218MB RSS, 1.88s, 1 tests [PASS]
 ML策略单元测试
 
-测试机器学习策略基类和具体实现的功能
+测试机器学习策略基类和具体实现的功能。
+基于当前源码实际接口编写。
 """
 
 import unittest
@@ -13,418 +13,528 @@ import os
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch, MagicMock
 
-# 测试导入
-try:
-    from ginkgo.trading.strategies.ml_strategy_base import StrategyMLBase
-    from ginkgo.trading.strategies.ml_predictor import StrategyMLPredictor
-    from ginkgo.entities import Signal
-    from ginkgo.enums import DIRECTION_TYPES, SOURCE_TYPES
-    ML_STRATEGIES_AVAILABLE = True
-except ImportError as e:
-    ML_STRATEGIES_AVAILABLE = False
-    print(f"ML策略模块不可用: {e}")
+from ginkgo.trading.strategies.ml_strategy_base import StrategyMLBase
+from ginkgo.trading.strategies.ml_predictor import StrategyMLPredictor
+from ginkgo.entities import Signal
+from ginkgo.enums import DIRECTION_TYPES
 
 
-class MockModel:
-    """模拟ML模型用于测试"""
-    
+def _make_test_data(n_days=100):
+    """生成测试用 OHLCV 数据"""
+    dates = pd.date_range(start="2023-01-01", periods=n_days, freq="D")
+    np.random.seed(42)
+    base_price = 100
+    price_changes = np.random.normal(0, 0.01, n_days).cumsum()
+    prices = base_price * np.exp(price_changes)
+
+    df = pd.DataFrame(
+        {
+            "timestamp": dates,
+            "open": prices * np.random.uniform(0.995, 1.005, n_days),
+            "high": prices * np.random.uniform(1.000, 1.020, n_days),
+            "low": prices * np.random.uniform(0.980, 1.000, n_days),
+            "close": prices,
+            "volume": np.random.randint(1000000, 5000000, n_days),
+        }
+    )
+    df["high"] = np.maximum(df[["open", "close"]].max(axis=1), df["high"])
+    df["low"] = np.minimum(df[["open", "close"]].min(axis=1), df["low"])
+    return df
+
+
+class _MockModel:
+    """模拟 ML 模型"""
+
     def __init__(self, name="MockModel"):
         self.name = name
         self.is_trained = True
-        self._metadata = {
-            'name': name,
-            'model_type': 'test',
-            'feature_count': 10
-        }
-        
+        self._metadata = {"name": name, "model_type": "test", "feature_count": 10}
+
     def predict(self, X):
-        # 返回模拟预测结果
-        return pd.DataFrame(np.random.normal(0, 0.02, (len(X), 1)), columns=['prediction'])
-    
+        return pd.DataFrame(
+            np.random.normal(0, 0.02, (len(X), 1)), columns=["prediction"]
+        )
+
     def get_metadata(self):
         return self._metadata.copy()
-    
+
     @classmethod
-    def load(cls, filepath):
+    def load(cls, filepath, **kwargs):
         return cls()
 
 
-class MockEvent:
-    """模拟市场事件"""
-    
-    def __init__(self, code="000001.SZ", timestamp=None):
-        self.code = code
-        self.timestamp = timestamp or datetime.now()
-
-
-class MockFeatureProcessor:
-    """模拟特征处理器"""
-    
-    def __init__(self):
+class _MockFeatureProcessor:
+    def __init__(self, **kwargs):
         self.is_fitted = True
-        
+
     def transform(self, X):
         return X
 
 
-class MockAlphaFactors:
-    """模拟Alpha因子计算器"""
-    
+class _MockAlphaFactors:
+    def __init__(self, **kwargs):
+        pass
+
     def calculate_all_factors(self, df):
-        # 添加一些模拟因子
         result = df.copy()
-        result['ma_5'] = result['close'].rolling(5).mean()
-        result['rsi_14'] = 50 + np.random.normal(0, 10, len(result))
-        result['volatility'] = result['close'].pct_change().rolling(20).std()
+        if "close" in result.columns:
+            result["ma_5"] = result["close"].rolling(5).mean()
+            result["rsi_14"] = 50 + np.random.normal(0, 10, len(result))
+            result["volatility"] = result["close"].pct_change().rolling(20).std()
         return result
 
 
-@unittest.skipIf(not ML_STRATEGIES_AVAILABLE, "ML策略模块不可用")
+# 统一 patch 目标：源码实际导入路径
+ML_BASE_PATCHES = [
+    patch("ginkgo.trading.strategies.ml_strategy_base.BaseModel", _MockModel),
+    patch(
+        "ginkgo.trading.strategies.ml_strategy_base.FeatureProcessor",
+        _MockFeatureProcessor,
+    ),
+    patch(
+        "ginkgo.trading.strategies.ml_strategy_base.AlphaFactors", _MockAlphaFactors
+    ),
+]
+
+
+def _with_mocks(fn):
+    """装饰器：为测试方法应用 ML 模块 mock"""
+
+    def wrapper(self):
+        with ML_BASE_PATCHES[0], ML_BASE_PATCHES[1], ML_BASE_PATCHES[2]:
+            fn(self)
+
+    wrapper.__name__ = fn.__name__
+    return wrapper
+
+
 class TestStrategyMLBase(unittest.TestCase):
-    """测试ML策略基类"""
-    
+    """测试 ML 策略基类"""
+
     def setUp(self):
-        """设置测试环境"""
         self.portfolio_info = {
             "uuid": "test_portfolio",
             "now": datetime.now(),
-            "positions": {}
+            "positions": {},
         }
-        
-        self.test_event = MockEvent()
-        
-        # 创建测试数据
-        dates = pd.date_range(start='2023-01-01', end='2023-12-31', freq='D')
-        n_samples = len(dates)
-        
-        base_price = 100
-        price_changes = np.random.normal(0, 0.01, n_samples).cumsum()
-        prices = base_price * np.exp(price_changes)
-        
-        self.test_data = pd.DataFrame({
-            'timestamp': dates,
-            'open': prices * np.random.uniform(0.995, 1.005, n_samples),
-            'high': prices * np.random.uniform(1.000, 1.020, n_samples),
-            'low': prices * np.random.uniform(0.980, 1.000, n_samples),
-            'close': prices,
-            'volume': np.random.randint(1000000, 5000000, n_samples)
-        })
-        
-        # 确保价格逻辑正确
-        self.test_data['high'] = np.maximum(
-            self.test_data[['open', 'close']].max(axis=1), 
-            self.test_data['high']
-        )
-        self.test_data['low'] = np.minimum(
-            self.test_data[['open', 'close']].min(axis=1), 
-            self.test_data['low']
-        )
+        self.test_event = Mock(code="000001.SZ", timestamp=datetime.now())
+        self.test_data = _make_test_data()
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    def test_ml_strategy_initialization(self):
-        """测试ML策略初始化"""
-        strategy = StrategyMLBase(
-            name="TestMLStrategy",
-            signal_threshold=0.02,
-            enable_monitoring=True
-        )
-        
-        self.assertEqual(strategy.name, "TestMLStrategy")
-        self.assertEqual(strategy._signal_threshold, 0.02)
+    @_with_mocks
+    def test_initialization_defaults(self):
+        """测试默认参数初始化"""
+        strategy = StrategyMLBase()
+        self.assertEqual(strategy.name, "MLStrategy")
+        self.assertEqual(strategy._signal_threshold, 0.01)
         self.assertTrue(strategy._enable_monitoring)
         self.assertFalse(strategy.is_model_loaded())
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)  
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    @patch('os.path.exists')
-    def test_model_loading(self, mock_exists):
-        """测试模型加载"""
-        mock_exists.return_value = True
-        
-        strategy = StrategyMLBase(name="TestStrategy")
-        
-        # 测试成功加载
-        result = strategy.load_model("test_model.pkl")
-        self.assertTrue(result)
-        self.assertTrue(strategy.is_model_loaded())
-        
-        # 测试获取模型信息
-        model_info = strategy.get_model_info()
-        self.assertIn('name', model_info)
-        self.assertIn('model_type', model_info)
+    @_with_mocks
+    def test_initialization_custom_params(self):
+        """测试自定义参数初始化"""
+        strategy = StrategyMLBase(
+            name="CustomML",
+            signal_threshold=0.05,
+            lookback_days=120,
+            enable_monitoring=False,
+        )
+        self.assertEqual(strategy.name, "CustomML")
+        self.assertEqual(strategy._signal_threshold, 0.05)
+        self.assertEqual(strategy._lookback_days, 120)
+        self.assertFalse(strategy._enable_monitoring)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    @patch('ginkgo.data.get_bars')
-    def test_feature_extraction(self, mock_get_bars):
-        """测试特征提取"""
-        mock_get_bars.return_value = self.test_data
-        
-        strategy = StrategyMLBase(name="TestStrategy")
-        
-        # 测试特征提取
-        features = strategy.extract_features("000001.SZ", datetime.now())
-        
-        self.assertIsNotNone(features)
-        self.assertIsInstance(features, pd.DataFrame)
-        self.assertGreater(features.shape[1], self.test_data.shape[1])  # 应该有更多特征
+    @_with_mocks
+    def test_model_loading_success(self):
+        """测试模型成功加载"""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            model_path = f.name
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    @patch('os.path.exists')
-    def test_prediction(self, mock_exists):
-        """测试预测功能"""
-        mock_exists.return_value = True
-        
+        try:
+            strategy = StrategyMLBase(name="TestStrategy")
+            result = strategy.load_model(model_path)
+            self.assertTrue(result)
+            self.assertTrue(strategy.is_model_loaded())
+        finally:
+            os.unlink(model_path)
+
+    @_with_mocks
+    def test_model_loading_nonexistent_path(self):
+        """测试加载不存在的模型文件"""
         strategy = StrategyMLBase(name="TestStrategy")
-        strategy.load_model("test_model.pkl")
-        
-        # 创建测试特征数据
-        features = pd.DataFrame(np.random.random((1, 10)), columns=[f'feature_{i}' for i in range(10)])
-        
-        # 测试预测
+        result = strategy.load_model("/nonexistent/model.pkl")
+        self.assertFalse(result)
+        self.assertFalse(strategy.is_model_loaded())
+
+    @_with_mocks
+    def test_get_model_info(self):
+        """测试获取模型信息"""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            model_path = f.name
+
+        try:
+            strategy = StrategyMLBase(name="TestStrategy")
+            strategy.load_model(model_path)
+
+            info = strategy.get_model_info()
+            self.assertIn("name", info)
+            self.assertIn("model_type", info)
+            self.assertIn("feature_count", info)
+        finally:
+            os.unlink(model_path)
+
+    @_with_mocks
+    def test_predict_without_model(self):
+        """测试未加载模型时预测返回 None"""
+        strategy = StrategyMLBase(name="TestStrategy")
+        features = pd.DataFrame(np.random.random((1, 10)))
         result = strategy.predict(features, "000001.SZ")
-        
-        self.assertIsNotNone(result)
-        self.assertIn('prediction', result)
-        self.assertIn('confidence', result)
-        self.assertIn('code', result)
+        self.assertIsNone(result)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    @patch('os.path.exists')
-    def test_signal_generation(self, mock_exists):
-        """测试信号生成"""
-        mock_exists.return_value = True
-        
+    @_with_mocks
+    def test_predict_with_model(self):
+        """测试带模型的预测"""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            model_path = f.name
+
+        try:
+            strategy = StrategyMLBase(name="TestStrategy")
+            strategy.load_model(model_path)
+
+            features = pd.DataFrame(
+                np.random.random((1, 10)),
+                columns=[f"feature_{i}" for i in range(10)],
+            )
+            result = strategy.predict(features, "000001.SZ")
+            self.assertIsNotNone(result)
+            self.assertIn("prediction", result)
+            self.assertIn("confidence", result)
+            self.assertIn("code", result)
+            self.assertEqual(result["code"], "000001.SZ")
+        finally:
+            os.unlink(model_path)
+
+    @_with_mocks
+    def test_signal_generation_long(self):
+        """测试生成买入信号"""
         strategy = StrategyMLBase(name="TestStrategy", signal_threshold=0.01)
-        strategy.load_model("test_model.pkl")
-        
-        # 测试买入信号
+        # 绑定 portfolio_id 等上下文，否则 Signal 初始化会失败
+        mock_ctx = Mock(portfolio_id="test_portfolio", engine_id="test_engine", task_id="test_task")
+        strategy._context = mock_ctx
+
         prediction_result = {
-            'prediction': 0.05,  # 5% 预测收益
-            'confidence': 0.8,
-            'code': '000001.SZ'
+            "prediction": 0.05,
+            "confidence": 0.8,
+            "code": "000001.SZ",
         }
-        
         signals = strategy.generate_signals_from_prediction(
             self.portfolio_info, "000001.SZ", prediction_result
         )
-        
         self.assertGreater(len(signals), 0)
         self.assertIsInstance(signals[0], Signal)
         self.assertEqual(signals[0].direction, DIRECTION_TYPES.LONG)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
+    @_with_mocks
+    def test_signal_generation_below_threshold(self):
+        """测试低于阈值不生成信号"""
+        strategy = StrategyMLBase(name="TestStrategy", signal_threshold=0.1)
+        prediction_result = {
+            "prediction": 0.01,
+            "confidence": 0.8,
+            "code": "000001.SZ",
+        }
+        signals = strategy.generate_signals_from_prediction(
+            self.portfolio_info, "000001.SZ", prediction_result
+        )
+        self.assertEqual(len(signals), 0)
+
+    @_with_mocks
     def test_performance_monitoring(self):
         """测试性能监控"""
         strategy = StrategyMLBase(name="TestStrategy", enable_monitoring=True)
-        
-        # 添加一些预测历史
+        # 需要至少 20 条记录（含 actual_return）才能计算指标
         for i in range(25):
             strategy.update_performance_monitoring(
-                "000001.SZ", 
+                "000001.SZ",
                 np.random.normal(0, 0.02),
-                np.random.normal(0, 0.02)
+                np.random.normal(0, 0.02),
             )
-        
         metrics = strategy.get_performance_metrics()
-        
-        self.assertIn('direction_accuracy', metrics)
-        self.assertIn('information_coefficient', metrics)
-        self.assertIn('prediction_count', metrics)
+        self.assertIn("direction_accuracy", metrics)
+        self.assertIn("information_coefficient", metrics)
+        self.assertIn("prediction_count", metrics)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    @patch('ginkgo.data.get_bars')
-    @patch('os.path.exists')
-    def test_cal_method(self, mock_exists, mock_get_bars):
-        """测试主计算方法"""
-        mock_exists.return_value = True
-        mock_get_bars.return_value = self.test_data
-        
+    @_with_mocks
+    def test_performance_monitoring_disabled(self):
+        """测试禁用监控时不记录"""
+        strategy = StrategyMLBase(name="TestStrategy", enable_monitoring=False)
+        strategy.update_performance_monitoring("000001.SZ", 0.01, 0.02)
+        self.assertEqual(len(strategy._prediction_history), 0)
+
+    @_with_mocks
+    def test_extract_features_with_data(self):
+        """测试传入数据时特征提取"""
         strategy = StrategyMLBase(name="TestStrategy")
-        strategy.load_model("test_model.pkl")
-        
-        # 测试事件驱动计算
+        features = strategy.extract_features(
+            "000001.SZ", datetime.now(), history_data=self.test_data
+        )
+        self.assertIsNotNone(features)
+        self.assertIsInstance(features, pd.DataFrame)
+        # AlphaFactors 应添加额外列
+        self.assertGreater(features.shape[1], self.test_data.shape[1])
+
+    @_with_mocks
+    def test_extract_features_caching(self):
+        """测试特征缓存"""
+        strategy = StrategyMLBase(name="TestStrategy")
+        dt = datetime(2023, 6, 1)
+        # 第一次调用
+        f1 = strategy.extract_features(
+            "000001.SZ", dt, history_data=self.test_data
+        )
+        # 第二次调用（应命中缓存）
+        f2 = strategy.extract_features(
+            "000001.SZ", dt, history_data=self.test_data
+        )
+        self.assertIsNotNone(f1)
+        self.assertIsNotNone(f2)
+
+    @_with_mocks
+    def test_cal_method_no_model(self):
+        """测试未加载模型时 cal 返回空列表"""
+        strategy = StrategyMLBase(name="TestStrategy")
         signals = strategy.cal(self.portfolio_info, self.test_event)
-        
         self.assertIsInstance(signals, list)
-        # 由于是随机预测，不一定有信号，但不应该出错
+        self.assertEqual(len(signals), 0)
+
+    @_with_mocks
+    def test_cal_method_with_model(self):
+        """测试 cal 主计算方法"""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            model_path = f.name
+
+        try:
+            strategy = StrategyMLBase(name="TestStrategy")
+            strategy.load_model(model_path)
+
+            # mock data_feeder
+            strategy._data_feeder = Mock()
+            strategy._data_feeder.get_historical_data.return_value = self.test_data
+
+            signals = strategy.cal(self.portfolio_info, self.test_event)
+            self.assertIsInstance(signals, list)
+        finally:
+            os.unlink(model_path)
+
+    @_with_mocks
+    def test_set_signal_threshold(self):
+        """测试动态修改信号阈值"""
+        strategy = StrategyMLBase(name="TestStrategy")
+        strategy.set_signal_threshold(0.05)
+        self.assertEqual(strategy._signal_threshold, 0.05)
+
+    @_with_mocks
+    def test_strategy_summary(self):
+        """测试策略摘要"""
+        strategy = StrategyMLBase(name="TestStrategy")
+        summary = strategy.get_strategy_summary()
+        self.assertIn("name", summary)
+        self.assertIn("model_loaded", summary)
+        self.assertIn("signal_threshold", summary)
+        self.assertIn("performance_metrics", summary)
+
+    @_with_mocks
+    def test_reload_model(self):
+        """测试模型重载"""
+        with tempfile.NamedTemporaryFile(suffix=".pkl", delete=False) as f:
+            model_path = f.name
+
+        try:
+            strategy = StrategyMLBase(name="TestStrategy", model_path=model_path)
+            self.assertTrue(strategy.is_model_loaded())
+            result = strategy.reload_model()
+            self.assertTrue(result)
+        finally:
+            os.unlink(model_path)
+
+    @_with_mocks
+    def test_reload_model_no_path(self):
+        """测试无路径时重载失败"""
+        strategy = StrategyMLBase(name="TestStrategy")
+        result = strategy.reload_model()
+        self.assertFalse(result)
 
 
-@unittest.skipIf(not ML_STRATEGIES_AVAILABLE, "ML策略模块不可用")
 class TestStrategyMLPredictor(unittest.TestCase):
-    """测试ML预测策略"""
-    
+    """测试 ML 预测策略"""
+
     def setUp(self):
-        """设置测试环境"""
         self.portfolio_info = {
             "uuid": "test_portfolio",
             "now": datetime.now(),
-            "positions": {}
+            "positions": {},
         }
-        
-        self.test_event = MockEvent()
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    def test_ml_predictor_initialization(self):
-        """测试ML预测策略初始化"""
+    @_with_mocks
+    def test_initialization_defaults(self):
+        """测试默认参数初始化"""
+        strategy = StrategyMLPredictor()
+        self.assertEqual(strategy.name, "MLPredictor")
+        self.assertEqual(strategy._prediction_horizon, 5)
+        self.assertEqual(strategy._confidence_threshold, 0.7)
+        self.assertEqual(strategy._return_threshold, 0.02)
+
+    @_with_mocks
+    def test_initialization_custom_params(self):
+        """测试自定义参数初始化"""
         strategy = StrategyMLPredictor(
-            name="TestMLPredictor",
+            name="CustomPredictor",
             prediction_horizon=10,
             confidence_threshold=0.8,
             return_threshold=0.03,
-            risk_management=True
         )
-        
-        self.assertEqual(strategy.name, "TestMLPredictor")
+        self.assertEqual(strategy.name, "CustomPredictor")
         self.assertEqual(strategy._prediction_horizon, 10)
         self.assertEqual(strategy._confidence_threshold, 0.8)
         self.assertEqual(strategy._return_threshold, 0.03)
-        self.assertTrue(strategy._risk_management)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    def test_signal_generation_with_thresholds(self):
-        """测试带阈值的信号生成"""
+    @_with_mocks
+    def test_signal_generation_high_confidence(self):
+        """测试高置信度生成买入信号"""
         strategy = StrategyMLPredictor(
             name="TestPredictor",
             confidence_threshold=0.7,
-            return_threshold=0.02
+            return_threshold=0.02,
         )
-        
-        # 测试高置信度、高收益预测
+        mock_ctx = Mock(portfolio_id="test_portfolio", engine_id="test_engine", task_id="test_task")
+        strategy._context = mock_ctx
+
         prediction_result = {
-            'prediction': 0.05,  # 5% 预测收益
-            'confidence': 0.9,   # 90% 置信度
-            'code': '000001.SZ'
+            "prediction": 0.05,
+            "confidence": 0.9,
+            "code": "000001.SZ",
         }
-        
         signals = strategy.generate_signals_from_prediction(
             self.portfolio_info, "000001.SZ", prediction_result
         )
-        
         self.assertGreater(len(signals), 0)
         self.assertEqual(signals[0].direction, DIRECTION_TYPES.LONG)
-        
-        # 测试低置信度情况
-        prediction_result['confidence'] = 0.5
-        
+
+    @_with_mocks
+    def test_signal_generation_low_confidence(self):
+        """测试低置信度不生成信号"""
+        strategy = StrategyMLPredictor(
+            name="TestPredictor",
+            confidence_threshold=0.7,
+            return_threshold=0.02,
+        )
+        prediction_result = {
+            "prediction": 0.05,
+            "confidence": 0.5,
+            "code": "000001.SZ",
+        }
         signals = strategy.generate_signals_from_prediction(
             self.portfolio_info, "000001.SZ", prediction_result
         )
-        
-        self.assertEqual(len(signals), 0)  # 应该没有信号
+        self.assertEqual(len(signals), 0)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    def test_risk_management(self):
-        """测试风险管理"""
+    @_with_mocks
+    def test_signal_generation_below_return_threshold(self):
+        """测试低于收益率阈值不生成信号"""
         strategy = StrategyMLPredictor(
             name="TestPredictor",
-            risk_management=True,
-            stop_loss_ratio=0.05,
-            take_profit_ratio=0.10
+            confidence_threshold=0.5,
+            return_threshold=0.05,
         )
-        
-        # 模拟持仓情况
-        strategy._entry_prices["000001.SZ"] = 100.0
-        strategy._position_directions["000001.SZ"] = DIRECTION_TYPES.LONG
-        
-        # 创建包含当前价格的投资组合信息
-        portfolio_with_position = self.portfolio_info.copy()
-        portfolio_with_position["positions"] = {
-            "000001.SZ": Mock(price=95.0, cost=100.0)  # 5% 亏损
+        prediction_result = {
+            "prediction": 0.02,
+            "confidence": 0.9,
+            "code": "000001.SZ",
         }
-        
-        # 测试止损
-        risk_signals = strategy._check_risk_management(portfolio_with_position, "000001.SZ")
-        
-        self.assertGreater(len(risk_signals), 0)
-        self.assertEqual(risk_signals[0].direction, DIRECTION_TYPES.SHORT)
-        self.assertIn("STOP_LOSS", risk_signals[0].reason)
+        signals = strategy.generate_signals_from_prediction(
+            self.portfolio_info, "000001.SZ", prediction_result
+        )
+        self.assertEqual(len(signals), 0)
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
-    def test_position_tracking(self):
-        """测试持仓跟踪"""
-        strategy = StrategyMLPredictor(name="TestPredictor")
-        
-        # 模拟进场
-        strategy._entry_prices["000001.SZ"] = 100.0
-        strategy._entry_times["000001.SZ"] = datetime.now() - timedelta(days=5)
-        strategy._position_directions["000001.SZ"] = DIRECTION_TYPES.LONG
-        
-        # 获取持仓信息
-        position_info = strategy.get_position_info()
-        
-        self.assertIn("000001.SZ", position_info)
-        self.assertEqual(position_info["000001.SZ"]["entry_price"], 100.0)
-        self.assertEqual(position_info["000001.SZ"]["direction"], DIRECTION_TYPES.LONG)
-        self.assertGreaterEqual(position_info["000001.SZ"]["duration"], 5)
+    @_with_mocks
+    def test_short_signal_with_position(self):
+        """测试持仓时生成卖出信号"""
+        portfolio_with_position = self.portfolio_info.copy()
+        portfolio_with_position["positions"] = {"000001.SZ": Mock()}
 
-    @patch('ginkgo.trading.strategies.ml_strategy_base.BaseModel', MockModel)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.FeatureProcessor', MockFeatureProcessor)
-    @patch('ginkgo.backtest.strategy.strategies.ml_strategy_base.AlphaFactors', MockAlphaFactors)
+        strategy = StrategyMLPredictor(
+            name="TestPredictor",
+            confidence_threshold=0.5,
+            return_threshold=0.02,
+        )
+        mock_ctx = Mock(portfolio_id="test_portfolio", engine_id="test_engine", task_id="test_task")
+        strategy._context = mock_ctx
+
+        prediction_result = {
+            "prediction": -0.05,
+            "confidence": 0.9,
+            "code": "000001.SZ",
+        }
+        signals = strategy.generate_signals_from_prediction(
+            portfolio_with_position, "000001.SZ", prediction_result
+        )
+        self.assertGreater(len(signals), 0)
+        self.assertEqual(signals[0].direction, DIRECTION_TYPES.SHORT)
+
+    @_with_mocks
     def test_strategy_summary(self):
-        """测试策略摘要"""
+        """测试策略摘要包含预测器特有字段"""
         strategy = StrategyMLPredictor(
             name="TestPredictor",
             prediction_horizon=5,
             confidence_threshold=0.8,
-            return_threshold=0.02
+            return_threshold=0.02,
         )
-        
         summary = strategy.get_strategy_summary()
-        
-        self.assertIn('name', summary)
-        self.assertIn('prediction_horizon', summary)
-        self.assertIn('confidence_threshold', summary)
-        self.assertIn('return_threshold', summary)
-        self.assertIn('model_loaded', summary)
-        self.assertIn('active_positions', summary)
+        self.assertIn("name", summary)
+        self.assertIn("prediction_horizon", summary)
+        self.assertEqual(summary["prediction_horizon"], 5)
+        self.assertIn("confidence_threshold", summary)
+        self.assertEqual(summary["confidence_threshold"], 0.8)
+        self.assertIn("return_threshold", summary)
+        self.assertEqual(summary["return_threshold"], 0.02)
+        self.assertIn("model_loaded", summary)
+
+    @_with_mocks
+    def test_str_representation(self):
+        """测试字符串表示"""
+        strategy = StrategyMLPredictor(name="TestPredictor")
+        s = str(strategy)
+        self.assertIn("TestPredictor", s)
+        self.assertIn("MLPredictor", s)
+
+    @_with_mocks
+    def test_short_selling_not_allowed(self):
+        """测试默认不允许做空"""
+        strategy = StrategyMLPredictor(name="TestPredictor")
+        self.assertFalse(strategy._is_short_selling_allowed())
 
 
 class TestMLStrategyIntegration(unittest.TestCase):
-    """测试ML策略集成"""
-    
+    """测试 ML 策略集成"""
+
     def test_imports(self):
         """测试模块导入"""
-        try:
-            from ginkgo.trading.strategies import ML_STRATEGIES_AVAILABLE
-            if ML_STRATEGIES_AVAILABLE:
-                from ginkgo.trading.strategies import StrategyMLBase, StrategyMLPredictor
-                self.assertIsNotNone(StrategyMLBase)
-                self.assertIsNotNone(StrategyMLPredictor)
-            else:
-                self.skipTest("ML策略模块不可用")
-        except ImportError:
-            self.skipTest("策略模块导入失败")
+        from ginkgo.trading.strategies import StrategyMLBase, StrategyMLPredictor
+
+        self.assertIsNotNone(StrategyMLBase)
+        self.assertIsNotNone(StrategyMLPredictor)
 
     def test_strategy_inheritance(self):
         """测试策略继承关系"""
-        if ML_STRATEGIES_AVAILABLE:
-            from ginkgo.trading.strategies import StrategyMLBase, StrategyMLPredictor, BaseStrategy
+        from ginkgo.trading.strategies import (
+            StrategyMLBase,
+            StrategyMLPredictor,
+            BaseStrategy,
+        )
 
-            # 检查继承关系
-            self.assertTrue(issubclass(StrategyMLBase, BaseStrategy))
-            self.assertTrue(issubclass(StrategyMLPredictor, StrategyMLBase))
+        self.assertTrue(issubclass(StrategyMLBase, BaseStrategy))
+        self.assertTrue(issubclass(StrategyMLPredictor, StrategyMLBase))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/backtest/test_ml_strategy.py
+++ b/tests/unit/backtest/test_ml_strategy.py
@@ -313,8 +313,12 @@ class TestStrategyMLBase(unittest.TestCase):
             model_path = f.name
 
         try:
-            strategy = StrategyMLBase(name="TestStrategy")
+            strategy = StrategyMLBase(name="TestStrategy", signal_threshold=0.01)
             strategy.load_model(model_path)
+
+            # 绑定上下文，否则 Signal 初始化会失败
+            mock_ctx = Mock(portfolio_id="test_portfolio", engine_id="test_engine", task_id="test_task")
+            strategy._context = mock_ctx
 
             # mock data_feeder
             strategy._data_feeder = Mock()


### PR DESCRIPTION
## Summary
- 修正 `test_ml_strategy.py` 中所有 `@patch` 路径，从旧路径 `ginkgo.backtest.strategy.strategies.ml_strategy_base` 更新为当前路径 `ginkgo.trading.strategies.ml_strategy_base`
- 删除了源码中不存在的接口测试（`_risk_management`、`_entry_prices`、`_position_directions`、`stop_loss_ratio`、`take_profit_ratio`）
- 按当前源码实际构造函数和方法签名重新设计全部 30 个测试用例
- 为信号生成测试添加 `_context` mock，解决 `Signal.__init__` 对 `portfolio_id` 的类型检查问题

## Test plan
- [x] `pytest tests/unit/backtest/test_ml_strategy.py` — 30/30 passed
- [ ] 全量单元测试确认无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)