### PR TITLE
fix(#4582): 消除 3 处 API 层直调 CRUD 违规

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -1066,7 +1066,9 @@ async def get_backtest_analyzers(uuid: str):
         # fix(#4582): 通过 AnalyzerService 查询，不再直调 container.analyzer_record_crud()
         analyzer_service = container.analyzer_service()
         result = analyzer_service.find_by_portfolio(portfolio_id=portfolio_id, task_id=task_id)
-        records = result.data if result.success else []
+        if not result.success:
+            raise BusinessError(result.error or "查询分析器记录失败")
+        records = result.data
 
         from collections import OrderedDict
         grouped = OrderedDict()

--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -1063,9 +1063,10 @@ async def get_backtest_analyzers(uuid: str):
 
         result_service = get_result_service()
 
-        # Get analyzer records for this portfolio filtered by task_id
-        analyzer_crud = container.analyzer_record_crud()
-        records = analyzer_crud.find_by_portfolio(portfolio_id=portfolio_id, task_id=task_id)
+        # fix(#4582): 通过 AnalyzerService 查询，不再直调 container.analyzer_record_crud()
+        analyzer_service = container.analyzer_service()
+        result = analyzer_service.find_by_portfolio(portfolio_id=portfolio_id, task_id=task_id)
+        records = result.data if result.success else []
 
         from collections import OrderedDict
         grouped = OrderedDict()

--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -206,8 +206,10 @@ async def list_portfolios(
             order_by="update_at",
             desc_order=True,
         )
-        portfolios = result.data["items"] if result.success else []
-        total = result.data["total"] if result.success else 0
+        if not result.success:
+            raise BusinessError(result.error or "查询投资组合失败")
+        portfolios = result.data["items"]
+        total = result.data["total"]
 
         items = []
         for p in (portfolios or []):

--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -198,16 +198,16 @@ async def list_portfolios(
         if keyword:
             filters["name"] = keyword
 
-        # 分页查询
-        crud = portfolio_service._crud_repo
-        portfolios = crud.find(
+        # fix(#4582): 通过 Service 方法分页查询，不再直调 _crud_repo
+        result = portfolio_service.list_paginated(
             filters=filters,
             page=page,
             page_size=page_size,
             order_by="update_at",
             desc_order=True,
         )
-        total = crud.count(filters=filters)
+        portfolios = result.data["items"] if result.success else []
+        total = result.data["total"] if result.success else 0
 
         items = []
         for p in (portfolios or []):

--- a/api/api/validation.py
+++ b/api/api/validation.py
@@ -110,24 +110,16 @@ async def list_results(
     try:
         import json
         svc = get_validation_service()
-        crud = svc._result_crud
-        if not crud:
+        # fix(#4582): 通过 Service 方法查询，不再直调 _result_crud
+        result = svc.list_results(
+            portfolio_id=portfolio_id, method=method,
+            page=page - 1, page_size=page_size,
+        )
+        if not result.success:
             return paginated(items=[], total=0, page=page, page_size=page_size)
 
-        filters = {}
-        if portfolio_id:
-            filters["portfolio_id"] = portfolio_id
-        if method:
-            filters["method"] = method
-
-        total = crud.count(filters=filters) if filters else crud.count()
-        records = crud.find(
-            filters=filters if filters else None,
-            page=page - 1,
-            page_size=page_size,
-            order_by="create_at",
-            desc_order=True,
-        )
+        records = result.data["items"]
+        total = result.data["total"]
 
         items = []
         for r in records:
@@ -155,13 +147,12 @@ async def get_result(result_id: str):
     try:
         import json
         svc = get_validation_service()
-        crud = svc._result_crud
-        if not crud:
-            raise BusinessError("验证结果存储不可用")
+        # fix(#4582): 通过 Service 方法查询，不再直调 _result_crud
+        result = svc.get_result(result_id)
+        if not result.success:
+            raise BusinessError(result.error or "验证结果查询失败")
 
-        record = crud.get(result_id)
-        if not record:
-            raise BusinessError("验证结果不存在")
+        record = result.data
 
         return ok(data={
             "uuid": record.uuid,

--- a/api/api/validation.py
+++ b/api/api/validation.py
@@ -116,7 +116,7 @@ async def list_results(
             page=page - 1, page_size=page_size,
         )
         if not result.success:
-            return paginated(items=[], total=0, page=page, page_size=page_size)
+            raise BusinessError(result.error or "查询验证结果失败")
 
         records = result.data["items"]
         total = result.data["total"]

--- a/src/ginkgo/data/services/analyzer_service.py
+++ b/src/ginkgo/data/services/analyzer_service.py
@@ -127,6 +127,41 @@ class AnalyzerService(BaseService):
             GLOG.ERROR(f"按 task_id 查询失败: {e}")
             return ServiceResult.error(f"按 task_id 查询失败: {e}")
 
+    # fix(#4582): 封装 find_by_portfolio，避免 API 层直调 CRUD
+    def find_by_portfolio(
+        self,
+        portfolio_id: str,
+        analyzer_name: Optional[str] = None,
+        task_id: Optional[str] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> ServiceResult:
+        """按 portfolio 查询 analyzer 记录
+
+        Args:
+            portfolio_id: 投资组合ID
+            analyzer_name: 分析器名称（可选）
+            task_id: 运行会话ID（可选）
+            start_date: 起始日期（可选）
+            end_date: 结束日期（可选）
+
+        Returns:
+            ServiceResult: 查询结果
+        """
+        try:
+            records = self._crud_repo.find_by_portfolio(
+                portfolio_id=portfolio_id,
+                analyzer_name=analyzer_name,
+                task_id=task_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            GLOG.INFO(f"按 portfolio 查询成功: portfolio_id={portfolio_id}, count={len(records) if records else 0}")
+            return ServiceResult.success(records)
+        except Exception as e:
+            GLOG.ERROR(f"按 portfolio 查询失败: {e}")
+            return ServiceResult.error(f"按 portfolio 查询失败: {e}")
+
     def get_latest_by_portfolio(
         self,
         portfolio_id: str,

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -70,6 +70,41 @@ class PortfolioService(BaseService):
 
         return False
 
+    # fix(#4582): 封装分页查询，避免 API 层直调 _crud_repo
+    def list_paginated(
+        self,
+        filters: Optional[Dict] = None,
+        page: int = 0,
+        page_size: int = 20,
+        order_by: str = "update_at",
+        desc_order: bool = True,
+    ) -> ServiceResult:
+        """分页查询投资组合列表
+
+        Args:
+            filters: 查询过滤条件
+            page: 页码（从0开始）
+            page_size: 每页数量
+            order_by: 排序字段
+            desc_order: 是否降序
+
+        Returns:
+            ServiceResult: data 包含 items（列表）和 total（总数）
+        """
+        try:
+            items = self._crud_repo.find(
+                filters=filters,
+                page=page,
+                page_size=page_size,
+                order_by=order_by,
+                desc_order=desc_order,
+            )
+            total = self._crud_repo.count(filters=filters)
+            return ServiceResult.success(data={"items": items or [], "total": total})
+        except Exception as e:
+            GLOG.ERROR(f"分页查询投资组合失败: {e}")
+            return ServiceResult.error(f"分页查询投资组合失败: {e}")
+
     @retry(max_try=3)
     def add(
         self,

--- a/src/ginkgo/data/services/validation_service.py
+++ b/src/ginkgo/data/services/validation_service.py
@@ -75,9 +75,9 @@ class ValidationService(BaseService):
             if method:
                 filters["method"] = method
 
-            total = self._result_crud.count(filters=filters) if filters else self._result_crud.count()
+            total = self._result_crud.count(filters=filters)
             records = self._result_crud.find(
-                filters=filters if filters else None,
+                filters=filters or None,
                 page=page,
                 page_size=page_size,
                 order_by="create_at",
@@ -102,10 +102,11 @@ class ValidationService(BaseService):
             if not self._result_crud:
                 return ServiceResult.error("验证结果存储不可用")
 
-            record = self._result_crud.get(result_id)
-            if not record:
+            # fix(#4582): ValidationResultCRUD 继承 BaseCRUD，无 get()，用 find() 替代
+            records = self._result_crud.find(filters={"uuid": result_id})
+            if not records:
                 return ServiceResult.error("验证结果不存在")
-            return ServiceResult.success(record)
+            return ServiceResult.success(records[0])
         except Exception as e:
             GLOG.ERROR(f"获取验证结果失败: {e}")
             return ServiceResult.error(f"获取验证结果失败: {e}")

--- a/src/ginkgo/data/services/validation_service.py
+++ b/src/ginkgo/data/services/validation_service.py
@@ -46,6 +46,70 @@ class ValidationService(BaseService):
         self._analyzer_crud = analyzer_record_crud
         self._result_crud = validation_result_crud
 
+    # fix(#4582): 封装验证结果查询，避免 API 层直调 _result_crud
+    def list_results(
+        self,
+        portfolio_id: str = None,
+        method: str = None,
+        page: int = 0,
+        page_size: int = 20,
+    ) -> ServiceResult:
+        """分页查询验证结果列表
+
+        Args:
+            portfolio_id: 投资组合ID（可选）
+            method: 验证方法（可选）
+            page: 页码（从0开始）
+            page_size: 每页数量
+
+        Returns:
+            ServiceResult: data 包含 items 和 total
+        """
+        try:
+            if not self._result_crud:
+                return ServiceResult.success(data={"items": [], "total": 0})
+
+            filters = {}
+            if portfolio_id:
+                filters["portfolio_id"] = portfolio_id
+            if method:
+                filters["method"] = method
+
+            total = self._result_crud.count(filters=filters) if filters else self._result_crud.count()
+            records = self._result_crud.find(
+                filters=filters if filters else None,
+                page=page,
+                page_size=page_size,
+                order_by="create_at",
+                desc_order=True,
+            )
+            return ServiceResult.success(data={"items": records or [], "total": total})
+        except Exception as e:
+            GLOG.ERROR(f"查询验证结果列表失败: {e}")
+            return ServiceResult.error(f"查询验证结果列表失败: {e}")
+
+    # fix(#4582): 封装单条验证结果查询
+    def get_result(self, result_id: str) -> ServiceResult:
+        """获取单条验证结果
+
+        Args:
+            result_id: 验证结果UUID
+
+        Returns:
+            ServiceResult: data 为验证结果记录
+        """
+        try:
+            if not self._result_crud:
+                return ServiceResult.error("验证结果存储不可用")
+
+            record = self._result_crud.get(result_id)
+            if not record:
+                return ServiceResult.error("验证结果不存在")
+            return ServiceResult.success(record)
+        except Exception as e:
+            GLOG.ERROR(f"获取验证结果失败: {e}")
+            return ServiceResult.error(f"获取验证结果失败: {e}")
+
     @staticmethod
     def _get_analyzer_class(name: str):
         """通过名称查找分析器类，读取 aggregation_type 等类属性"""

--- a/tests/api/test_api_crud_bypass.py
+++ b/tests/api/test_api_crud_bypass.py
@@ -1,0 +1,180 @@
+"""
+Tests for API→CRUD bypass elimination (#4582).
+
+Verifies that API layer uses Service methods instead of directly
+accessing CRUD instances (_crud_repo, _result_crud, container.analyzer_record_crud()).
+
+Issue: #4582
+"""
+
+import pytest
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _repo_root() -> Path:
+    """Get repo root (works in worktree too)."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+_API_ROOT = _repo_root() / "api" / "api"
+
+
+def _read_api_source(filename: str) -> str:
+    """Read API source file, stripping comments."""
+    lines = (_API_ROOT / filename).read_text().splitlines()
+    # Remove comment lines (which may reference the banned pattern in docs)
+    return "\n".join(line for line in lines if not line.strip().startswith("#"))
+
+
+# ── Slice 1: PortfolioService.list_paginated ──────────────────────────
+
+
+class TestPortfolioServiceListPaginated:
+    """PortfolioService.list_paginated should wrap CRUD find+count."""
+
+    def test_returns_service_result_with_items_and_total(self):
+        """list_paginated returns ServiceResult with items list and total count."""
+        from ginkgo.data.services.portfolio_service import PortfolioService
+
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = [MagicMock(uuid="p1"), MagicMock(uuid="p2")]
+        mock_crud.count.return_value = 2
+
+        svc = PortfolioService(
+            crud_repo=mock_crud,
+            portfolio_file_mapping_crud=MagicMock(),
+        )
+        result = svc.list_paginated(
+            filters={"name": "test"},
+            page=1,
+            page_size=20,
+            order_by="update_at",
+            desc_order=True,
+        )
+
+        assert isinstance(result, ServiceResult)
+        assert result.success
+        assert result.data["total"] == 2
+        assert len(result.data["items"]) == 2
+        mock_crud.find.assert_called_once_with(
+            filters={"name": "test"},
+            page=1,
+            page_size=20,
+            order_by="update_at",
+            desc_order=True,
+        )
+        mock_crud.count.assert_called_once_with(filters={"name": "test"})
+
+
+class TestPortfolioApiNoCrudBypass:
+    """api/api/portfolio.py must not access portfolio_service._crud_repo."""
+
+    def test_no_crud_repo_access(self):
+        source = _read_api_source("portfolio.py")
+        assert "_crud_repo" not in source, (
+            "portfolio.py still accesses _crud_repo directly"
+        )
+
+
+# ── Slice 2: AnalyzerService.find_by_portfolio ────────────────────────
+
+
+class TestAnalyzerServiceFindByPortfolio:
+    """AnalyzerService.find_by_portfolio should delegate to CRUD."""
+
+    def test_returns_service_result_with_records(self):
+        from ginkgo.data.services.analyzer_service import AnalyzerService
+
+        mock_crud = MagicMock()
+        mock_crud.find_by_portfolio.return_value = [MagicMock(name="net_value")]
+
+        svc = AnalyzerService(analyzer_crud=mock_crud)
+        result = svc.find_by_portfolio(
+            portfolio_id="pf-1", task_id="task-1"
+        )
+
+        assert isinstance(result, ServiceResult)
+        assert result.success
+        assert len(result.data) == 1
+        mock_crud.find_by_portfolio.assert_called_once_with(
+            portfolio_id="pf-1", analyzer_name=None,
+            task_id="task-1", start_date=None, end_date=None,
+        )
+
+
+class TestBacktestApiNoCrudBypass:
+    """api/api/backtest.py must not call container.analyzer_record_crud()."""
+
+    def test_no_analyzer_record_crud_access(self):
+        source = _read_api_source("backtest.py")
+        assert "analyzer_record_crud" not in source, (
+            "backtest.py still directly calls container.analyzer_record_crud()"
+        )
+
+
+# ── Slice 3: ValidationService.list_results + get_result ──────────────
+
+
+class TestValidationServiceListResults:
+    """ValidationService.list_results should wrap CRUD find+count."""
+
+    def test_returns_service_result_with_items_and_total(self):
+        from ginkgo.data.services.validation_service import ValidationService
+
+        mock_result_crud = MagicMock()
+        mock_result_crud.find.return_value = [MagicMock(uuid="r1")]
+        mock_result_crud.count.return_value = 1
+
+        svc = ValidationService(
+            analyzer_record_crud=MagicMock(),
+            validation_result_crud=mock_result_crud,
+        )
+        result = svc.list_results(
+            portfolio_id="pf-1", method="segment_stability",
+            page=0, page_size=20,
+        )
+
+        assert isinstance(result, ServiceResult)
+        assert result.success
+        assert result.data["total"] == 1
+        assert len(result.data["items"]) == 1
+
+
+class TestValidationServiceGetResult:
+    """ValidationService.get_result should wrap CRUD get."""
+
+    def test_returns_service_result_with_record(self):
+        from ginkgo.data.services.validation_service import ValidationService
+
+        mock_record = MagicMock(uuid="r-1", task_id="t-1")
+        mock_result_crud = MagicMock()
+        mock_result_crud.get.return_value = mock_record
+
+        svc = ValidationService(
+            analyzer_record_crud=MagicMock(),
+            validation_result_crud=mock_result_crud,
+        )
+        result = svc.get_result("r-1")
+
+        assert isinstance(result, ServiceResult)
+        assert result.success
+        assert result.data == mock_record
+        mock_result_crud.get.assert_called_once_with("r-1")
+
+
+class TestValidationApiNoCrudBypass:
+    """api/api/validation.py must not access svc._result_crud."""
+
+    def test_no_result_crud_access(self):
+        source = _read_api_source("validation.py")
+        assert "_result_crud" not in source, (
+            "validation.py still accesses _result_crud directly"
+        )

--- a/tests/api/test_api_crud_bypass.py
+++ b/tests/api/test_api_crud_bypass.py
@@ -149,14 +149,14 @@ class TestValidationServiceListResults:
 
 
 class TestValidationServiceGetResult:
-    """ValidationService.get_result should wrap CRUD get."""
+    """ValidationService.get_result should wrap CRUD find by uuid."""
 
     def test_returns_service_result_with_record(self):
         from ginkgo.data.services.validation_service import ValidationService
 
         mock_record = MagicMock(uuid="r-1", task_id="t-1")
         mock_result_crud = MagicMock()
-        mock_result_crud.get.return_value = mock_record
+        mock_result_crud.find.return_value = [mock_record]
 
         svc = ValidationService(
             analyzer_record_crud=MagicMock(),
@@ -167,7 +167,7 @@ class TestValidationServiceGetResult:
         assert isinstance(result, ServiceResult)
         assert result.success
         assert result.data == mock_record
-        mock_result_crud.get.assert_called_once_with("r-1")
+        mock_result_crud.find.assert_called_once_with(filters={"uuid": "r-1"})
 
 
 class TestValidationApiNoCrudBypass:


### PR DESCRIPTION
## Summary

CLAUDE.md 架构规则「API 层禁止直接调用 CRUD，必须通过 Service 层」被 3 处代码违反。本次修复在每个 Service 中封装所需方法，API 改调 Service。

**修复内容：**
- `PortfolioService.list_paginated()` — 封装 `find()` + `count()` 分页查询
- `AnalyzerService.find_by_portfolio()` — 封装组合维度查询
- `ValidationService.list_results()` + `get_result()` — 封装验证结果查询

**API 改调：**
- `api/portfolio.py` — `_crud_repo` → `list_paginated()`
- `api/backtest.py` — `container.analyzer_record_crud()` → `analyzer_service.find_by_portfolio()`
- `api/validation.py` — `_result_crud` → `svc.list_results()` + `svc.get_result()`

## Test plan

- `pytest tests/api/test_api_crud_bypass.py` — 7 个测试验证 Service 方法和 API 源码检查
- `pytest tests/unit/test_portfolio_management_crud_leak.py` — 确认无回归

Closes #4582

🤖 Generated with [Claude Code](https://claude.com/claude-code)