### PR TITLE
chore(#3903,#3901): 对齐 Python 版本声明与 mypy 配置

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,5 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-redis, types-pytz]
-        args: [--ignore-missing-imports, --no-strict-optional]
+        args: []
 files: ^(?:src/ginkgo|api)/.*\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9", 
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Office/Business :: Financial :: Investment",
@@ -164,7 +161,7 @@ where = ["src"]
 # 工具配置
 [tool.black]
 line-length = 120
-target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
+target-version = ['py311', 'py312']
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -308,7 +305,7 @@ directory = "htmlcov"
 
 [tool.ruff]
 line-length = 120
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "C4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,6 +194,23 @@ warn_no_return = true
 warn_unreachable = true
 strict_equality = true
 
+# 第三方库缺少 type stubs，仅对这些模块放宽缺失导入检查
+[[tool.mypy.overrides]]
+module = [
+    "apscheduler.*",
+    "asyncmy.*",
+    "baostock.*",
+    "clickhouse_sqlalchemy.*",
+    "jose.*",
+    "kafka.*",
+    "mootdx.*",
+    "plotext.*",
+    "pymysql.*",
+    "textual.*",
+    "tushare.*",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 # 测试发现配置
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

修复两处项目配置不一致问题，来源同 PR #3898 code review。

### #3903 — ruff/black target-version 与 requires-python 不对齐
- `requires-python = ">=3.11"` 为基准
- ruff `target-version`: `"py312"` → `"py311"`（对齐最低版本）
- black `target-version`: 移除 py38/py39/py310，保留 `[py311, py312]`
- classifiers: 移除低于 3.11 的版本声明（py38/py39/py310）

### #3901 — mypy pre-commit 宽松参数与 pyproject.toml 严格配置矛盾
- 移除 `.pre-commit-config.yaml` 中 mypy 的 `--ignore-missing-imports --no-strict-optional` 覆盖参数
- pre-commit mypy 现在与 `pyproject.toml [tool.mypy]` 使用相同的严格配置

## Test plan
- [x] 配置语法正确（TOML/YAML 格式验证）
- [x] `requires-python`、ruff、black、classifiers 版本声明一致
- [x] pre-commit mypy 不再覆盖 pyproject.toml 设置

Closes #3903
Closes #3901

🤖 Generated with [Claude Code](https://claude.com/claude-code)