### PR TITLE
fix: 批量修复回测零交易问题 (#5937 #5955 #5974 #5960 #5958)

### DIFF
--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -65,10 +65,6 @@ class UserCRUD(BaseCRUD[MUser]):
                 'min': 0,
                 'max': 64
             },
-                'type': 'string',
-                'min': 0,
-                'max': 128
-            },
 
             # 是否激活 - 布尔值
             'is_active': {

--- a/src/ginkgo/data/services/component_parameter_extractor.py
+++ b/src/ginkgo/data/services/component_parameter_extractor.py
@@ -226,8 +226,8 @@ class ComponentParameterExtractor:
             param_index = 0
 
             for param_name, param in init_signature.parameters.items():
-                # 跳过self, args, kwargs（name保留，确保索引与构造函数位置一致）
-                if param_name in ['self', 'args', 'kwargs']:
+                # #5955: 跳过 self/args/kwargs/name — name 是框架参数，非业务参数
+                if param_name in ['self', 'args', 'kwargs', 'name']:
                     continue
 
                 parameters[param_index] = param_name
@@ -277,8 +277,8 @@ class ComponentParameterExtractor:
             for arg in init_method.args.args:
                 arg_name = arg.arg
 
-                # 跳过self, args, kwargs（name保留）
-                if arg_name in ['self', 'args', 'kwargs']:
+                # #5955: 跳过 self/args/kwargs/name — name 是框架参数，非业务参数
+                if arg_name in ['self', 'args', 'kwargs', 'name']:
                     continue
 
                 parameters[param_index] = arg_name
@@ -331,8 +331,8 @@ class ComponentParameterExtractor:
             for arg in init_method.args.args:
                 arg_name = arg.arg
 
-                # 跳过self, args, kwargs（name保留）
-                if arg_name in ['self', 'args', 'kwargs']:
+                # #5955: 跳过 self/args/kwargs/name — name 是框架参数，非业务参数
+                if arg_name in ['self', 'args', 'kwargs', 'name']:
                     continue
 
                 parameters[param_index] = arg_name

--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -11,9 +11,54 @@ ComponentLoader - 组件加载器
 """
 
 import json
-from typing import Dict, Any
+from typing import Dict, Any, List
 from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.trading.portfolios import PortfolioT1Backtest
+
+
+def resolve_param_kwargs(
+    component_params: list,
+    param_indices: List[int],
+    param_names: Dict[int, str],
+) -> Dict[str, Any]:
+    """将 DB 参数值映射到组件构造函数的 kwargs。
+
+    #5974: 支持新旧两种索引方案：
+    - 新组合（#5955 后创建）：索引从 0 开始，name 已跳过
+    - 旧组合（#5955 前创建）：索引从 1 开始（0=name）
+
+    策略：先尝试直接匹配，若全部失败则尝试整体偏移 -1。
+    """
+    if not component_params or not param_indices:
+        return {}
+
+    # 第一轮：直接匹配（新组合）
+    kwargs: Dict[str, Any] = {}
+    mapped = 0
+    for i, val in enumerate(component_params):
+        orig_idx = param_indices[i]
+        if orig_idx in param_names:
+            kwargs[param_names[orig_idx]] = val
+            mapped += 1
+
+    if mapped == len(component_params):
+        return kwargs
+
+    # 第二轮：旧组合，索引整体偏移 -1（name 曾在 index 0）
+    shifted: Dict[str, Any] = {}
+    shifted_mapped = 0
+    for i, val in enumerate(component_params):
+        orig_idx = param_indices[i]
+        shifted_idx = orig_idx - 1
+        if shifted_idx >= 0 and shifted_idx in param_names:
+            shifted[param_names[shifted_idx]] = val
+            shifted_mapped += 1
+
+    # 选择匹配更多的方案
+    if shifted_mapped > mapped:
+        return shifted
+
+    return kwargs
 
 
 class ComponentLoader:
@@ -88,6 +133,7 @@ class ComponentLoader:
                         self._logger.DEBUG(f"Found {len(component_params)} params: {component_params}")
 
                         # 用动态参数提取器获取参数名，构建 kwargs
+                        # #5974: 使用 resolve_param_kwargs 处理新旧索引兼容
                         try:
                             from ginkgo.data.services.component_parameter_extractor import get_component_parameter_names
                             file_crud_local = container.cruds.file()
@@ -98,10 +144,9 @@ class ComponentLoader:
                                 file_type_str = type_map.get(component_type)
                                 if file_type_str:
                                     param_names = get_component_parameter_names(comp_name, code_content, file_type_str, file_id)
-                                    for i, val in enumerate(component_params):
-                                        orig_idx = param_indices[i]
-                                        if orig_idx in param_names:
-                                            component_kwargs[param_names[orig_idx]] = val
+                                    component_kwargs = resolve_param_kwargs(
+                                        component_params, param_indices, param_names,
+                                    )
                         except Exception as e:
                             self._logger.WARN(f"Failed to resolve param names, falling back to positional: {e}")
                     else:

--- a/src/ginkgo/trading/services/_assembly/infrastructure_factory.py
+++ b/src/ginkgo/trading/services/_assembly/infrastructure_factory.py
@@ -255,32 +255,34 @@ class InfrastructureFactory:
     def setup_engine_infrastructure(
         engine: Any, logger: GinkgoLogger = None, engine_data: Dict[str, Any] = None, skip_feeder: bool = False
     ) -> bool:
-        """Set up matchmaking and data feeding for the engine."""
+        """Set up matchmaking and data feeding for the engine.
+
+        #5937: skip_feeder=True 时跳过 feeder 创建，等待后续
+               setup_data_feeder_for_engine() 在 portfolio 绑定后再创建。
+        """
         try:
             _logger = logger or GLOG
 
-            # 📝 修复事件处理顺序：先添加Portfolio，后添加Router，与Example保持一致
-            # 将在后面Portfolio添加完成后再绑定Router
+            # #5937: 仅在 skip_feeder=False 时创建并绑定 feeder
+            if not skip_feeder:
+                feeder = BacktestFeeder("ExampleFeeder")
 
-            # Set up data feeder
-            feeder = BacktestFeeder("ExampleFeeder")
+                # 使用时间控制引擎的数据馈送接入，以确保 advance_time_to 能触发数据更新
+                if hasattr(engine, "set_data_feeder"):
+                    engine.set_data_feeder(feeder)
+                else:
+                    # 兼容老接口
+                    engine.bind_datafeeder(feeder)
+                # 去订阅/广播：由引擎推进直接调用 Feeder.advance_to_time 注入事件
+                # 同时确保 Feeder 能够直接回注事件（可选）
+                if hasattr(feeder, "set_event_publisher"):
+                    feeder.set_event_publisher(engine.put)
+                # 注册兴趣更新事件给Feeder
+                from ginkgo.trading.events import EventInterestUpdate
 
-            # 使用时间控制引擎的数据馈送接入，以确保 advance_time_to 能触发数据更新
-            if hasattr(engine, "set_data_feeder"):
-                engine.set_data_feeder(feeder)
-            else:
-                # 兼容老接口
-                engine.bind_datafeeder(feeder)
-            # 去订阅/广播：由引擎推进直接调用 Feeder.advance_to_time 注入事件
-            # 同时确保 Feeder 能够直接回注事件（可选）
-            if hasattr(feeder, "set_event_publisher"):
-                feeder.set_event_publisher(engine.put)
-            # 注册兴趣更新事件给Feeder
-            from ginkgo.trading.events import EventInterestUpdate
+                engine.register(EVENT_TYPES.INTERESTUPDATE, feeder.on_interest_update)
 
-            engine.register(EVENT_TYPES.INTERESTUPDATE, feeder.on_interest_update)
-
-            # Set up gateway and broker (restored original binding logic)
+            # Set up gateway and broker (always needed, regardless of skip_feeder)
             from ginkgo.trading.gateway.trade_gateway import TradeGateway
             broker = InfrastructureFactory.create_broker_from_config(engine_data or {})
             gateway = TradeGateway(brokers=[broker])
@@ -289,7 +291,7 @@ class InfrastructureFactory:
             if hasattr(gateway, "set_event_publisher"):
                 gateway.set_event_publisher(engine.put)
 
-            _logger.DEBUG("Engine infrastructure setup completed")
+            _logger.DEBUG(f"Engine infrastructure setup completed (skip_feeder={skip_feeder})")
             return True
 
         except Exception as e:

--- a/tests/unit/data/services/test_parameter_extractor_skip_name.py
+++ b/tests/unit/data/services/test_parameter_extractor_skip_name.py
@@ -1,0 +1,95 @@
+"""
+TDD test for #5955: get_component_parameter_names() should skip framework 'name'.
+
+Bug: Index 0 maps to 'name' (framework display name) instead of the first
+business parameter. When CLI users pass --param '0:value', they intend to set
+a business param like 'codes' or 'rsi_period', not the component name.
+
+Root cause: _extract_via_ast_analysis_content and _extract_via_dynamic_import
+skip 'self'/'args'/'kwargs' but intentionally keep 'name'.
+"""
+import pytest
+from ginkgo.data.services.component_parameter_extractor import (
+    get_component_parameter_names,
+    ComponentParameterExtractor,
+)
+
+
+# Fake component source code simulating a typical strategy
+_FAKE_STRATEGY_CODE = '''
+from ginkgo.trading.bases.base_strategy import BaseStrategy
+
+class FakeStrategy(BaseStrategy):
+    """Test strategy with name + business params."""
+
+    def __init__(self, name: str = "FakeStrategy", period: int = 14,
+                 threshold: float = 0.5, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.period = period
+        self.threshold = threshold
+'''
+
+_FAKE_SELECTOR_CODE = '''
+from ginkgo.trading.bases.base_selector import BaseSelector
+
+class FixedSelector(BaseSelector):
+    """Selector with name + codes."""
+
+    def __init__(self, name: str = "FixedSelector", codes=None, **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.codes = codes or []
+'''
+
+
+@pytest.mark.unit
+class TestParameterExtractionSkipsName:
+    """参数提取应跳过框架参数 name"""
+
+    def test_ast_content_skips_name_strategy(self):
+        """策略参数索引 0 应为 period，不是 name"""
+        result = get_component_parameter_names(
+            "FakeStrategy",
+            file_content=_FAKE_STRATEGY_CODE,
+            component_type="strategy",
+        )
+        assert result is not None
+        assert "name" not in result.values()
+        # 索引 0 应为第一个业务参数
+        assert result[0] == "period"
+        assert result[1] == "threshold"
+
+    def test_ast_content_skips_name_selector(self):
+        """选择器参数索引 0 应为 codes，不是 name"""
+        result = get_component_parameter_names(
+            "FixedSelector",
+            file_content=_FAKE_SELECTOR_CODE,
+            component_type="selector",
+        )
+        assert result is not None
+        assert "name" not in result.values()
+        assert result[0] == "codes"
+
+    def test_empty_params_when_only_name(self):
+        """只有 name 一个参数时，应返回空映射"""
+        code = '''
+class SimpleStrategy:
+    def __init__(self, name="Simple"):
+        self.name = name
+'''
+        result = get_component_parameter_names(
+            "SimpleStrategy",
+            file_content=code,
+            component_type="strategy",
+        )
+        assert result is not None
+        assert len(result) == 0
+
+    def test_parameter_count_excludes_name(self):
+        """参数计数应排除 name"""
+        result = get_component_parameter_names(
+            "FakeStrategy",
+            file_content=_FAKE_STRATEGY_CODE,
+            component_type="strategy",
+        )
+        # period + threshold = 2 (not 3 with name)
+        assert len(result) == 2

--- a/tests/unit/trading/services/test_component_loader_param_compat.py
+++ b/tests/unit/trading/services/test_component_loader_param_compat.py
@@ -1,0 +1,89 @@
+"""
+TDD test for #5974: component_loader parameter index backward compatibility.
+
+Bug: After #5955 (skipping 'name' in param extraction), old portfolios that
+stored params with indices 1,2,3... (where 0=name) can't be correctly mapped
+to the new param_names {0:"codes", 1:"period"} (where name is excluded).
+
+Root cause: get_component_parameter_names() now skips 'name', shifting indices.
+Old DB records still use the pre-shift indices.
+
+Fix: component_loader must detect old-style indices and apply a shift.
+"""
+import pytest
+from ginkgo.trading.services._assembly.component_loader import resolve_param_kwargs
+
+
+@pytest.mark.unit
+class TestParamIndexBackwardCompat:
+    """参数索引向后兼容性测试"""
+
+    def test_new_style_indices_match_directly(self):
+        """新组合：索引 0 直接匹配 param_names"""
+        param_names = {0: "codes", 1: "period"}
+        result = resolve_param_kwargs(
+            component_params=['"000001.SH"', 14],
+            param_indices=[0, 1],
+            param_names=param_names,
+        )
+        assert result == {"codes": '"000001.SH"', "period": 14}
+
+    def test_old_style_indices_shifted_by_one(self):
+        """旧组合：索引 1,2 需要减 1 匹配 param_names（因为 name 曾在 0）"""
+        param_names = {0: "codes", 1: "period"}
+        result = resolve_param_kwargs(
+            component_params=['"000001.SH"', 14],
+            param_indices=[1, 2],
+            param_names=param_names,
+        )
+        assert result == {"codes": '"000001.SH"', "period": 14}
+
+    def test_old_style_single_param(self):
+        """旧组合只绑定了 1 个参数：索引 1 → 应映射到 param_names[0]"""
+        param_names = {0: "codes"}
+        result = resolve_param_kwargs(
+            component_params=['"000001.SH"'],
+            param_indices=[1],
+            param_names=param_names,
+        )
+        assert result == {"codes": '"000001.SH"'}
+
+    def test_empty_params_returns_empty(self):
+        """无参数时返回空 dict"""
+        result = resolve_param_kwargs(
+            component_params=[],
+            param_indices=[],
+            param_names={0: "codes"},
+        )
+        assert result == {}
+
+    def test_unknown_index_skipped(self):
+        """索引不在 param_names 中应跳过，不崩溃"""
+        param_names = {0: "codes"}
+        result = resolve_param_kwargs(
+            component_params=["value"],
+            param_indices=[99],
+            param_names=param_names,
+        )
+        # 99 不在 param_names，99-1=98 也不在 → 空
+        assert result == {}
+
+    def test_new_style_partial_params(self):
+        """新组合只绑定了第二个参数：索引 1 → period"""
+        param_names = {0: "codes", 1: "period"}
+        result = resolve_param_kwargs(
+            component_params=[14],
+            param_indices=[1],
+            param_names=param_names,
+        )
+        assert result == {"period": 14}
+
+    def test_old_style_strategy_with_threshold(self):
+        """旧组合：策略有 3 个业务参数，索引 1,2,3"""
+        param_names = {0: "codes", 1: "period", 2: "threshold"}
+        result = resolve_param_kwargs(
+            component_params=['"000001.SH"', 20, 0.8],
+            param_indices=[1, 2, 3],
+            param_names=param_names,
+        )
+        assert result == {"codes": '"000001.SH"', "period": 20, "threshold": 0.8}

--- a/tests/unit/trading/services/test_infrastructure_factory_skip_feeder.py
+++ b/tests/unit/trading/services/test_infrastructure_factory_skip_feeder.py
@@ -1,0 +1,65 @@
+"""
+TDD test for #5937: InfrastructureFactory.setup_engine_infrastructure
+must respect skip_feeder parameter.
+
+Bug: skip_feeder=True is accepted but ignored, causing double feeder
+creation → first feeder misses selector codes → 0 trades.
+
+Fix order: tracer bullet → verify skip_feeder behavior → commit.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.trading.services._assembly.infrastructure_factory import InfrastructureFactory
+
+
+@pytest.mark.unit
+class TestSetupEngineInfrastructureSkipFeeder:
+    """setup_engine_infrastructure 的 skip_feeder 行为"""
+
+    def test_skip_feeder_true_does_not_bind_feeder(self):
+        """skip_feeder=True 时，不应向引擎绑定任何 feeder"""
+        mock_engine = MagicMock()
+
+        with patch("ginkgo.trading.services._assembly.infrastructure_factory.GLOG"):
+            InfrastructureFactory.setup_engine_infrastructure(
+                engine=mock_engine,
+                logger=MagicMock(),
+                engine_data={},
+                skip_feeder=True,
+            )
+
+        # feeder 不应被绑定
+        mock_engine.set_data_feeder.assert_not_called()
+        mock_engine.bind_datafeeder.assert_not_called()
+
+    def test_skip_feeder_false_binds_feeder(self):
+        """skip_feeder=False（默认）时，应正常绑定 feeder"""
+        mock_engine = MagicMock()
+
+        with patch("ginkgo.trading.services._assembly.infrastructure_factory.GLOG"):
+            InfrastructureFactory.setup_engine_infrastructure(
+                engine=mock_engine,
+                logger=MagicMock(),
+                engine_data={},
+                skip_feeder=False,
+            )
+
+        # feeder 应被绑定（set_data_feeder 或 bind_datafeeder 二选一）
+        assert (mock_engine.set_data_feeder.called
+                or mock_engine.bind_datafeeder.called)
+
+    def test_skip_feeder_true_still_sets_up_gateway(self):
+        """skip_feeder=True 时，broker 和 gateway 仍应正常设置"""
+        mock_engine = MagicMock()
+
+        with patch("ginkgo.trading.services._assembly.infrastructure_factory.GLOG"):
+            InfrastructureFactory.setup_engine_infrastructure(
+                engine=mock_engine,
+                logger=MagicMock(),
+                engine_data={"broker": "backtest"},
+                skip_feeder=True,
+            )
+
+        # gateway（router）仍应被绑定
+        mock_engine.bind_router.assert_called_once()

--- a/tests/unit/trading/services/test_portfolio_data_feeder_propagation.py
+++ b/tests/unit/trading/services/test_portfolio_data_feeder_propagation.py
@@ -1,0 +1,86 @@
+"""
+TDD test for #5960/#5958: data_feeder propagation from portfolio to strategies.
+
+Verifies that the full chain works:
+  Engine → portfolio.bind_data_feeder(feeder) → strategy.bind_data_feeder(feeder)
+  → strategy.data_feeder returns the feeder
+
+Also verifies that StrategyDataMixin.get_bars_cached() can use the injected
+feeder's time_controller instead of falling back to datetime.now().
+"""
+import pytest
+from unittest.mock import MagicMock, PropertyMock
+from datetime import datetime
+
+from ginkgo.trading.strategies.strategy_base import BaseStrategy
+from ginkgo.trading.interfaces.mixins.strategy_data_mixin import StrategyDataMixin
+
+
+class FakeDataStrategy(BaseStrategy, StrategyDataMixin):
+    """测试用策略：使用 StrategyDataMixin"""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        StrategyDataMixin.__init__(self)
+
+    def cal(self, portfolio_info, event, *args, **kwargs):
+        return []
+
+
+@pytest.mark.unit
+class TestDataFeederPropagation:
+    """data_feeder 从 portfolio 传播到 strategy 的完整链路"""
+
+    def test_strategy_has_data_feeder_property(self):
+        """BaseStrategy 应有 data_feeder 属性"""
+        strategy = FakeDataStrategy(name="test")
+        assert hasattr(strategy, 'data_feeder')
+
+    def test_strategy_bind_data_feeder_sets_attribute(self):
+        """bind_data_feeder 应设置 _data_feeder"""
+        strategy = FakeDataStrategy(name="test")
+        mock_feeder = MagicMock()
+
+        strategy.bind_data_feeder(mock_feeder)
+
+        assert strategy.data_feeder is mock_feeder
+
+    def test_strategy_data_feeder_initially_none(self):
+        """初始时 data_feeder 应为 None"""
+        strategy = FakeDataStrategy(name="test")
+        assert strategy.data_feeder is None
+
+    def test_get_bars_cached_uses_time_controller_when_feeder_set(self):
+        """有 feeder 和 time_controller 时，get_bars_cached 应使用回测时间"""
+        strategy = FakeDataStrategy(name="test")
+
+        # 设置 mock feeder 带 time_controller
+        mock_feeder = MagicMock()
+        mock_feeder.time_controller = MagicMock()
+        backtest_time = datetime(2025, 10, 1, 12, 0, 0)
+        mock_feeder.time_controller.now.return_value = backtest_time
+
+        # 设置 bar_service 返回空结果
+        mock_bar_service = MagicMock()
+        mock_result = MagicMock()
+        mock_result.success = False
+        mock_result.data = None
+        mock_bar_service.get.return_value = mock_result
+        mock_feeder.bar_service = mock_bar_service
+
+        strategy.bind_data_feeder(mock_feeder)
+
+        # 调用 get_bars_cached
+        bars = strategy.get_bars_cached("600000.SH", count=10, use_cache=False)
+
+        # 验证使用了 time_controller.now() 获取时间
+        assert mock_feeder.time_controller.now.called
+
+    def test_get_bars_cached_falls_back_to_datetime_now_without_feeder(self):
+        """没有 feeder 时，get_bars_cached 使用 datetime.now()（不应发生在回测中）"""
+        strategy = FakeDataStrategy(name="test")
+        # data_feeder 为 None → 不应使用 time_controller
+        assert strategy.data_feeder is None
+        # get_bars_cached 会走 datetime.now() 分支并返回 []
+        # 这个测试只是验证不崩溃
+        bars = strategy.get_bars_cached("600000.SH", count=10, use_cache=False)
+        assert isinstance(bars, list)


### PR DESCRIPTION
## Summary

批量修复回测引擎产生零交易（0 signals / 0 trades）的五类根因。

### 修复内容

| Issue | 根因 | 修复 |
|-------|------|------|
| #5937 | `skip_feeder` 参数被忽略，双重 Feeder 创建导致首次传播时 `engine.portfolios` 为空 | `infrastructure_factory.py` 尊重 `skip_feeder=True`，推迟到 portfolio 绑定后再创建 Feeder |
| #5955 | 参数索引 0 映射到框架参数 `name` 而非业务参数 | `component_parameter_extractor.py` 三处提取方法跳过 `name` |
| #5974 | #5955 后旧组合参数索引偏移不兼容（旧: name 在 index 0） | `component_loader.py` 新增 `resolve_param_kwargs()` 双轮匹配（直射 + 偏移 -1） |
| #5960 | data_feeder 未注入策略，`get_bars_cached()` 走 `datetime.now()` 回退 | **已被 #5937 修复**（Feeder 在 portfolio 绑定后创建 → 传播链正常） |
| #5958 | 同 #5960 | **已被 #5937 修复** |

### 附加修复
- 移除 `user_crud.py` 中 #4659 遗留的重复验证块

## Test plan
- 19 个新增单元测试全部通过
  - `test_infrastructure_factory_skip_feeder.py` (3 tests) — #5937
  - `test_parameter_extractor_skip_name.py` (4 tests) — #5955
  - `test_component_loader_param_compat.py` (7 tests) — #5974
  - `test_portfolio_data_feeder_propagation.py` (5 tests) — #5960/#5958

Closes #5937
Closes #5955
Closes #5974
Closes #5960
Closes #5958
