### PR TITLE
fix(#4568): 添加 mypy overrides 替代 pre-commit --ignore-missing-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,5 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies: [types-PyYAML, types-requests, types-redis, types-pytz]
-        args: [--ignore-missing-imports, --no-strict-optional]
+        args: []
 files: ^(?:src/ginkgo|api)/.*\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,18 @@ warn_no_return = true
 warn_unreachable = true
 strict_equality = true
 
+# Third-party packages without type stubs
+[[tool.mypy.overrides]]
+module = [
+    "clickhouse_sqlalchemy.*",
+    "kafka.*",
+    "baostock.*",
+    "tushare.*",
+    "mootdx.*",
+    "dependency_injector.*",
+]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 # 测试发现配置
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

修复 PR #4568 code review 反馈：移除 `--ignore-missing-imports` 会导致 33 个导入无类型第三方库的文件 CI 失败。

### 问题
- `--ignore-missing-imports` 是必要的 workaround，不是冗余参数
- 项目依赖 6 个无类型 stub 的第三方包：clickhouse_sqlalchemy, kafka, baostock, tushare, mootdx, dependency_injector
- 直接移除会导致 mypy 在 33 个源文件上报 `Cannot find implementation or library stubs for module` 错误

### 修复
- 将 workaround 从 pre-commit args 迁移到 `pyproject.toml [[tool.mypy.overrides]]`
- 只针对无 stub 的 6 个包跳过 `ignore_missing_imports`，其余严格检查保持不变

### 文件变更
- `pyproject.toml` — 新增 `[[tool.mypy.overrides]]` 块
- `.pre-commit-config.yaml` — 移除宽松参数（PR #4568 原始改动）

🤖 Generated with [Claude Code](https://claude.com/claude-code)