### PR TITLE
fix: 批量修复 CLI 相关问题 (#5326 #5331 #5325 #5327 #5329 #5323 #5330 #5322 #5324)

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -475,6 +475,11 @@ def cat_task(
             if value and value != 0:
                 stats_lines.append(f"[bold]{label}:[/bold] {value}")
         console.print(Panel("\n".join(stats_lines), title=":1234: Statistics"))
+    elif status_val == "completed":
+        console.print(Panel(
+            "[yellow]⚠️ No trades generated — selector may have returned empty symbols.[/yellow]",
+            title=":warning: Warning",
+        ))
 
 
 def _save_results(service, task_uuid: str, engine, portfolio_id: str):

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -401,6 +401,7 @@ def cat_task(
     info_lines = []
     info_lines.append(f"[bold]UUID:[/bold]         {task.uuid}")
     info_lines.append(f"[bold]Task ID:[/bold]      {task.task_id}")
+    info_lines.append(f"[dim]  \U0001f4a1 查看分析结果: ginkgo result show --run-id {task.task_id}[/dim]")
     info_lines.append(f"[bold]Name:[/bold]         {task.name}")
     info_lines.append(f"[bold]Portfolio:[/bold]    {task.portfolio_id}")
     info_lines.append(f"[bold]Engine:[/bold]       {task.engine_id}")

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -350,7 +350,7 @@ def list_tasks(
             name[:20],
             portfolio_id,
             f"[{status_style}]{status_val}[/{status_style}]",
-            f"{progress:.0%}" if isinstance(progress, (int, float)) else str(progress),
+            f"{int(progress)}%" if isinstance(progress, (int, float)) else str(progress),
             created,
         )
 

--- a/src/ginkgo/client/components_cli.py
+++ b/src/ginkgo/client/components_cli.py
@@ -219,6 +219,41 @@ def show(
         console.print(f"[red]:x:[/red] Error: {e}")
 
 @app.command()
+def info(
+    name: str = typer.Argument(..., help="Component name (e.g. moving_average_crossover)"),
+):
+    """
+    [blue]:information:[/blue] Show component parameter definitions.
+
+    Examples:
+        ginkgo component info moving_average_crossover
+        ginkgo component info fixed_selector
+    """
+    from ginkgo.data.services.component_parameter_extractor import ComponentParameterExtractor
+
+    extractor = ComponentParameterExtractor()
+    params = extractor.extract_component_parameters(name)
+    defaults = extractor.extract_component_parameter_defaults(name)
+
+    console.print(f"\n[bold]:information_source: Component:[/bold] {name}")
+
+    if not params:
+        console.print("[dim]  No parameters defined (uses default template).[/dim]")
+        return
+
+    param_table = Table(show_header=True, header_style="bold cyan")
+    param_table.add_column("Index", style="dim", width=8)
+    param_table.add_column("Parameter", style="white", width=25)
+    param_table.add_column("Default", style="green", width=20)
+
+    for idx in sorted(params.keys()):
+        param_name = params[idx]
+        default_val = defaults.get(param_name, "-")
+        param_table.add_row(str(idx), param_name, str(default_val))
+
+    console.print(param_table)
+
+@app.command()
 def validate(
     component_id: str = typer.Argument(..., help="Component UUID"),
 ):

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -20,10 +20,19 @@ from rich.table import Table
 from rich.tree import Tree
 from rich import print as rprint
 
+from ginkgo.enums import PORTFOLIO_MODE_TYPES
 from ginkgo.libs import GLOG
 
 app = typer.Typer(help=":bank: Portfolio management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
+
+
+def _format_portfolio_mode(mode_value) -> str:
+    """将 Portfolio mode 字段格式化为可读文本。#5326"""
+    if mode_value is None:
+        return "N/A"
+    enum_val = PORTFOLIO_MODE_TYPES.from_int(mode_value)
+    return enum_val.name if enum_val else str(mode_value)
 
 
 def collect_portfolio_components(portfolio_id: str, container) -> dict:
@@ -342,7 +351,7 @@ def get(
             table.add_row("Initial Capital", f"¥{portfolio.initial_capital:,.2f}")
             table.add_row("Current Capital", f"¥{portfolio.current_capital:,.2f}")
             table.add_row("Cash", f"¥{portfolio.cash:,.2f}")
-            table.add_row("Mode", str(getattr(portfolio, 'mode', 'N/A')))
+            table.add_row("Mode", _format_portfolio_mode(getattr(portfolio, 'mode', None)))
             table.add_row("Description", str(portfolio.desc or "No description"))
 
             console.print(table)

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -290,7 +290,8 @@ def create(
         portfolio_service = container.portfolio_service()
         result = portfolio_service.add(
             name=name,
-            description=description or ""
+            description=description or "",
+            initial_capital=initial_capital,
         )
 
         if result.success:

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -21,6 +21,7 @@ from rich.tree import Tree
 from rich import print as rprint
 
 from ginkgo.enums import PORTFOLIO_MODE_TYPES
+from ginkgo.data.services.component_parameter_extractor import get_component_parameter_names
 from ginkgo.libs import GLOG
 
 app = typer.Typer(help=":bank: Portfolio management", rich_markup_mode="rich")
@@ -552,17 +553,32 @@ def bind_component(
         # 解析参数
         parameters = {}
         if params:
+            # 获取组件参数名映射（用于关键字解析）
+            param_names = {}
+            try:
+                param_names = get_component_parameter_names(
+                    file_name, file_id=resolved_file_uuid, component_type=component_type
+                ) or {}
+            except Exception:
+                pass  # 参数名提取失败时回退到纯 index 模式
+            name_to_index = {v: k for k, v in param_names.items()} if param_names else {}
+
             for param in params:
                 if ':' not in param:
-                    console.print(f":x: Invalid parameter format: '{param}'. Use 'index:value' format.")
+                    console.print(f":x: Invalid parameter format: '{param}'. Use 'index:value' or 'key:value' format.")
                     raise typer.Exit(1)
+                key_str, value = param.split(':', 1)
                 try:
-                    index_str, value = param.split(':', 1)
-                    index = int(index_str)
+                    index = int(key_str)
                     parameters[index] = value
                 except ValueError:
-                    console.print(f":x: Invalid parameter format: '{param}'. Index must be an integer.")
-                    raise typer.Exit(1)
+                    # 非整数，尝试作为关键字解析
+                    if key_str in name_to_index:
+                        parameters[name_to_index[key_str]] = value
+                    else:
+                        valid_keys = ", ".join(sorted(name_to_index.keys())) if name_to_index else "(无法获取参数定义)"
+                        console.print(f":x: Unknown parameter '{key_str}'. Valid keys: {valid_keys}")
+                        raise typer.Exit(1)
 
         # 使用 MappingService 创建绑定
         mapping_service = container.mapping_service()

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -92,6 +92,7 @@ class PortfolioService(BaseService):
         name: str,
         mode: PORTFOLIO_MODE_TYPES = PORTFOLIO_MODE_TYPES.BACKTEST,
         description: str = None,
+        initial_capital: float = None,
         **kwargs
     ) -> ServiceResult:
         """
@@ -101,6 +102,7 @@ class PortfolioService(BaseService):
             name: 投资组合名称
             mode: 运行模式 (BACKTEST/PAPER/LIVE)
             description: 可选描述
+            initial_capital: 初始资金（默认 1000000.0）
 
         Returns:
             ServiceResult: 操作结果
@@ -125,12 +127,16 @@ class PortfolioService(BaseService):
             mode_name = mode.name if hasattr(mode, 'name') else str(mode)
 
             # 创建投资组合
+            capital = initial_capital if initial_capital is not None else 1000000.0
             with self._crud_repo.get_session() as session:
                 portfolio_record = self._crud_repo.create(
                     name=name,
                     mode=PORTFOLIO_MODE_TYPES.validate_input(mode) or PORTFOLIO_MODE_TYPES.BACKTEST.value,
                     state=PORTFOLIO_RUNSTATE_TYPES.INITIALIZED.value,
                     desc=description or f"{mode_name} portfolio: {name}",
+                    initial_capital=capital,
+                    current_capital=capital,
+                    cash=capital,
                     session=session,
                 )
 

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -101,7 +101,7 @@ class DeploymentService(BaseService):
                 )
             except Exception:
                 pass
-            return ServiceResult(success=False, error=f"部署失败: {str(e)}")
+            return ServiceResult(success=False, error=str(e))
 
     def _deploy_core(
         self,

--- a/src/ginkgo/workers/backtest_worker/progress_tracker.py
+++ b/src/ginkgo/workers/backtest_worker/progress_tracker.py
@@ -221,7 +221,9 @@ class ProgressTracker:
                 if current_stage:
                     result_fields["current_stage"] = current_stage
 
-            # 完成状态时，设置结果字段
+            # 完成状态时，设置结果字段和进度 100%
+            if status == "completed":
+                result_fields["progress"] = 100
             if result:
                 result_fields.update({
                     "total_pnl": result.get("total_pnl", 0.0),

--- a/src/ginkgo/workers/backtest_worker/task_helpers.py
+++ b/src/ginkgo/workers/backtest_worker/task_helpers.py
@@ -104,9 +104,11 @@ def load_portfolio_components(portfolio_id: str, task_uuid: str = "cli") -> Dict
         )
 
     strategy_names = [c["name"] for c in components["strategies"] if c.get("name")]
+    selector_names = [c["name"] for c in components["selectors"] if c.get("name")]
     risk_names = [c["name"] for c in components["risk_managers"] if c.get("name")]
     sizer_names = [c["name"] for c in components["sizers"] if c.get("name")]
     GLOG.INFO(f"[{task_uuid[:8]}] Assembly: "
+              f"selectors={selector_names}, "
               f"strategies={strategy_names}, "
               f"risk_managers={risk_names}, "
               f"sizers={sizer_names}")

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -1,0 +1,76 @@
+# #5329 backtest cat 输出提示 result show 用法
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import re
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    """去除 ANSI 转义码"""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _mock_task():
+    """构造一个 mock backtest task 对象"""
+    task = MagicMock()
+    task.uuid = "abc123456789"
+    task.task_id = "task-run-id-001"
+    task.name = "Test Backtest"
+    task.portfolio_id = "port-001"
+    task.engine_id = "engine-001"
+    task.status = "completed"
+    task.progress = 100
+    task.create_at = "2025-01-01"
+    task.start_time = "2025-01-01T10:00:00"
+    task.end_time = "2025-01-01T10:05:00"
+    task.duration_seconds = "300"
+    task.error_message = None
+    task.config_snapshot = None
+    # metrics（float 属性，0.0 跳过展示块）
+    task.final_portfolio_value = 0.0
+    task.total_pnl = 0.0
+    task.max_drawdown = 0.0
+    task.sharpe_ratio = 0.0
+    task.annual_return = 0.0
+    task.win_rate = 0.0
+    # stats（int 属性，0 跳过展示块）
+    task.total_signals = 0
+    task.total_orders = 0
+    task.total_positions = 0
+    task.total_events = 0
+    return task
+
+
+class TestBacktestCatResultHint:
+    """#5329 backtest cat 应提示 result show 用法"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_cat_shows_result_show_hint(self, mock_container):
+        """#5329 backtest cat 输出应包含 result show --run-id 提示"""
+        from ginkgo.client.backtest_cli import app
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = True
+        result.data = _mock_task()
+        mock_service.get_by_id.return_value = result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "task-run-id-001"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        # 应包含提示，指引用户使用 result show --run-id
+        assert "result show --run-id" in plain
+        # 提示应包含实际的 task_id
+        assert "task-run-id-001" in plain

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -74,3 +74,53 @@ class TestBacktestCatResultHint:
         assert "result show --run-id" in plain
         # 提示应包含实际的 task_id
         assert "task-run-id-001" in plain
+
+
+class TestBacktestListProgressFormat:
+    """#5323 list 命令 progress 格式化应为 N% 而非 N00%"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_shows_correct_progress_percentage(self, mock_container):
+        """#5323 progress=50 应显示 50% 而非 5000%"""
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.progress = 50
+
+        mock_service = MagicMock()
+        list_result = MagicMock()
+        list_result.is_success.return_value = True
+        list_result.data = {"data": [task], "total": 1}
+        mock_service.list.return_value = list_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["list"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        # progress=50 应显示 "50%" 而非 "5000%"
+        assert "50%" in plain
+        assert "5000%" not in plain
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_shows_100_percent_on_completed(self, mock_container):
+        """#5323 completed 任务 progress=100 应显示 100%"""
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.progress = 100
+        task.status = "completed"
+
+        mock_service = MagicMock()
+        list_result = MagicMock()
+        list_result.is_success.return_value = True
+        list_result.data = {"data": [task], "total": 1}
+        mock_service.list.return_value = list_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["list"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        assert "100%" in plain
+        assert "10000%" not in plain

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -124,3 +124,33 @@ class TestBacktestListProgressFormat:
         plain = _strip_ansi(invoke_result.output)
         assert "100%" in plain
         assert "10000%" not in plain
+
+
+class TestBacktestCatNoTradesWarning:
+    """#5322 completed 回测无交易时应显示警告"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_cat_shows_no_trades_warning_when_zero_stats(self, mock_container):
+        """#5322 completed 回测 stats 全为 0 时应显示 'No trades' 提示"""
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.status = "completed"
+        # stats 全为 0（默认值）
+        task.total_signals = 0
+        task.total_orders = 0
+        task.total_positions = 0
+        task.total_events = 0
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = True
+        result.data = task
+        mock_service.get_by_id.return_value = result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "abc123456789"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        assert "No trades" in plain or "未产生" in plain or "no trades" in plain.lower()

--- a/tests/unit/client/test_components_cli.py
+++ b/tests/unit/client/test_components_cli.py
@@ -212,3 +212,39 @@ class TestComponentsExceptions:
         assert result.exit_code == 0
         # 验证 Rich Table 被渲染（虽然表头由 Rich 格式化，但 ID 列应该存在）
         assert "ID" in result.output
+
+
+# ============================================================================
+# #5324 component info 命令
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestComponentInfoCommand:
+    """#5324 component info 显示参数定义"""
+
+    @patch("ginkgo.data.services.component_parameter_extractor.ComponentParameterExtractor")
+    def test_info_shows_parameter_names_and_defaults(self, MockExtractor, cli_runner):
+        """#5324 info 命令应显示组件参数名和默认值"""
+        mock_extractor = MagicMock()
+        mock_extractor.extract_component_parameters.return_value = {0: "fast_period", 1: "slow_period"}
+        mock_extractor.extract_component_parameter_defaults.return_value = {"fast_period": 10, "slow_period": 30}
+        MockExtractor.return_value = mock_extractor
+
+        result = cli_runner.invoke(components_cli.app, ["info", "moving_average_crossover"])
+        assert result.exit_code == 0
+        assert "fast_period" in result.output
+        assert "slow_period" in result.output
+
+    @patch("ginkgo.data.services.component_parameter_extractor.ComponentParameterExtractor")
+    def test_info_shows_component_not_found(self, MockExtractor, cli_runner):
+        """#5324 info 命令对不存在的组件显示错误"""
+        mock_extractor = MagicMock()
+        mock_extractor.extract_component_parameters.return_value = {}
+        mock_extractor.extract_component_parameter_defaults.return_value = {}
+        MockExtractor.return_value = mock_extractor
+
+        result = cli_runner.invoke(components_cli.app, ["info", "nonexistent_component"])
+        assert result.exit_code == 0
+        assert "No parameters" in result.output or "no parameters" in result.output.lower() or "未找到" in result.output

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -431,8 +431,9 @@ class TestPortfolioDelete:
 class TestPortfolioBindComponent:
     """portfolio bind-component 命令"""
 
+    @patch("ginkgo.client.portfolio_cli.get_component_parameter_names", return_value={})
     @patch("ginkgo.data.containers.container")
-    def test_bind_success(self, mock_container, cli_runner, mock_portfolio):
+    def test_bind_success(self, mock_container, mock_get_names, cli_runner, mock_portfolio):
         """成功绑定组件到 portfolio"""
         mock_pf_service = MagicMock()
         # bind 源码检查 len(data) > 0，需要传列表
@@ -462,9 +463,10 @@ class TestPortfolioBindComponent:
         assert result.exit_code == 0
         assert "binding created successfully" in result.output
 
+    @patch("ginkgo.client.portfolio_cli.get_component_parameter_names", return_value={})
     @patch("ginkgo.data.containers.container")
-    def test_bind_with_params(self, mock_container, cli_runner, mock_portfolio):
-        """绑定组件并设置参数"""
+    def test_bind_with_params(self, mock_container, mock_get_names, cli_runner, mock_portfolio):
+        """绑定组件并设置参数（index 格式向后兼容）"""
         mock_pf_service = MagicMock()
         mock_pf_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
 
@@ -491,8 +493,9 @@ class TestPortfolioBindComponent:
             "--type", "risk", "--param", "0:0.1", "--param", "1:100"
         ])
         assert result.exit_code == 0
-        assert "binding created successfully" in result.output
-        assert "2 parameter(s) set" in result.output
+        output = _strip_ansi(result.output)
+        assert "binding created successfully" in output
+        assert "2 parameter(s) set" in output
 
     def test_bind_missing_type(self, cli_runner):
         """缺少 --type 参数时失败"""
@@ -501,8 +504,9 @@ class TestPortfolioBindComponent:
         ])
         assert result.exit_code != 0
 
+    @patch("ginkgo.client.portfolio_cli.get_component_parameter_names", return_value={})
     @patch("ginkgo.data.containers.container")
-    def test_bind_invalid_type(self, mock_container, cli_runner, mock_portfolio):
+    def test_bind_invalid_type(self, mock_container, mock_get_names, cli_runner, mock_portfolio):
         """无效的组件类型时失败"""
         mock_pf_service = MagicMock()
         mock_pf_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
@@ -520,6 +524,49 @@ class TestPortfolioBindComponent:
         ])
         assert result.exit_code == 1
         assert "Invalid component type" in result.output
+
+    @patch("ginkgo.client.portfolio_cli.get_component_parameter_names")
+    @patch("ginkgo.data.containers.container")
+    def test_bind_with_keyword_params(self, mock_container, mock_get_names, cli_runner, mock_portfolio):
+        """#5325 支持关键字格式 --param short_period:20"""
+        mock_pf_service = MagicMock()
+        mock_pf_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
+
+        mock_file = MagicMock()
+        mock_file.uuid = "file-uuid-kw"
+        mock_file.name = "moving_average_crossover"
+
+        mock_file_service = MagicMock()
+        mock_file_service.get_by_uuid.return_value = ServiceResult.success(data=mock_file)
+
+        mock_mapping = MagicMock()
+        mock_mapping.uuid = "mapping-uuid-kw"
+
+        mock_mapping_service = MagicMock()
+        mock_mapping_service.create_portfolio_file_binding.return_value = ServiceResult.success(data=mock_mapping)
+        mock_mapping_service.create_component_parameters.return_value = ServiceResult.success(data=None)
+
+        mock_container.portfolio_service.return_value = mock_pf_service
+        mock_container.file_service.return_value = mock_file_service
+        mock_container.mapping_service.return_value = mock_mapping_service
+
+        # 返回参数名映射 {0: "short_period", 1: "long_period"}
+        mock_get_names.return_value = {0: "short_period", 1: "long_period"}
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "bind-component", "TestPortfolio", "moving_average_crossover",
+            "--type", "strategy",
+            "--param", "short_period:20",
+            "--param", "long_period:60"
+        ])
+        assert result.exit_code == 0
+        assert "binding created successfully" in result.output
+        # 验证 create_component_parameters 收到的是 index 格式
+        call_args = mock_mapping_service.create_component_parameters.call_args
+        params_arg = call_args.kwargs.get("parameters") or call_args[1].get("parameters")
+        assert params_arg is not None
+        assert params_arg[0] == "20"
+        assert params_arg[1] == "60"
 
 
 @pytest.mark.unit

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -13,6 +13,7 @@ Portfolio CLI 单元测试
 """
 
 import os
+import re
 
 os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
 
@@ -24,6 +25,11 @@ from typer.testing import CliRunner
 
 from ginkgo.client import portfolio_cli
 from ginkgo.data.services.base_service import ServiceResult
+
+
+def _strip_ansi(text: str) -> str:
+    """去除 ANSI 转义码，便于断言"""
+    return re.sub(r'\x1b\[[0-9;]*m', '', text)
 
 
 @pytest.fixture
@@ -189,22 +195,45 @@ class TestPortfolioCreate:
     def test_create_success(self, mock_container, cli_runner, mock_portfolio):
         """成功创建 portfolio"""
         mock_service = MagicMock()
-        mock_service.create.return_value = ServiceResult.success(data=mock_portfolio)
+        mock_service.add.return_value = ServiceResult.success(
+            data={"uuid": "new-portfolio-uuid", "name": "MyPortfolio"}
+        )
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, [
             "create", "--name", "MyPortfolio", "--capital", "500000"
         ])
         assert result.exit_code == 0
-        assert "created successfully" in result.output
-        assert "MyPortfolio" in result.output
-        assert "500,000" in result.output
+        output = _strip_ansi(result.output)
+        assert "created successfully" in output
+        assert "MyPortfolio" in output
+        assert "500,000" in output
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_passes_initial_capital_to_service(self, mock_container, cli_runner):
+        """#5331 create 命令必须将 initial_capital 传给 service.add()"""
+        mock_service = MagicMock()
+        mock_service.add.return_value = ServiceResult.success(
+            data={"uuid": "new-uuid", "name": "CapTest"}
+        )
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "create", "--name", "CapTest", "--capital", "2000000"
+        ])
+        assert result.exit_code == 0
+        # 验证 service.add 被调用时传入了 initial_capital
+        call_kwargs = mock_service.add.call_args
+        assert call_kwargs is not None
+        # 传入的 capital 值应为 2000000
+        passed_capital = call_kwargs.kwargs.get("initial_capital") or call_kwargs[1].get("initial_capital")
+        assert passed_capital == 2000000.0
 
     @patch("ginkgo.data.containers.container")
     def test_create_live_portfolio(self, mock_container, cli_runner, mock_portfolio):
         """创建实盘 portfolio"""
         mock_service = MagicMock()
-        mock_service.create.return_value = ServiceResult.success(data=mock_portfolio)
+        mock_service.add.return_value = ServiceResult.success(data={"uuid": "live-uuid", "name": "LivePF"})
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, [
@@ -223,7 +252,7 @@ class TestPortfolioCreate:
     def test_create_service_error(self, mock_container, cli_runner):
         """服务返回错误时创建失败"""
         mock_service = MagicMock()
-        mock_service.create.return_value = ServiceResult.error(error="Name already exists")
+        mock_service.add.return_value = ServiceResult.error(error="Name already exists")
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, [

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -66,6 +66,7 @@ def mock_portfolio():
     p.current_capital = 950000.0
     p.cash = 500000.0
     p.is_live = False
+    p.mode = 0  # BACKTEST 枚举值（整数）
     p.desc = "Test description"
     return p
 
@@ -314,6 +315,36 @@ class TestPortfolioGet:
         result = cli_runner.invoke(portfolio_cli.app, ["get", "some-uuid"])
         assert result.exit_code == 1
         assert "Error" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_mode_shows_readable_text_backtest(self, mock_container, cli_runner, mock_portfolio):
+        """#5326 Mode 字段显示 BACKTEST 而非数字 0"""
+        mock_portfolio.mode = 0
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=mock_portfolio)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["get", "portfolio-uuid-001"])
+        assert result.exit_code == 0
+        assert "BACKTEST" in result.output
+        # 不应出现裸数字 0 作为 Mode
+        lines = result.output.split("\n")
+        mode_line = next((l for l in lines if "Mode" in l), None)
+        assert mode_line is not None
+        # Mode 行不应以数字结尾（排除表格边框中的数字）
+        assert "BACKTEST" in mode_line
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_mode_shows_readable_text_paper(self, mock_container, cli_runner, mock_portfolio):
+        """#5326 Mode 字段显示 PAPER 而非数字 1"""
+        mock_portfolio.mode = 1
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=mock_portfolio)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["get", "portfolio-uuid-001"])
+        assert result.exit_code == 0
+        assert "PAPER" in result.output
 
 
 # ============================================================================

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -83,3 +83,22 @@ class TestDeploymentServiceDeploy:
         assert result.success
         svc._deployment_crud.add.assert_called_once()
         svc._deploy_core.assert_called_once()
+
+
+class TestDeploymentServiceErrorMessages:
+    """#5327 错误信息不应重复"""
+
+    def test_error_message_no_duplicate_prefix(self):
+        """#5327 deploy 异常时 service error 不应包含 '部署失败:' 前缀（CLI 负责加）"""
+        svc = _make_svc()
+        svc._portfolio_service.get.return_value = _mock_portfolio_found()
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        svc._deployment_crud.add.return_value = MagicMock(success=True, data=MagicMock(uuid="d1"))
+
+        # _deploy_core 抛 RuntimeError（如 line 136: 创建Portfolio失败: ...）
+        svc._deploy_core = MagicMock(side_effect=RuntimeError("创建Portfolio失败: 投资组合名称已存在"))
+
+        result = svc.deploy(portfolio_id="p1", mode=PORTFOLIO_MODE_TYPES.PAPER, name="Dup")
+        assert not result.success
+        # service error 不应有 "部署失败:" 前缀（CLI 层加）
+        assert not result.error.startswith("部署失败:")

--- a/tests/unit/workers/test_task_helpers.py
+++ b/tests/unit/workers/test_task_helpers.py
@@ -1,0 +1,71 @@
+# #5330 Assembly 日志应包含 selectors 组件
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock, patch
+from ginkgo.enums import FILE_TYPES
+
+
+class TestLoadPortfolioComponentsAssemblyLog:
+    """#5330 load_portfolio_components 的 Assembly 日志应包含 selectors"""
+
+    @patch("ginkgo.workers.backtest_worker.task_helpers.GLOG")
+    @patch("ginkgo.workers.backtest_worker.task_helpers.data_container")
+    def test_assembly_log_includes_selectors(self, mock_container, mock_glog):
+        """#5330 Assembly 日志应包含 selectors 组件名称"""
+        from ginkgo.workers.backtest_worker.task_helpers import load_portfolio_components
+
+        # Mock portfolio_file_mapping CRUD
+        mock_mapping_crud = MagicMock()
+
+        selector_mapping = MagicMock()
+        selector_mapping.type = FILE_TYPES.SELECTOR.value
+        selector_mapping.file_id = "file-selector-001"
+        selector_mapping.uuid = "map-001"
+
+        strategy_mapping = MagicMock()
+        strategy_mapping.type = FILE_TYPES.STRATEGY.value
+        strategy_mapping.file_id = "file-strategy-001"
+        strategy_mapping.uuid = "map-002"
+
+        mock_mapping_crud.find.return_value = [selector_mapping, strategy_mapping]
+        mock_container.cruds.portfolio_file_mapping.return_value = mock_mapping_crud
+
+        # Mock file CRUD
+        mock_file_crud = MagicMock()
+
+        selector_file = MagicMock()
+        selector_file.name = "fixed_selector"
+
+        strategy_file = MagicMock()
+        strategy_file.name = "random_signal"
+
+        mock_file_crud.find.side_effect = [
+            [selector_file],   # selector 查询
+            [strategy_file],   # strategy 查询
+        ]
+        mock_container.cruds.file.return_value = mock_file_crud
+
+        result = load_portfolio_components(
+            portfolio_id="port-001",
+            task_uuid="test-uuid-12345678",
+        )
+
+        # 验证 GLOG.INFO 被调用且参数包含 selectors
+        info_calls = [c for c in mock_glog.INFO.call_args_list]
+        assembly_call = None
+        for c in info_calls:
+            if "Assembly" in str(c):
+                assembly_call = c
+                break
+
+        assert assembly_call is not None, "Assembly log line should exist"
+        log_msg = str(assembly_call)
+        assert "selectors=" in log_msg, f"Assembly log should contain selectors=, got: {log_msg}"
+        assert "fixed_selector" in log_msg, f"Assembly log should contain selector name, got: {log_msg}"


### PR DESCRIPTION
## Summary

批量修复 9 个 CLI 相关 issue：

| Issue | 类型 | 修复内容 |
|-------|------|----------|
| #5331 | bug | Portfolio capital 创建与查询显示不一致 — `portfolio_service.add()` 接受 `initial_capital` 参数 |
| #5322 | bug | 回测空转无校验 — `backtest cat` completed 状态零交易时显示 ⚠️ 警告 |
| #5326 | bug | Portfolio Mode 显示数字 — 使用 `PORTFOLIO_MODE_TYPES.from_int()` 格式化 |
| #5325 | feature | 参数绑定支持关键字格式 — 通过 `get_component_parameter_names` 反查 index |
| #5324 | feature | component info 命令 — 新增子命令显示参数名和默认值 |
| #5323 | bug | progress 始终 0% — 修复 list 格式化 (`:.0%` → `int()%`) + completed 时写入 progress=100 |
| #5330 | bug | Assembly 日志遗漏 selectors — 添加 selector_names 到日志输出 |
| #5329 | bug | Task ID/run-id 混淆 — `backtest cat` 输出添加 `result show --run-id` 提示 |
| #5327 | bug | deploy 错误信息重复 — service 层移除 "部署失败:" 前缀 |

## Test plan

```bash
# 运行所有相关单元测试
python -m pytest tests/unit/client/test_portfolio_cli.py \
  tests/unit/client/test_backtest_cli.py \
  tests/unit/client/test_components_cli.py \
  tests/unit/trading/services/test_deployment_service.py \
  tests/unit/workers/test_task_helpers.py \
  -x --tb=short -o "addopts="
```

全部 43 passed, 1 skipped, 0 failed。

Closes #5331
Closes #5322
Closes #5326
Closes #5325
Closes #5324
Closes #5323
Closes #5330
Closes #5329
Closes #5327

🤖 Generated with [Claude Code](https://claude.com/claude-code)