### PR TITLE
fix: delete_user 删除用户后撤销旧 token (#6057 review)

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -332,6 +332,10 @@ async def delete_user(uuid: str):
 
         logger.info(f"User deleted: {uuid}")
 
+        # 撤销该用户所有 token（防止已删除账户的旧 session 仍可用）
+        from middleware.auth import token_blacklist
+        token_blacklist.revoke_user(uuid)
+
         return ok(message=f"User {uuid} deleted")
 
     except HTTPException:

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -206,3 +206,46 @@ class TestSecretKeyConfig:
         from core.config import Settings
         with pytest.raises(ValueError, match="SECRET_KEY"):
             Settings(SECRET_KEY="your-secret-key-change-in-production")
+
+
+# ============================================================
+# PR #6057 review: delete_user 后旧 token 应被撤销
+# ============================================================
+
+class TestTokenBlacklistOnDeleteUser:
+    """删除用户后该用户所有 token 应失效"""
+
+    def test_delete_user_revokes_tokens(self):
+        """delete_user 应调用 token_blacklist.revoke_user 撤销旧 token"""
+        from api.settings import delete_user
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.delete_user.return_value = MagicMock(success=True)
+
+            with patch("middleware.auth.token_blacklist") as mock_bl:
+                asyncio.run(delete_user("user-to-delete"))
+
+                mock_bl.revoke_user.assert_called_once_with("user-to-delete")
+
+    def test_delete_user_without_revoke_leaves_token_valid(self):
+        """验证问题存在：未 revoke 时旧 token 仍然有效"""
+        from middleware.auth import token_blacklist, verify_token
+        from jose import JWTError
+
+        token_blacklist._store.clear()
+        token_blacklist._user_revoked.clear()
+
+        payload = _default_payload(user_uuid="doomed-user")
+        payload["jti"] = "delete-test-jti"
+        token = _make_token(payload)
+
+        # 确认 token 有效
+        decoded = verify_token(token)
+        assert decoded["user_uuid"] == "doomed-user"
+
+        # 撤销（模拟 delete_user 应做的操作）
+        token_blacklist.revoke_user("doomed-user")
+
+        # 确认被拒绝
+        with pytest.raises(JWTError, match="revoked"):
+            verify_token(token)


### PR DESCRIPTION
## Summary

PR #6057 review 第 6 条反馈修复。

### 问题
`delete_user` 删除用户后未调用 `token_blacklist.revoke_user()`，与同 PR 中修复的 `change_password`（auth.py:235）和 `reset_user_password`（settings.py:304-305）不一致。被删除用户的旧 JWT 在自然过期前（最长 1440 分钟）仍可访问 API。

### 修复
- `api/api/settings.py` — `delete_user` 在 `return ok()` 前添加 `token_blacklist.revoke_user(uuid)`
- `tests/api/test_jwt_security.py` — 新增 `TestTokenBlacklistOnDeleteUser`（2 个测试）

### Test plan
- [x] `tests/api/test_jwt_security.py` — 12 passed
- [x] `tests/api/test_api_crud_bypass.py` — 7 passed（无回归）

🤖 Generated with [Claude Code](https://claude.com/claude-code)