### PR TITLE
fix: component_loader 参数索引映射使用原始DB索引

### DIFF
--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -78,11 +78,13 @@ class ComponentLoader:
                     component_kwargs = {}
                     if param_records:
                         sorted_params = sorted(param_records, key=lambda p: p.index)
+                        param_indices = []
                         for p in sorted_params:
                             try:
                                 component_params.append(json.loads(p.value) if p.value else p.value)
                             except (json.JSONDecodeError, TypeError):
                                 component_params.append(p.value)
+                            param_indices.append(p.index)
                         self._logger.DEBUG(f"Found {len(component_params)} params: {component_params}")
 
                         # 用动态参数提取器获取参数名，构建 kwargs
@@ -96,9 +98,10 @@ class ComponentLoader:
                                 file_type_str = type_map.get(component_type)
                                 if file_type_str:
                                     param_names = get_component_parameter_names(comp_name, code_content, file_type_str, file_id)
-                                    for idx, val in enumerate(component_params):
-                                        if idx in param_names:
-                                            component_kwargs[param_names[idx]] = val
+                                    for i, val in enumerate(component_params):
+                                        orig_idx = param_indices[i]
+                                        if orig_idx in param_names:
+                                            component_kwargs[param_names[orig_idx]] = val
                         except Exception as e:
                             self._logger.WARN(f"Failed to resolve param names, falling back to positional: {e}")
                     else:
@@ -337,7 +340,7 @@ class ComponentLoader:
                 """统一加载组件：ORM 对象或 dict（必须含 file_id）"""
                 if isinstance(mapping, dict) and "file_id" in mapping:
                     return _instantiate_component_from_file(
-                        mapping["file_id"], mapping.get("type", component_type_int), mapping["mapping_uuid"]
+                        mapping["file_id"], mapping.get("type", component_type_int), mapping.get("mapping_uuid") or mapping.get("mount_id")
                     )
                 else:
                     return _instantiate_component_from_file(


### PR DESCRIPTION
## 修复内容
`component_loader.py` 第99行 `enumerate(component_params)` 重新编号参数索引从0开始，丢失原始 DB 参数索引。

## 根因
用户通过 `--param '1:"000001.SZ,..."'` 设置参数索引为1（对应 codes），但 enumerate 将其重编号为0（对应 name），导致参数映射到错误的 kwarg。

## 修复方案
引入 `param_indices` 列表保存原始 DB 索引，构建 kwargs 时使用原始索引。

## 验证
回测 `8bcc9ea8` 成功运行，FixedSelector 正确加载 6 只蓝筹股代码，产生 77 信号 60 笔交易。

Closes #4653