### PR TITLE
fix: 删除 ApiKeyService 调用不存在的 CRUD 方法 (#4556)

### DIFF
--- a/src/ginkgo/data/services/api_key_service.py
+++ b/src/ginkgo/data/services/api_key_service.py
@@ -137,9 +137,6 @@ class ApiKeyService:
                     "message": "API Key not found"
                 }
 
-            # 获取账号信息
-            account = self.crud._verify_account(api_key.account_uuid)
-
             return {
                 "success": True,
                 "data": {


### PR DESCRIPTION
## Summary
- `api_key_service.py:141` 调用了 `self.crud._verify_account()`，但 `ApiKeyCRUD` 无此方法，运行时 `AttributeError`
- 该调用返回值未被后续代码使用，属于死代码，直接删除

## Test plan
- [x] `tests/unit/data/crud/test_api_key_crud_mock.py` 13 tests passed
- [x] Python 语法检查通过
- [x] grep 确认 `_verify_account` 引用已清除

Closes #4556

🤖 Generated with [Claude Code](https://claude.com/claude-code)