### PR TITLE
fix(#4574): 修复研究页路由嵌套和数据同步API对接

### DIFF
--- a/web-ui/src/api/modules/data.ts
+++ b/web-ui/src/api/modules/data.ts
@@ -88,7 +88,7 @@ export const dataApi = {
   },
 
   /**
-   * 获取数据状态
+   * 获取数据状态（对接 /api/v1/data/stats）
    */
   getStatus(): Promise<{
     bar_count: number
@@ -96,7 +96,15 @@ export const dataApi = {
     stock_count: number
     last_sync: string
   }> {
-    return request.get('/api/v1/data/status')
+    return request.get('/api/v1/data/stats').then((res: any) => {
+      const d = res.data || res
+      return {
+        bar_count: d.total_bars || 0,
+        tick_count: d.total_ticks || 0,
+        stock_count: d.total_stocks || 0,
+        last_sync: d.latest_update || '-',
+      }
+    })
   },
 
   /**

--- a/web-ui/src/router/index.ts
+++ b/web-ui/src/router/index.ts
@@ -40,16 +40,28 @@ const routes: RouteRecordRaw[] = [
 
   // ===== 研究 =====
   { path: '/research', name: 'Research', redirect: '/research/factor', meta: { title: '研究' } },
-  { path: '/research/factor', name: 'FactorResearch', component: () => import('@/views/research/ResearchPage.vue'), meta: { title: '因子分析' } },
-  { path: '/research/factor/ic', name: 'ICAnalysis', component: () => import('@/views/research/ICAnalysis.vue'), meta: { title: 'IC 分析' } },
-  { path: '/research/factor/layering', name: 'FactorLayering', component: () => import('@/views/research/FactorLayering.vue'), meta: { title: '因子分层' } },
-  { path: '/research/factor/orthogonal', name: 'FactorOrthogonalization', component: () => import('@/views/research/FactorOrthogonalization.vue'), meta: { title: '因子正交化' } },
-  { path: '/research/factor/comparison', name: 'FactorComparison', component: () => import('@/views/research/FactorComparison.vue'), meta: { title: '因子比较' } },
-  { path: '/research/factor/decay', name: 'FactorDecay', component: () => import('@/views/research/FactorDecay.vue'), meta: { title: '因子衰减' } },
-  { path: '/research/optimization', name: 'Optimization', component: () => import('@/views/research/ResearchPage.vue'), meta: { title: '参数优化' } },
-  { path: '/research/optimization/grid', name: 'GridSearch', component: () => import('@/views/optimization/GridSearch.vue'), meta: { title: '网格搜索' } },
-  { path: '/research/optimization/genetic', name: 'GeneticOptimizer', component: () => import('@/views/optimization/GeneticOptimizer.vue'), meta: { title: '遗传算法' } },
-  { path: '/research/optimization/bayesian', name: 'BayesianOptimizer', component: () => import('@/views/optimization/BayesianOptimizer.vue'), meta: { title: '贝叶斯优化' } },
+  {
+    path: '/research/factor',
+    component: () => import('@/views/research/ResearchPage.vue'),
+    children: [
+      { path: '', name: 'FactorResearch', redirect: '/research/factor/ic' },
+      { path: 'ic', name: 'ICAnalysis', component: () => import('@/views/research/ICAnalysis.vue'), meta: { title: 'IC 分析' } },
+      { path: 'layering', name: 'FactorLayering', component: () => import('@/views/research/FactorLayering.vue'), meta: { title: '因子分层' } },
+      { path: 'orthogonal', name: 'FactorOrthogonalization', component: () => import('@/views/research/FactorOrthogonalization.vue'), meta: { title: '因子正交化' } },
+      { path: 'comparison', name: 'FactorComparison', component: () => import('@/views/research/FactorComparison.vue'), meta: { title: '因子比较' } },
+      { path: 'decay', name: 'FactorDecay', component: () => import('@/views/research/FactorDecay.vue'), meta: { title: '因子衰减' } },
+    ],
+  },
+  {
+    path: '/research/optimization',
+    component: () => import('@/views/research/ResearchPage.vue'),
+    children: [
+      { path: '', name: 'Optimization', redirect: '/research/optimization/grid' },
+      { path: 'grid', name: 'GridSearch', component: () => import('@/views/optimization/GridSearch.vue'), meta: { title: '网格搜索' } },
+      { path: 'genetic', name: 'GeneticOptimizer', component: () => import('@/views/optimization/GeneticOptimizer.vue'), meta: { title: '遗传算法' } },
+      { path: 'bayesian', name: 'BayesianOptimizer', component: () => import('@/views/optimization/BayesianOptimizer.vue'), meta: { title: '贝叶斯优化' } },
+    ],
+  },
 
   // ===== 回测中心 =====
   { path: '/backtests', name: 'BacktestCenter', component: () => import('@/views/backtest/BacktestListPage.vue'), meta: { title: '回测中心' } },


### PR DESCRIPTION
Closes #4574

### 修复内容

1. **研究页路由嵌套**: `/research/factor` 和 `/research/optimization` 改为嵌套 children 路由
   - 访问 `/research/factor` 自动重定向到 IC 分析页（不再空白）
   - 访问 `/research/optimization` 自动重定向到网格搜索页
2. **数据同步 API**: `getStatus()` 对接已有的 `/api/v1/data/stats`，替代不存在的 `/api/v1/data/status`

### 变更文件
```
web-ui/src/router/index.ts        | 32 ++++++++++++++++++++++----------
web-ui/src/api/modules/data.ts    | 12 ++++++++++--
```