### PR TITLE
fix(#5899): /auth/verify 手动验证 token + is_admin 从 DB 查询

### DIFF
--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -203,9 +203,9 @@ async def verify_token_endpoint(req: Request):
             credential = svc.get_credential(user_uuid)
             if credential:
                 is_admin = credential.is_admin
-        except Exception:
-            pass  # DB 查询失败时回退到 JWT 中的值
-            is_admin = payload.get("is_admin", False)
+        except Exception as e:
+            # #5899: fail-closed — DB 不可用时 is_admin=False，与 /auth/me 一致
+            logger.warning(f"#5899: DB query failed for is_admin, user={user_uuid}: {e}")
 
     return ok(data={
         "valid": True,

--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -176,18 +176,49 @@ async def logout(req: Request):
     return ok(message="Logged out successfully")
 
 
-@router.get("/verify")
-async def verify_token(req: Request):
-    user_uuid = req.state.user_uuid if hasattr(req.state, "user_uuid") else None
-    username = req.state.username if hasattr(req.state, "username") else None
-    is_admin = req.state.is_admin if hasattr(req.state, "is_admin") else False
+async def verify_token_endpoint(req: Request):
+    """#5899: 手动验证 token（端点在 PUBLIC_PATHS，中间件不处理）"""
+    # 从 header 或 query param 提取 token
+    authorization = req.headers.get("Authorization", "")
+    if authorization.startswith("Bearer "):
+        token = authorization[7:]
+    else:
+        token = req.query_params.get("token")
+
+    if not token:
+        return ok(data={"valid": False, "user_uuid": None, "username": None, "is_admin": False})
+
+    try:
+        from middleware.auth import verify_token as _verify_jwt
+        payload = _verify_jwt(token)
+    except Exception:
+        return ok(data={"valid": False, "user_uuid": None, "username": None, "is_admin": False})
+
+    # #5899: is_admin 从 DB 查询（与 /auth/me 一致），不信任 JWT 中的值
+    user_uuid = payload.get("user_uuid")
+    is_admin = False
+    if user_uuid:
+        try:
+            svc = get_user_service()
+            credential = svc.get_credential(user_uuid)
+            if credential:
+                is_admin = credential.is_admin
+        except Exception:
+            pass  # DB 查询失败时回退到 JWT 中的值
+            is_admin = payload.get("is_admin", False)
 
     return ok(data={
         "valid": True,
         "user_uuid": user_uuid,
-        "username": username,
-        "is_admin": is_admin
+        "username": payload.get("username"),
+        "is_admin": is_admin,
     })
+
+
+@router.get("/verify")
+async def verify_token_route(req: Request):
+    """#5899: /auth/verify 路由入口"""
+    return await verify_token_endpoint(req)
 
 
 @router.post("/change-password")

--- a/tests/api/test_auth_verify.py
+++ b/tests/api/test_auth_verify.py
@@ -1,0 +1,150 @@
+# Issue: #5899
+# Upstream: api.api.auth, api.middleware.auth
+# Downstream: pytest
+# Role: /auth/verify 端点行为测试
+
+"""
+/auth/verify 端点测试 — #5899
+
+验证：
+- 无 token → valid=False
+- 有效 token → valid=True + 用户信息（is_admin 从 DB）
+- 无效/黑名单 token → valid=False
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from datetime import datetime, timedelta
+
+pytestmark = pytest.mark.unit
+
+
+def _make_token(payload: dict) -> str:
+    from jose import jwt
+    from core.config import settings
+    return jwt.encode(payload, settings.SECRET_KEY, algorithm="HS256")
+
+
+def _default_payload(user_uuid="user-001", username="testuser",
+                     is_admin=False, cred_uuid="cred-001"):
+    return {
+        "user_uuid": user_uuid,
+        "credential_uuid": cred_uuid,
+        "username": username,
+        "is_admin": is_admin,
+        "exp": datetime.utcnow() + timedelta(hours=1),
+    }
+
+
+def _mock_request(headers=None, query_params=None):
+    """模拟 FastAPI Request"""
+    state = SimpleNamespace()
+    req = MagicMock()
+    req.state = state
+    req.headers = headers or {}
+    req.query_params = query_params or {}
+    return req
+
+
+# ============================================================
+# Test 1: 无 token → valid=False
+# ============================================================
+
+class TestVerifyNoToken:
+    """#5899: 无 token 时 verify 返回 valid=False"""
+
+    @pytest.mark.asyncio
+    async def test_no_auth_header_returns_invalid(self):
+        from api.auth import verify_token_endpoint
+        req = _mock_request(headers={})
+        result = await verify_token_endpoint(req)
+        assert result["data"]["valid"] is False
+        assert result["data"]["user_uuid"] is None
+        assert result["data"]["username"] is None
+        assert result["data"]["is_admin"] is False
+
+    @pytest.mark.asyncio
+    async def test_malformed_auth_header_returns_invalid(self):
+        from api.auth import verify_token_endpoint
+        req = _mock_request(headers={"Authorization": "NotBearer abc"})
+        result = await verify_token_endpoint(req)
+        assert result["data"]["valid"] is False
+
+
+# ============================================================
+# Test 2: 有效 token → valid=True + 用户信息
+# ============================================================
+
+class TestVerifyValidToken:
+    """#5899: 有效 token 返回用户信息"""
+
+    @pytest.mark.asyncio
+    async def test_valid_token_returns_user_info(self):
+        """有效 token → valid=True, 返回 user_uuid + username"""
+        from api.auth import verify_token_endpoint
+        token = _make_token(_default_payload(user_uuid="u-1", username="alice"))
+        req = _mock_request(headers={"Authorization": f"Bearer {token}"})
+        result = await verify_token_endpoint(req)
+        assert result["data"]["valid"] is True
+        assert result["data"]["user_uuid"] == "u-1"
+        assert result["data"]["username"] == "alice"
+
+    @pytest.mark.asyncio
+    async def test_is_admin_from_db_not_jwt(self):
+        """#5899: is_admin 应从 DB 查询，不是 JWT 中的值"""
+        from api.auth import verify_token_endpoint
+
+        # JWT 中 is_admin=False
+        payload = _default_payload(user_uuid="u-admin", username="admin", is_admin=False)
+        token = _make_token(payload)
+
+        # mock get_user_service → credential.is_admin=True（DB 说是 admin）
+        mock_cred = MagicMock()
+        mock_cred.is_admin = True
+        mock_svc = MagicMock()
+        mock_svc.get_credential.return_value = mock_cred
+
+        with patch("api.auth.get_user_service", return_value=mock_svc):
+            req = _mock_request(headers={"Authorization": f"Bearer {token}"})
+            result = await verify_token_endpoint(req)
+
+        # is_admin 应来自 DB (True)，而非 JWT (False)
+        assert result["data"]["is_admin"] is True
+
+
+# ============================================================
+# Test 3: 无效/黑名单 token → valid=False
+# ============================================================
+
+class TestVerifyInvalidToken:
+    """#5899: 无效/黑名单 token 返回 valid=False"""
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_returns_invalid(self):
+        """伪造 token → valid=False"""
+        from api.auth import verify_token_endpoint
+        req = _mock_request(headers={"Authorization": "Bearer this.is.not.valid"})
+        result = await verify_token_endpoint(req)
+        assert result["data"]["valid"] is False
+        assert result["data"]["user_uuid"] is None
+
+    @pytest.mark.asyncio
+    async def test_blacklisted_token_returns_invalid(self):
+        """#5802: 黑名单中的 token → valid=False"""
+        from api.auth import verify_token_endpoint
+        from middleware.auth import token_blacklist
+
+        payload = _default_payload()
+        payload["jti"] = "jti-to-be-blacklisted"
+        token = _make_token(payload)
+
+        token_blacklist._store.clear()
+        token_blacklist.add("jti-to-be-blacklisted")
+
+        req = _mock_request(headers={"Authorization": f"Bearer {token}"})
+        result = await verify_token_endpoint(req)
+        assert result["data"]["valid"] is False
+
+        # cleanup
+        token_blacklist._store.clear()

--- a/tests/api/test_auth_verify.py
+++ b/tests/api/test_auth_verify.py
@@ -148,3 +148,32 @@ class TestVerifyInvalidToken:
 
         # cleanup
         token_blacklist._store.clear()
+
+
+# ============================================================
+# Test 4: DB 异常时 fail-closed（is_admin=False）
+# ============================================================
+
+class TestVerifyDBFailure:
+    """#5899: DB 查询异常时 is_admin 必须 fail-closed，不回退 JWT"""
+
+    @pytest.mark.asyncio
+    async def test_db_exception_is_admin_false(self):
+        """DB 抛异常时 is_admin=False，不回退到 JWT 中的 is_admin=True"""
+        from api.auth import verify_token_endpoint
+
+        # JWT 中 is_admin=True（伪造的）
+        payload = _default_payload(user_uuid="u-fake-admin", username="attacker", is_admin=True)
+        token = _make_token(payload)
+
+        # mock DB 查询抛异常
+        mock_svc = MagicMock()
+        mock_svc.get_credential.side_effect = Exception("connection pool exhausted")
+
+        with patch("api.auth.get_user_service", return_value=mock_svc):
+            req = _mock_request(headers={"Authorization": f"Bearer {token}"})
+            result = await verify_token_endpoint(req)
+
+        # fail-closed: token 有效但 is_admin 必须为 False
+        assert result["data"]["valid"] is True
+        assert result["data"]["is_admin"] is False


### PR DESCRIPTION
## Summary

修复 3 个认证安全问题：

1. **`/auth/verify` 返回 null 用户信息** — 根因：端点在 PUBLIC_PATHS 中，中间件跳过 token 解析，导致 req.state 无用户数据。修复：端点手动提取验证 token。
2. **is_admin 不一致** — JWT 中的 is_admin 是签发时快照，`/auth/me` 从 DB 查实时值。修复：`/auth/verify` 的 is_admin 也从 DB 查询，与 `/auth/me` 一致。
3. **无效 token 返回 valid=True** — 原实现不验证 token 就返回 valid=True。修复：无效/黑名单 token 返回 valid=False。

## Changes

- `api/api/auth.py`: 重写 verify 端点，手动提取 token → 验证 → DB 查 is_admin
- `tests/api/test_auth_verify.py`: 6 个 TDD 行为测试

## Test plan

```bash
python -m pytest tests/api/test_auth_verify.py tests/api/test_jwt_security.py -q
```

Closes #5899