### PR TITLE
refactor(#4589): 提取 BaseService 通用分页方法

### DIFF
--- a/src/ginkgo/data/services/base_service.py
+++ b/src/ginkgo/data/services/base_service.py
@@ -252,7 +252,8 @@ class BaseService(ABC):
             total = crud.count(filters=filters)
             return ServiceResult.success(data={"items": items or [], "total": total})
         except Exception as e:
-            return ServiceResult.error(str(e))
+            GLOG.ERROR(f"{self._service_name} 分页查询失败: {e}")
+            return ServiceResult.error(f"{self._service_name} 分页查询失败: {e}")
 
     def create_result(self, success: bool = False, error: str = None) -> ServiceResult:
         """

--- a/src/ginkgo/data/services/base_service.py
+++ b/src/ginkgo/data/services/base_service.py
@@ -214,6 +214,46 @@ class BaseService(ABC):
         """
         return self._service_name
 
+    # fix(#4589): 通用分页查询方法，消除 Service 层重复 boilerplate
+    def _paginated_query(
+        self,
+        filters=None,
+        page: int = 0,
+        page_size: int = 20,
+        order_by: str = None,
+        desc_order: bool = True,
+        crud_repo=None,
+    ) -> ServiceResult:
+        """通用分页查询：find + count → ServiceResult({items, total})
+
+        子类可直接调用，避免重复 find/count/信封组装。
+        支持传入自定义 crud_repo，适用于 Service 持有多个 CRUD 实例的场景。
+
+        Args:
+            filters: 查询过滤条件
+            page: 页码（从0开始）
+            page_size: 每页数量
+            order_by: 排序字段
+            desc_order: 是否降序
+            crud_repo: 可选 CRUD 实例，默认使用 self._crud_repo
+
+        Returns:
+            ServiceResult: data 包含 items（列表）和 total（总数）
+        """
+        try:
+            crud = crud_repo or self._crud_repo
+            items = crud.find(
+                filters=filters,
+                page=page,
+                page_size=page_size,
+                order_by=order_by,
+                desc_order=desc_order,
+            )
+            total = crud.count(filters=filters)
+            return ServiceResult.success(data={"items": items or [], "total": total})
+        except Exception as e:
+            return ServiceResult.error(str(e))
+
     def create_result(self, success: bool = False, error: str = None) -> ServiceResult:
         """
         Create standardized ServiceResult instance for operation response

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -71,6 +71,7 @@ class PortfolioService(BaseService):
         return False
 
     # fix(#4582): 封装分页查询，避免 API 层直调 _crud_repo
+    # fix(#4589): 改用 BaseService._paginated_query() 通用方法
     def list_paginated(
         self,
         filters: Optional[Dict] = None,
@@ -79,31 +80,11 @@ class PortfolioService(BaseService):
         order_by: str = "update_at",
         desc_order: bool = True,
     ) -> ServiceResult:
-        """分页查询投资组合列表
-
-        Args:
-            filters: 查询过滤条件
-            page: 页码（从0开始）
-            page_size: 每页数量
-            order_by: 排序字段
-            desc_order: 是否降序
-
-        Returns:
-            ServiceResult: data 包含 items（列表）和 total（总数）
-        """
-        try:
-            items = self._crud_repo.find(
-                filters=filters,
-                page=page,
-                page_size=page_size,
-                order_by=order_by,
-                desc_order=desc_order,
-            )
-            total = self._crud_repo.count(filters=filters)
-            return ServiceResult.success(data={"items": items or [], "total": total})
-        except Exception as e:
-            GLOG.ERROR(f"分页查询投资组合失败: {e}")
-            return ServiceResult.error(f"分页查询投资组合失败: {e}")
+        """分页查询投资组合列表"""
+        return self._paginated_query(
+            filters=filters, page=page, page_size=page_size,
+            order_by=order_by, desc_order=desc_order,
+        )
 
     @retry(max_try=3)
     def add(

--- a/src/ginkgo/data/services/validation_service.py
+++ b/src/ginkgo/data/services/validation_service.py
@@ -47,6 +47,7 @@ class ValidationService(BaseService):
         self._result_crud = validation_result_crud
 
     # fix(#4582): 封装验证结果查询，避免 API 层直调 _result_crud
+    # fix(#4589): 改用 BaseService._paginated_query() 通用方法
     def list_results(
         self,
         portfolio_id: str = None,
@@ -54,39 +55,21 @@ class ValidationService(BaseService):
         page: int = 0,
         page_size: int = 20,
     ) -> ServiceResult:
-        """分页查询验证结果列表
+        """分页查询验证结果列表"""
+        if not self._result_crud:
+            return ServiceResult.success(data={"items": [], "total": 0})
 
-        Args:
-            portfolio_id: 投资组合ID（可选）
-            method: 验证方法（可选）
-            page: 页码（从0开始）
-            page_size: 每页数量
+        filters = {}
+        if portfolio_id:
+            filters["portfolio_id"] = portfolio_id
+        if method:
+            filters["method"] = method
 
-        Returns:
-            ServiceResult: data 包含 items 和 total
-        """
-        try:
-            if not self._result_crud:
-                return ServiceResult.success(data={"items": [], "total": 0})
-
-            filters = {}
-            if portfolio_id:
-                filters["portfolio_id"] = portfolio_id
-            if method:
-                filters["method"] = method
-
-            total = self._result_crud.count(filters=filters)
-            records = self._result_crud.find(
-                filters=filters or None,
-                page=page,
-                page_size=page_size,
-                order_by="create_at",
-                desc_order=True,
-            )
-            return ServiceResult.success(data={"items": records or [], "total": total})
-        except Exception as e:
-            GLOG.ERROR(f"查询验证结果列表失败: {e}")
-            return ServiceResult.error(f"查询验证结果列表失败: {e}")
+        return self._paginated_query(
+            filters=filters or None, page=page, page_size=page_size,
+            order_by="create_at", desc_order=True,
+            crud_repo=self._result_crud,
+        )
 
     # fix(#4582): 封装单条验证结果查询
     def get_result(self, result_id: str) -> ServiceResult:

--- a/tests/unit/test_base_service_pagination.py
+++ b/tests/unit/test_base_service_pagination.py
@@ -1,0 +1,79 @@
+"""
+Tests for BaseService._paginated_query() (#4589).
+
+Verifies the common pagination method extracted into BaseService
+for reuse across PortfolioService, ValidationService, etc.
+
+Issue: #4589
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.data.services.base_service import BaseService, ServiceResult
+
+
+class TestBaseServicePaginatedQuery:
+    """BaseService._paginated_query should provide common find+count pagination."""
+
+    def test_returns_service_result_with_items_and_total(self):
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = [MagicMock(uuid="a"), MagicMock(uuid="b")]
+        mock_crud.count.return_value = 42
+
+        svc = BaseService(crud_repo=mock_crud)
+        result = svc._paginated_query(
+            filters={"name": "test"},
+            page=1,
+            page_size=20,
+            order_by="update_at",
+            desc_order=True,
+        )
+
+        assert isinstance(result, ServiceResult)
+        assert result.success
+        assert result.data["total"] == 42
+        assert len(result.data["items"]) == 2
+        mock_crud.find.assert_called_once_with(
+            filters={"name": "test"},
+            page=1, page_size=20,
+            order_by="update_at", desc_order=True,
+        )
+        mock_crud.count.assert_called_once_with(filters={"name": "test"})
+
+    def test_returns_empty_when_crud_returns_none(self):
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = None
+        mock_crud.count.return_value = 0
+
+        svc = BaseService(crud_repo=mock_crud)
+        result = svc._paginated_query()
+
+        assert result.success
+        assert result.data["items"] == []
+        assert result.data["total"] == 0
+
+    def test_returns_error_on_exception(self):
+        mock_crud = MagicMock()
+        mock_crud.find.side_effect = Exception("DB down")
+
+        svc = BaseService(crud_repo=mock_crud)
+        result = svc._paginated_query()
+
+        assert not result.success
+        assert "DB down" in result.error
+
+    def test_uses_custom_crud_repo_when_provided(self):
+        """crud_repo 参数允许 Service 查询非默认 CRUD 实例。"""
+        default_crud = MagicMock()
+        custom_crud = MagicMock()
+        custom_crud.find.return_value = [MagicMock(uuid="x")]
+        custom_crud.count.return_value = 1
+
+        svc = BaseService(crud_repo=default_crud)
+        result = svc._paginated_query(crud_repo=custom_crud)
+
+        assert result.success
+        assert result.data["total"] == 1
+        custom_crud.find.assert_called_once()
+        default_crud.find.assert_not_called()


### PR DESCRIPTION
## Summary

PR #4587 在 PortfolioService 和 ValidationService 中引入了重复的分页 boilerplate（`find() → count() → ServiceResult.success({items, total})`）。本次提取通用方法消除重复。

**变更：**
- `BaseService._paginated_query()` — 通用分页查询方法，支持 `crud_repo` 参数覆盖默认 CRUD
- `PortfolioService.list_paginated()` — 改用 `_paginated_query()`
- `ValidationService.list_results()` — 改用 `_paginated_query(crud_repo=_result_crud)`

**设计决策：** `crud_repo` 可选参数允许持有多个 CRUD 的 Service（如 ValidationService）指定查询目标，避免线程不安全的临时切换。

## Test plan

- `pytest tests/unit/test_base_service_pagination.py` — 4 个新测试
- `pytest tests/api/test_api_crud_bypass.py` — 7 个既有测试确认无回归

Closes #4589

🤖 Generated with [Claude Code](https://claude.com/claude-code)