### PR TITLE
fix: 修复33个pytest collection errors (#4080)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,6 +247,12 @@ markers = [
     "error_handling: 错误处理测试",
     "infrastructure: 基础设施测试",
     "refactor: 重构验证测试",
+    "engine: 引擎测试",
+    "time_controlled: 时间控制引擎测试",
+    "event_processing: 事件处理测试",
+    "lifecycle: 生命周期测试",
+    "clickhouse: ClickHouse数据库测试",
+    "mysql: MySQL数据库测试",
 ]
 
 # 警告过滤

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,8 +1,26 @@
+# Issue #3849 + #4080: 移除 api/ 的 sys.path.insert
+# 原实现将 api/ 目录加入 sys.path，导致 api/core/ 和 api/services/
+# 与 tests/unit/core/、tests/integration/data/services/ 产生命名空间冲突
+# （28 个 collection errors）。需要 api 模块的测试应使用 conftest fixture 延迟导入。
 import sys
 from pathlib import Path
 
-# Issue #3849: 统一管理 api/ 目录路径，避免各测试文件重复 sys.path.insert
-api_dir = Path(__file__).parent.parent.parent / "api"
-api_str = str(api_dir)
-if api_str not in sys.path:
-    sys.path.insert(0, api_str)
+import pytest
+
+
+_API_DIR = str(Path(__file__).parent.parent.parent / "api")
+
+
+@pytest.fixture(scope="session")
+def api_modules():
+    """仅在测试执行时将 api/ 临时加入 sys.path，完成后移除。
+
+    使用方式:
+        def test_something(api_modules):
+            from services.saga_transaction import SagaTransaction
+    """
+    if _API_DIR not in sys.path:
+        sys.path.insert(0, _API_DIR)
+    yield
+    if _API_DIR in sys.path:
+        sys.path.remove(_API_DIR)

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -11,7 +11,7 @@ import pytest
 _API_DIR = str(Path(__file__).parent.parent.parent / "api")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(autouse=True, scope="session")
 def api_modules():
     """仅在测试执行时将 api/ 临时加入 sys.path，完成后移除。
 

--- a/tests/api/test_saga_transaction.py
+++ b/tests/api/test_saga_transaction.py
@@ -2,13 +2,58 @@
 Saga 事务管理器测试
 
 测试 Saga 模式的事务一致性和补偿机制。
+
+Issue #4080: 使用 autouse fixture 延迟添加 api/ 到 sys.path，
+避免收集阶段 api/core/ 和 api/services/ 与 tests/unit/core/ 等产生命名空间冲突。
 """
+import sys
+from pathlib import Path
+
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime
 
-from services.saga_transaction import SagaTransaction, SagaStep, PortfolioSagaFactory
-from models.transaction import TransactionRecord
+_API_DIR = str(Path(__file__).parent.parent.parent / "api")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _setup_api_path():
+    """仅在测试执行阶段（非收集阶段）将 api/ 加入 sys.path。
+
+    session scope 确保只在 saga 测试实际运行时添加路径，
+    而在 pytest 收集其他测试文件时不会污染命名空间。
+    收集完成后执行 teardown 移除路径。
+    """
+    if _API_DIR not in sys.path:
+        sys.path.insert(0, _API_DIR)
+    yield
+    if _API_DIR in sys.path:
+        sys.path.remove(_API_DIR)
+
+
+# 延迟导入：在 fixture 执行后才能导入 api 模块
+# 模块级变量先设为 None，由 _init_api_modules fixture 在测试执行前初始化
+SagaTransaction = None
+SagaStep = None
+PortfolioSagaFactory = None
+TransactionRecord = None
+
+
+@pytest.fixture(autouse=True)
+def _init_api_modules():
+    """每个测试前确保 api 模块已导入"""
+    global SagaTransaction, SagaStep, PortfolioSagaFactory, TransactionRecord
+    if SagaTransaction is None:
+        from services.saga_transaction import (
+            SagaTransaction as _ST,
+            SagaStep as _SS,
+            PortfolioSagaFactory as _PSF,
+        )
+        from models.transaction import TransactionRecord as _TR
+        SagaTransaction = _ST
+        SagaStep = _SS
+        PortfolioSagaFactory = _PSF
+        TransactionRecord = _TR
 
 
 @pytest.mark.tdd

--- a/tests/api/test_saga_transaction.py
+++ b/tests/api/test_saga_transaction.py
@@ -3,32 +3,12 @@ Saga 事务管理器测试
 
 测试 Saga 模式的事务一致性和补偿机制。
 
-Issue #4080: 使用 autouse fixture 延迟添加 api/ 到 sys.path，
-避免收集阶段 api/core/ 和 api/services/ 与 tests/unit/core/ 等产生命名空间冲突。
+Issue #4080: 延迟导入 api 模块，避免收集阶段 api/core/ 和 api/services/
+与 tests/unit/core/ 等产生命名空间冲突。sys.path 由 conftest.py 的 api_modules fixture 管理。
 """
-import sys
-from pathlib import Path
-
 import pytest
 from unittest.mock import Mock, AsyncMock, patch
 from datetime import datetime
-
-_API_DIR = str(Path(__file__).parent.parent.parent / "api")
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _setup_api_path():
-    """仅在测试执行阶段（非收集阶段）将 api/ 加入 sys.path。
-
-    session scope 确保只在 saga 测试实际运行时添加路径，
-    而在 pytest 收集其他测试文件时不会污染命名空间。
-    收集完成后执行 teardown 移除路径。
-    """
-    if _API_DIR not in sys.path:
-        sys.path.insert(0, _API_DIR)
-    yield
-    if _API_DIR in sys.path:
-        sys.path.remove(_API_DIR)
 
 
 # 延迟导入：在 fixture 执行后才能导入 api 模块


### PR DESCRIPTION
## Summary
- 修复 pytest 全量收集时的 33 个 collection errors（根因：`sys.path` 命名空间污染 + 缺失 marker 定义）
- `api/conftest.py` 不再做模块级 `sys.path.insert`，改用 session fixture 延迟加载，避免 `api/core/` 和 `api/services/` 截胡 `tests/unit/core/` 等的包解析
- `test_saga_transaction.py` 模块级导入改为 fixture 内延迟导入
- 删除 `tests/integration/data/drivers/__init__.py`（空文件，截胡 `drivers` 模块名导致 `database/drivers/` 收集失败）
- `pyproject.toml` 添加 6 个缺失 marker：`engine`、`time_controlled`、`event_processing`、`lifecycle`、`clickhouse`、`mysql`

## 修复详情

| 错误类型 | 数量 | 修复方式 |
|----------|------|---------|
| `api/` sys.path 污染 → `ModuleNotFoundError: No module named 'core.xxx'/'services.xxx'` | 28 | 重构 api/conftest.py 和 saga 测试导入 |
| `data/drivers/__init__.py` 截胡 `drivers` 模块名 | 4 | 删除空 __init__.py |
| `engine`/`time_controlled` 等 marker 未注册 | 1 | pyproject.toml 添加 marker |

## Test plan
- [x] `python -m pytest --collect-only` → 33 errors → **0 errors**, 9364 tests collected
- [x] 分目录收集验证无回归
- [ ] 运行 `python -m pytest tests/unit/core/ tests/integration/data/services/` 验证受影响目录正常
- [ ] 运行 `python -m pytest tests/api/` 验证 saga 测试仍能通过

Closes #4080

🤖 Generated with [Claude Code](https://claude.com/claude-code)