### PR TITLE
fix: 清理 smoke test 中 _verify_account 残留 mock

### DIFF
--- a/tests/unit/services/smoke/test_api_key_service_smoke.py
+++ b/tests/unit/services/smoke/test_api_key_service_smoke.py
@@ -47,7 +47,6 @@ class TestApiKeyServiceSmoke:
         mock_key.get_permissions_list.return_value = ["read"]
         mock_key.is_expired.return_value = False
         mock_crud.get_api_key_by_uuid.return_value = mock_key
-        mock_crud._verify_account.return_value = MagicMock()
         result = svc.get_api_key(uuid="u1")
         assert result is not None
         assert isinstance(result, dict)


### PR DESCRIPTION
## Summary
- 移除 `test_api_key_service_smoke.py` 中对已删除方法 `_verify_account` 的残留 mock 行
- 跟进 PR #4557 的清理工作

## Test plan
- [x] 移除一行死代码 mock，无逻辑变更

🤖 Generated with [Claude Code](https://claude.com/claude-code)