### PR TITLE
Add plotext dependency for terminal result charts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
     "pyarrow>=17.0.0",
     "pydantic>=2.10.0",
     "pydantic-settings>=2.0.0",
+    "plotext>=5.3.0",
     "pygments>=2.19.0",
     "pyjwt>=2.10.0",
     "pymysql>=1.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1230,6 +1230,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pandas" },
     { name = "playwright" },
+    { name = "plotext" },
     { name = "prometheus-client" },
     { name = "protobuf" },
     { name = "psutil" },
@@ -1345,6 +1346,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.3.0" },
     { name = "playwright", specifier = ">=1.59.0" },
     { name = "playwright", marker = "extra == 'e2e'", specifier = ">=1.40.0" },
+    { name = "plotext", specifier = ">=5.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "prometheus-client", specifier = ">=0.22.0" },
     { name = "protobuf", specifier = ">=6.31.0" },
@@ -2819,6 +2821,15 @@ wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/72/a1/717ac5bc99f387c0f60def91271ea4262125c0815d764a5d1776a272275c/playwright-1.59.0-py3-none-win32.whl", hash = "sha256:6989c476be2b9cd3e24a18cc9dcf202e266fb3d91e3e5395cd668c54ea54b119", size = 37713698, upload-time = "2026-04-29T08:11:27.251Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/0f/a5/4e630ee05d8b46b840f943268e86d6063703e8dadb2d3eb405c7b9b2e48c/playwright-1.59.0-py3-none-win_amd64.whl", hash = "sha256:d5a5cc064b82ca92996080025710844e417f44df8fda9001102c28f44174171c", size = 37713704, upload-time = "2026-04-29T08:11:30.41Z" },
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/eb/0c/3ece41761ba13c8321009aefcaec7a016eb42799c42eef5e03ace7f2de5b/playwright-1.59.0-py3-none-win_arm64.whl", hash = "sha256:93581ad515728cadc8af39b288a5633ba6d36e7d72048e79d890ce01ea2156f9", size = 33956745, upload-time = "2026-04-29T08:11:34.738Z" },
+]
+
+[[package]]
+name = "plotext"
+version = "5.3.2"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/c9/d7/f75f397af966fe252d0d34ffd3cae765317fce2134f925f95e7d6725d1ce/plotext-5.3.2.tar.gz", hash = "sha256:52d1e932e67c177bf357a3f0fe6ce14d1a96f7f7d5679d7b455b929df517068e", size = 61967, upload-time = "2024-09-24T15:13:37.728Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f6/1e/12fe7c40cd2099a1f454518754ed229b01beaf3bbb343127f0cc13ce6c22/plotext-5.3.2-py3-none-any.whl", hash = "sha256:394362349c1ddbf319548cfac17ca65e6d5dfc03200c40dfdc0503b3e95a2283", size = 64047, upload-time = "2024-09-24T15:13:36.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add plotext>=5.3.0 to the package dependencies
- keep the existing terminal chart implementation and CLI behavior unchanged

## Verification
- parsed pyproject.toml with Python 	omllib
- confirmed project.dependencies now contains exactly one plotext>=5.3.0 entry
- confirmed the existing mypy plotext.* ignore remains unchanged
- confirmed the patch is limited to adding the missing dependency requested by #4838

Fixes #4838