### PR TITLE
fix(#6012): remove orphaned dict lines in user_crud.py causing IndentationError

### DIFF
--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -65,10 +65,6 @@ class UserCRUD(BaseCRUD[MUser]):
                 'min': 0,
                 'max': 64
             },
-                'type': 'string',
-                'min': 0,
-                'max': 128
-            },
 
             # 是否激活 - 布尔值
             'is_active': {

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -48,7 +48,7 @@ class TestUserCRUDFieldConfig:
         """配置包含 user_type, name, is_active"""
         config = crud_instance._get_field_config()
 
-        required_keys = {"user_type", "name", "is_active"}
+        required_keys = {"user_type", "username", "is_active"}
         assert required_keys.issubset(set(config.keys())), \
             f"缺少字段: {required_keys - set(config.keys())}"
 


### PR DESCRIPTION
## Summary

`user_crud.py` 第 68-71 行残留了 `username→name` 重构时的孤儿 dict value（缺少 key），导致 Python 解析 IndentationError。

任何触发 `from ginkgo.data.crud import UserCRUD` 导入链的命令都会崩溃，包括：
- `backtest cat/list`
- `record signal/order/analyzer`
- `data get day`

**修复**：删除 4 行孤儿代码。

**文件变更**：
- `src/ginkgo/data/crud/user_crud.py` — 删除第 68-71 行孤儿 dict value
- `tests/unit/data/crud/test_user_crud_mock.py` — 修正 `name→username` 字段名断言（测试文件与 master 代码对齐）

## Test plan

```bash
python -m pytest tests/unit/data/crud/test_user_crud_mock.py -x -o "addopts="
# 11 passed
```

Closes #6012