### PR TITLE
feat(#4573): 回测列表页改用无限滚动懒加载

### DIFF
--- a/web-ui/src/components/common/ListPage.vue
+++ b/web-ui/src/components/common/ListPage.vue
@@ -116,7 +116,7 @@
         </table>
 
         <!-- 分页 -->
-        <div v-if="totalCount > 0" class="pagination-bar">
+        <div v-if="totalCount > 0 && !infiniteScroll" class="pagination-bar">
           <div class="pagination-info">
             共 {{ totalCount }} 条{{ totalPages > 1 ? `，第 ${innerPage} / ${totalPages} 页` : '' }}
           </div>
@@ -134,7 +134,11 @@
             </select>
           </div>
         </div>
+
       </div>
+
+      <!-- 无限滚动触发器插槽（在 list-content 内、table-card 外） -->
+      <slot name="afterTable" />
     </div>
   </div>
 </template>
@@ -170,6 +174,7 @@ const props = withDefaults(defineProps<{
   pageSize?: number
   pageSizes?: number[]
   serverPagination?: boolean
+  infiniteScroll?: boolean
 }>(), {
   loading: false,
   rowKey: 'id',
@@ -186,6 +191,7 @@ const props = withDefaults(defineProps<{
   pageSize: 20,
   pageSizes: () => [10, 20, 50, 100],
   serverPagination: false,
+  infiniteScroll: false,
 })
 
 const emit = defineEmits<{
@@ -217,9 +223,9 @@ const resolvedColumns = computed(() => {
   return cols
 })
 
-// Client-side pagination
+// Client-side pagination (infiniteScroll always shows all data)
 const pageData = computed(() => {
-  if (props.serverPagination || props.total != null) return props.dataSource
+  if (props.serverPagination || props.total != null || props.infiniteScroll) return props.dataSource
   const start = (innerPage.value - 1) * innerPageSize.value
   return props.dataSource.slice(start, start + innerPageSize.value)
 })
@@ -381,6 +387,7 @@ function formatValue(val: any): string {
 /* Content */
 .list-content {
   flex: 1;
+  min-height: 0;
   overflow-y: auto;
 }
 

--- a/web-ui/src/views/backtest/BacktestListPage.vue
+++ b/web-ui/src/views/backtest/BacktestListPage.vue
@@ -3,22 +3,17 @@
     title="回测中心"
     :columns="columns"
     :data-source="tasks"
-    :loading="loading"
+    :loading="loading && tasks.length === 0"
     row-key="uuid"
     :searchable="false"
     :creatable="false"
-    :total="total"
-    :page="currentPage"
-    :page-size="pageSize"
-    :server-pagination="true"
+    :infinite-scroll="true"
     clickable
-    @update:page="onPageChange"
-    @update:page-size="onPageSizeChange"
     @sort="onSort"
     @row-click="goDetail"
   >
     <template #filters>
-      <select v-model="statusFilter" class="filter-select" @change="fetchTasks">
+      <select v-model="statusFilter" class="filter-select" @change="resetAndFetch">
         <option value="">全部状态</option>
         <option value="completed">已完成</option>
         <option value="running">进行中</option>
@@ -84,11 +79,20 @@
     <template #created_at="{ record }">
       <span class="val-muted">{{ formatTime(record.created_at) }}</span>
     </template>
+
+    <!-- 无限滚动触发器 -->
+    <template #afterTable>
+      <div v-if="tasks.length > 0" ref="loadMoreTrigger" class="load-more-trigger">
+        <div v-if="loadingMore" class="spinner spinner-small"></div>
+        <div v-else-if="!hasMore" class="no-more">没有更多了</div>
+        <div v-else class="load-more-sentinel"></div>
+      </div>
+    </template>
   </ListPage>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 import ListPage from '@/components/common/ListPage.vue'
 import StatusTag from '@/components/common/StatusTag.vue'
@@ -98,12 +102,15 @@ const router = useRouter()
 
 const tasks = ref<any[]>([])
 const loading = ref(false)
+const loadingMore = ref(false)
 const total = ref(0)
-const currentPage = ref(1)
-const pageSize = ref(20)
+const currentPage = ref(0)
+const pageSize = 20
 const statusFilter = ref('')
 const sortBy = ref('annual_return')
 const sortOrder = ref<'asc' | 'desc'>('desc')
+
+const hasMore = computed(() => tasks.value.length < total.value)
 
 const columns = [
   { title: '任务名称', dataIndex: 'name', key: 'name', width: 200 },
@@ -128,44 +135,87 @@ function goDetail(record: any) {
   router.push(`/portfolios/${record.portfolio_id}/backtests/${record.uuid}`)
 }
 
-function onPageChange(p: number) {
-  currentPage.value = p
-  fetchTasks()
-}
-
-function onPageSizeChange(s: number) {
-  pageSize.value = s
-  currentPage.value = 1
-  fetchTasks()
-}
-
 function onSort(field: string, order: 'asc' | 'desc') {
   sortBy.value = field
   sortOrder.value = order
-  fetchTasks()
+  resetAndFetch()
 }
 
-async function fetchTasks() {
-  loading.value = true
+async function resetAndFetch() {
+  currentPage.value = 0
+  tasks.value = []
+  total.value = 0
+  // 断开旧 observer，首次 fetch 完成后重建
+  if (observer) { observer.disconnect(); observer = null }
+  await fetchTasks(false)
+  nextTick(() => setupObserver())
+}
+
+async function fetchTasks(append: boolean) {
+  if (append) {
+    if (!hasMore.value || loading.value || loadingMore.value) return
+    loadingMore.value = true
+    currentPage.value += 1
+  } else {
+    loading.value = true
+    currentPage.value = 1
+  }
+
   try {
-    const params: any = { page: currentPage.value, page_size: pageSize.value }
+    const params: any = { page: currentPage.value, page_size: pageSize }
     if (statusFilter.value) params.status = statusFilter.value
     if (sortBy.value) {
       params.sort_by = sortBy.value
       params.sort_order = sortOrder.value
     }
     const res: any = await backtestApi.list(params)
-    tasks.value = res?.data || []
+    const newData = res?.data || []
+    if (append) {
+      tasks.value.push(...newData)
+    } else {
+      tasks.value = newData
+    }
     total.value = res?.meta?.total || 0
   } catch {
-    tasks.value = []
-    total.value = 0
+    if (!append) {
+      tasks.value = []
+      total.value = 0
+    }
   } finally {
     loading.value = false
+    loadingMore.value = false
   }
 }
 
-onMounted(() => fetchTasks())
+const loadMore = () => fetchTasks(true)
+
+// IntersectionObserver — 只建一次，靠 loadingMore/hasMore 守卫防重入
+const loadMoreTrigger = ref<HTMLElement>()
+let observer: IntersectionObserver | null = null
+
+const setupObserver = () => {
+  if (!loadMoreTrigger.value || observer) return
+  const scrollableContainer = document.querySelector('.list-content')
+  if (!scrollableContainer) return
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries[0].isIntersecting && hasMore.value && !loading.value && !loadingMore.value) {
+        loadMore()
+      }
+    },
+    { root: scrollableContainer as Element, rootMargin: '200px', threshold: 0.1 }
+  )
+  observer.observe(loadMoreTrigger.value)
+}
+
+onMounted(async () => {
+  await fetchTasks(false)
+  nextTick(() => setupObserver())
+})
+
+onUnmounted(() => {
+  if (observer) observer.disconnect()
+})
 </script>
 
 <style scoped>
@@ -198,4 +248,30 @@ onMounted(() => fetchTasks())
   cursor: pointer;
 }
 .filter-select:focus { outline: none; border-color: #1890ff; }
+
+.load-more-trigger {
+  display: flex;
+  justify-content: center;
+  padding: 16px;
+}
+
+.spinner-small {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #2a2a3e;
+  border-top-color: #1890ff;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.no-more {
+  color: #5a5a6e;
+  font-size: 12px;
+}
+
+.load-more-sentinel {
+  height: 1px;
+}
 </style>


### PR DESCRIPTION
Closes #4573

### 变更内容

- **ListPage.vue**: 新增 `infiniteScroll` prop、`afterTable` 插槽、`min-height: 0` 修复 flex 滚动
- **BacktestListPage.vue**: IntersectionObserver 驱动无限滚动、追加式数据获取、重置+重建 observer 生命周期

### 变更文件树

```
web-ui/src/components/common/ListPage.vue       | 13 ++-
web-ui/src/views/backtest/BacktestListPage.vue  | 136 ++++++++++++++------
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)