### PR TITLE
fix: 修复 risk_managementss 全项目拼写错误 (#4555)

### DIFF
--- a/src/ginkgo/core/interfaces/portfolio_interface.py
+++ b/src/ginkgo/core/interfaces/portfolio_interface.py
@@ -59,7 +59,7 @@ class BasePortfolio(ABC):
         self._analyzers = []
         self._sizers = []
         self._selectors = []
-        self._risk_managementss = []
+        self._risk_managements = []
         
         # 组合配置
         self._rebalance_frequency = RebalanceFrequency.DAILY
@@ -96,9 +96,9 @@ class BasePortfolio(ABC):
         return self._selectors
     
     @property
-    def risk_managementss(self) -> List[BaseRiskManagement]:
+    def risk_managements(self) -> List[BaseRiskManagement]:
         """风险管理器列表"""
-        return self._risk_managementss
+        return self._risk_managements
     
     @property
     def current_cash(self) -> float:
@@ -161,8 +161,8 @@ class BasePortfolio(ABC):
             
     def add_risk_managements(self, risk_mgmt: BaseRiskManagement) -> None:
         """添加风险管理器"""
-        if risk_mgmt not in self._risk_managementss:
-            self._risk_managementss.append(risk_mgmt)
+        if risk_mgmt not in self._risk_managements:
+            self._risk_managements.append(risk_mgmt)
     
     def set_strategy_weight(self, strategy_name: str, weight: float) -> None:
         """设置策略权重"""

--- a/src/ginkgo/data/services/file_service.py
+++ b/src/ginkgo/data/services/file_service.py
@@ -780,7 +780,7 @@ class FileService(FileSearchMixin, BaseService):
 
         file_type_map = {
             "analysis/analyzers": FILE_TYPES.ANALYZER,
-            "strategy/risk_managementss": FILE_TYPES.RISKMANAGER,
+            "strategy/risk_managements": FILE_TYPES.RISKMANAGER,
             "strategy/selectors": FILE_TYPES.SELECTOR,
             "strategy/sizers": FILE_TYPES.SIZER,
             "strategy/strategies": FILE_TYPES.STRATEGY,

--- a/src/ginkgo/libs/validators/risk_validator.py
+++ b/src/ginkgo/libs/validators/risk_validator.py
@@ -52,7 +52,7 @@ class RiskValidator(BaseValidator):
                 details=f"Must define a class that inherits from {self.required_base_class}",
                 suggestions=[
                     f"Create a class that inherits from {self.required_base_class}",
-                    "Import the base class: from ginkgo.trading.risk_managementss.base_risk import BaseRiskManagement"
+                    "Import the base class: from ginkgo.trading.risk_management.base_risk import BaseRiskManagement"
                 ]
             ))
             return results

--- a/src/ginkgo/libs/validators/validation_rules.py
+++ b/src/ginkgo/libs/validators/validation_rules.py
@@ -112,7 +112,7 @@ class ValidationRules:
             )
         ],
         'required_imports': [
-            'ginkgo.trading.risk_managementss.base_risk'
+            'ginkgo.trading.risk_management.base_risk'
         ],
         'forbidden_operations': [
             'os.system',

--- a/src/ginkgo/trading/services/component_factory_service.py
+++ b/src/ginkgo/trading/services/component_factory_service.py
@@ -61,7 +61,7 @@ class ComponentFactoryService:
             from ginkgo.trading.analysis.analyzers import BaseAnalyzer
             from ginkgo.trading.selectors import BaseSelector
             from ginkgo.trading.sizers import BaseSizer
-            from ginkgo.trading.risk_managementss import BaseRiskManagement as BaseRisk
+            from ginkgo.trading.risk_management import BaseRiskManagement as BaseRisk
 
             self._base_class_mapping = {
                 FILE_TYPES.STRATEGY: BaseStrategy,

--- a/tests/unit/core/interfaces/test_portfolio_interface.py
+++ b/tests/unit/core/interfaces/test_portfolio_interface.py
@@ -138,7 +138,7 @@ class TestBasePortfolioConstruction:
         assert portfolio.analyzers == []
         assert portfolio.sizers == []
         assert portfolio.selectors == []
-        assert portfolio.risk_managementss == []
+        assert portfolio.risk_managements == []
 
     def test_initial_cash_equals_capital(self):
         """初始现金等于初始资金"""
@@ -197,7 +197,7 @@ class TestBasePortfolioComponentManagement:
         portfolio = ConcretePortfolio()
         risk = MagicMock()
         portfolio.add_risk_managements(risk)
-        assert risk in portfolio.risk_managementss
+        assert risk in portfolio.risk_managements
 
 
 # ── BasePortfolio 策略权重测试 ─────────────────────────────────────────

--- a/tests/unit/test_risk_management_typo.py
+++ b/tests/unit/test_risk_management_typo.py
@@ -1,0 +1,17 @@
+"""Verify no risk_managementss typo in production code.
+
+# Issue #4555
+"""
+import subprocess
+
+
+def test_no_double_s_in_source():
+    """risk_managementss (double-s) must not appear in src/."""
+    result = subprocess.run(
+        ["grep", "-rn", "risk_managementss", "src/"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0, (
+        f"Found typo in source:\n{result.stdout}"
+    )


### PR DESCRIPTION
## Summary

全项目修正 `risk_managementss`（双 s）拼写错误为 `risk_management` / `risk_managements`。

- `component_factory_service.py` — 模块导入路径（运行时 `ModuleNotFoundError`）
- `portfolio_interface.py` — 属性名和属性（`_risk_managementss` → `_risk_managements`）
- `file_service.py` — 字符串键名
- `validation_rules.py` / `risk_validator.py` — 模块路径字符串

来源：PR #4553 冒烟测试 review 时发现。

## Test plan

- [x] `test_no_double_s_in_source` — grep 确认 src/ 零匹配
- [x] `test_portfolio_interface` — 50 个测试全部通过（含属性引用更新）
- [ ] 冒烟测试验证 ComponentFactoryService.initialize() 正常加载风控组件

Closes #4555

🤖 Generated with [Claude Code](https://claude.com/claude-code)