### PR TITLE
fix(#5899): /auth/verify 增加 is_active 检查

### DIFF
--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -202,6 +202,8 @@ async def verify_token_endpoint(req: Request):
             svc = get_user_service()
             credential = svc.get_credential(user_uuid)
             if credential:
+                if not credential.is_active:
+                    return ok(data={"valid": False, "user_uuid": None, "username": None, "is_admin": False})
                 is_admin = credential.is_admin
         except Exception as e:
             # #5899: fail-closed — DB 不可用时 is_admin=False，与 /auth/me 一致

--- a/tests/api/test_auth_verify.py
+++ b/tests/api/test_auth_verify.py
@@ -177,3 +177,33 @@ class TestVerifyDBFailure:
         # fail-closed: token 有效但 is_admin 必须为 False
         assert result["data"]["valid"] is True
         assert result["data"]["is_admin"] is False
+
+
+# ============================================================
+# Test 5: 被禁用用户 → valid=False（is_active 检查）
+# ============================================================
+
+class TestVerifyDisabledUser:
+    """#5899: is_active=False 的用户 token 应返回 valid=False"""
+
+    @pytest.mark.asyncio
+    async def test_disabled_user_returns_invalid(self):
+        """credential.is_active=False 时 verify 返回 valid=False"""
+        from api.auth import verify_token_endpoint
+
+        payload = _default_payload(user_uuid="u-disabled", username="disabled")
+        token = _make_token(payload)
+
+        # mock: credential 存在但 is_active=False
+        mock_cred = MagicMock()
+        mock_cred.is_admin = False
+        mock_cred.is_active = False
+        mock_svc = MagicMock()
+        mock_svc.get_credential.return_value = mock_cred
+
+        with patch("api.auth.get_user_service", return_value=mock_svc):
+            req = _mock_request(headers={"Authorization": f"Bearer {token}"})
+            result = await verify_token_endpoint(req)
+
+        assert result["data"]["valid"] is False
+        assert result["data"]["is_admin"] is False


### PR DESCRIPTION
## Summary

Review PR #6069 发现：`/auth/verify` 端点检查了 `is_admin` 但遗漏了 `is_active`，被禁用用户的 token 仍返回 `valid=True`。

## Changes
- `api/api/auth.py`: 在 `verify_token_endpoint` 中增加 `credential.is_active` 检查
- `tests/api/test_auth_verify.py`: 新增 `TestVerifyDisabledUser` 测试

## Test plan
```bash
python -m pytest tests/api/test_auth_verify.py -q
```

Follow-up #6069
Refs #5899