### PR TITLE
fix: 实现 check_commands() Kafka 命令消费 (#3856)

### DIFF
--- a/src/ginkgo/livecore/scheduler/command_handler.py
+++ b/src/ginkgo/livecore/scheduler/command_handler.py
@@ -52,18 +52,23 @@ class CommandHandler:
 
     def check_commands(self, command_consumer):
         """
-        非阻塞检查并处理命令
+        非阻塞检查并处理命令 (#3856)
+
+        通过 consumer.consumer.poll() 非阻塞读取 Kafka 消息，
+        遍历并分发给 process_command() 处理。
 
         Args:
-            command_consumer: Kafka 命令消费者
+            command_consumer: GinkgoConsumer 命令消费者实例
         """
         if not command_consumer:
             return
 
         try:
-            import json
-            # TODO: 适配 GinkgoConsumer 的接口
-            pass
+            messages = command_consumer.consumer.poll(timeout_ms=1000)
+            for tp, records in messages.items():
+                for record in records:
+                    if record.value:
+                        self.process_command(record.value)
         except Exception as e:
             logger.error(f"Error checking commands: {e}")
 

--- a/tests/unit/livecore/test_scheduler_components.py
+++ b/tests/unit/livecore/test_scheduler_components.py
@@ -1,6 +1,9 @@
-"""Smoke tests for livecore.scheduler sub-components -- #3870"""
+"""Smoke tests for livecore.scheduler sub-components -- #3870
+
+#3856 check_commands() TDD tests
+"""
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 try:
     from ginkgo.livecore.scheduler.load_balancer import LoadBalancer
@@ -62,34 +65,96 @@ class TestLoadBalancer:
         assert isinstance(changes, dict)
 
 
+def _make_handler(**overrides):
+    """Helper: 创建 CommandHandler 实例 (#3856)"""
+    defaults = dict(
+        scheduler_ref=MagicMock(),
+        schedule_loop_callback=MagicMock(),
+        get_healthy_nodes_callback=MagicMock(),
+        get_current_plan_callback=MagicMock(return_value={}),
+        get_all_portfolios_callback=MagicMock(return_value=[]),
+        assign_portfolios_callback=MagicMock(),
+        publish_update_callback=MagicMock(),
+        send_command_callback=MagicMock(),
+    )
+    defaults.update(overrides)
+    return CommandHandler(**defaults)
+
+
 @pytest.mark.skipif(not HAS_CMD, reason="CommandHandler not available")
 class TestCommandHandler:
     def test_instantiation(self):
-        handler = CommandHandler(
-            scheduler_ref=MagicMock(),
-            schedule_loop_callback=MagicMock(),
-            get_healthy_nodes_callback=MagicMock(),
-            get_current_plan_callback=MagicMock(return_value={}),
-            get_all_portfolios_callback=MagicMock(return_value=[]),
-            assign_portfolios_callback=MagicMock(),
-            publish_update_callback=MagicMock(),
-            send_command_callback=MagicMock(),
-        )
+        handler = _make_handler()
         assert handler is not None
 
     def test_process_unknown_command(self):
-        handler = CommandHandler(
-            scheduler_ref=MagicMock(),
-            schedule_loop_callback=MagicMock(),
-            get_healthy_nodes_callback=MagicMock(),
-            get_current_plan_callback=MagicMock(return_value={}),
-            get_all_portfolios_callback=MagicMock(return_value=[]),
-            assign_portfolios_callback=MagicMock(),
-            publish_update_callback=MagicMock(),
-            send_command_callback=MagicMock(),
-        )
+        handler = _make_handler()
         # Should not crash on unknown command
         handler.process_command({"type": "unknown_command", "params": {}})
+
+    # --- #3856 check_commands() tests ---
+
+    def test_check_commands_none_consumer_returns_immediately(self):
+        """check_commands(None) 应立即返回，不抛异常"""
+        handler = _make_handler()
+        handler.check_commands(None)  # 不应抛异常
+
+    def test_check_commands_empty_poll_does_not_process(self):
+        """poll 返回空消息时不触发 process_command"""
+        handler = _make_handler()
+        mock_consumer = MagicMock()
+        mock_consumer.consumer.poll.return_value = {}
+
+        with patch.object(handler, 'process_command') as mock_process:
+            handler.check_commands(mock_consumer)
+            mock_process.assert_not_called()
+            mock_consumer.consumer.poll.assert_called_once()
+
+    def test_check_commands_dispatches_message_to_process_command(self):
+        """收到消息时提取 value 并调用 process_command"""
+        handler = _make_handler()
+        mock_consumer = MagicMock()
+
+        # Kafka poll 返回格式: {TopicPartition: [ConsumerRecord, ...]}
+        mock_tp = MagicMock()
+        mock_tp.topic = "scheduler.commands"
+        mock_tp.partition = 0
+
+        mock_record = MagicMock()
+        mock_record.value = {"command": "pause", "timestamp": "2026-01-01", "params": {}}
+
+        mock_consumer.consumer.poll.return_value = {mock_tp: [mock_record]}
+
+        with patch.object(handler, 'process_command') as mock_process:
+            handler.check_commands(mock_consumer)
+            mock_process.assert_called_once_with({"command": "pause", "timestamp": "2026-01-01", "params": {}})
+
+    def test_check_commands_handles_multiple_messages(self):
+        """单次 poll 多条消息全部处理"""
+        handler = _make_handler()
+        mock_consumer = MagicMock()
+
+        mock_tp = MagicMock()
+        records = []
+        for cmd in ["pause", "resume", "status"]:
+            rec = MagicMock()
+            rec.value = {"command": cmd, "params": {}}
+            records.append(rec)
+
+        mock_consumer.consumer.poll.return_value = {mock_tp: records}
+
+        with patch.object(handler, 'process_command') as mock_process:
+            handler.check_commands(mock_consumer)
+            assert mock_process.call_count == 3
+
+    def test_check_commands_poll_exception_does_not_raise(self):
+        """poll 异常时应捕获并记录日志，不向调用方抛异常"""
+        handler = _make_handler()
+        mock_consumer = MagicMock()
+        mock_consumer.consumer.poll.side_effect = Exception("Kafka error")
+
+        # 不应抛异常
+        handler.check_commands(mock_consumer)
 
 
 @pytest.mark.skipif(not HAS_HB, reason="HeartbeatChecker not available")


### PR DESCRIPTION
## Summary

`livecore/scheduler/command_handler.py` 中 `check_commands()` 是空桩实现（`pass`），导致 Scheduler 无法处理 Kafka 调度命令（pause/resume/recalculate/schedule/migrate/status）。

**修复内容**：用项目标准模式 `consumer.consumer.poll(timeout_ms=1000)` 非阻塞读取 Kafka 消息，遍历提取 value 分发给已有的 `process_command()` 处理。

**变更文件**：
- `src/ginkgo/livecore/scheduler/command_handler.py` — 实现空桩方法
- `tests/unit/livecore/test_scheduler_components.py` — 新增 5 个行为测试

## Test plan

- [x] `check_commands(None)` 立即返回无异常
- [x] 空消息不触发 process_command
- [x] 单条消息正确分发到 process_command
- [x] 多条消息全部处理
- [x] poll 异常捕获不中断调度循环
- [x] 全部 18 个组件测试通过无回归

Closes #3856

🤖 Generated with [Claude Code](https://claude.com/claude-code)