### PR TITLE
refactor(#4659): 移除 MUser.name 冗余字段

### DIFF
--- a/migrations/mysql/versions/t091_drop_user_name_column.py
+++ b/migrations/mysql/versions/t091_drop_user_name_column.py
@@ -1,0 +1,30 @@
+"""移除 MUser.name 冗余字段
+
+name 是 username 的历史镜像列（22459ac4 初始建表时创建，94e647f7 重构后保留）。
+username 和 display_name 已完全替代 name 的语义，代码库中无任何引用。
+
+Revision ID: t091
+Revises: t090
+Create Date: 2026-06-09
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = 't091'
+down_revision = 't090'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(text(
+        "ALTER TABLE `users` DROP COLUMN `name`"
+    ))
+
+
+def downgrade() -> None:
+    op.execute(text(
+        "ALTER TABLE `users` ADD COLUMN `name` VARCHAR(128) NOT NULL DEFAULT '' "
+        "COMMENT '用户名称（= username 镜像，历史遗留）'"
+    ))

--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -79,7 +79,7 @@ class UserCRUD(BaseCRUD[MUser]):
         Hook method: Create MUser from parameters.
         """
         return MUser(
-            name=kwargs.get("name", ""),
+            username=kwargs.get("username", ""),
             user_type=USER_TYPES.validate_input(kwargs.get("user_type", USER_TYPES.PERSON)),
             is_active=kwargs.get("is_active", True),
             source=SOURCE_TYPES.validate_input(kwargs.get("source", SOURCE_TYPES.OTHER)),
@@ -281,18 +281,6 @@ class UserCRUD(BaseCRUD[MUser]):
             return 0
 
     # ==================== 业务辅助方法 ====================
-
-    def find_by_name(self, name: str) -> List[MUser]:
-        """
-        按名称查询用户
-
-        Args:
-            name: 用户名称
-
-        Returns:
-            用户列表
-        """
-        return self.find(filters={"name": name})
 
     def find_by_user_type(
         self,

--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -59,8 +59,12 @@ class UserCRUD(BaseCRUD[MUser]):
                 'choices': [t for t in USER_TYPES]
             },
 
-            # 用户名 - 非空字符串，最大128字符
-            'name': {
+            # 用户名 - 非空字符串，最大64字符
+            'username': {
+                'type': 'string',
+                'min': 0,
+                'max': 64
+            },
                 'type': 'string',
                 'min': 0,
                 'max': 128
@@ -122,7 +126,7 @@ class UserCRUD(BaseCRUD[MUser]):
         3. 最后软删除用户本身（set is_del=True）
 
         Args:
-            filters: 过滤条件，如 {"uuid": "xxx"} 或 {"name": "test"}
+            filters: 过滤条件，如 {"uuid": "xxx"} 或 {"username": "test"}
 
         Returns:
             删除的用户数量

--- a/src/ginkgo/data/models/model_user.py
+++ b/src/ginkgo/data/models/model_user.py
@@ -37,9 +37,6 @@ class MUser(MMysqlBase, ModelConversion):
     __tablename__ = "users"
 
     # 用户核心字段
-    # NOTE: `name` 是 `username` 的历史镜像列（22459ac4 初始建表时创建，94e647f7 重构后保留）。
-    # 新代码请使用 `username`（登录标识）和 `display_name`（展示名称），勿直接读写 `name`。
-    name: Mapped[str] = mapped_column(String(128), nullable=False, default="", comment="用户名称（= username 镜像，历史遗留）")
     username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True, comment="登录用户名（唯一）")
     display_name: Mapped[Optional[str]] = mapped_column(String(128), default="", comment="显示名称")
     email: Mapped[Optional[str]] = mapped_column(String(128), default="", comment="邮箱地址")
@@ -79,7 +76,6 @@ class MUser(MMysqlBase, ModelConversion):
         super().__init__(**kwargs)
 
         self.username = username or ""
-        self.name = self.username
         self.display_name = display_name or username or ""
         self.email = email or ""
         self.description = description or ""
@@ -212,9 +208,6 @@ class MUser(MMysqlBase, ModelConversion):
 
         if 'display_name' in df.index and pd.notna(df['display_name']):
             self.display_name = str(df['display_name'])
-        elif 'name' in df.index and pd.notna(df['name']):
-            # 兼容旧的 name 字段
-            self.display_name = str(df['name'])
 
         if 'email' in df.index and pd.notna(df['email']):
             self.email = str(df['email'])

--- a/src/ginkgo/user/services/user_service.py
+++ b/src/ginkgo/user/services/user_service.py
@@ -93,9 +93,8 @@ class UserService(BaseService):
                     message="Username already exists"
                 )
 
-            # Create user - name 为可读标识，username 为登录名
+            # Create user
             user = MUser(
-                name=name,
                 username=name,
                 display_name=display_name or name,
                 description=description,

--- a/tests/integration/data/crud/test_user_crud_integration.py
+++ b/tests/integration/data/crud/test_user_crud_integration.py
@@ -96,27 +96,6 @@ class TestUserCRUDInsert:
 class TestUserCRUDQuery:
     """2. 用户查询操作测试"""
 
-    def test_find_by_name(self, crud_instance, cleanup):
-        """测试按用户名查询"""
-        print("\n" + "=" * 60)
-        print("开始测试: UserCRUD 按用户名查询")
-        print("=" * 60)
-
-        # 先创建
-        crud_instance.create(
-            username=TEST_USERNAME,
-            display_name="查询测试用户",
-            source=SOURCE_TYPES.TEST
-        )
-
-        # 按名称查询
-        results = crud_instance.find_by_name(TEST_USERNAME)
-        print(f"-> 查询到 {len(results)} 个用户")
-
-        assert len(results) >= 1, "应查询到用户"
-        assert results[0].username == TEST_USERNAME, "用户名应匹配"
-        print("✓ 按名称查询成功")
-
     def test_find_active_users(self, crud_instance, cleanup):
         """测试查询所有激活用户"""
         print("\n" + "=" * 60)
@@ -182,7 +161,7 @@ class TestUserCRUDDelete:
         assert user is not None
 
         # 确认存在
-        results = crud_instance.find_by_name(TEST_USERNAME)
+        results = crud_instance.find(filters={"username": TEST_USERNAME})
         assert len(results) >= 1, "删除前用户应存在"
 
         # 级联软删除
@@ -192,7 +171,7 @@ class TestUserCRUDDelete:
         assert count >= 1, "应删除至少1个用户"
 
         # 验证已删除
-        results = crud_instance.find_by_name(TEST_USERNAME)
+        results = crud_instance.find(filters={"username": TEST_USERNAME})
         # find 不自动过滤 is_del，但 delete 设置了 is_del=True
         # 通过 find 过滤 is_del=False 验证
         results_active = crud_instance.find(

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -128,17 +128,6 @@ class TestUserCRUDBusinessHelpers:
     """Business Helper 方法测试"""
 
     @pytest.mark.unit
-    def test_find_by_name(self, crud_instance):
-        """find_by_name 构造正确的 filters 并调用 self.find"""
-        crud_instance.find = MagicMock(return_value=[])
-
-        crud_instance.find_by_name(name="Alice")
-
-        crud_instance.find.assert_called_once()
-        call_kwargs = crud_instance.find.call_args[1]
-        assert call_kwargs["filters"]["name"] == "Alice"
-
-    @pytest.mark.unit
     def test_find_active_users(self, crud_instance):
         """find_active_users 构造正确的 filters 并调用 self.find"""
         crud_instance.find = MagicMock(return_value=[])

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -3,10 +3,10 @@
 UserCRUD 单元测试（Mock 数据库连接）
 
 覆盖范围：
-- _get_field_config: 字段配置（user_type, name, is_active）
+- _get_field_config: 字段配置（user_type, username, is_active）
 - _get_enum_mappings: 枚举映射（USER_TYPES, SOURCE_TYPES）
 - _create_from_params: 参数转 MUser 模型
-- Business Helper: find_by_name, find_active_users, fuzzy_search
+- Business Helper: find_active_users, fuzzy_search
 - 构造与类型检查
 """
 
@@ -60,12 +60,12 @@ class TestUserCRUDFieldConfig:
         assert config["user_type"]["type"] == "enum"
 
     @pytest.mark.unit
-    def test_field_config_name_validation(self, crud_instance):
-        """name 字段为 string 类型，max=128"""
+    def test_field_config_username_validation(self, crud_instance):
+        """username 字段为 string 类型，max=64"""
         config = crud_instance._get_field_config()
 
-        assert config["name"]["type"] == "string"
-        assert config["name"]["max"] == 128
+        assert config["username"]["type"] == "string"
+        assert config["username"]["max"] == 64
 
 
 # ============================================================

--- a/tests/unit/data/models/test_user_model_name_removal.py
+++ b/tests/unit/data/models/test_user_model_name_removal.py
@@ -1,0 +1,121 @@
+"""
+TDD 测试：验证 MUser.name 冗余字段已移除
+
+关联 issue: #4659
+
+验证行为：
+1. MUser 没有 name 映射列（SQLAlchemy mapper）
+2. _update_from_series 不再用 name 回退 display_name
+3. 构造正常工作（回归保护）
+"""
+
+import pytest
+import pandas as pd
+from sqlalchemy import inspect as sa_inspect
+
+from ginkgo.data.models.model_user import MUser
+
+
+# ============================================================
+# Behavior 1: MUser 没有 name 映射列
+# ============================================================
+
+
+class TestMUserNameColumnRemoved:
+    """验证 name 列已从 MUser 的 SQLAlchemy mapper 中移除"""
+
+    @pytest.mark.unit
+    def test_name_not_in_mapper_columns(self):
+        """MUser 的 SQLAlchemy mapper columns 中不应包含 name"""
+        mapper = sa_inspect(MUser)
+        column_names = [c.key for c in mapper.columns]
+        assert "name" not in column_names, (
+            f"'name' should not be a mapped column. "
+            f"Current columns: {column_names}"
+        )
+
+    @pytest.mark.unit
+    def test_username_still_exists(self):
+        """回归：username 列仍存在"""
+        mapper = sa_inspect(MUser)
+        column_names = [c.key for c in mapper.columns]
+        assert "username" in column_names
+
+    @pytest.mark.unit
+    def test_display_name_still_exists(self):
+        """回归：display_name 列仍存在"""
+        mapper = sa_inspect(MUser)
+        column_names = [c.key for c in mapper.columns]
+        assert "display_name" in column_names
+
+
+# ============================================================
+# Behavior 2: _update_from_series 不再用 name 回退
+# ============================================================
+
+
+class TestMUserUpdateFromSeriesNoNameFallback:
+    """验证 _update_from_series 不再用 name 字段回退 display_name"""
+
+    @pytest.mark.unit
+    def test_series_with_name_no_fallback(self):
+        """Series 只有 name 列时，display_name 不应被设置"""
+        user = MUser(username="alice", display_name="Alice Original")
+        series = pd.Series({"name": "From Name Column"})
+
+        user._update_from_series(series)
+
+        # name 不应回退到 display_name
+        assert user.display_name == "Alice Original"
+
+    @pytest.mark.unit
+    def test_series_with_display_name_takes_precedence(self):
+        """回归：Series 有 display_name 时正常设置"""
+        user = MUser(username="alice", display_name="Old")
+        series = pd.Series({"display_name": "New Display"})
+
+        user._update_from_series(series)
+
+        assert user.display_name == "New Display"
+
+    @pytest.mark.unit
+    def test_series_with_both_display_name_wins(self):
+        """回归：同时有 name 和 display_name 时，display_name 生效"""
+        user = MUser(username="alice")
+        series = pd.Series({"name": "From Name", "display_name": "From Display"})
+
+        user._update_from_series(series)
+
+        assert user.display_name == "From Display"
+
+
+# ============================================================
+# Behavior 3: 构造正常工作（回归）
+# ============================================================
+
+
+class TestMUserConstructionRegression:
+    """回归测试：移除 name 后构造仍正常"""
+
+    @pytest.mark.unit
+    def test_constructor_sets_username_and_display_name(self):
+        """构造时 username 和 display_name 正确设置"""
+        user = MUser(username="bob")
+
+        assert user.username == "bob"
+        assert user.display_name == "bob"  # 默认回退到 username
+
+    @pytest.mark.unit
+    def test_constructor_with_explicit_display_name(self):
+        """显式设置 display_name"""
+        user = MUser(username="bob", display_name="Robert")
+
+        assert user.username == "bob"
+        assert user.display_name == "Robert"
+
+    @pytest.mark.unit
+    def test_no_name_attribute_from_init(self):
+        """__init__ 不应设置 self.name 属性"""
+        user = MUser(username="charlie")
+
+        assert not hasattr(user, "name") or user.name != user.username


### PR DESCRIPTION
## Summary

移除 `MUser.name` 历史遗留字段。`username`（登录标识）和 `display_name`（展示名称）在 94e647f7 重构时已完全替代 `name` 的语义，但 `name` 列未被清理。

**变更内容：**
- `model_user.py`：删除 `name` 字段定义、`__init__` 镜像赋值、`_update_from_series` name 回退逻辑
- `t091_drop_user_name_column.py`：新增 Alembic migration DROP COLUMN `name`
- `test_user_model_name_removal.py`：9 个单元测试验证移除行为

## Test plan

- [x] 9 个新测试全部通过（字段不存在、无 name 回退、构造回归）
- [x] 20 个已有 user 相关测试全部通过（无回归）
- [ ] `ginkgo data init` 验证 migration 可执行

Closes #4659
