### PR TITLE
fix(#5577,#5443): engine_config 日期映射到 task 级别字段

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -291,13 +291,20 @@ def create_backtest_task(data: BacktestTaskCreate) -> dict:
         portfolio_name = "Unknown Portfolio"
 
     # 使用服务层创建任务
+    # #5577 #5443: engine_config 日期映射到 task 级别字段
+    create_kwargs = {
+        "name": data.name,
+        "portfolio_id": primary_portfolio_uuid,
+        "portfolio_name": portfolio_name,
+        "config_snapshot": config,
+    }
+    if data.engine_config.start_date:
+        create_kwargs["backtest_start_date"] = data.engine_config.start_date
+    if data.engine_config.end_date:
+        create_kwargs["backtest_end_date"] = data.engine_config.end_date
+
     task_service = get_backtest_task_service()
-    result = task_service.create(
-        name=data.name,
-        portfolio_id=primary_portfolio_uuid,
-        portfolio_name=portfolio_name,
-        config_snapshot=config,
-    )
+    result = task_service.create(**create_kwargs)
 
     if not result.is_success():
         raise BusinessError(f"Failed to create backtest task: {result.error}")

--- a/src/ginkgo/data/crud/backtest_task_crud.py
+++ b/src/ginkgo/data/crud/backtest_task_crud.py
@@ -72,12 +72,20 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
         # 生成 task_id（如果未提供），使用与 uuid 相同的规则
         task_id = kwargs.get("task_id") or IdentityUtils.generate_task_id()
 
+        # #5577 #5443: 日期字段从字符串转为 datetime
+        raw_start = kwargs.get("backtest_start_date")
+        raw_end = kwargs.get("backtest_end_date")
+        backtest_start_date = datetime_normalize(raw_start) if raw_start else None
+        backtest_end_date = datetime_normalize(raw_end) if raw_end else None
+
         model = MBacktestTask(
             uuid=task_id,  # 会话实体的 uuid = task_id
             task_id=task_id,
             name=kwargs.get("name", ""),  # 用户可指定名称
             engine_id=kwargs.get("engine_id", ""),
             portfolio_id=kwargs.get("portfolio_id", ""),
+            backtest_start_date=backtest_start_date,
+            backtest_end_date=backtest_end_date,
             start_time=kwargs.get("start_time"),
             end_time=kwargs.get("end_time"),
             status=kwargs.get("status", "created"),

--- a/tests/api/test_backtest_date_mapping.py
+++ b/tests/api/test_backtest_date_mapping.py
@@ -1,0 +1,114 @@
+# #5577 #5443 — engine_config 日期映射到 task 级别字段
+"""
+验证 API 创建回测时 engine_config.start_date/end_date 映射到
+backtest_start_date/backtest_end_date 任务字段。
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestBuildBacktestConfigIncludesDates:
+    """build_backtest_config 应正确包含日期"""
+
+    def test_config_contains_start_and_end_dates(self):
+        from api.backtest import build_backtest_config, BacktestTaskCreate, EngineConfig
+
+        data = BacktestTaskCreate(
+            name="test",
+            portfolio_uuids=["p-uuid-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+        config = build_backtest_config(data)
+        assert config["start_date"] == "2025-06-01"
+        assert config["end_date"] == "2025-12-31"
+
+
+class TestCreateBacktestTaskPassesDateFields:
+    """create_backtest_task 应把 engine_config 日期传给 task_service.create()"""
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_create_passes_backtest_start_date_to_service(
+        self, mock_get_service, mock_portfolio
+    ):
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+
+        create_backtest_task(data)
+
+        call_kwargs = mock_service.create.call_args.kwargs
+        assert "backtest_start_date" in call_kwargs, \
+            f"create() 未收到 backtest_start_date, 实际参数: {list(call_kwargs.keys())}"
+        assert call_kwargs["backtest_start_date"] == "2025-06-01"
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_create_passes_backtest_end_date_to_service(
+        self, mock_get_service, mock_portfolio
+    ):
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+
+        create_backtest_task(data)
+
+        call_kwargs = mock_service.create.call_args.kwargs
+        assert "backtest_end_date" in call_kwargs, \
+            f"create() 未收到 backtest_end_date, 实际参数: {list(call_kwargs.keys())}"
+        assert call_kwargs["backtest_end_date"] == "2025-12-31"
+
+
+class TestCRUDDatetimeConversion:
+    """CRUD 层应正确将字符串日期转为 datetime"""
+
+    def test_backtest_task_crud_parses_string_dates(self):
+        from ginkgo.data.crud.backtest_task_crud import BacktestTaskCRUD
+        from ginkgo.libs import datetime_normalize
+
+        crud = BacktestTaskCRUD()
+        # datetime_normalize 应能处理 "YYYY-MM-DD" 格式
+        result = datetime_normalize("2025-06-01")
+        assert result is not None
+        assert result.year == 2025
+        assert result.month == 6
+        assert result.day == 1


### PR DESCRIPTION
## Summary

API 创建回测时 `engine_config.start_date/end_date` 只存入 `config_snapshot` JSON，未映射到 `backtest_start_date`/`backtest_end_date` 数据库列，导致 Worker 启动报 "Missing dates: start_date=, end_date="。

**修复内容**：
- `api/api/backtest.py`: `create_backtest_task()` 补传 `backtest_start_date`/`backtest_end_date` 参数给 `task_service.create()`
- `src/ginkgo/data/crud/backtest_task_crud.py`: `_create_from_params()` 补上日期字段构造，字符串通过 `datetime_normalize` 转 datetime

**注**：#6044 已在 `start_task` 阶段加了 config_snapshot 回退（治标），本 PR 在创建时正确映射（治本）。

## Test plan

- `tests/api/test_backtest_date_mapping.py`: 4 个测试验证 API 层传参 + datetime 转换
- 冒烟测试 37 passed（backtest 相关 + API 周边测试）

Closes #5577
Closes #5443

🤖 Generated with [Claude Code](https://claude.com/claude-code)