### PR TITLE
fix(#4659): 清理 MUser.name 字段残留引用

### DIFF
--- a/src/ginkgo/client/user_cli.py
+++ b/src/ginkgo/client/user_cli.py
@@ -57,7 +57,8 @@ def create_user(
             console.print(Panel.fit(
                 f"[green]:white_check_mark: User created successfully![/green]\n\n"
                 f"[cyan]UUID:[/cyan] {result.data['uuid']}\n"
-                f"[cyan]Name:[/cyan] {result.data['name']}\n"
+                f"[cyan]Username:[/cyan] {result.data.get('username', '')}\n"
+                f"[cyan]Display Name:[/cyan] {result.data.get('display_name', '')}\n"
                 f"[cyan]Description:[/cyan] {result.data['description']}\n"
                 f"[cyan]Type:[/cyan] {result.data['user_type']}\n"
                 f"[cyan]Active:[/cyan] {result.data['is_active']}",
@@ -254,7 +255,8 @@ def update_user(
             console.print(Panel.fit(
                 f"[green]:white_check_mark: User updated successfully![/green]\n\n"
                 f"[cyan]UUID:[/cyan] {result.data['uuid']}\n"
-                f"[cyan]Name:[/cyan] {result.data['name']}\n"
+                f"[cyan]Username:[/cyan] {result.data.get('username', '')}\n"
+                f"[cyan]Display Name:[/cyan] {result.data.get('display_name', '')}\n"
                 f"[cyan]Type:[/cyan] {result.data['user_type']}\n"
                 f"[cyan]Description:[/cyan] {result.data['description'] or 'N/A'}\n"
                 f"[cyan]Active:[/cyan] {result.data['is_active']}",

--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -65,10 +65,6 @@ class UserCRUD(BaseCRUD[MUser]):
                 'min': 0,
                 'max': 64
             },
-                'type': 'string',
-                'min': 0,
-                'max': 128
-            },
 
             # 是否激活 - 布尔值
             'is_active': {
@@ -320,11 +316,11 @@ class UserCRUD(BaseCRUD[MUser]):
         query: str
     ) -> ModelList[MUser]:
         """
-        模糊搜索用户 - 在 uuid 和 name 字段中搜索
+        模糊搜索用户 - 在 uuid、username 和 display_name 字段中搜索
 
         支持的输入格式：
         - UUID格式（32位16进制字符）：精确匹配uuid字段
-        - 其他格式：在uuid和name字段中进行模糊匹配
+        - 其他格式：在uuid、username和display_name字段中进行模糊匹配
 
         Args:
             query: 搜索关键词（UUID或用户名）

--- a/tests/integration/data/crud/test_user_crud_integration.py
+++ b/tests/integration/data/crud/test_user_crud_integration.py
@@ -7,7 +7,7 @@ UserCRUD 继承 BaseCRUD，使用 MUser 模型，存储在 MySQL 中。
 
 测试范围：
 1. 插入操作 - create 创建用户
-2. 查询操作 - find_by_name, find_active_users, fuzzy_search
+2. 查询操作 - find_active_users, fuzzy_search
 3. 更新操作 - modify 更新用户属性
 4. 删除操作 - delete 级联软删除
 """

--- a/tests/unit/client/test_user_cli.py
+++ b/tests/unit/client/test_user_cli.py
@@ -83,7 +83,8 @@ class TestUserCreate:
         mock_user_service.add_user.return_value = ServiceResult.success(
             data={
                 "uuid": "user-uuid-001",
-                "name": "John Doe",
+                "username": "john_doe",
+                "display_name": "John Doe",
                 "description": "Test user",
                 "user_type": "PERSON",
                 "is_active": True,
@@ -100,7 +101,7 @@ class TestUserCreate:
         """创建 channel 类型用户"""
         mock_container.user_service.return_value = mock_user_service
         mock_user_service.add_user.return_value = ServiceResult.success(
-            data={"uuid": "user-uuid-002", "name": "Trading Bot", "description": "", "user_type": "CHANNEL", "is_active": True}
+            data={"uuid": "user-uuid-002", "username": "trading_bot", "display_name": "Trading Bot", "description": "", "user_type": "CHANNEL", "is_active": True}
         )
         result = cli_runner.invoke(user_cli.app, ["create", "--name", "Trading Bot", "--type", "channel"])
         assert result.exit_code == 0
@@ -111,7 +112,7 @@ class TestUserCreate:
         """创建非活跃用户"""
         mock_container.user_service.return_value = mock_user_service
         mock_user_service.add_user.return_value = ServiceResult.success(
-            data={"uuid": "user-uuid-003", "name": "Inactive User", "description": "", "user_type": "PERSON", "is_active": False}
+            data={"uuid": "user-uuid-003", "username": "inactive_user", "display_name": "Inactive User", "description": "", "user_type": "PERSON", "is_active": False}
         )
         result = cli_runner.invoke(user_cli.app, ["create", "--name", "Inactive User", "--inactive"])
         assert result.exit_code == 0
@@ -204,7 +205,7 @@ class TestUserUpdate:
         """更新用户信息成功"""
         mock_container.user_service.return_value = mock_user_service
         mock_user_service.update_user.return_value = ServiceResult.success(
-            data={"uuid": "user-uuid-001", "name": "New Name", "user_type": "PERSON", "description": "Updated", "is_active": True}
+            data={"uuid": "user-uuid-001", "username": "new_name", "display_name": "New Name", "user_type": "PERSON", "description": "Updated", "is_active": True}
         )
         result = cli_runner.invoke(user_cli.app, ["update", "user-uuid-001", "--name", "New Name"])
         assert result.exit_code == 0

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -45,10 +45,10 @@ class TestUserCRUDFieldConfig:
 
     @pytest.mark.unit
     def test_field_config_has_required_keys(self, crud_instance):
-        """配置包含 user_type, name, is_active"""
+        """配置包含 user_type, username, is_active"""
         config = crud_instance._get_field_config()
 
-        required_keys = {"user_type", "name", "is_active"}
+        required_keys = {"user_type", "username", "is_active"}
         assert required_keys.issubset(set(config.keys())), \
             f"缺少字段: {required_keys - set(config.keys())}"
 
@@ -101,14 +101,14 @@ class TestUserCRUDCreateFromParams:
         from ginkgo.data.models import MUser
 
         params = {
-            "name": "测试用户",
+            "username": "测试用户",
             "user_type": USER_TYPES.PERSON,
         }
 
         model = crud_instance._create_from_params(**params)
 
         assert isinstance(model, MUser)
-        # MUser 没有 name 列，_create_from_params 传入 name 参数但模型不映射
+        assert model.username == "测试用户"
         assert model.is_active is True
 
     @pytest.mark.unit


### PR DESCRIPTION
## Summary

PR #5333 删除了 `MUser.name` 字段，但以下残留未清理，导致合并后存在运行时崩溃和测试失效。

### 运行时崩溃（KeyError / 语法破损）
- `user_cli.py:60,257` — `result.data["name"]` 键不存在 → **KeyError**
- `user_crud.py:68-71` — `_get_field_config` 删除 `name` 键时只删了键名、留下值 → **字典语法破损**

### 测试失效
- `test_user_crud_mock.py:51` — 断言期望 `_get_field_config()` 返回 `"name"` 键
- `test_user_crud_mock.py:104` — 传入 `"name"` 参数被静默忽略，测试意图失效
- `test_user_cli.py` — mock data 仍用 `"name"` 键，与新输出格式不匹配

### 文档残留
- `user_crud.py:323` — `fuzzy_search` docstring 仍提及 `name`
- `test_user_crud_integration.py:10` — 文件头仍列出 `find_by_name`

## Test plan

- [x] 35 unit tests passed（crud mock + user service + cli）
- [x] 17 user model tests passed（无回归）
- [ ] `ginkgo data init` 验证无破坏性变更

Closes #4659

🤖 Generated with [Claude Code](https://claude.com/claude-code)