### PR TITLE
test(#5915): 添加 import 回归检测 — 防止循环导入/import 顺序/单例初始化

### DIFF
--- a/tests/unit/test_import_regression.py
+++ b/tests/unit/test_import_regression.py
@@ -1,0 +1,116 @@
+"""
+Import 回归检测测试
+
+防止 #5915 类问题再次发生：
+- 循环导入（config.py/logger.py 不应引用 ginkgo.libs）
+- from __future__ import annotations 必须在所有 import 前
+- ginkgo.libs 全局单例可正常初始化
+
+性能: ~2s, N tests [PASS]
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SRC_ROOT = Path(__file__).parent.parent.parent / "src" / "ginkgo"
+
+# 早期启动模块：在 ginkgo.libs.__init__ 创建单例前被导入，
+# 绝对不能 from ginkgo.libs import ... 否则循环依赖
+_EARLY_BOOT_MODULES = [
+    "libs/core/config.py",
+    "libs/core/logger.py",
+]
+
+
+def _read_source(rel_path: str) -> str:
+    """读取源文件内容"""
+    full = _SRC_ROOT / rel_path
+    if not full.exists():
+        pytest.skip(f"{rel_path} not found")
+    return full.read_text()
+
+
+class TestEarlyBootNoGinkgoLibsImport:
+    """早期启动模块禁止反向引用 ginkgo.libs，防止循环导入。"""
+
+    @pytest.mark.parametrize("rel_path", _EARLY_BOOT_MODULES)
+    def test_no_ginkgo_libs_import(self, rel_path: str):
+        """config.py / logger.py 源码不含 'from ginkgo.libs import'"""
+        source = _read_source(rel_path)
+        assert "from ginkgo.libs import" not in source, (
+            f"{rel_path} 包含 'from ginkgo.libs import ...'，"
+            f"会导致循环导入（#5915）。"
+            f"请改用 print() 或 logging 标准库。"
+        )
+
+
+def _collect_future_import_files() -> list[Path]:
+    """收集所有含 from __future__ import 的 .py 文件"""
+    files = []
+    for py_file in _SRC_ROOT.rglob("*.py"):
+        try:
+            source = py_file.read_text()
+            if "from __future__ import" in source:
+                files.append(py_file)
+        except (OSError, UnicodeDecodeError):
+            continue
+    return files
+
+
+class TestFutureImportFirst:
+    """from __future__ import 必须是文件中第一条 import 语句。"""
+
+    @pytest.mark.parametrize(
+        "py_file",
+        _collect_future_import_files(),
+        ids=lambda p: str(p.relative_to(_SRC_ROOT)),
+    )
+    def test_future_before_all_imports(self, py_file: Path):
+        """AST 分析：__future__ import 节点必须在所有其他 import 节点之前"""
+        source = py_file.read_text()
+        tree = ast.parse(source)
+
+        future_idx = None
+        first_other_import = None
+
+        for i, node in enumerate(tree.body):
+            if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+                future_idx = i
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                if future_idx is None and first_other_import is None:
+                    first_other_import = i
+
+        rel = py_file.relative_to(_SRC_ROOT)
+        assert future_idx is not None, f"{rel}: 含 __future__ 引用但 AST 解析失败"
+        assert first_other_import is None or future_idx < first_other_import, (
+            f"{rel}: 'from __future__ import' 在第 {future_idx} 条语句，"
+            f"但其他 import 在第 {first_other_import} 条。"
+            f"__future__ import 必须在所有 import 之前（#5915 / clock.py）。"
+        )
+
+
+class TestGinkgoLibsSingletonImportable:
+    """验证 ginkgo.libs 全局单例可正常初始化，防止启动即崩溃。"""
+
+    def test_glog_importable(self):
+        """from ginkgo.libs import GLOG 不抛异常"""
+        from ginkgo.libs import GLOG  # noqa: F401
+
+    def test_gconf_importable(self):
+        """from ginkgo.libs import GCONF 不抛异常"""
+        from ginkgo.libs import GCONF  # noqa: F401
+
+    def test_gtm_importable(self):
+        """from ginkgo.libs import GTM 不抛异常"""
+        from ginkgo.libs import GTM  # noqa: F401
+
+    def test_glog_has_info_method(self):
+        """GLOG 实例具有 INFO 等日志方法"""
+        from ginkgo.libs import GLOG
+
+        assert hasattr(GLOG, "INFO"), "GLOG 缺少 INFO 方法"
+        assert callable(GLOG.INFO)


### PR DESCRIPTION
## Summary

Issue #5915 的最后一项验收标准：**CI import 回归检测**。

背景：PR #5328 (squash merge) 曾丢失分支上的修复 commit，导致 `config.py` 循环导入被重新引入 master。commit `193731de` 已修复，但缺少回归保护。

### 新增测试 (`tests/unit/test_import_regression.py`)

| 测试类 | 检测内容 | 防止 |
|--------|---------|------|
| `TestEarlyBootNoGinkgoLibsImport` | config.py/logger.py 源码不含 `from ginkgo.libs import` | 循环导入 (#5915) |
| `TestFutureImportFirst` | AST 分析 `from __future__ import` 必须在所有 import 前 | clock.py 式 import 顺序错乱 |
| `TestGinkgoLibsSingletonImportable` | GLOG/GCONF/GTM 可正常导入且有正确接口 | 启动即崩溃 |

### 验收标准完成情况

- [x] 分支合并前修复 clock.py import 顺序 → 已在 master 正确
- [x] 分支合并前修复 config.py 循环导入 → `193731de` 已修
- [x] CI 添加 import 回归检测 → **本 PR**

## Test plan

```bash
python -m pytest tests/unit/test_import_regression.py -v -o "addopts="
```

12 个测试全部通过，耗时 <0.2s。

Closes #5915

🤖 Generated with [Claude Code](https://claude.com/claude-code)