### PR TITLE
fix: 批量修复定时任务失败问题 (#4667 #4666 #4662 #4661)

### DIFF
--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -254,7 +254,7 @@ def pause(
             source="cli"
         )
 
-        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, command_dto.model_dump_json())
+        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, command_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Pause command sent successfully[/green]")
@@ -296,7 +296,7 @@ def resume(
             source="cli"
         )
 
-        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, command_dto.model_dump_json())
+        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, command_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Resume command sent successfully[/green]")

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -818,7 +818,7 @@ def _store_deploy_source(paper_portfolio_id: str, source_portfolio_id: str) -> N
         from ginkgo import services
         redis_svc = services.data.redis_service()
         if redis_svc:
-            redis_svc.set(f"deviation:source:{paper_portfolio_id}", source_portfolio_id)
+            redis_svc.set_cache(f"deviation:source:{paper_portfolio_id}", source_portfolio_id)
             GLOG.INFO(f"[DEPLOY] Stored source mapping: {source_portfolio_id[:8]} -> {paper_portfolio_id[:8]}")
     except Exception as e:
         GLOG.WARN(f"[DEPLOY] Failed to store source mapping in Redis: {e}")
@@ -876,7 +876,7 @@ def _generate_baseline_if_possible(paper_portfolio_id: str, source_portfolio_id:
         # 缓存到 Redis
         redis_svc = services.data.redis_service()
         if redis_svc:
-            redis_svc.set(f"deviation:baseline:{paper_portfolio_id}", json.dumps(baseline, default=str))
+            redis_svc.set_cache(f"deviation:baseline:{paper_portfolio_id}", json.dumps(baseline, default=str))
             GLOG.INFO(f"[DEPLOY] Baseline cached: slice_period={baseline.get('slice_period_days')}, "
                        f"metrics={len(baseline.get('baseline_stats', {}))}")
 
@@ -904,7 +904,8 @@ def generate_baseline(
     redis_svc = services.data.redis_service()
     source_id = None
     if redis_svc:
-        source_id = redis_svc.get(f"deviation:source:{portfolio_id}")
+        src_result = redis_svc.get_cache(f"deviation:source:{portfolio_id}")
+        source_id = src_result.data if src_result and src_result.is_success() else None
 
     if not source_id:
         source_id = source

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -842,12 +842,13 @@ def _generate_baseline_if_possible(paper_portfolio_id: str, source_portfolio_id:
             GLOG.WARN(f"[DEPLOY] No completed backtest found for source {source_portfolio_id[:8]}, skipping baseline")
             return
 
-        tasks = task_result.data
+        # task_service.list() returns paginated dict: {"data": [...], "total": N, ...}
+        tasks = task_result.data.get("data", []) if isinstance(task_result.data, dict) else task_result.data
         if not tasks:
             GLOG.WARN(f"[DEPLOY] No completed backtest found for source {source_portfolio_id[:8]}, skipping baseline")
             return
 
-        latest_task = tasks[0] if isinstance(tasks, list) else tasks
+        latest_task = tasks[0]
         task_id = getattr(latest_task, 'task_id', None)
         engine_id = getattr(latest_task, 'engine_id', None)
 

--- a/src/ginkgo/client/scheduler_cli.py
+++ b/src/ginkgo/client/scheduler_cli.py
@@ -384,7 +384,7 @@ def migrate(
         # Send migration command to Kafka
         console.print(f"\\n:satellite: Sending migration command to Kafka...")
         producer = GinkgoProducer()
-        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, migration_dto.model_dump_json())
+        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, migration_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Migration command sent successfully[/green]")
@@ -444,7 +444,7 @@ def reload(
         # Send reload command to Kafka
         console.print(f"\\n:satellite: Sending reload command to Kafka...")
         producer = GinkgoProducer()
-        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, reload_dto.model_dump_json())
+        success = producer.send(KafkaTopics.SCHEDULE_UPDATES, reload_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Reload command sent successfully[/green]")
@@ -532,7 +532,7 @@ def recalculate(
             source="cli"
         )
 
-        success = producer.send("scheduler.commands", command_dto.model_dump_json())
+        success = producer.send("scheduler.commands", command_dto.model_dump())
 
         if success:
             console.print(f":white_check_mark: [green]Recalculate command sent successfully[/green]")
@@ -639,7 +639,7 @@ def schedule(
             source="cli"
         )
 
-        success = producer.send("scheduler.commands", command_dto.model_dump_json())
+        success = producer.send("scheduler.commands", command_dto.model_dump())
 
         if success:
             console.print(f":white_check_mark: [green]Schedule command sent successfully[/green]")
@@ -676,7 +676,7 @@ def pause():
             source="cli"
         )
 
-        success = producer.send("scheduler.commands", command_dto.model_dump_json())
+        success = producer.send("scheduler.commands", command_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Pause command sent successfully[/green]")
@@ -714,7 +714,7 @@ def resume():
             source="cli"
         )
 
-        success = producer.send("scheduler.commands", command_dto.model_dump_json())
+        success = producer.send("scheduler.commands", command_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Resume command sent successfully[/green]")
@@ -755,7 +755,7 @@ def status():
             source="cli"
         )
 
-        success = producer.send("scheduler.commands", command_dto.model_dump_json())
+        success = producer.send("scheduler.commands", command_dto.model_dump())
 
         if success:
             console.print(":white_check_mark: [green]Status command sent successfully[/green]")

--- a/src/ginkgo/livecore/data_manager.py
+++ b/src/ginkgo/livecore/data_manager.py
@@ -521,16 +521,16 @@ class DataManager(threading.Thread):
             GLOG.ERROR(f"Failed to handle control command: {e}")
 
     @retry(max_try=3, backoff_factor=2)
-    def _publish_to_kafka(self, topic: str, message: str) -> None:
+    def _publish_to_kafka(self, topic: str, message) -> None:
         """
         发布消息到 Kafka（带重试）
 
         Args:
             topic: Kafka 主题
-            message: JSON 消息
+            message: dict (GinkgoProducer.value_serializer 会自动 json.dumps)
         """
         if self._producer:
-            self._producer.send(topic=topic, message=message)
+            self._producer.send(topic, message)
             GLOG.DEBUG(f"Published to {topic}")
 
     def _on_live_data_received(self, event: EventBase, source: str) -> None:
@@ -568,7 +568,7 @@ class DataManager(threading.Thread):
                 # 发布到 Kafka（带重试）
                 self._publish_to_kafka(
                     topic=KafkaTopics.MARKET_DATA,
-                    message=dto.model_dump_json(),
+                    message=dto.model_dump(),
                 )
                 GLOG.DEBUG(f"Published PriceUpdateDTO to Kafka: {event.code} (source: {source})")
 

--- a/src/ginkgo/livecore/scheduler/plan_manager.py
+++ b/src/ginkgo/livecore/scheduler/plan_manager.py
@@ -160,18 +160,24 @@ class PlanManager:
 
     @staticmethod
     def _get_all_portfolios() -> List[Dict]:
-        """获取所有 live Portfolio（静态方法便于测试）"""
+        """获取所有 PAPER + LIVE Portfolio（静态方法便于测试）
+
+        is_live 是 MPortfolio 的 @property (mode >= PAPER)，不是数据库字段。
+        必须按 mode 分别查询 PAPER 和 LIVE。
+        """
         try:
             from ginkgo import services
+            from ginkgo.enums import PORTFOLIO_MODE_TYPES
 
             portfolio_service = services.data.portfolio_service()
-            result = portfolio_service.get(is_live=True)
 
-            if result.success:
-                return result.data
-            else:
-                logger.error(f"Failed to get portfolios: {result.message}")
-                return []
+            all_portfolios = []
+            for mode in (PORTFOLIO_MODE_TYPES.PAPER, PORTFOLIO_MODE_TYPES.LIVE):
+                result = portfolio_service.get(mode=mode)
+                if result.success and result.data:
+                    all_portfolios.extend(result.data)
+
+            return all_portfolios
 
         except Exception as e:
             logger.error(f"Failed to get portfolios: {e}")

--- a/src/ginkgo/livecore/scheduler/publisher.py
+++ b/src/ginkgo/livecore/scheduler/publisher.py
@@ -122,7 +122,7 @@ class SchedulePublisher:
 
             success = self.kafka_producer.send(
                 topic=KafkaTopics.SCHEDULE_UPDATES,
-                msg=command_dto.model_dump_json()
+                msg=command_dto.model_dump()
             )
 
             if not success:

--- a/src/ginkgo/livecore/task_timer.py
+++ b/src/ginkgo/livecore/task_timer.py
@@ -642,8 +642,8 @@ class TaskTimer:
                 source="task_timer"
             )
 
-            # 直接发送到 ginkgo.data.commands
-            self._publish_to_data_commands(command_dto.model_dump_json())
+            # 直接发送到 ginkgo.data.commands (pass dict to avoid double encoding, #4667)
+            self._publish_to_data_commands(command_dto.model_dump())
             GLOG.INFO("Sent stockinfo command to DataWorker")
 
             # 发送Discord通知
@@ -757,8 +757,8 @@ class TaskTimer:
                 source="task_timer"
             )
 
-            # 发布到Kafka（带重试）
-            self._publish_to_kafka(command_dto.model_dump_json())
+            # 发布到Kafka（带重试, pass dict to avoid double encoding, #4667）
+            self._publish_to_kafka(command_dto.model_dump())
             GLOG.INFO("Sent update_selector command to Kafka")
             self._send_notification("Selector更新命令已发送", "UPDATE_SELECTOR")
 
@@ -816,7 +816,7 @@ class TaskTimer:
                 params={},
                 source="task_timer"
             )
-            self._publish_to_kafka(command_dto.model_dump_json())
+            self._publish_to_kafka(command_dto.model_dump())
             GLOG.INFO("Sent paper_trading advance command")
 
             self._send_notification("纸上交易推进命令已发送", "PAPER_TRADING")
@@ -874,7 +874,7 @@ class TaskTimer:
                         params=cmd_payload,
                         source="task_timer"
                     )
-                    self._publish_to_data_commands(command_dto.model_dump_json())
+                    self._publish_to_data_commands(command_dto.model_dump())
 
                 processed += len(batch)
                 GLOG.INFO(f"Progress: {processed}/{total} ({processed*100//total}%)")
@@ -886,12 +886,12 @@ class TaskTimer:
         except Exception as e:
             GLOG.ERROR(f"Failed to send batch {command} commands: {e}")
 
-    def _publish_to_data_commands(self, message: str) -> None:
+    def _publish_to_data_commands(self, message: dict) -> None:
         """
         发布命令到 ginkgo.data.commands topic（带重试）
 
         Args:
-            message: JSON格式的命令
+            message: 命令字典（dict，由 model_dump() 生成）
         """
         if self._producer:
             try:
@@ -985,7 +985,7 @@ class TaskTimer:
             return False
 
     @retry(max_try=3, backoff_factor=2)
-    def _publish_to_kafka(self, message: str) -> None:
+    def _publish_to_kafka(self, message: dict) -> None:
         """
         发布控制命令到Kafka（带重试）
 
@@ -994,28 +994,19 @@ class TaskTimer:
         - 其他控制命令 → ginkgo.live.control.commands
 
         Args:
-            message: JSON格式的控制命令
+            message: 命令字典（dict，由 model_dump() 生成）
         """
         if self._producer:
-            # 解析消息判断命令类型
-            try:
-                import json
-                message_data = json.loads(message)
-                command = message_data.get("command", "")
+            # 从 dict 读取 command 字段路由到正确的 topic (#4667)
+            command = message.get("command", "")
 
-                # 数据采集命令发送到专用 topic
-                if command in ("bar_snapshot", "stockinfo", "adjustfactor", "tick"):
-                    topic = KafkaTopics.DATA_COMMANDS
-                else:
-                    topic = KafkaTopics.CONTROL_COMMANDS
+            # 数据采集命令发送到专用 topic
+            if command in ("bar_snapshot", "stockinfo", "adjustfactor", "tick"):
+                topic = KafkaTopics.DATA_COMMANDS
+            else:
+                topic = KafkaTopics.CONTROL_COMMANDS
 
-                self._producer.send(
-                    topic=topic,
-                    msg=message,
-                )
-            except json.JSONDecodeError:
-                # 如果解析失败，发送到默认 topic
-                self._producer.send(
-                    topic=KafkaTopics.CONTROL_COMMANDS,
-                    msg=message,
-                )
+            self._producer.send(
+                topic=topic,
+                msg=message,
+            )

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -355,7 +355,7 @@ class TradeGatewayAdapter(Thread):
             )
 
             # 发布到Kafka
-            self.kafka_producer.send(KafkaTopics.ORDERS_FEEDBACK, feedback_dto.model_dump_json())
+            self.kafka_producer.send(KafkaTopics.ORDERS_FEEDBACK, feedback_dto.model_dump())
             GLOG.INFO(f"Fill event sent to Kafka for order {fill_event.order.uuid[:8]}")
 
         except Exception as e:

--- a/src/ginkgo/notifier/ginkgo_notifier.py
+++ b/src/ginkgo/notifier/ginkgo_notifier.py
@@ -102,7 +102,7 @@ class GinkgoNotifier(INotificationService):
         # Fallback到原来的实现
         if self._producer:
             notification_dto = NotificationDTO(type=NotificationDTO.Types.BEEP)
-            self._producer.send("notify", notification_dto.model_dump_json())
+            self._producer.send("notify", notification_dto.model_dump())
         # beepbeep(2000, 1, 20, 30)
 
     def beep_coin(self) -> None:
@@ -122,7 +122,7 @@ class GinkgoNotifier(INotificationService):
         # Fallback到原来的实现
         if self._producer:
             notification_dto = NotificationDTO(type=NotificationDTO.Types.BEEP)
-            self._producer.send("notify", notification_dto.model_dump_json())
+            self._producer.send("notify", notification_dto.model_dump())
         # beepbeep(1920, 1, 30, 40)
         # beepbeep(2180, 1, 60, 230)
     

--- a/src/ginkgo/trading/analysis/evaluation/backtest_evaluator.py
+++ b/src/ginkgo/trading/analysis/evaluation/backtest_evaluator.py
@@ -70,11 +70,11 @@ class BacktestEvaluator:
         Returns:
             Dict: 完整的评估结果
         """
-        GLOG.info(f"开始回测稳定性评估: portfolio={portfolio_id}, engine={engine_id}")
+        GLOG.INFO(f"开始回测稳定性评估: portfolio={portfolio_id}, engine={engine_id}")
         
         try:
             # 1. 获取回测数据
-            GLOG.info("步骤1: 获取回测数据")
+            GLOG.INFO("步骤1: 获取回测数据")
             backtest_data = self.data_manager.get_backtest_data(
                 portfolio_id=portfolio_id,
                 engine_id=engine_id,
@@ -84,11 +84,11 @@ class BacktestEvaluator:
             
             # 验证数据完整性
             if self._validate_backtest_data(backtest_data):
-                GLOG.error("回测数据验证失败")
+                GLOG.ERROR("回测数据验证失败")
                 return {'status': 'failed', 'reason': 'invalid_data'}
                 
             # 2. 寻找最佳切片周期
-            GLOG.info("步骤2: 寻找最佳切片周期")
+            GLOG.INFO("步骤2: 寻找最佳切片周期")
             optimal_period, stability_score, period_analysis = self.period_optimizer.find_optimal_slice_period(
                 analyzer_data=backtest_data['analyzer_data'],
                 signal_data=backtest_data['signal_data'],
@@ -96,7 +96,7 @@ class BacktestEvaluator:
             )
             
             # 3. 使用最佳周期重新切片
-            GLOG.info(f"步骤3: 使用最佳周期({optimal_period}天)重新切片")
+            GLOG.INFO(f"步骤3: 使用最佳周期({optimal_period}天)重新切片")
             optimal_slices = self.data_manager.slice_data_by_period(backtest_data, optimal_period)
             
             # 4. 平衡切片
@@ -107,15 +107,15 @@ class BacktestEvaluator:
             )
             
             # 5. 计算每个切片的指标
-            GLOG.info("步骤4: 计算切片指标")
+            GLOG.INFO("步骤4: 计算切片指标")
             slice_metrics = self._calculate_slice_metrics(balanced_slices)
             
             # 6. 计算稳定性分析
-            GLOG.info("步骤5: 计算稳定性分析")
+            GLOG.INFO("步骤5: 计算稳定性分析")
             stability_analysis = self._analyze_metric_stability(slice_metrics)
             
             # 7. 生成基准数据
-            GLOG.info("步骤6: 生成监控基准")
+            GLOG.INFO("步骤6: 生成监控基准")
             monitoring_baseline = self._create_monitoring_baseline(slice_metrics, optimal_period, balanced_slices)
             
             # 8. 生成综合评估报告
@@ -142,11 +142,11 @@ class BacktestEvaluator:
                 'recommendations': self._generate_recommendations(stability_analysis, optimal_period)
             }
             
-            GLOG.info("回测稳定性评估完成")
+            GLOG.INFO("回测稳定性评估完成")
             return evaluation_result
             
         except Exception as e:
-            GLOG.error(f"回测稳定性评估失败: {e}")
+            GLOG.ERROR(f"回测稳定性评估失败: {e}")
             return {'status': 'error', 'error': str(e)}
             
     def create_live_monitor(self, 
@@ -162,7 +162,7 @@ class BacktestEvaluator:
         Returns:
             LiveDeviationDetector: 实盘偏离检测器实例
         """
-        GLOG.info("创建实盘监控器")
+        GLOG.INFO("创建实盘监控器")
         
         baseline_stats = monitoring_baseline.get('baseline_stats', {})
         slice_period = monitoring_baseline.get('slice_period_days', 30)
@@ -175,7 +175,7 @@ class BacktestEvaluator:
         )
         monitor._daily_curves = daily_curves
         
-        GLOG.info(f"实盘监控器创建完成，切片周期: {slice_period}天")
+        GLOG.INFO(f"实盘监控器创建完成，切片周期: {slice_period}天")
         return monitor
         
     def _validate_backtest_data(self, backtest_data: Dict[str, pd.DataFrame]) -> bool:
@@ -194,18 +194,18 @@ class BacktestEvaluator:
         
         # 检查基本数据存在
         if analyzer_data.empty:
-            GLOG.error("Analyzer数据为空")
+            GLOG.ERROR("Analyzer数据为空")
             return True
             
         # 检查必要列存在
         required_analyzer_cols = ['timestamp', 'name', 'value']
         if not all(col in analyzer_data.columns for col in required_analyzer_cols):
-            GLOG.error(f"Analyzer数据缺少必要列: {required_analyzer_cols}")
+            GLOG.ERROR(f"Analyzer数据缺少必要列: {required_analyzer_cols}")
             return True
             
         # 检查数据量
         if len(analyzer_data) < 10:
-            GLOG.error(f"Analyzer数据量太少: {len(analyzer_data)}")
+            GLOG.ERROR(f"Analyzer数据量太少: {len(analyzer_data)}")
             return True
             
         return False
@@ -457,8 +457,8 @@ class BacktestEvaluator:
         try:
             with open(file_path, 'w', encoding='utf-8') as f:
                 json.dump(evaluation_result, f, indent=2, ensure_ascii=False, default=str)
-            GLOG.info(f"评估报告已导出到: {file_path}")
+            GLOG.INFO(f"评估报告已导出到: {file_path}")
             return True
         except Exception as e:
-            GLOG.error(f"导出评估报告失败: {e}")
+            GLOG.ERROR(f"导出评估报告失败: {e}")
             return False

--- a/src/ginkgo/trading/analysis/evaluation/deviation_checker.py
+++ b/src/ginkgo/trading/analysis/evaluation/deviation_checker.py
@@ -31,7 +31,8 @@ class DeviationChecker:
         try:
             redis_svc = services.data.redis_service()
             if redis_svc:
-                cached = redis_svc.get(f"deviation:baseline:{portfolio_id}")
+                result = redis_svc.get_cache(f"deviation:baseline:{portfolio_id}")
+                cached = result.data if result and result.is_success() else None
                 if cached:
                     return json.loads(cached)
         except Exception:
@@ -41,7 +42,8 @@ class DeviationChecker:
             redis_svc = services.data.redis_service()
             source_id = None
             if redis_svc:
-                source_id = redis_svc.get(f"deviation:source:{portfolio_id}")
+                src_result = redis_svc.get_cache(f"deviation:source:{portfolio_id}")
+                source_id = src_result.data if src_result and src_result.is_success() else None
 
             if not source_id:
                 GLOG.DEBUG(f"[DEV-CHECKER] No source portfolio for {portfolio_id[:8]}")
@@ -54,7 +56,11 @@ class DeviationChecker:
             if not task_result.is_success() or not task_result.data:
                 return None
 
-            latest_task = task_result.data[0] if isinstance(task_result.data, list) else task_result.data
+            # task_service.list() returns paginated dict: {"data": [...], "total": N, ...}
+            tasks = task_result.data.get("data", []) if isinstance(task_result.data, dict) else task_result.data
+            if not tasks:
+                return None
+            latest_task = tasks[0]
             task_id = getattr(latest_task, "task_id", None)
             engine_id = getattr(latest_task, "engine_id", None)
             if not task_id:
@@ -73,7 +79,7 @@ class DeviationChecker:
                 return None
 
             if redis_svc:
-                redis_svc.set(
+                redis_svc.set_cache(
                     f"deviation:baseline:{portfolio_id}",
                     json.dumps(baseline, default=str),
                 )
@@ -89,7 +95,8 @@ class DeviationChecker:
         try:
             redis_svc = services.data.redis_service()
             if redis_svc:
-                config_json = redis_svc.get(f"deviation:config:{portfolio_id}")
+                cfg_result = redis_svc.get_cache(f"deviation:config:{portfolio_id}")
+                config_json = cfg_result.data if cfg_result and cfg_result.is_success() else None
                 if config_json:
                     return json.loads(config_json)
         except Exception:

--- a/src/ginkgo/trading/analysis/evaluation/live_deviation_detector.py
+++ b/src/ginkgo/trading/analysis/evaluation/live_deviation_detector.py
@@ -80,7 +80,7 @@ class LiveDeviationDetector:
         # 初始化当前切片
         if self.current_slice_data['start_date'] is None:
             self.current_slice_data['start_date'] = current_time
-            GLOG.info(f"开始新的切片: {current_time}")
+            GLOG.INFO(f"开始新的切片: {current_time}")
             
         # 添加新数据
         if analyzer_records:
@@ -96,7 +96,7 @@ class LiveDeviationDetector:
         slice_end_time = self.current_slice_data['start_date'] + timedelta(days=self.slice_period_days)
         
         if current_time >= slice_end_time:
-            GLOG.info(f"切片完成: {self.current_slice_data['start_date']} 到 {slice_end_time}")
+            GLOG.INFO(f"切片完成: {self.current_slice_data['start_date']} 到 {slice_end_time}")
             return True
             
         return False
@@ -109,7 +109,7 @@ class LiveDeviationDetector:
             Dict: 偏离分析结果
         """
         if not self.current_slice_data['analyzer_data']:
-            GLOG.warn("当前切片无analyzer数据，跳过偏离检测")
+            GLOG.WARN("当前切片无analyzer数据，跳过偏离检测")
             return {'status': 'no_data'}
             
         # 计算当前切片指标
@@ -146,7 +146,7 @@ class LiveDeviationDetector:
         # 重置当前切片
         self._reset_current_slice()
         
-        GLOG.info(f"偏离检测完成，整体等级: {overall_deviation_level}")
+        GLOG.INFO(f"偏离检测完成，整体等级: {overall_deviation_level}")
         
         return {
             'status': 'completed',

--- a/src/ginkgo/trading/analysis/evaluation/slice_data_manager.py
+++ b/src/ginkgo/trading/analysis/evaluation/slice_data_manager.py
@@ -50,7 +50,7 @@ class SliceDataManager:
         Returns:
             Dict: 包含analyzer_data, signal_data, order_data的字典
         """
-        GLOG.info(f"获取回测数据: portfolio={portfolio_id}, engine={engine_id}")
+        GLOG.INFO(f"获取回测数据: portfolio={portfolio_id}, engine={engine_id}")
         
         try:
             from ginkgo import services
@@ -83,7 +83,7 @@ class SliceDataManager:
             signal_data = self._preprocess_signal_data(signal_data)
             order_data = self._preprocess_order_data(order_data)
             
-            GLOG.info(f"数据获取完成: analyzer={len(analyzer_data)}, signal={len(signal_data)}, order={len(order_data)}")
+            GLOG.INFO(f"数据获取完成: analyzer={len(analyzer_data)}, signal={len(signal_data)}, order={len(order_data)}")
             
             return {
                 'analyzer_data': analyzer_data,
@@ -92,7 +92,7 @@ class SliceDataManager:
             }
             
         except Exception as e:
-            GLOG.error(f"获取回测数据失败: {e}")
+            GLOG.ERROR(f"获取回测数据失败: {e}")
             raise
             
     def _preprocess_analyzer_data(self, data: pd.DataFrame) -> pd.DataFrame:
@@ -192,10 +192,10 @@ class SliceDataManager:
         start_date, end_date = self._get_data_time_range(analyzer_data, signal_data, order_data)
         
         if start_date is None or end_date is None:
-            GLOG.warn("无法确定数据时间范围")
+            GLOG.WARN("无法确定数据时间范围")
             return []
             
-        GLOG.info(f"数据时间范围: {start_date} 到 {end_date}")
+        GLOG.INFO(f"数据时间范围: {start_date} 到 {end_date}")
         
         # 创建切片
         slices = []
@@ -227,7 +227,7 @@ class SliceDataManager:
             current_start = current_end
             slice_index += 1
             
-        GLOG.info(f"数据切片完成: 共{len(slices)}个切片")
+        GLOG.INFO(f"数据切片完成: 共{len(slices)}个切片")
         return slices
         
     def _get_data_time_range(self, *dataframes) -> Tuple[Optional[datetime], Optional[datetime]]:
@@ -324,7 +324,7 @@ class SliceDataManager:
             else:
                 balanced_slices.append(current_slice)
                 
-        GLOG.info(f"切片平衡调整完成: {len(slices)} -> {len(balanced_slices)}")
+        GLOG.INFO(f"切片平衡调整完成: {len(slices)} -> {len(balanced_slices)}")
         return balanced_slices
         
     def _merge_slices(self, slice1: Dict, slice2: Dict) -> Dict:

--- a/src/ginkgo/trading/analysis/evaluation/slice_period_optimizer.py
+++ b/src/ginkgo/trading/analysis/evaluation/slice_period_optimizer.py
@@ -55,14 +55,14 @@ class SlicePeriodOptimizer:
         Returns:
             tuple: (最优周期, 稳定性评分, 详细分析结果)
         """
-        GLOG.info("开始寻找最佳切片周期...")
+        GLOG.INFO("开始寻找最佳切片周期...")
         
         best_period = None
         best_score = 0
         analysis_results = {}
         
         for period in self.candidate_periods:
-            GLOG.info(f"测试周期: {period}天")
+            GLOG.INFO(f"测试周期: {period}天")
             
             # 1. 按周期切片
             slices = self._slice_data_by_period(analyzer_data, signal_data, order_data, period)
@@ -70,7 +70,7 @@ class SlicePeriodOptimizer:
             # 2. 检查平衡性
             balance_check = self._check_slice_balance(slices)
             if not balance_check['is_balanced']:
-                GLOG.warn(f"周期{period}天不满足平衡性要求: {balance_check['reason']}")
+                GLOG.WARN(f"周期{period}天不满足平衡性要求: {balance_check['reason']}")
                 continue
                 
             # 3. 计算稳定性评分
@@ -91,7 +91,7 @@ class SlicePeriodOptimizer:
         if best_period is None:
             raise ValueError("未找到满足条件的切片周期")
             
-        GLOG.info(f"最优切片周期: {best_period}天, 稳定性评分: {best_score:.4f}")
+        GLOG.INFO(f"最优切片周期: {best_period}天, 稳定性评分: {best_score:.4f}")
         return best_period, best_score, analysis_results
         
     def _slice_data_by_period(self, 

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -1030,7 +1030,7 @@ class ExecutionNode:
                         )
 
                         # 发送到Kafka
-                        success = self.order_producer.send(KafkaTopics.ORDERS_SUBMISSION, order_dto.model_dump_json())
+                        success = self.order_producer.send(KafkaTopics.ORDERS_SUBMISSION, order_dto.model_dump())
                         if success:
                             GLOG.INFO(f"Order {event.uuid} sent to Kafka via output_queue")
                         else:

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -527,3 +527,85 @@ class TestPortfolioUnbindComponent:
         ])
         assert result.exit_code == 1
         assert "Failed to delete binding" in result.output
+
+
+# ============================================================================
+# #4666 Bug 2: _generate_baseline_if_possible pagination handling
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestGenerateBaselinePagination:
+    """#4666 Bug 2: task_service.list() returns paginated dict, not plain list.
+
+    BacktestTaskService.list() returns ServiceResult.success({
+        "data": [...], "total": N, "page": 0, "page_size": 20
+    }).
+    The code must extract the inner "data" list, not treat the outer dict as a list.
+    """
+
+    def test_extracts_task_id_from_paginated_result(self):
+        """_generate_baseline_if_possible must extract task_id from paginated dict.
+
+        BacktestTaskService.list() returns ServiceResult.data = {"data": [...], "total": N}.
+        The function must unwrap the inner list, not treat the outer dict as a task.
+        """
+        from ginkgo.client.portfolio_cli import _generate_baseline_if_possible
+
+        # Mock backtest_task_service returning paginated dict
+        mock_task = MagicMock()
+        mock_task.task_id = "task-abc-123"
+        mock_task.engine_id = "engine-xyz"
+
+        mock_task_svc = MagicMock()
+        mock_task_svc.list.return_value = ServiceResult.success({
+            "data": [mock_task],
+            "total": 1,
+            "page": 0,
+            "page_size": 20,
+        })
+
+        # Mock evaluator (prevent real evaluation)
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate_backtest_stability.return_value = {
+            "status": "success",
+            "monitoring_baseline": {"slice_period_days": 30, "baseline_stats": {"sharpe": {}}},
+        }
+
+        # Mock redis service
+        mock_redis = MagicMock()
+
+        mock_services = MagicMock()
+        mock_services.data.backtest_task_service.return_value = mock_task_svc
+        mock_services.data.redis_service.return_value = mock_redis
+
+        with patch("ginkgo.services", mock_services), \
+             patch("ginkgo.trading.analysis.evaluation.backtest_evaluator.BacktestEvaluator",
+                   return_value=mock_evaluator):
+            _generate_baseline_if_possible("paper-id", "source-id")
+
+        # The evaluator must have been called with the correct engine_id
+        mock_evaluator.evaluate_backtest_stability.assert_called_once_with(
+            portfolio_id="source-id",
+            engine_id="engine-xyz",
+        )
+
+    def test_handles_empty_paginated_result(self):
+        """When paginated result has empty data list, function must not crash."""
+        from ginkgo.client.portfolio_cli import _generate_baseline_if_possible
+
+        mock_task_svc = MagicMock()
+        mock_task_svc.list.return_value = ServiceResult.success({
+            "data": [],
+            "total": 0,
+            "page": 0,
+            "page_size": 20,
+        })
+
+        mock_services = MagicMock()
+        mock_services.data.backtest_task_service.return_value = mock_task_svc
+
+        with patch("ginkgo.services", mock_services):
+            # Should not crash — just return silently
+            _generate_baseline_if_possible("paper-id", "source-id")

--- a/tests/unit/livecore/test_plan_manager.py
+++ b/tests/unit/livecore/test_plan_manager.py
@@ -1,0 +1,96 @@
+"""Tests for PlanManager -- #4661"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+@pytest.fixture()
+def mock_services():
+    """Create a mock services module."""
+    svc = MagicMock()
+    with patch("ginkgo.services", svc):
+        yield svc
+
+
+@pytest.mark.tdd
+class TestGetAllPortfolios:
+    """#4661: _get_all_portfolios must query PAPER + LIVE modes explicitly.
+
+    The old code called portfolio_service.get(is_live=True), but `is_live`
+    is a @property on MPortfolio (mode >= PAPER), not a queryable DB field.
+    It falls into **kwargs and is silently dropped by kwargs.get('filters', {}),
+    returning ALL portfolios including BACKTEST ones.
+
+    Fix: query PAPER mode and LIVE mode separately, then merge.
+    """
+
+    def test_queries_paper_and_live_modes(self, mock_services):
+        """Must call portfolio_service.get() once for PAPER and once for LIVE."""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        paper_portfolio = MagicMock()
+        paper_portfolio.mode = 1  # PAPER
+
+        live_portfolio = MagicMock()
+        live_portfolio.mode = 2  # LIVE
+
+        mock_pf_svc = MagicMock()
+        mock_pf_svc.get.side_effect = [
+            ServiceResult.success([paper_portfolio]),
+            ServiceResult.success([live_portfolio]),
+        ]
+        mock_services.data.portfolio_service.return_value = mock_pf_svc
+
+        result = PlanManager._get_all_portfolios()
+
+        # Must have called get() twice — once for PAPER, once for LIVE
+        assert mock_pf_svc.get.call_count == 2
+        calls = mock_pf_svc.get.call_args_list
+
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+        modes_called = []
+        for call in calls:
+            mode_arg = call.kwargs.get("mode")
+            if mode_arg is not None:
+                modes_called.append(mode_arg)
+
+        # Both PAPER and LIVE modes must be queried
+        assert PORTFOLIO_MODE_TYPES.PAPER in modes_called, \
+            f"PAPER mode not queried. Modes called: {modes_called}"
+        assert PORTFOLIO_MODE_TYPES.LIVE in modes_called, \
+            f"LIVE mode not queried. Modes called: {modes_called}"
+
+        # Result must contain both portfolios
+        assert len(result) == 2
+
+    def test_does_not_query_backtest_mode(self, mock_services):
+        """Must NOT return BACKTEST portfolios."""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        mock_pf_svc = MagicMock()
+        mock_pf_svc.get.side_effect = [
+            ServiceResult.success([]),  # PAPER: none
+            ServiceResult.success([]),  # LIVE: none
+        ]
+        mock_services.data.portfolio_service.return_value = mock_pf_svc
+
+        result = PlanManager._get_all_portfolios()
+
+        assert result == []
+        # Should not call with is_live=True (which is silently dropped)
+        for call in mock_pf_svc.get.call_args_list:
+            assert "is_live" not in call.kwargs, \
+                "is_live should not be used — it's a @property, not a DB field"
+
+    def test_returns_empty_on_service_error(self, mock_services):
+        """Must return empty list when service fails."""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        mock_pf_svc = MagicMock()
+        mock_pf_svc.get.return_value = ServiceResult.error("DB error")
+        mock_services.data.portfolio_service.return_value = mock_pf_svc
+
+        result = PlanManager._get_all_portfolios()
+
+        assert result == []

--- a/tests/unit/livecore/test_task_timer.py
+++ b/tests/unit/livecore/test_task_timer.py
@@ -1,6 +1,6 @@
 """Smoke tests for livecore.task_timer -- #3870"""
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, PropertyMock
 
 try:
     from ginkgo.livecore.task_timer import TaskTimer
@@ -28,3 +28,71 @@ class TestTaskTimer:
         timer = TaskTimer()
         result = timer.validate_config()
         assert isinstance(result, bool)
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="TaskTimer not available")
+class TestTaskTimerKafkaPublishing:
+    """#4667: TaskTimer must pass dict (not str) to Kafka Producer.
+
+    The GinkgoProducer.value_serializer does json.dumps(v).encode().
+    If v is already a JSON string, the result is double-encoded.
+    If v is a dict, serialization is correct (single pass).
+    """
+
+    def _make_timer_with_mock_producer(self):
+        """Create a TaskTimer with a mocked producer that captures send() calls."""
+        timer = TaskTimer()
+        mock_producer = MagicMock()
+        mock_producer.send = MagicMock()
+        timer._producer = mock_producer
+        return timer, mock_producer
+
+    def test_paper_trading_job_sends_dict_not_str(self):
+        """Paper trading command must be sent as dict, not JSON string."""
+        timer, mock_producer = self._make_timer_with_mock_producer()
+
+        timer._paper_trading_job()
+
+        mock_producer.send.assert_called_once()
+        call_kwargs = mock_producer.send.call_args
+        msg = call_kwargs.kwargs.get("msg") or call_kwargs[1].get("msg") or call_kwargs[0][1]
+        assert isinstance(msg, dict), (
+            f"Expected dict but got {type(msg).__name__}. "
+            f"This causes double encoding via value_serializer=json.dumps(v). "
+            f"Use model_dump() instead of model_dump_json()."
+        )
+
+    def test_stockinfo_job_sends_dict_not_str(self):
+        """Stockinfo command must be sent as dict to data.commands topic."""
+        timer, mock_producer = self._make_timer_with_mock_producer()
+
+        timer._stockinfo_job()
+
+        mock_producer.send.assert_called_once()
+        msg = mock_producer.send.call_args.kwargs.get("msg") or mock_producer.send.call_args[0][1]
+        assert isinstance(msg, dict), f"Expected dict but got {type(msg).__name__}"
+
+    def test_publish_to_kafka_routes_by_command_type(self):
+        """_publish_to_kafka should read command from dict to route to correct topic."""
+        from ginkgo.interfaces.kafka_topics import KafkaTopics
+        timer, mock_producer = self._make_timer_with_mock_producer()
+
+        message = {"command": "paper_trading", "params": {}, "source": "test"}
+        timer._publish_to_kafka(message)
+
+        mock_producer.send.assert_called_once()
+        topic = mock_producer.send.call_args.kwargs.get("topic") or mock_producer.send.call_args[0][0]
+        assert topic == KafkaTopics.CONTROL_COMMANDS
+
+    def test_publish_to_kafka_routes_data_commands(self):
+        """Data commands (bar_snapshot, stockinfo, etc.) must route to DATA_COMMANDS topic."""
+        from ginkgo.interfaces.kafka_topics import KafkaTopics
+        timer, mock_producer = self._make_timer_with_mock_producer()
+
+        for cmd in ("bar_snapshot", "stockinfo", "adjustfactor", "tick"):
+            mock_producer.send.reset_mock()
+            message = {"command": cmd, "params": {}, "source": "test"}
+            timer._publish_to_kafka(message)
+
+            topic = mock_producer.send.call_args.kwargs.get("topic") or mock_producer.send.call_args[0][0]
+            assert topic == KafkaTopics.DATA_COMMANDS, f"Command '{cmd}' should route to DATA_COMMANDS"

--- a/tests/unit/test_model_dump_double_encoding.py
+++ b/tests/unit/test_model_dump_double_encoding.py
@@ -1,0 +1,237 @@
+"""Tests for model_dump_json() double encoding -- PR review Issue 2.
+
+GinkgoProducer.value_serializer does json.dumps(v).encode("utf-8").
+When v is a str (from model_dump_json()), it gets double-encoded.
+When v is a dict (from model_dump()), it serializes correctly.
+
+All producer.send() calls must pass dict, not str.
+"""
+import pytest
+import sys
+import types
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+
+
+# ============================================================================
+# trade_gateway_adapter.py — 实盘订单反馈 (production-critical)
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestTradeGatewayAdapterPublishFillEvent:
+    """_publish_fill_event must send dict to producer, not JSON string."""
+
+    def test_publish_fill_sends_dict_not_str(self):
+        """#4667: feedback_dto.model_dump_json() causes double encoding."""
+        from ginkgo.livecore.trade_gateway_adapter import TradeGatewayAdapter
+
+        adapter = TradeGatewayAdapter.__new__(TradeGatewayAdapter)
+        mock_producer = MagicMock()
+        adapter.kafka_producer = mock_producer
+
+        mock_order = MagicMock()
+        mock_order.uuid = "order-uuid-12345678"
+        mock_order.code = "000001.SZ"
+        mock_order.direction = MagicMock()
+        mock_order.direction.value = "LONG"
+
+        fill_event = MagicMock()
+        fill_event.order = mock_order
+        fill_event.portfolio_id = "portfolio-123"
+        fill_event.engine_id = "engine-456"
+        fill_event.task_id = "task-789"
+        fill_event.filled_quantity = 100
+        fill_event.fill_price = 10.5
+        fill_event.timestamp = datetime(2026, 1, 1, 10, 0, 0)
+
+        with patch("ginkgo.livecore.trade_gateway_adapter.GLOG"):
+            adapter._publish_fill_event(fill_event)
+
+        mock_producer.send.assert_called_once()
+        value = mock_producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )
+
+
+# ============================================================================
+# publisher.py — 实时调度指令 (production-critical)
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestPublisherPublishScheduleChange:
+    """send_schedule_command must send dict to producer, not JSON string."""
+
+    def test_publish_schedule_sends_dict_not_str(self):
+        """publisher: command_dto.model_dump_json() causes double encoding."""
+        from ginkgo.livecore.scheduler.publisher import SchedulePublisher
+
+        publisher = SchedulePublisher.__new__(SchedulePublisher)
+        mock_producer = MagicMock()
+        publisher.kafka_producer = mock_producer
+
+        change = {
+            "portfolio_id": "portfolio-1234567890",
+            "from_node": "node-A",
+            "to_node": "node-B",
+        }
+
+        # ScheduleUpdateDTO is imported inside the function body
+        with patch("ginkgo.interfaces.dtos.ScheduleUpdateDTO") as MockDTO:
+            mock_dto = MagicMock()
+            mock_dto.model_dump.return_value = {"command": "migrate", "portfolio_id": "portfolio-123"}
+            mock_dto.model_dump_json.return_value = '{"command": "migrate"}'
+            MockDTO.Commands = MagicMock()
+            MockDTO.Commands.PORTFOLIO_MIGRATE = "migrate"
+            MockDTO.return_value = mock_dto
+
+            publisher.send_schedule_command(change)
+
+        # send(topic=..., msg=...)  — msg is the second positional arg
+        mock_producer.send.assert_called_once()
+        value = mock_producer.send.call_args.kwargs.get("msg") or mock_producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )
+
+
+# ============================================================================
+# ginkgo_notifier.py — 通知 fallback 路径
+# Import chain: ginkgo_notifier → notifier_telegram → ResultPlot → matplotlib
+# Must mock notifier_telegram before importing ginkgo_notifier.
+# ============================================================================
+
+
+def _make_notifier():
+    """Create a GinkgoNotifier with mocked producer, avoiding matplotlib import."""
+    # Mock the telegram module (which pulls in matplotlib via ResultPlot)
+    if "ginkgo.notifier.notifier_telegram" not in sys.modules:
+        tel_mock = types.ModuleType("ginkgo.notifier.notifier_telegram")
+        tel_mock.echo = MagicMock()
+        tel_mock.run_telebot = MagicMock()
+        sys.modules["ginkgo.notifier.notifier_telegram"] = tel_mock
+
+    from ginkgo.notifier.ginkgo_notifier import GinkgoNotifier
+    notifier = GinkgoNotifier.__new__(GinkgoNotifier)
+    notifier._producer = MagicMock()
+    notifier._kafka_service = None  # Force fallback path
+    return notifier
+
+
+@pytest.mark.tdd
+class TestGinkgoNotifierBeepDoubleEncoding:
+    """beep()/beep_coin() fallback must send dict, not JSON string."""
+
+    def test_beep_sends_dict_not_str(self):
+        """beep() fallback: model_dump_json() causes double encoding."""
+        notifier = _make_notifier()
+
+        with patch("ginkgo.notifier.ginkgo_notifier.GCONF") as mock_conf:
+            mock_conf.QUIET = False
+            with patch("ginkgo.notifier.ginkgo_notifier.GLOG"):
+                notifier.beep()
+
+        value = notifier._producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )
+
+    def test_beep_coin_sends_dict_not_str(self):
+        """beep_coin() fallback: model_dump_json() causes double encoding."""
+        notifier = _make_notifier()
+
+        with patch("ginkgo.notifier.ginkgo_notifier.GCONF") as mock_conf:
+            mock_conf.QUIET = False
+            with patch("ginkgo.notifier.ginkgo_notifier.GLOG"):
+                notifier.beep_coin()
+
+        value = notifier._producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )
+
+
+# ============================================================================
+# scheduler_cli.py — CLI 命令
+# GinkgoProducer is imported inside function bodies from
+# ginkgo.data.drivers.ginkgo_kafka — patch at the source.
+# No GLOG/GCONF at module level — only GinkgoProducer + DTOs inside functions.
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestSchedulerCliSendUsesModelDump:
+    """scheduler_cli commands must send dict to producer via GinkgoProducer.
+
+    GinkgoProducer is imported inside function bodies, all DTOs too.
+    We test by patching GinkgoProducer at source and invoking via typer.testing.CliRunner.
+    """
+
+    def _invoke_and_check(self, app_cmd, args):
+        """Helper: invoke a Typer command and assert producer.send got dict."""
+        from typer.testing import CliRunner
+        runner = CliRunner()
+        mock_producer = MagicMock()
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer), \
+             patch("ginkgo.data.crud.RedisCRUD"), \
+             patch("ginkgo.interfaces.dtos.ScheduleUpdateDTO") as MockDTO, \
+             patch("ginkgo.interfaces.dtos.SchedulerCommandDTO") as MockCmdDTO:
+            # Configure mock DTOs to have real model_dump/model_dump_json
+            mock_dto = MagicMock()
+            mock_dto.model_dump.return_value = {"command": "test", "portfolio_id": "pf-001"}
+            mock_dto.model_dump_json.return_value = '{"command": "test"}'
+            mock_dto.timestamp = "2026-01-01T00:00:00"
+            MockDTO.return_value = mock_dto
+            MockDTO.Commands = MagicMock()
+            MockCmdDTO.return_value = mock_dto
+            MockCmdDTO.Commands = MagicMock()
+
+            runner.invoke(app_cmd, args)
+
+        assert mock_producer.send.called, "producer.send() was never called — CLI path not reached"
+        value = mock_producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )
+
+    def test_migrate_sends_dict(self):
+        """migrate: model_dump_json() causes double encoding."""
+        from ginkgo.client.scheduler_cli import app
+        self._invoke_and_check(app, ["migrate", "pf-001", "--target", "node-B", "--force"])
+
+    def test_reload_sends_dict(self):
+        """reload: model_dump_json() causes double encoding."""
+        from ginkgo.client.scheduler_cli import app
+        self._invoke_and_check(app, ["reload", "pf-001", "--force"])
+
+    def test_pause_sends_dict(self):
+        """pause: model_dump_json() causes double encoding."""
+        from ginkgo.client.scheduler_cli import app
+        # pause() takes no arguments
+        from typer.testing import CliRunner
+        runner = CliRunner()
+        mock_producer = MagicMock()
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer), \
+             patch("ginkgo.interfaces.dtos.SchedulerCommandDTO") as MockCmdDTO:
+            mock_dto = MagicMock()
+            mock_dto.model_dump.return_value = {"command": "pause", "source": "cli"}
+            mock_dto.model_dump_json.return_value = '{"command": "pause"}'
+            MockCmdDTO.return_value = mock_dto
+            MockCmdDTO.Commands = MagicMock()
+            runner.invoke(app, ["pause"])
+
+        assert mock_producer.send.called, "producer.send() was never called — CLI path not reached"
+        value = mock_producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )

--- a/tests/unit/test_model_dump_double_encoding_round2.py
+++ b/tests/unit/test_model_dump_double_encoding_round2.py
@@ -113,3 +113,50 @@ class TestExecutionCliDoubleEncoding:
             f"Expected dict (model_dump), got {type(value).__name__}. "
             "Use model_dump() not model_dump_json() to avoid double encoding."
         )
+
+
+# ============================================================================
+# data_manager.py — 实时行情发布 (round 3: double encoding + TypeError)
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestDataManagerPublishToKafka:
+    """data_manager._publish_to_kafka must use correct send() signature and pass dict."""
+
+    def test_publish_uses_positional_args_not_kwargs(self):
+        """GinkgoProducer.send(self, topic, msg) — 'message' kwarg causes TypeError."""
+        import ginkgo.livecore.data_manager as mod
+
+        source = inspect.getsource(mod)
+        bad = re.findall(r"_producer\.send\(.*message=", source)
+        assert len(bad) == 0, (
+            "Found send(message=...) in data_manager.py — GinkgoProducer.send() "
+            "parameter is 'msg' not 'message'. Use positional args: send(topic, value)."
+        )
+
+    def test_live_data_publishes_dict_not_str(self):
+        """_on_live_data_received must pass model_dump() dict, not model_dump_json() str."""
+        import ginkgo.livecore.data_manager as mod
+
+        source = inspect.getsource(mod)
+        bad = re.findall(r"model_dump_json", source)
+        assert len(bad) == 0, (
+            f"Found model_dump_json() in data_manager.py ({len(bad)} sites). "
+            "GinkgoProducer.value_serializer calls json.dumps() — use model_dump() instead."
+        )
+
+    def test_price_update_dto_model_dump_returns_dict(self):
+        """PriceUpdateDTO.model_dump() must return dict for Kafka serializer."""
+        from ginkgo.interfaces.dtos import PriceUpdateDTO
+
+        dto = PriceUpdateDTO(
+            symbol="000001.SZ",
+            timestamp="2026-01-01T10:00:00",
+            price=10.5,
+            source="test",
+        )
+        result = dto.model_dump()
+        assert isinstance(result, dict), (
+            f"PriceUpdateDTO.model_dump() returned {type(result).__name__}, expected dict."
+        )

--- a/tests/unit/test_model_dump_double_encoding_round2.py
+++ b/tests/unit/test_model_dump_double_encoding_round2.py
@@ -1,0 +1,115 @@
+"""Tests for model_dump_json() double encoding — PR review round 2.
+
+3 additional sites found in execution_cli.py (2) and node.py (1).
+Same double-encoding root cause: GinkgoProducer.value_serializer calls
+json.dumps() on whatever it receives, so passing a str (from model_dump_json)
+results in double-encoded JSON.
+
+Strategy:
+- node.py: OrderSubmissionDTO is imported inside a closure, can't mock it.
+  Instead: (a) verify DTO.model_dump() returns dict (contract test),
+  (b) verify source code uses model_dump() not model_dump_json() (static).
+- execution_cli.py: mock GinkgoProducer only, let real ScheduleUpdateDTO flow.
+"""
+import inspect
+import re
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ============================================================================
+# node.py — 实盘订单提交 (production-critical, highest priority)
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestExecutionNodeOrderSubmission:
+    """ExecutionNode must send dict to order_producer, not JSON string."""
+
+    def test_order_submission_dto_model_dump_returns_dict(self):
+        """OrderSubmissionDTO.model_dump() must return dict for Kafka serializer."""
+        from ginkgo.interfaces.dtos import OrderSubmissionDTO
+
+        dto = OrderSubmissionDTO(
+            order_id="order-123",
+            portfolio_id="pf-001",
+            code="000001.SZ",
+            direction="LONG",
+            volume=100,
+            price="10.5",
+            timestamp="2026-01-01T10:00:00",
+        )
+        result = dto.model_dump()
+        assert isinstance(result, dict), (
+            f"OrderSubmissionDTO.model_dump() returned {type(result).__name__}, expected dict. "
+            "Kafka value_serializer calls json.dumps() — passing a dict is correct."
+        )
+
+    def test_node_source_uses_model_dump_not_json(self):
+        """#4667: node.py order submission must use model_dump() not model_dump_json().
+
+        OrderSubmissionDTO is imported inside listener_thread closure,
+        so runtime mocking is infeasible. Static source verification instead.
+        """
+        import ginkgo.workers.execution_node.node as mod
+
+        source = inspect.getsource(mod)
+        # Find the ORDERS_SUBMISSION send line
+        pattern = r"order_producer\.send\(.*model_dump"
+        matches = re.findall(pattern, source)
+        assert len(matches) >= 1, (
+            "Expected order_producer.send(...model_dump()) in node.py — not found"
+        )
+        # Verify NO model_dump_json near ORDERS_SUBMISSION
+        bad_pattern = r"ORDERS_SUBMISSION.*model_dump_json"
+        bad_matches = re.findall(bad_pattern, source)
+        assert len(bad_matches) == 0, (
+            f"Found model_dump_json() near ORDERS_SUBMISSION in node.py: {bad_matches}. "
+            "This causes double encoding — use model_dump() instead."
+        )
+
+
+# ============================================================================
+# execution_cli.py — NODE_PAUSE / NODE_RESUME commands
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestExecutionCliDoubleEncoding:
+    """execution_cli pause/resume must send dict to producer, not JSON string."""
+
+    def test_node_pause_sends_dict_not_str(self):
+        """execution_cli pause: model_dump_json() causes double encoding."""
+        from typer.testing import CliRunner
+        from ginkgo.client.execution_cli import app
+
+        runner = CliRunner()
+        mock_producer = MagicMock()
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer):
+            runner.invoke(app, ["pause", "--node-id", "node-1"])
+
+        assert mock_producer.send.called, "producer.send() was never called"
+        value = mock_producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )
+
+    def test_node_resume_sends_dict_not_str(self):
+        """execution_cli resume: model_dump_json() causes double encoding."""
+        from typer.testing import CliRunner
+        from ginkgo.client.execution_cli import app
+
+        runner = CliRunner()
+        mock_producer = MagicMock()
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer):
+            runner.invoke(app, ["resume", "--node-id", "node-1"])
+
+        assert mock_producer.send.called, "producer.send() was never called"
+        value = mock_producer.send.call_args[0][1]
+        assert isinstance(value, dict), (
+            f"Expected dict (model_dump), got {type(value).__name__}. "
+            "Use model_dump() not model_dump_json() to avoid double encoding."
+        )

--- a/tests/unit/trading/analysis/test_backtest_evaluator.py
+++ b/tests/unit/trading/analysis/test_backtest_evaluator.py
@@ -1,0 +1,47 @@
+"""Tests for BacktestEvaluator -- #4666"""
+import pytest
+
+try:
+    from ginkgo.trading.analysis.evaluation.backtest_evaluator import BacktestEvaluator
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestEvaluator not available")
+class TestBacktestEvaluatorGLOG:
+    """#4666: All GLOG calls must use uppercase methods (INFO/ERROR, not info/error).
+
+    GinkgoLogger only exposes INFO(), ERROR(), etc. (uppercase).
+    Lowercase calls raise AttributeError at runtime.
+    """
+
+    def test_create_live_monitor_does_not_crash_on_glog(self):
+        """create_live_monitor calls GLOG twice -- must not raise AttributeError."""
+        evaluator = BacktestEvaluator()
+        baseline = {
+            "baseline_stats": {"sharpe_ratio": {"mean": 1.5, "std": 0.2, "median": 1.4}},
+            "slice_period_days": 30,
+        }
+        # Should not raise AttributeError from GLOG.info()
+        monitor = evaluator.create_live_monitor(baseline)
+        assert monitor is not None
+
+    def test_evaluate_backtest_stability_invalid_data_no_glog_crash(self):
+        """evaluate_backtest_stability must not crash on GLOG when data is invalid."""
+        import pandas as pd
+        from unittest.mock import patch
+
+        evaluator = BacktestEvaluator()
+
+        # Mock get_backtest_data to return empty data (triggers GLOG.error in validation)
+        empty_data = {
+            "analyzer_data": pd.DataFrame(columns=["timestamp", "name", "value"]),
+            "signal_data": pd.DataFrame(),
+            "order_data": pd.DataFrame(),
+        }
+        with patch.object(evaluator.data_manager, "get_backtest_data", return_value=empty_data):
+            result = evaluator.evaluate_backtest_stability(portfolio_id="test", engine_id="test")
+
+        # Should return a failed result, NOT raise AttributeError
+        assert result["status"] == "failed"

--- a/tests/unit/trading/analysis/test_deviation_checker.py
+++ b/tests/unit/trading/analysis/test_deviation_checker.py
@@ -5,6 +5,8 @@ import types
 from unittest.mock import MagicMock, patch
 import sys
 
+from ginkgo.data.services.base_service import ServiceResult
+
 
 @pytest.fixture()
 def _deviation_checker_env(monkeypatch):
@@ -56,19 +58,19 @@ class TestGetBaseline:
         checker = DeviationChecker()
         baseline = {"net_value": {"mean": 1.0, "std": 0.1}}
         mock_redis = MagicMock()
-        mock_redis.get.return_value = json.dumps(baseline)
+        mock_redis.get_cache.return_value = ServiceResult.success(data=json.dumps(baseline))
 
         _setup_redis_service(mock_services, mock_redis)
         result = checker.get_baseline("p-001")
 
         assert result == baseline
-        mock_redis.get.assert_called_once_with("deviation:baseline:p-001")
+        mock_redis.get_cache.assert_called_once_with("deviation:baseline:p-001")
 
     def test_returns_none_when_no_source_mapping(self, _deviation_checker_env):
         DeviationChecker, mock_services = _deviation_checker_env
         checker = DeviationChecker()
         mock_redis = MagicMock()
-        mock_redis.get.return_value = None
+        mock_redis.get_cache.return_value = ServiceResult.success(data=None)
 
         _setup_redis_service(mock_services, mock_redis)
         result = checker.get_baseline("p-001")
@@ -82,7 +84,7 @@ class TestGetDeviationConfig:
         DeviationChecker, mock_services = _deviation_checker_env
         checker = DeviationChecker()
         mock_redis = MagicMock()
-        mock_redis.get.return_value = None
+        mock_redis.get_cache.return_value = ServiceResult.success(data=None)
 
         _setup_redis_service(mock_services, mock_redis)
         result = checker.get_deviation_config("p-001")
@@ -95,7 +97,7 @@ class TestGetDeviationConfig:
         checker = DeviationChecker()
         config = {"auto_takedown": True, "check_time": "21:00"}
         mock_redis = MagicMock()
-        mock_redis.get.return_value = json.dumps(config)
+        mock_redis.get_cache.return_value = ServiceResult.success(data=json.dumps(config))
 
         _setup_redis_service(mock_services, mock_redis)
         result = checker.get_deviation_config("p-001")
@@ -169,3 +171,133 @@ class TestSendDeviationAlert:
         checker = DeviationChecker()
         checker._producer = None
         checker.send_deviation_alert("p-001", "MODERATE", {})
+
+
+# ============================================================================
+# #4662: RedisService API contract — get_cache()/set_cache(), not get()/set()
+# ============================================================================
+
+
+@pytest.mark.tdd
+class TestDeviationCheckerRedisAPI:
+    """#4662: DeviationChecker must use get_cache()/set_cache() returning ServiceResult.
+
+    RedisService exposes:
+      - set_cache(key, value, expire_seconds=3600) → ServiceResult
+      - get_cache(key) → ServiceResult  (extract .data for the value)
+
+    The methods .get() and .set() do NOT exist on RedisService.
+    """
+
+    def test_get_baseline_uses_get_cache_for_cached_value(self, _deviation_checker_env):
+        """get_baseline must call get_cache() not get() for baseline lookup."""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        DeviationChecker, mock_services = _deviation_checker_env
+        checker = DeviationChecker()
+
+        mock_redis = MagicMock()
+        mock_redis.get_cache.return_value = ServiceResult.success(
+            data=json.dumps({"net_value": {"mean": 1.0, "std": 0.1}})
+        )
+
+        _setup_redis_service(mock_services, mock_redis)
+        result = checker.get_baseline("p-001")
+
+        # Must call get_cache, not the non-existent get()
+        mock_redis.get_cache.assert_called_once_with("deviation:baseline:p-001")
+        mock_redis.get.assert_not_called()
+        assert result is not None
+
+    def test_get_baseline_uses_get_cache_for_source_lookup(self, _deviation_checker_env):
+        """When baseline not cached, must use get_cache() to find source portfolio."""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        DeviationChecker, mock_services = _deviation_checker_env
+        checker = DeviationChecker()
+
+        mock_redis = MagicMock()
+        # First call: baseline miss (None)
+        # Second call: source miss (None)
+        mock_redis.get_cache.return_value = ServiceResult.success(data=None)
+
+        _setup_redis_service(mock_services, mock_redis)
+        result = checker.get_baseline("p-001")
+
+        # get_cache should have been called for both baseline and source
+        assert mock_redis.get_cache.call_count >= 1
+        mock_redis.get.assert_not_called()
+        assert result is None
+
+    def test_get_baseline_uses_set_cache_to_store(self, _deviation_checker_env):
+        """When computing baseline, must use set_cache() not set() to store."""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        DeviationChecker, mock_services = _deviation_checker_env
+        checker = DeviationChecker()
+
+        mock_task = MagicMock()
+        mock_task.task_id = "task-123"
+        mock_task.engine_id = "engine-456"
+
+        mock_task_svc = MagicMock()
+        mock_task_svc.list.return_value = ServiceResult.success(data=[mock_task])
+
+        mock_evaluator_cls = MagicMock()
+        mock_evaluator = mock_evaluator_cls.return_value
+        mock_evaluator.evaluate_backtest_stability.return_value = {
+            "status": "success",
+            "monitoring_baseline": {"slice_period_days": 30, "baseline_stats": {}},
+        }
+
+        mock_redis = MagicMock()
+        # get_cache is called multiple times with different keys:
+        # 1st: baseline lookup → miss (None)
+        # 2nd: source lookup → hit ("source-789")
+        mock_redis.get_cache.side_effect = [
+            ServiceResult.success(data=None),
+            ServiceResult.success(data="source-789"),
+        ]
+        mock_redis.set_cache.return_value = ServiceResult.success()
+
+        mock_services.data.redis_service.return_value = mock_redis
+        mock_services.data.backtest_task_service.return_value = mock_task_svc
+
+        # Patch the module-level import by injecting into sys.modules
+        import types
+        evaluator_mod = types.ModuleType("ginkgo.trading.analysis.evaluation.backtest_evaluator")
+        evaluator_mod.BacktestEvaluator = mock_evaluator_cls
+
+        import sys
+        saved = sys.modules.get("ginkgo.trading.analysis.evaluation.backtest_evaluator")
+        sys.modules["ginkgo.trading.analysis.evaluation.backtest_evaluator"] = evaluator_mod
+        try:
+            result = checker.get_baseline("p-001")
+        finally:
+            if saved is not None:
+                sys.modules["ginkgo.trading.analysis.evaluation.backtest_evaluator"] = saved
+            else:
+                del sys.modules["ginkgo.trading.analysis.evaluation.backtest_evaluator"]
+
+        # Must call set_cache, not the non-existent set()
+        mock_redis.set_cache.assert_called_once()
+        mock_redis.set.assert_not_called()
+        assert result is not None
+
+    def test_get_deviation_config_uses_get_cache(self, _deviation_checker_env):
+        """get_deviation_config must use get_cache() not get()."""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        DeviationChecker, mock_services = _deviation_checker_env
+        checker = DeviationChecker()
+
+        config = {"auto_takedown": True, "check_time": "21:00"}
+        mock_redis = MagicMock()
+        mock_redis.get_cache.return_value = ServiceResult.success(data=json.dumps(config))
+
+        _setup_redis_service(mock_services, mock_redis)
+        result = checker.get_deviation_config("p-001")
+
+        mock_redis.get_cache.assert_called_once_with("deviation:config:p-001")
+        mock_redis.get.assert_not_called()
+        assert result["auto_takedown"] is True

--- a/tests/unit/trading/analysis/test_evaluation_glog.py
+++ b/tests/unit/trading/analysis/test_evaluation_glog.py
@@ -1,0 +1,77 @@
+"""Tests for evaluation/ directory GLOG uppercase -- PR review Issue 1"""
+import pytest
+import pandas as pd
+from unittest.mock import patch, MagicMock
+
+from ginkgo.trading.analysis.evaluation.slice_data_manager import SliceDataManager
+from ginkgo.trading.analysis.evaluation.live_deviation_detector import LiveDeviationDetector
+from ginkgo.trading.analysis.evaluation.slice_period_optimizer import SlicePeriodOptimizer
+
+
+@pytest.mark.tdd
+class TestSliceDataManagerGLOG:
+    """GLOG calls in SliceDataManager must use uppercase methods."""
+
+    def test_get_backtest_data_no_glog_crash(self):
+        """get_backtest_data calls GLOG — must not raise AttributeError."""
+        mgr = SliceDataManager()
+        mock_services = MagicMock()
+        mock_crud = MagicMock()
+        mock_crud.get_by_task_id.return_value = pd.DataFrame()
+        mock_crud.find.return_value = pd.DataFrame()
+        mock_services.data.cruds.analyzer_record.return_value = mock_crud
+        mock_services.data.cruds.signal.return_value = mock_crud
+        mock_services.data.cruds.order_record.return_value = mock_crud
+
+        with patch("ginkgo.services", mock_services):
+            result = mgr.get_backtest_data(portfolio_id="test", engine_id="test")
+        # Should return dict with DataFrames, NOT crash on GLOG
+        assert isinstance(result, dict)
+
+    def test_slice_data_by_period_no_glog_crash(self):
+        """slice_data_by_period calls GLOG.info — must not crash."""
+        mgr = SliceDataManager()
+        data = {
+            "analyzer_data": pd.DataFrame({"timestamp": [], "name": [], "value": []}),
+            "signal_data": pd.DataFrame(),
+            "order_data": pd.DataFrame(),
+        }
+        result = mgr.slice_data_by_period(data, period_days=30)
+        # Should return empty list, NOT crash on GLOG
+        assert isinstance(result, list)
+
+
+@pytest.mark.tdd
+class TestLiveDeviationDetectorGLOG:
+    """GLOG calls in LiveDeviationDetector must use uppercase methods."""
+
+    def test_accumulate_live_data_no_glog_crash(self):
+        """accumulate_live_data calls GLOG — must not crash."""
+        detector = LiveDeviationDetector(
+            baseline_stats={"sharpe": {"mean": 1.0, "std": 0.2}},
+            slice_period_days=30,
+        )
+        result = detector.accumulate_live_data(
+            analyzer_records=[],
+            signal_records=[],
+            order_records=[],
+        )
+        # Should return False (empty data), NOT crash on GLOG
+        assert isinstance(result, bool)
+
+
+@pytest.mark.tdd
+class TestSlicePeriodOptimizerGLOG:
+    """GLOG calls in SlicePeriodOptimizer must use uppercase methods."""
+
+    def test_find_optimal_slice_period_no_glog_crash(self):
+        """find_optimal_slice_period calls GLOG — must not crash with AttributeError."""
+        optimizer = SlicePeriodOptimizer()
+        empty = pd.DataFrame({"timestamp": pd.Series(dtype="datetime64[ns]"), "name": pd.Series(dtype=str), "value": pd.Series(dtype=float)})
+        # Empty data raises ValueError (no valid period found), NOT AttributeError from GLOG
+        with pytest.raises(ValueError, match="切片周期"):
+            optimizer.find_optimal_slice_period(
+                analyzer_data=empty,
+                signal_data=pd.DataFrame(),
+                order_data=pd.DataFrame(),
+            )


### PR DESCRIPTION
## Summary

批量修复 4 个 P0 定时任务失败问题：

### #4667 — TaskTimer Kafka 双重编码
- `model_dump_json()` 生成 JSON str → `_publish_to_kafka` 将其作为 str 传给 Producer
- `GinkgoProducer.value_serializer` 再做一次 `json.dumps(str)`，导致双重编码
- **Fix**: 改用 `model_dump()` 传 dict，移除多余的 `json.loads()` 路由步骤

### #4666 — BacktestEvaluator GLOG 方法名 + task 分页
- `GLOG.info()`/`GLOG.error()` 不存在，GinkgoLogger 只有大写 `INFO()`/`ERROR()`
- `BacktestTaskService.list()` 返回分页 dict `{"data": [...], "total": N}`，代码当作 list 处理
- **Fix**: 替换为大写方法名，从 dict 中正确提取 `data` 字段

### #4662 — RedisService API 调用错误（7 处）
- `redis_svc.get()`/`redis_svc.set()` 不存在，RedisService 只暴露 `get_cache()`/`set_cache()` 返回 ServiceResult
- 3 处在 `portfolio_cli.py`，4 处在 `deviation_checker.py`
- **Fix**: 全部替换为 `get_cache()`/`set_cache()`，正确处理 ServiceResult

### #4661 — Scheduler 查询 portfolio 静默丢弃 is_live
- `portfolio_service.get(is_live=True)` 中 `is_live` 落入 `**kwargs`，被 `kwargs.get("filters", {})` 丢弃
- 实际返回所有 portfolio（含 BACKTEST），而非仅 PAPER+LIVE
- **Fix**: 改为按 `mode=PORTFOLIO_MODE_TYPES.PAPER` 和 `mode=PORTFOLIO_MODE_TYPES.LIVE` 分别查询后合并

## Files Changed
- `src/ginkgo/livecore/task_timer.py` — Kafka 序列化修复
- `src/ginkgo/trading/analysis/evaluation/backtest_evaluator.py` — GLOG 方法名修复
- `src/ginkgo/client/portfolio_cli.py` — Redis API + 分页数据修复
- `src/ginkgo/trading/analysis/evaluation/deviation_checker.py` — Redis API + 分页数据修复
- `src/ginkgo/livecore/scheduler/plan_manager.py` — portfolio mode 查询修复

## Test Plan
- 28 个新增/更新单元测试全部通过
- 每个 fix 独立测试：Kafka 序列化、GLOG 方法、Redis API 契约、分页提取、mode 查询

Closes #4667
Closes #4666
Closes #4662
Closes #4661

🤖 Generated with [Claude Code](https://claude.com/claude-code)