### PR TITLE
fix: 批量修复 Bars 日期筛选、Worker 僵尸、净值数据为空 (#5900 #5862 #5841)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -312,8 +312,8 @@ async def get_bars(
         start_dt = datetime.fromisoformat(start_date) if start_date else None
         end_dt = datetime.fromisoformat(end_date) if end_date else None
 
-        # 如果没有提供任何筛选条件，默认查询最近1年的数据
-        if not code and not start_dt and not end_dt:
+        # 未提供日期范围时，默认查询最近1年数据
+        if not start_dt and not end_dt:
             from datetime import timedelta
             end_dt = datetime.utcnow()
             start_dt = end_dt - timedelta(days=365)
@@ -328,7 +328,7 @@ async def get_bars(
             page=page - 1,  # Service层page是0-based
             page_size=page_size,
             order_by="timestamp",
-            desc_order=False
+            desc_order=True
         )
 
         if not result.is_success() or not result.data:

--- a/src/ginkgo/client/worker_cli.py
+++ b/src/ginkgo/client/worker_cli.py
@@ -6,6 +6,7 @@
 Ginkgo Worker CLI - Worker管理命令
 """
 
+import sys
 import typer
 from typing import Optional
 from rich.console import Console
@@ -249,6 +250,9 @@ def backtest_run(
         try:
             while worker.is_running:
                 time.sleep(1)
+            # Worker 引擎自行停止（非 Ctrl+C），退出进程让 supervisor 重启
+            console.print("\n[yellow]:warning: Worker stopped unexpectedly, exiting process...[/yellow]")
+            sys.exit(1)
         except KeyboardInterrupt:
             console.print("\n\n[yellow]:warning: Shutting down...[/yellow]")
             worker.stop()

--- a/src/ginkgo/trading/services/engine_assembly_service.py
+++ b/src/ginkgo/trading/services/engine_assembly_service.py
@@ -617,6 +617,11 @@ class EngineAssemblyService(BaseService):
             # 监控：创建引擎后的状态
             self._logger.INFO(f"🔍 [STATE] After create_base_engine: {engine.status} (state: {engine.state})")
 
+            # 将回测任务的 task_id 注入引擎，使分析器写入的记录与回测任务关联
+            # 修复 #5841：缺少此步骤导致引擎启动时自生成随机 task_id，分析器数据无法被 API 查到
+            if self._current_task_id:
+                engine.set_task_id(self._current_task_id)
+
             # Setup basic engine infrastructure (router only, not feeder yet)
             InfrastructureFactory.setup_engine_infrastructure(engine, logger, engine_data, skip_feeder=True)
 


### PR DESCRIPTION
## Summary

批量修复三个核心问题：

### #5900 Bars 日期筛选与默认排序
- **根因**：默认日期范围条件 `not code and not start_dt and not end_dt` 导致指定 code 但无日期时跳过默认范围，返回全量数据；排序为升序，最新数据在末尾
- **修复**：条件改为 `not start_dt and not end_dt`（去掉 `not code`）；排序改为降序

### #5862 BacktestWorker 僵尸进程
- **根因**：Worker 引擎自行停止后（while 循环正常退出），CLI 进程不退出，形成僵尸进程
- **修复**：循环退出后 `sys.exit(1)`，让 supervisor 自动重启

### #5841 回测净值数据为空
- **根因**：`EngineAssemblyService._perform_backtest_engine_assembly` 从 `engine_data` 读取了 task_id，但从未调用 `engine.set_task_id()` 传播给 EngineContext。引擎 `start()` 时 `_task_id` 为 None → 自生成随机 task_id。分析器用随机 ID 写入记录，API 用原始 task_uuid 查询 → 不匹配
- **修复**：引擎创建后、portfolio 绑定前，调用 `engine.set_task_id(self._current_task_id)`
- **影响范围**：所有分析器数据（net_value、signal_count 等）

## Test plan
- [ ] 指定 code 不指定日期范围调用 `/api/v1/data/bars`，应返回最近一年数据且按时间降序
- [ ] 启动 BacktestWorker，回测完成后 Worker 进程应自动退出
- [ ] 运行回测后查看净值图表，应正确显示数据

Closes #5900
Closes #5862
Closes #5841

🤖 Generated with [Claude Code](https://claude.com/claude-code)