### PR TITLE
fix: LiveDataFeeder 防崩修复 — connection_manager 为 None 时不再崩溃

### DIFF
--- a/src/ginkgo/trading/feeders/live_feeder.py
+++ b/src/ginkgo/trading/feeders/live_feeder.py
@@ -493,13 +493,24 @@ class LiveDataFeeder(ILiveDataFeeder):
     
     async def _async_main(self):
         """异步主循环"""
-        # 建立连接
         self.status = DataFeedStatus.CONNECTING
-        if await self.connection_manager.connect():
+
+        # 优先使用子类的自定义连接方式（如 EastMoneyFeeder._async_connect）
+        if hasattr(self, '_async_connect'):
+            connected = await self._async_connect()
+        elif self.connection_manager is not None:
+            connected = await self.connection_manager.connect()
+        else:
+            GLOG.ERROR("No connection method available (neither _async_connect nor connection_manager)")
+            self.status = DataFeedStatus.ERROR
+            return
+
+        if connected:
             self.status = DataFeedStatus.CONNECTED
-            
-            # 启动消息接收循环
-            await self._message_loop()
+            if hasattr(self, '_async_message_loop'):
+                await self._async_message_loop()
+            elif self.connection_manager is not None:
+                await self._message_loop()
         else:
             self.status = DataFeedStatus.ERROR
     


### PR DESCRIPTION
## Summary
- `_async_main` 增加 `hasattr` 检查，优先使用子类的 `_async_connect` / `_async_message_loop`
- 无子类覆盖且 `connection_manager` 为 None 时，打印 ERROR 日志并设 ERROR 状态，不再抛异常
- Closes #4561

## Test plan
- [ ] LiveCore 启动不再崩溃（打印 ERROR 日志而非 traceback）
- [ ] 有 `connection_manager` 的子类行为不变

🤖 Generated with [Claude Code](https://claude.com/claude-code)