### PR TITLE
fix(#5533): 修复剩余 21 处 ORDERSTATUS_TYPES.NEW→REJECTED

### DIFF
--- a/src/ginkgo/trading/brokers/futures_broker.py
+++ b/src/ginkgo/trading/brokers/futures_broker.py
@@ -138,7 +138,7 @@ class FuturesBroker(LiveBrokerBase):
             # 期货规则检查
             if not self._validate_futures_order_rules(order):
                 return BrokerExecutionResult(
-                    status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                    status=ORDERSTATUS_TYPES.REJECTED,
                     broker_order_id=broker_order_id,
                     error_message="Order violates 期货交易规则"
                 )
@@ -146,7 +146,7 @@ class FuturesBroker(LiveBrokerBase):
             # 保证金检查
             if not self._check_margin_requirement(order):
                 return BrokerExecutionResult(
-                    status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                    status=ORDERSTATUS_TYPES.REJECTED,
                     broker_order_id=broker_order_id,
                     error_message="Insufficient margin for futures position"
                 )
@@ -162,7 +162,7 @@ class FuturesBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 期货订单提交失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 error_message=f"期货订单提交失败: {str(e)}"
             )
 
@@ -189,7 +189,7 @@ class FuturesBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 期货撤单失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"期货撤单失败: {str(e)}"
             )
@@ -219,7 +219,7 @@ class FuturesBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 期货查单失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"期货查单失败: {str(e)}"
             )

--- a/src/ginkgo/trading/brokers/hk_stock_broker.py
+++ b/src/ginkgo/trading/brokers/hk_stock_broker.py
@@ -131,7 +131,7 @@ class HKStockBroker(LiveBrokerBase):
             # 港股规则检查
             if not self._validate_hk_order_rules(order):
                 return BrokerExecutionResult(
-                    status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                    status=ORDERSTATUS_TYPES.REJECTED,
                     broker_order_id=broker_order_id,
                     error_message="Order violates 港股交易规则"
                 )
@@ -147,7 +147,7 @@ class HKStockBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 港股订单提交失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 error_message=f"港股订单提交失败: {str(e)}"
             )
 
@@ -174,7 +174,7 @@ class HKStockBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 港股撤单失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"港股撤单失败: {str(e)}"
             )
@@ -204,7 +204,7 @@ class HKStockBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 港股查单失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"港股查单失败: {str(e)}"
             )

--- a/src/ginkgo/trading/brokers/live_broker_base.py
+++ b/src/ginkgo/trading/brokers/live_broker_base.py
@@ -128,7 +128,7 @@ class LiveBrokerBase(BaseBroker, ABC):
         if not self.validate_order(order):
             GLOG.WARN(f"❌ Order validation failed: {order.uuid[:8]}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 error_message="Order validation failed by LiveBroker"
             )
 
@@ -136,7 +136,7 @@ class LiveBrokerBase(BaseBroker, ABC):
         if not self._api_connected:
             GLOG.ERROR(f"❌ API not connected for {self.market}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 error_message=f"API not connected for {self.market}"
             )
 
@@ -157,7 +157,7 @@ class LiveBrokerBase(BaseBroker, ABC):
         except Exception as e:
             GLOG.ERROR(f"❌ Submit to exchange failed: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"Exchange submission error: {str(e)}"
             )
@@ -208,7 +208,7 @@ class LiveBrokerBase(BaseBroker, ABC):
 
         if not self._api_connected:
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 error_message="API not connected"
             )
 
@@ -228,7 +228,7 @@ class LiveBrokerBase(BaseBroker, ABC):
         except Exception as e:
             GLOG.ERROR(f"❌ Cancel from exchange failed: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"Exchange cancel error: {str(e)}"
             )

--- a/src/ginkgo/trading/brokers/us_stock_broker.py
+++ b/src/ginkgo/trading/brokers/us_stock_broker.py
@@ -135,7 +135,7 @@ class USStockBroker(LiveBrokerBase):
             # 美股规则检查
             if not self._validate_us_order_rules(order):
                 return BrokerExecutionResult(
-                    status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                    status=ORDERSTATUS_TYPES.REJECTED,
                     broker_order_id=broker_order_id,
                     error_message="Order violates 美股交易规则"
                 )
@@ -151,7 +151,7 @@ class USStockBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 美股订单提交失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 error_message=f"美股订单提交失败: {str(e)}"
             )
 
@@ -178,7 +178,7 @@ class USStockBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 美股撤单失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"美股撤单失败: {str(e)}"
             )
@@ -208,7 +208,7 @@ class USStockBroker(LiveBrokerBase):
         except Exception as e:
             GLOG.ERROR(f"❌ 美股查单失败: {e}")
             return BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 broker_order_id=broker_order_id,
                 error_message=f"美股查单失败: {str(e)}"
             )

--- a/src/ginkgo/trading/gateway/trade_gateway.py
+++ b/src/ginkgo/trading/gateway/trade_gateway.py
@@ -562,7 +562,7 @@ class TradeGateway(BaseTradeGateway):
         # 更新订单跟踪状态
         if result.broker_order_id and hasattr(self, '_processing_orders'):
             # 如果有跟踪的订单，移除跟踪
-            if result.status in [ORDERSTATUS_TYPES.FILLED, ORDERSTATUS_TYPES.CANCELED, ORDERSTATUS_TYPES.NEW]:
+            if result.status in [ORDERSTATUS_TYPES.FILLED, ORDERSTATUS_TYPES.CANCELED, ORDERSTATUS_TYPES.REJECTED]:
                 self.remove_tracked_order(result.broker_order_id)
 
     def _update_position(self, order: Order, result: BrokerExecutionResult):
@@ -610,7 +610,7 @@ class TradeGateway(BaseTradeGateway):
         # 处理不同的执行结果
         if result.status in [ORDERSTATUS_TYPES.FILLED, ORDERSTATUS_TYPES.PARTIAL_FILLED]:
             GLOG.INFO(f"✅ ASYNC FILL: {result.filled_volume} {order.code} @ {result.filled_price}")
-        elif result.status == ORDERSTATUS_TYPES.NEW:  # REJECTED
+        elif result.status == ORDERSTATUS_TYPES.REJECTED:
             GLOG.WARN(f"❌ ASYNC REJECT: {result.error_message}")
         elif result.status == ORDERSTATUS_TYPES.CANCELED:
             GLOG.INFO(f"🚫 ASYNC CANCEL: {result.broker_order_id}")

--- a/src/ginkgo/trading/gateway/trade_gateway.py
+++ b/src/ginkgo/trading/gateway/trade_gateway.py
@@ -301,7 +301,7 @@ class TradeGateway(BaseTradeGateway):
             GLOG.ERROR(f"Sync execution failed for {order.uuid[:8]}: {e}\n{traceback.format_exc()}")
             # 发布错误事件
             error_result = BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 order=order,
                 error_message=f"Sync execution error: {str(e)}"
             )
@@ -399,7 +399,7 @@ class TradeGateway(BaseTradeGateway):
             GLOG.ERROR(f"Async execution failed for {order.uuid[:8]}: {e}")
             # 发布错误事件
             error_result = BrokerExecutionResult(
-                status=ORDERSTATUS_TYPES.NEW,  # REJECTED
+                status=ORDERSTATUS_TYPES.REJECTED,
                 order=order,
                 error_message=f"Async execution error: {str(e)}"
             )
@@ -619,7 +619,7 @@ class TradeGateway(BaseTradeGateway):
         self._handle_execution_result(result)
 
         # 移除订单跟踪（仅在最终状态时）
-        if result.status in [ORDERSTATUS_TYPES.FILLED, ORDERSTATUS_TYPES.NEW,  # REJECTED
+        if result.status in [ORDERSTATUS_TYPES.FILLED, ORDERSTATUS_TYPES.REJECTED,
                              ORDERSTATUS_TYPES.CANCELED]:
             self.remove_tracked_order(result.broker_order_id)
             GLOG.DEBUG(f"Removed tracking for completed order: {result.broker_order_id}")

--- a/tests/unit/trading/brokers/test_broker_type_fixes.py
+++ b/tests/unit/trading/brokers/test_broker_type_fixes.py
@@ -87,3 +87,36 @@ class TestAShareBrokerRejectedStatus:
         # 不应存在 NEW + REJECTED 注释的组合
         assert 'ORDERSTATUS_TYPES.NEW,  # REJECTED' not in source, \
             "Found ORDERSTATUS_TYPES.NEW with # REJECTED comment - should use ORDERSTATUS_TYPES.REJECTED"
+
+
+class TestTradeGatewayRejectedStatus:
+    """#5533: trade_gateway 中不应有 NEW 伪装为 REJECTED 的任何变体"""
+
+    def test_no_new_with_rejected_comment(self):
+        """trade_gateway.py 中不应存在任何形式的 NEW + # REJECTED 组合"""
+        import inspect
+        from ginkgo.trading.gateway.trade_gateway import TradeGateway
+
+        source = inspect.getsource(TradeGateway)
+        # 覆盖逗号和冒号两种语法
+        assert 'NEW,  # REJECTED' not in source, \
+            "Found ORDERSTATUS_TYPES.NEW, with # REJECTED comment"
+        assert 'NEW:  # REJECTED' not in source, \
+            "Found ORDERSTATUS_TYPES.NEW: with # REJECTED comment"
+
+    def test_handle_execution_result_removes_rejected_tracking(self):
+        """_handle_execution_result 应对 REJECTED 状态移除订单跟踪"""
+        import inspect
+        from ginkgo.trading.gateway.trade_gateway import TradeGateway
+
+        source = inspect.getsource(TradeGateway._handle_execution_result)
+        # 终态列表应包含 REJECTED 而非 NEW
+        assert 'ORDERSTATUS_TYPES.REJECTED' in source, \
+            "_handle_execution_result should include REJECTED in terminal status list"
+        # 终态列表不应包含 NEW（NEW 不是终态）
+        # 排除注释和字符串中的 NEW
+        for line in source.split('\n'):
+            stripped = line.strip()
+            if 'result.status in [' in stripped and 'ORDERSTATUS_TYPES' in stripped:
+                assert 'ORDERSTATUS_TYPES.NEW' not in stripped, \
+                    f"Terminal status list should not contain NEW: {stripped}"


### PR DESCRIPTION
## Summary

PR #6069 review 发现 PR #6051 只修了 ashare_broker.py 的 4 处，剩余 5 个文件共 21 处 `ORDERSTATUS_TYPES.NEW, # REJECTED` 未触及。

## Changes

| 文件 | 修复数 |
|------|--------|
| `live_broker_base.py` | 5 |
| `futures_broker.py` | 5 |
| `hk_stock_broker.py` | 4 |
| `us_stock_broker.py` | 4 |
| `trade_gateway.py` | 3 |

## Details

- 所有 `ORDERSTATUS_TYPES.NEW, # REJECTED` → `ORDERSTATUS_TYPES.REJECTED,`
- trade_gateway.py:622 的 `NEW` 在终态列表判断中，改为 `REJECTED` 后被拒绝订单也会正确移除跟踪

## Test

已有测试 `test_broker_type_fixes.py` 全部通过（8/8）

References #5533 #5484

🤖 Generated with [Claude Code](https://claude.ai/code)