### PR TITLE
perf: /portfolios/stats 从 O(n) 优化为 O(1) SQL 聚合

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -255,54 +255,16 @@ async def list_portfolios(
 async def get_portfolio_stats():
     """获取 Portfolio 统计数据"""
     try:
-        # 获取 PortfolioService
         portfolio_service = get_portfolio_service()
-
-        # 使用 count 方法获取总数
-        total_result = portfolio_service.count()
-        total = total_result.data.get("count", 0) if total_result.is_success() else 0
-
-        # 获取所有数据用于计算资产和净值
-        result = portfolio_service.get(page=0, page_size=10000)
-
-        total_assets = 0
-        avg_net_value = 1.0
-        running = 0
-
-        if result.is_success() and result.data:
-            portfolios = result.data
-            total_assets = sum(float(p.initial_capital) for p in portfolios if p.initial_capital)
-
-            # 计算平均净值和运行中数量
-            net_values = []
-            for p in portfolios:
-                # 统计运行中的投资组合
-                # 注意：旧版MPortfolio使用is_running字段
-                is_running = getattr(p, 'is_running', None)
-
-                if is_running == 1:
-                    running += 1
-
-                if p.initial_capital and p.cash and float(p.initial_capital) > 0:
-                    net_values.append(float(p.cash) / float(p.initial_capital))
-
-            avg_net_value = sum(net_values) / len(net_values) if net_values else 1.0
-
-        return ok(data={
-            "total": total,
-            "running": running,
-            "avg_net_value": round(avg_net_value, 4),
-            "total_assets": total_assets,
-        }, message="Stats retrieved successfully")
-
+        result = portfolio_service.get_stats()
+        data = result.data if result.is_success() else {
+            "total": 0, "running": 0, "avg_net_value": 1.0, "total_assets": 0,
+        }
+        return ok(data=data, message="Stats retrieved successfully")
     except Exception as e:
-        logger.error(f"Error getting portfolio stats: {str(e)}")
-        # 发生错误时返回默认值
+        logger.error(f"Error getting portfolio stats: {e}")
         return ok(data={
-            "total": 0,
-            "running": 0,
-            "avg_net_value": 1.0,
-            "total_assets": 0,
+            "total": 0, "running": 0, "avg_net_value": 1.0, "total_assets": 0,
         }, message="Stats retrieved successfully")
 
 

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -877,6 +877,45 @@ class PortfolioService(BaseService):
             GLOG.ERROR(f"统计投资组合失败: {str(e)}")
             return ServiceResult.error(f"统计投资组合失败: {str(e)}")
 
+    def get_stats(self) -> ServiceResult:
+        """获取 Portfolio 聚合统计（数据库级别 O(1)）"""
+        try:
+            from sqlalchemy import func
+            from ginkgo.data.models.model_portfolio import MPortfolio
+
+            crud = self._crud_repo
+
+            total = crud.count(filters={"is_del": False})
+            running = crud.count(filters={"is_del": False, "state": 1})
+
+            conn = crud._get_connection()
+            with conn.get_session() as s:
+                row = s.query(
+                    func.sum(MPortfolio.initial_capital),
+                    func.avg(MPortfolio.cash / MPortfolio.initial_capital),
+                ).filter(
+                    MPortfolio.is_del == False,
+                    MPortfolio.initial_capital > 0,
+                ).one()
+
+            total_assets = float(row[0] or 0)
+            avg_net_value = round(float(row[1] or 1.0), 4)
+
+            return ServiceResult.success({
+                "total": total,
+                "running": running,
+                "avg_net_value": avg_net_value,
+                "total_assets": total_assets,
+            })
+        except Exception as e:
+            GLOG.ERROR(f"获取 Portfolio 统计失败: {e}")
+            return ServiceResult.success({
+                "total": 0,
+                "running": 0,
+                "avg_net_value": 1.0,
+                "total_assets": 0,
+            })
+
     def exists(self, portfolio_id: str = None, name: str = None, **kwargs) -> ServiceResult:
         """
         检查投资组合是否存在


### PR DESCRIPTION
## Summary
- `PortfolioService.get_stats()` 用 SQL COUNT + SUM + AVG 替代全量加载
- API 层简化为调用 service 方法
- 修正字段引用：`state=1` 替代不存在的 `is_running`

## Test plan
- [ ] `curl http://localhost:8000/api/v1/portfolios/stats` 返回正确的 total/running/avg_net_value/total_assets
- [ ] 无组合时返回默认值而非报错

🤖 Generated with [Claude Code](https://claude.com/claude-code)