### PR TITLE
fix(#5483 #5494): 移除 pdb.set_trace + update_worth 使用 total_position

### DIFF
--- a/src/ginkgo/entities/position.py
+++ b/src/ginkgo/entities/position.py
@@ -281,7 +281,7 @@ class Position(TimeMixin, Base):
 
 
     def update_worth(self, *args, **kwargs) -> None:
-        w = (self.volume + self.frozen_volume) * self.price
+        w = self.total_position * self.price
         self._worth = round(w, 2)
         self._last_update = self.get_current_time()
 
@@ -596,10 +596,11 @@ class Position(TimeMixin, Base):
                 f"cost: ${self.cost}, frozen: {self.frozen_volume}")
             return True
         except Exception as e:
-            import pdb
-
-            pdb.set_trace()
-            GLOG.ERROR(f"Error during sell operation - price: {price}, volume: {volume}, error: {e}")
+            GLOG.ERROR(f"Error during sell operation - code: {self.code}, "
+                f"price: {price}, volume: {volume}, "
+                f"available: {self.volume}, frozen: {self.frozen_volume}, "
+                f"error: {e}")
+            return False
         finally:
             pass
 

--- a/tests/unit/trading/entities/test_position.py
+++ b/tests/unit/trading/entities/test_position.py
@@ -3210,3 +3210,154 @@ class TestPositionTradingRegimes:
         assert position.settlement_frozen_volume == 0
         expected_unrealized_after = Decimal('100') * (Decimal('12.0') - Decimal('10.0'))
         assert abs(position.unrealized_pnl - expected_unrealized_after) < Decimal('0.01')
+
+
+@pytest.mark.unit
+class TestPositionT1SettlementWorth:
+    """T+1 结算冻结持仓市值计算测试 (#5494)"""
+
+    def test_worth_includes_settlement_frozen_volume(self):
+        """update_worth 应使用 total_position（含 settlement_frozen_volume）计算市值
+
+        场景：T+1 买入日，所有股份在结算冻结中
+        - volume=0, frozen_volume=0, settlement_frozen_volume=1000
+        - worth 应 = 1000 * price，而非 0 * price = 0
+        """
+        position = Position(
+            portfolio_id="test_portfolio",
+            engine_id="test_engine",
+            task_id="test_run",
+            code="000001.SZ",
+            cost=Decimal('10.0'),
+            volume=0,                          # 可用为 0（T+1 买入日）
+            frozen_volume=0,
+            settlement_frozen_volume=1000,      # 全部在结算冻结
+            price=Decimal('15.0'),
+            timestamp="2023-01-01 10:00:00"
+        )
+
+        # worth 应等于 total_position * price = 1000 * 15 = 15000
+        # 而非 (volume + frozen_volume) * price = 0 * 15 = 0
+        assert position.total_position == 1000
+        assert position.worth == Decimal('15000.00')
+
+    def test_worth_equals_total_position_times_price(self):
+        """worth 计算应与 total_position * price 一致（混合持仓）"""
+        position = Position(
+            portfolio_id="test_portfolio",
+            engine_id="test_engine",
+            task_id="test_run",
+            code="000001.SZ",
+            cost=Decimal('10.0'),
+            volume=500,
+            frozen_volume=200,
+            settlement_frozen_volume=300,
+            price=Decimal('20.0'),
+            timestamp="2023-01-01 10:00:00"
+        )
+
+        assert position.total_position == 1000  # 500 + 200 + 300
+        # worth = total_position * price = 1000 * 20 = 20000
+        assert position.worth == Decimal('20000.00')
+
+    def test_worth_consistent_with_total_pnl(self):
+        """worth 和 total_pnl 应使用相同的持仓基数
+
+        total_pnl 用 total_position，worth 也应用 total_position
+        确保 净值 = worth + cash 与 PnL 计算一致
+        """
+        position = Position(
+            portfolio_id="test_portfolio",
+            engine_id="test_engine",
+            task_id="test_run",
+            code="000001.SZ",
+            cost=Decimal('10.0'),
+            volume=300,
+            frozen_volume=100,
+            settlement_frozen_volume=600,
+            price=Decimal('12.0'),
+            fee=Decimal('10.0'),
+            timestamp="2023-01-01 10:00:00"
+        )
+
+        # total_position = 1000
+        assert position.total_position == 1000
+
+        # worth = total_position * price = 1000 * 12 = 12000
+        assert position.worth == Decimal('12000.00')
+
+        # total_pnl = total_position * (price - cost) - fee = 1000 * 2 - 10 = 1990
+        assert position.total_pnl == Decimal('1990.0')
+
+        # 验证一致性：worth - cost_basis ≈ total_pnl
+        # cost_basis = total_position * cost = 1000 * 10 = 10000
+        cost_basis = Decimal(position.total_position) * position.cost
+        assert position.worth - cost_basis - position.fee == position.total_pnl
+
+    def test_update_worth_after_settlement_change(self):
+        """手动调整 settlement_frozen_volume 后 update_worth 应反映变化"""
+        position = Position(
+            portfolio_id="test_portfolio",
+            engine_id="test_engine",
+            task_id="test_run",
+            code="000001.SZ",
+            cost=Decimal('10.0'),
+            volume=500,
+            price=Decimal('12.0'),
+            timestamp="2023-01-01 10:00:00"
+        )
+
+        # 初始 worth = 500 * 12 = 6000
+        assert position.worth == Decimal('6000.00')
+
+        # 模拟 T+1 买入：直接设置 settlement_frozen_volume
+        position._settlement_frozen_volume = 500
+        position.update_worth()
+
+        # worth 应 = (500 + 0 + 500) * 12 = 12000
+        assert position.total_position == 1000
+        assert position.worth == Decimal('12000.00')
+
+
+@pytest.mark.unit
+class TestPositionSoldExceptionHandling:
+    """_sold 异常处理测试 (#5483)"""
+
+    def test_sold_exception_does_not_enter_debugger(self):
+        """_sold 异常应向上传播而非进入 pdb
+
+        验证：即使 _sold 内部出错，进程不应挂起
+        """
+        import inspect
+        from ginkgo.entities.position import Position as PositionClass
+
+        # 静态检查：源码中不应包含 pdb
+        source = inspect.getsource(PositionClass._sold)
+        assert 'pdb' not in source, "_sold 方法中不应包含 pdb 调试代码"
+        assert 'set_trace' not in source, "_sold 方法中不应包含 set_trace 调试代码"
+
+    def test_sold_exception_propagates_or_returns_gracefully(self):
+        """_sold 异常应被正确处理：日志记录 + 返回 False
+
+        而非进入交互式调试器挂起进程
+        """
+        from decimal import Decimal
+        from unittest.mock import patch
+
+        position = Position(
+            portfolio_id="test_portfolio",
+            engine_id="test_engine",
+            task_id="test_run",
+            code="000001.SZ",
+            cost=Decimal('100.0'),
+            volume=1000,
+            frozen_volume=500,
+            price=Decimal('100.0'),
+            timestamp="2023-01-01 10:00:00"
+        )
+
+        # 模拟 _sold 内部抛出异常
+        with patch.object(position, 'on_price_update', side_effect=RuntimeError("test error")):
+            # _sold 应捕获异常，记录日志，返回 False（不挂起）
+            result = position._sold(Decimal('110.0'), 100)
+            assert result is False


### PR DESCRIPTION
## Summary

两个 Position 实体缺陷批量修复：

### #5483 — pdb.set_trace() 遗留在生产代码
`sold()` 方法的 `except` 块中残留 `pdb.set_trace()`，在生产环境会挂起整个进程。
- 替换为 `GLOG.ERROR` 日志记录 + `return False`

### #5494 — update_worth 遗漏 settlement_frozen_volume
`update_worth` 只计算 `(volume + frozen_volume) * price`，遗漏 T+1 结算冻结股份，
导致买入日净值偏低。
- 改为 `total_position * price`，与 `update_total_pnl` 保持一致

## 文件变更
- `src/ginkgo/entities/position.py` — 两处修复
- `tests/unit/trading/entities/test_position.py` — 6 个新测试

## Test plan
- [x] 6 个新测试全绿（4 T1SettlementWorth + 2 SoldExceptionHandling）
- [x] 已有 Position 测试套件 80 passed, 0 failed, 无回归
- [x] pdb 静态检查：`pdb` 不再出现在 position.py 中
- [x] update_worth 与 update_total_pnl 使用相同的 total_position 基数

Closes #5483
Closes #5494

🤖 Generated with [Claude Code](https://claude.com/claude-code)