### PR TITLE
fix: JWT/认证安全批量修复 (#5802 #5582 #5448 #5770 #5679 #5464)

### DIFF
--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -163,7 +163,16 @@ async def register(data: RegisterRequest, req: Request):
 
 
 @router.post("/logout")
-async def logout():
+async def logout(req: Request):
+    """登出 — 将当前 token 加入黑名单（#5802）"""
+    from middleware.auth import token_blacklist
+
+    # 从 user state 获取 jti 并加入黑名单
+    user_state = getattr(req.state, "user", {})
+    jti = user_state.get("jti") if isinstance(user_state, dict) else None
+    if jti:
+        token_blacklist.add(jti)
+
     return ok(message="Logged out successfully")
 
 
@@ -221,6 +230,11 @@ async def change_password(data: ChangePasswordRequest, req: Request):
         )
 
     logger.info(f"Password changed for user: {user_uuid}")
+
+    # 撤销该用户所有旧 token（#5582, #5448）
+    from middleware.auth import token_blacklist
+    token_blacklist.revoke_user(user_uuid)
+
     return ok(message="Password changed successfully")
 
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -2,7 +2,7 @@
 系统设置相关API路由
 """
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Request
 from pydantic import BaseModel
 from typing import List, Optional
 from datetime import datetime
@@ -262,8 +262,24 @@ async def update_user(uuid: str, data: UserUpdate):
 
 
 @router.post("/users/{uuid}/reset-password")
-async def reset_user_password(uuid: str, data: dict):
-    """重置用户密码"""
+async def reset_user_password(uuid: str, data: dict, req: Request):
+    """重置用户密码（#5770, #5679: 增加 admin 权限校验）
+
+    权限规则：
+    - admin 可重置任意用户密码
+    - 普通用户只能重置自己的密码
+    - 响应不返回明文密码
+    """
+    # 权限校验（#5770, #5679）
+    caller_uuid = getattr(req.state, "user_uuid", None)
+    is_admin = getattr(req.state, "is_admin", False)
+
+    if not is_admin and caller_uuid != uuid:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only administrators can reset other users' passwords",
+        )
+
     try:
         user_service = get_user_service()
 
@@ -282,9 +298,10 @@ async def reset_user_password(uuid: str, data: dict):
                 detail="Failed to update password"
             )
 
-        logger.info(f"Password reset for user: {uuid}")
+        logger.info(f"Password reset for user: {uuid} by: {caller_uuid}")
 
-        return ok(data={"new_password": new_password}, message=f"Password for user {uuid} has been reset")
+        # #5770: 响应不包含明文密码
+        return ok(message=f"Password for user {uuid} has been reset")
 
     except HTTPException:
         raise

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -300,6 +300,10 @@ async def reset_user_password(uuid: str, data: dict, req: Request):
 
         logger.info(f"Password reset for user: {uuid} by: {caller_uuid}")
 
+        # 撤销该用户所有旧 token（防止被重置密码的账户旧 session 仍可用）
+        from middleware.auth import token_blacklist
+        token_blacklist.revoke_user(uuid)
+
         # #5770: 响应不包含明文密码
         return ok(message=f"Password for user {uuid} has been reset")
 

--- a/api/core/config.py
+++ b/api/core/config.py
@@ -9,11 +9,14 @@ import sys
 from pathlib import Path
 from typing import List
 from pydantic_settings import BaseSettings
-from pydantic import Field
+from pydantic import Field, model_validator
 
 # 添加 Ginkgo 源码路径
 ginkgo_path = Path(__file__).parent.parent.parent / "src"
 sys.path.insert(0, str(ginkgo_path))
+
+# #5464: 已知的默认 SECRET_KEY，禁止在生产使用
+_INSECURE_DEFAULT_KEY = "your-secret-key-change-in-production"
 
 
 class Settings(BaseSettings):
@@ -24,7 +27,8 @@ class Settings(BaseSettings):
     API_PORT: int = Field(default=8000, description="API服务端口")
 
     # JWT 配置
-    SECRET_KEY: str = Field(default="your-secret-key-change-in-production", description="JWT密钥")
+    # #5464: SECRET_KEY 必须通过环境变量设置，不提供安全默认值
+    SECRET_KEY: str = Field(default=_INSECURE_DEFAULT_KEY, description="JWT密钥（必须通过环境变量 SECRET_KEY 设置）")
     ACCESS_TOKEN_EXPIRE_MINUTES: int = Field(default=1440, description="Token过期时间（分钟）")
 
     # CORS 配置
@@ -41,6 +45,17 @@ class Settings(BaseSettings):
     # 调试模式
     DEBUG: bool = Field(default=False, description="调试模式")
 
+    @model_validator(mode="after")
+    def _validate_secret_key(self) -> "Settings":
+        """#5464: 拒绝不安全的默认 SECRET_KEY"""
+        if self.SECRET_KEY == _INSECURE_DEFAULT_KEY:
+            raise ValueError(
+                "SECRET_KEY must be set via environment variable and cannot use "
+                f"the default value '{_INSECURE_DEFAULT_KEY}'. "
+                "Generate a secure key with: python -c \"import secrets; print(secrets.token_urlsafe(32))\""
+            )
+        return self
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"
@@ -48,7 +63,7 @@ class Settings(BaseSettings):
         extra = "ignore"
 
 
-# 全局配置实例
+# 全局配置实例（需要 SECRET_KEY 环境变量）
 settings = Settings()
 
 

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -6,7 +6,9 @@ JWT认证中间件
 2. 如果 header 没有，检查 URL query param (token=xxx)
 3. 无 token 或 token 无效/过期 → 401
 4. WebSocket 由 handler 调用 verify_token() 自行校验（BaseHTTPMiddleware 不支持 WebSocket）
+5. Token 黑名单：logout/改密码后 token 立即失效（#5802, #5582, #5448）
 """
+import uuid as _uuid
 from fastapi import Request, HTTPException, status
 from starlette.middleware.base import BaseHTTPMiddleware
 from jose import JWTError, jwt
@@ -15,6 +17,69 @@ from typing import Optional
 
 from core.config import settings
 from core.logging import logger
+
+
+class TokenBlacklist:
+    """内存 Token 黑名单（#5802, #5582, #5448）
+
+    支持两种撤销粒度：
+    - 按 jti 撤销单个 token（logout）
+    - 按 user_uuid 撤销该用户所有 token（改密码）
+    """
+
+    def __init__(self):
+        # jti → True
+        self._store: set[str] = set()
+        # user_uuid → revoked_up_to timestamp
+        self._user_revoked: dict[str, datetime] = {}
+
+    def add(self, jti: str) -> None:
+        """将单个 token 加入黑名单"""
+        self._store.add(jti)
+
+    def is_blacklisted(self, jti: str) -> bool:
+        """检查 jti 是否在黑名单中"""
+        return jti in self._store
+
+    def revoke_user(self, user_uuid: str) -> None:
+        """撤销某用户的所有 token（记录时间戳）"""
+        self._user_revoked[user_uuid] = datetime.utcnow()
+
+    def is_user_revoked(self, user_uuid: str) -> bool:
+        """检查用户是否被全局撤销"""
+        return user_uuid in self._user_revoked
+
+    def check_revoked(self, payload: dict) -> bool:
+        """综合检查 token 是否被撤销（jti 或 user 维度）"""
+        jti = payload.get("jti")
+        if jti and jti in self._store:
+            return True
+
+        user_uuid = payload.get("user_uuid")
+        if user_uuid and user_uuid in self._user_revoked:
+            revoked_at = self._user_revoked[user_uuid]
+            # token 签发时间早于撤销时间 → 已撤销
+            token_iat = payload.get("iat")
+            if token_iat:
+                if isinstance(token_iat, (int, float)):
+                    token_time = datetime.utcfromtimestamp(token_iat)
+                else:
+                    token_time = token_iat
+                if token_time < revoked_at:
+                    return True
+            else:
+                # 无 iat 的旧 token，安全起见也撤销
+                return True
+        return False
+
+    def cleanup(self) -> None:
+        """清理过期条目（可选，token 自然过期后黑名单条目可清理）"""
+        # 简单实现：暂不清理，内存占用极小
+        pass
+
+
+# 全局单例
+token_blacklist = TokenBlacklist()
 
 
 class JWTAuthMiddleware(BaseHTTPMiddleware):
@@ -77,14 +142,33 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
 
 
 def verify_token(token: str) -> dict:
-    """验证并解码 token，供中间件和 WebSocket handler 共用"""
+    """验证并解码 token，供中间件和 WebSocket handler 共用
+
+    增加 token 黑名单检查（#5802, #5582, #5448）
+    """
     payload = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+
+    # 检查黑名单
+    if token_blacklist.check_revoked(payload):
+        raise JWTError("Token has been revoked")
+
     return payload
 
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None) -> str:
-    """创建访问令牌"""
+    """创建访问令牌
+
+    自动添加 jti（唯一 token ID）和 iat（签发时间）（#5802）
+    """
     to_encode = data.copy()
+
+    # 生成唯一 token ID（用于黑名单）
+    if "jti" not in to_encode:
+        to_encode["jti"] = str(_uuid.uuid4())
+
+    # 记录签发时间（用于 user 维度撤销判断）
+    if "iat" not in to_encode:
+        to_encode["iat"] = datetime.utcnow()
 
     if expires_delta:
         expire = datetime.utcnow() + expires_delta

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -2,6 +2,7 @@
 # 原实现将 api/ 目录加入 sys.path，导致 api/core/ 和 api/services/
 # 与 tests/unit/core/、tests/integration/data/services/ 产生命名空间冲突
 # （28 个 collection errors）。需要 api 模块的测试应使用 conftest fixture 延迟导入。
+import os
 import sys
 from pathlib import Path
 
@@ -9,6 +10,10 @@ import pytest
 
 
 _API_DIR = str(Path(__file__).parent.parent.parent / "api")
+
+# #5464: 确保测试环境有合法 SECRET_KEY，避免 config.py 全局 Settings() 报错
+if not os.environ.get("SECRET_KEY") or os.environ.get("SECRET_KEY") == "your-secret-key-change-in-production":
+    os.environ["SECRET_KEY"] = "test-secret-key-for-jwt-security-tests"
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -1,0 +1,208 @@
+# Issues: #5802, #5582, #5448, #5770, #5679, #5464
+# Upstream: api.middleware.auth, api.api.auth, api.api.settings, api.core.config
+# Downstream: pytest
+# Role: JWT/认证安全批量修复测试
+
+"""
+JWT 认证安全测试
+
+验证 6 个安全 issue 的修复：
+- #5802/#5582/#5448: Token 黑名单（logout/改密码后旧 token 失效）
+- #5770/#5679: reset-password 权限校验 + 不返回明文密码
+- #5464: SECRET_KEY 禁止默认值
+"""
+
+import asyncio
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime, timedelta
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_token(payload: dict) -> str:
+    """用 settings.SECRET_KEY 生成 JWT token（与 verify_token 一致）"""
+    from jose import jwt
+    from core.config import settings
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+
+def _default_payload(user_uuid="user-001", username="testuser",
+                     is_admin=False, cred_uuid="cred-001"):
+    """构造标准 JWT payload"""
+    return {
+        "user_uuid": user_uuid,
+        "credential_uuid": cred_uuid,
+        "username": username,
+        "is_admin": is_admin,
+        "exp": datetime.utcnow() + timedelta(hours=1),
+    }
+
+
+# ============================================================
+# #5802: Logout 后 token 应被拒绝
+# ============================================================
+
+class TestTokenBlacklistOnLogout:
+    """#5802: logout 后 token 应立即失效"""
+
+    def test_blacklisted_token_rejected_by_verify(self):
+        """logout 后 verify_token 应抛 JWTError"""
+        from middleware.auth import token_blacklist, verify_token
+        from jose import JWTError
+
+        payload = _default_payload()
+        payload["jti"] = "token-abc-123"
+        token = _make_token(payload)
+
+        # 先确认 token 有效
+        decoded = verify_token(token)
+        assert decoded["user_uuid"] == "user-001"
+
+        # 加入黑名单（模拟 logout）
+        token_blacklist.add("token-abc-123")
+
+        # 验证被拒绝
+        with pytest.raises(JWTError):
+            verify_token(token)
+
+    def test_logout_adds_token_to_blacklist(self):
+        """logout 端点应将 token 的 jti 写入黑名单"""
+        from middleware.auth import token_blacklist
+
+        token_blacklist._store.clear()
+        token_blacklist.add("jti-from-logout")
+
+        assert token_blacklist.is_blacklisted("jti-from-logout") is True
+
+    def test_non_blacklisted_token_still_valid(self):
+        """未加入黑名单的 token 应正常通过"""
+        from middleware.auth import token_blacklist, verify_token
+
+        token_blacklist._store.clear()
+        payload = _default_payload()
+        payload["jti"] = "valid-token-jti"
+        token = _make_token(payload)
+
+        # 未加黑名单，应正常解码
+        decoded = verify_token(token)
+        assert decoded["user_uuid"] == "user-001"
+
+
+# ============================================================
+# #5582/#5448: 改密码后旧 token 应被拒绝
+# ============================================================
+
+class TestTokenBlacklistOnPasswordChange:
+    """#5582/#5448: 改密码后旧 token 应失效"""
+
+    def test_revoke_all_user_tokens_after_password_change(self):
+        """改密码后该用户所有 token 应被批量撤销"""
+        from middleware.auth import token_blacklist
+
+        token_blacklist._store.clear()
+        token_blacklist.revoke_user("user-001")
+
+        assert token_blacklist.is_user_revoked("user-001") is True
+
+    def test_other_user_tokens_not_affected(self):
+        """改密码不应影响其他用户的 token"""
+        from middleware.auth import token_blacklist
+
+        token_blacklist._store.clear()
+        token_blacklist.revoke_user("user-001")
+
+        assert token_blacklist.is_user_revoked("user-002") is False
+
+    def test_revoked_user_token_rejected(self):
+        """被撤销用户的 token 应被拒绝"""
+        from middleware.auth import token_blacklist, verify_token
+        from jose import JWTError
+
+        token_blacklist._store.clear()
+        token_blacklist._user_revoked.clear()
+
+        payload = _default_payload()
+        payload["jti"] = "revoked-token"
+        token = _make_token(payload)
+
+        # 正常通过
+        decoded = verify_token(token)
+        assert decoded["user_uuid"] == "user-001"
+
+        # 撤销该用户
+        token_blacklist.revoke_user("user-001")
+
+        # 被拒绝
+        with pytest.raises(JWTError, match="revoked"):
+            verify_token(token)
+
+
+# ============================================================
+# #5770/#5679: reset-password 权限校验
+# ============================================================
+
+class TestResetPasswordAuthorization:
+    """#5770/#5679: reset-password 端点权限校验"""
+
+    def test_normal_user_cannot_reset_others_password(self):
+        """普通用户重置他人密码应返回 403"""
+        from api.settings import reset_user_password
+        from fastapi import HTTPException
+
+        req = MagicMock()
+        req.state.user_uuid = "user-normal"
+        req.state.is_admin = False
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(
+                reset_user_password("user-admin-uuid", {"new_password": "hacked123"}, req)
+            )
+        assert exc_info.value.status_code == 403
+
+    def test_admin_can_reset_others_password(self):
+        """管理员应能重置他人密码"""
+        from api.settings import reset_user_password
+
+        req = MagicMock()
+        req.state.user_uuid = "user-admin"
+        req.state.is_admin = True
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
+            result = asyncio.run(
+                reset_user_password("user-target-uuid", {"new_password": "NewPass123!"}, req)
+            )
+        # 不应抛异常
+        assert result is not None
+
+    def test_reset_password_response_no_plaintext(self):
+        """密码重置响应不应包含明文密码"""
+        from api.settings import reset_user_password
+
+        req = MagicMock()
+        req.state.user_uuid = "user-admin"
+        req.state.is_admin = True
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
+            result = asyncio.run(
+                reset_user_password("user-target-uuid", {"new_password": "Secret123!"}, req)
+            )
+        # 响应中不应有 new_password 字段
+        assert "new_password" not in str(result)
+
+
+# ============================================================
+# #5464: SECRET_KEY 禁止默认值
+# ============================================================
+
+class TestSecretKeyConfig:
+    """#5464: JWT SECRET_KEY 不应使用默认值"""
+
+    def test_config_refuses_default_secret_key(self):
+        """使用默认 SECRET_KEY 时应抛出 ValueError"""
+        from core.config import Settings
+        with pytest.raises(ValueError, match="SECRET_KEY"):
+            Settings(SECRET_KEY="your-secret-key-change-in-production")


### PR DESCRIPTION
## Summary

JWT/认证系统 6 个 P0 安全漏洞批量修复。

### 问题域 A：Token 黑名单机制（#5802, #5582, #5448）
- 引入 `TokenBlacklist` 类，支持 jti 维度（单个 token）和 user_uuid 维度（用户全部 token）撤销
- `logout` 端点将当前 token 的 jti 写入黑名单
- `change-password` 端点撤销该用户所有旧 token
- `verify_token()` 增加黑名单检查，已撤销 token 返回 JWTError
- JWT payload 自动添加 `jti`（唯一 ID）和 `iat`（签发时间）

### 问题域 B：reset-password 权限校验（#5770, #5679）
- `reset_user_password` 端点增加 `req: Request` 参数
- 校验调用者是 admin 或目标用户本人，否则返回 403
- 响应中移除明文密码（不再返回 `new_password` 字段）

### 问题域 C：SECRET_KEY 安全配置（#5464）
- `Settings` 增加 `model_validator`，使用默认值 `your-secret-key-change-in-production` 时抛出 `ValueError`
- 启动时检测，强制通过环境变量设置 SECRET_KEY

### 变更文件
- `api/middleware/auth.py` — TokenBlacklist 类 + verify_token 黑名单检查 + jti/iat 生成
- `api/api/auth.py` — logout 写黑名单、change-password 撤销用户 token
- `api/api/settings.py` — reset-password 权限校验 + 移除明文密码
- `api/core/config.py` — SECRET_KEY 拒绝默认值
- `tests/api/conftest.py` — 测试环境注入安全 SECRET_KEY
- `tests/api/test_jwt_security.py` — 10 个 TDD 安全测试

## Test plan
- [x] `tests/api/test_jwt_security.py` — 10 个测试全部通过
- [x] `tests/api/test_api_crud_bypass.py` — 无回归
- [ ] 手动验证：logout 后 token 不可用
- [ ] 手动验证：改密码后旧 token 不可用
- [ ] 手动验证：普通用户重置他人密码返回 403
- [ ] 手动验证：不设 SECRET_KEY 环境变量时 API 拒绝启动

Closes #5802
Closes #5582
Closes #5448
Closes #5770
Closes #5679
Closes #5464

🤖 Generated with [Claude Code](https://claude.com/claude-code)