### PR TITLE
fix(#5839): start_task 从 config_snapshot 恢复完整 Kafka 配置

### DIFF
--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -69,7 +69,7 @@ class UserCRUD(BaseCRUD[MUser]):
             # 是否激活 - 布尔值
             'is_active': {
                 'type': 'bool'
-            }
+            },
 
             # source字段使用模型默认值 SOURCE_TYPES.OTHER
         }

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -671,11 +671,22 @@ class BacktestTaskService(BaseService):
 
             real_uuid = task.uuid  # 用于更新状态
 
-            # 如果没有提供日期，使用数据库中的日期
+            # 从 config_snapshot 恢复配置作为基础
+            try:
+                snapshot_config = json.loads(task.config_snapshot) if task.config_snapshot else {}
+            except (json.JSONDecodeError, TypeError):
+                snapshot_config = {}
+
+            # 如果没有提供日期，依次尝试数据库列和 config_snapshot
             if not start_date and task.backtest_start_date:
                 start_date = task.backtest_start_date.strftime("%Y-%m-%d")
+            elif not start_date:
+                start_date = snapshot_config.get("start_date", "")
+
             if not end_date and task.backtest_end_date:
                 end_date = task.backtest_end_date.strftime("%Y-%m-%d")
+            elif not end_date:
+                end_date = snapshot_config.get("end_date", "")
 
             # 先更新状态为 pending，确保 Worker 查询时能看到正确的状态
             status_result = self.update_status(real_uuid, status="pending")
@@ -684,18 +695,33 @@ class BacktestTaskService(BaseService):
 
             GLOG.DEBUG(f"Updated task {real_uuid} status to pending")
 
+            # 构建 Kafka config：从 config_snapshot 恢复，显式参数覆盖
+            kafka_config = {}
+            # 从 snapshot 恢复所有字段作为基础
+            for key in ("initial_cash", "commission_rate", "slippage_rate", "frequency",
+                        "broker_type", "broker_attitude", "commission_min",
+                        "benchmark_return", "max_position_ratio",
+                        "stop_loss_ratio", "take_profit_ratio"):
+                if key in snapshot_config:
+                    kafka_config[key] = snapshot_config[key]
+
+            # 显式参数覆盖（start_date/end_date 已在上面处理）
+            kafka_config.update({
+                "start_date": start_date,
+                "end_date": end_date,
+                "analyzers": analyzers or [],
+            })
+            # initial_cash: snapshot 中的值优先，仅当调用方显式指定非默认值时覆盖
+            if initial_cash != 100000.0 or "initial_cash" not in kafka_config:
+                kafka_config["initial_cash"] = initial_cash
+
             producer = GinkgoProducer()
             assignment = {
                 "task_uuid": task_id,  # task_id 保持不变
                 "portfolio_uuid": portfolio_uuid or task.portfolio_id,
                 "name": name or task.name or f"backtest_{task_id[:8]}",
                 "command": "start",
-                "config": {
-                    "start_date": start_date,
-                    "end_date": end_date,
-                    "initial_cash": initial_cash,
-                    "analyzers": analyzers or [],
-                }
+                "config": kafka_config,
             }
 
             producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)

--- a/tests/unit/data/services/test_backtest_task_start_config.py
+++ b/tests/unit/data/services/test_backtest_task_start_config.py
@@ -1,0 +1,148 @@
+"""
+#5839: BacktestTaskService.start_task 从 config_snapshot 恢复完整配置
+
+覆盖：
+- start_task 从 config_snapshot 恢复 start_date/end_date（解决 Missing dates）
+- start_task 从 config_snapshot 恢复 commission_rate/slippage_rate 等字段
+- 显式传入参数覆盖 config_snapshot 中的值
+- config_snapshot 为空时回退到默认值
+"""
+
+import sys
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+from contextlib import contextmanager
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_task(**overrides):
+    """构建 mock task 对象"""
+    task = MagicMock()
+    task.uuid = "uuid-1234-5678"
+    task.task_id = "task-abc"
+    task.portfolio_id = "portfolio-001"
+    task.name = "test_backtest"
+    task.backtest_start_date = None
+    task.backtest_end_date = None
+    task.status = "completed"
+    task.config_snapshot = json.dumps({
+        "start_date": "2025-06-01",
+        "end_date": "2026-06-01",
+        "initial_cash": 200000.0,
+        "commission_rate": 0.0005,
+        "slippage_rate": 0.0002,
+        "frequency": "DAY",
+    })
+    for k, v in overrides.items():
+        setattr(task, k, v)
+    return task
+
+
+@contextmanager
+def _mock_kafka_and_container():
+    """统一 mock Kafka producer 和 container（旧数据清理）"""
+    mock_producer = MagicMock()
+    mock_container = MagicMock()
+    with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer), \
+         patch("ginkgo.data.containers.container", mock_container):
+        yield mock_producer
+
+
+@pytest.fixture
+def service():
+    crud = MagicMock()
+    svc = BacktestTaskService(crud_repo=crud)
+    return svc
+
+
+def _setup_task(service, task):
+    """配置 service mock 以支持 start_task 流程"""
+    service._crud_repo.get_by_uuid.return_value = task
+    service._crud_repo.find.return_value = []
+    service.update_status = MagicMock(return_value=ServiceResult.success(task, "ok"))
+
+
+def _get_kafka_config(mock_producer):
+    """从 Kafka producer.send 调用中提取 config dict"""
+    send_call = mock_producer.send.call_args
+    return send_call[0][1]["config"]
+
+
+class TestStartTaskRestoresConfigFromSnapshot:
+    """start_task 从 config_snapshot 恢复配置"""
+
+    @pytest.mark.unit
+    def test_restores_dates_from_config_snapshot(self, service):
+        """config_snapshot 中的日期应被恢复到 Kafka config"""
+        task = _make_task(backtest_start_date=None, backtest_end_date=None)
+        _setup_task(service, task)
+
+        with _mock_kafka_and_container() as mock_producer:
+            result = service.start_task(uuid="uuid-1234-5678")
+
+        assert result.is_success(), f"start_task failed: {result.error}"
+        config = _get_kafka_config(mock_producer)
+        assert config["start_date"] == "2025-06-01"
+        assert config["end_date"] == "2026-06-01"
+
+    @pytest.mark.unit
+    def test_restores_all_fields_from_config_snapshot(self, service):
+        """config_snapshot 中的所有配置字段应被恢复"""
+        task = _make_task()
+        _setup_task(service, task)
+
+        with _mock_kafka_and_container() as mock_producer:
+            result = service.start_task(uuid="uuid-1234-5678")
+
+        assert result.is_success()
+        config = _get_kafka_config(mock_producer)
+        assert config["initial_cash"] == 200000.0
+        assert config["commission_rate"] == 0.0005
+        assert config["slippage_rate"] == 0.0002
+        assert config["frequency"] == "DAY"
+
+    @pytest.mark.unit
+    def test_explicit_params_override_config_snapshot(self, service):
+        """显式传入的参数应覆盖 config_snapshot 中的值"""
+        task = _make_task()
+        _setup_task(service, task)
+
+        with _mock_kafka_and_container() as mock_producer:
+            result = service.start_task(
+                uuid="uuid-1234-5678",
+                start_date="2026-01-01",
+                end_date="2026-12-31",
+                initial_cash=500000.0,
+            )
+
+        assert result.is_success()
+        config = _get_kafka_config(mock_producer)
+        assert config["start_date"] == "2026-01-01"
+        assert config["end_date"] == "2026-12-31"
+        assert config["initial_cash"] == 500000.0
+        # config_snapshot 中的其他字段保留
+        assert config["commission_rate"] == 0.0005
+
+    @pytest.mark.unit
+    def test_fallback_when_config_snapshot_empty(self, service):
+        """config_snapshot 为空时回退到默认值"""
+        task = _make_task(config_snapshot="{}", backtest_start_date=None, backtest_end_date=None)
+        _setup_task(service, task)
+
+        with _mock_kafka_and_container() as mock_producer:
+            result = service.start_task(uuid="uuid-1234-5678")
+
+        assert result.is_success()
+        config = _get_kafka_config(mock_producer)
+        assert config["start_date"] == ""
+        assert config["end_date"] == ""
+        assert config["initial_cash"] == 100000.0


### PR DESCRIPTION
## Summary

回测引擎 `start_task()` 重建 Kafka assignment config 时只硬编码了 4 个字段（`start_date`/`end_date`/`initial_cash`/`analyzers`），导致：

- `start_date`/`end_date` 为空 → 引擎报 `Missing dates`
- `commission_rate`/`slippage_rate`/`frequency` 等字段丢失 → 使用 Worker 默认值
- 所有通过 `POST /{uuid}/start` 启动的回测 100% 失败

**根因**：`start_task()` 不读取数据库中的 `config_snapshot`（创建时已完整存储），而是从空的 `backtest_start_date`/`backtest_end_date` 列读取日期，又只硬编码 4 个字段到 Kafka config。

**修复**：
- 从 `task.config_snapshot` JSON 解析完整配置作为 Kafka config 基础
- 日期三级回退：DB 列 → config_snapshot → 空字符串
- `commission_rate`/`slippage_rate`/`frequency` 等字段从 snapshot 恢复
- 显式传入参数优先覆盖 snapshot 中的值

附带修复 `user_crud.py` 缺少逗号的 `IndentationError`。

## Test plan
```bash
PYTHONPATH=src:tests python -m pytest tests/unit/data/services/test_backtest_task_start_config.py -v -o \"addopts=\"
```

Closes #5839