### PR TITLE
fix(#6036): deal_long_filled 使用 event.frozen_money 替代废弃的 event.frozen

### DIFF
--- a/src/ginkgo/trading/portfolios/t1backtest.py
+++ b/src/ginkgo/trading/portfolios/t1backtest.py
@@ -858,15 +858,16 @@ class PortfolioT1Backtest(PortfolioBase):
             self.blog.log_engine_error_event(error_code="ORDER_FILLED_HANDLER_FAILED", error_message=str(e))
 
     def deal_long_filled(self, event: EventOrderPartiallyFilled, *args, **kwargs):
-        if self.frozen < event.frozen:
-            self.blog.log_engine_error_event(error_code="OVERFLOW_UNFREEZE", error_message=f"Cannot unfreeze {event.frozen} from {self.frozen}")
+        # #6036: event.frozen 已拆分为 frozen_money + frozen_volume，使用 frozen_money
+        if self.frozen < event.frozen_money:
+            self.blog.log_engine_error_event(error_code="OVERFLOW_UNFREEZE", error_message=f"Cannot unfreeze {event.frozen_money} from {self.frozen}")
             return
         if event.remain < 0:
             self.blog.log_engine_error_event(error_code="NEGATIVE_REMAIN", error_message="Order remain under 0")
             return
 
         # 重要修复：使用新的deduct_from_frozen方法正确处理部分成交
-        transaction_cost = event.frozen - event.remain
+        transaction_cost = event.frozen_money - event.remain
 
         # 使用新的公共方法：扣除成交花费，只将剩余未成交部分解冻
         self.deduct_from_frozen(cost=transaction_cost, unfreeze_remain=event.remain)

--- a/tests/unit/trading/portfolios/test_t1backtest.py
+++ b/tests/unit/trading/portfolios/test_t1backtest.py
@@ -635,7 +635,7 @@ class TestLongShortFillHandling:
         event.code = "000001.SZ"
         event.transaction_volume = 100
         event.transaction_price = Decimal("10.0")
-        event.frozen = Decimal("1000")
+        event.frozen_money = Decimal("1000")
         event.remain = Decimal("0")
         event.fee = Decimal("5")
         with patch('ginkgo.trading.portfolios.t1backtest.GLOG'), \
@@ -681,7 +681,7 @@ class TestLongShortFillHandling:
         event.code = "000001.SZ"
         event.transaction_volume = 100
         event.transaction_price = Decimal("10.0")
-        event.frozen = Decimal("1000")
+        event.frozen_money = Decimal("1000")
         event.remain = Decimal("0")
         event.fee = Decimal("5")
         with patch('ginkgo.trading.portfolios.t1backtest.GLOG'), \
@@ -728,7 +728,7 @@ class TestLongShortFillHandling:
         event.code = "000001.SZ"
         event.transaction_volume = 100
         event.transaction_price = Decimal("10.0")
-        event.frozen = Decimal("1000")  # frozen > self.frozen
+        event.frozen_money = Decimal("1000")  # frozen > self.frozen
         event.remain = Decimal("-10")  # negative remain
         event.fee = Decimal("0")
         with patch('ginkgo.trading.portfolios.t1backtest.GLOG'):


### PR DESCRIPTION
## Summary

PR #6056 将 `Order.frozen` 拆分为 `frozen_money` + `frozen_volume`，`EventOrderRelated` 也更新了代理属性。但 `t1backtest.py` 的 `deal_long_filled` 仍引用 `event.frozen`，运行时 `AttributeError` 导致做多订单成交处理失败。

**改动范围（2 文件）：**
- `t1backtest.py` L861-869：`event.frozen` → `event.frozen_money`（3 处）
- `test_t1backtest.py`：同步更新测试 Mock 属性名（3 处）

## Test plan

- `TestLongShortFillHandling` 5 个测试全部通过 ✅
- 验证 OVERFLOW_UNFREEZE 校验逻辑正常工作（frozen_money > self.frozen 时拒绝）

Closes #6036

🤖 Generated with [Claude Code](https://claude.com/claude-code)