### PR TITLE
fix(#6079): frozen 拆分后遗留问题 — frozen_money 计算不一致 + 类型转换缺失

### DIFF
--- a/src/ginkgo/data/crud/order_crud.py
+++ b/src/ginkgo/data/crud/order_crud.py
@@ -181,7 +181,7 @@ class OrderCRUD(BaseCRUD[MOrder]):
             volume=kwargs.get("volume"),
             limit_price=to_decimal(kwargs.get("limit_price", 0)),
             frozen_money=to_decimal(kwargs.get("frozen_money", 0)),
-            frozen_volume=kwargs.get("frozen_volume", 0),
+            frozen_volume=int(kwargs.get("frozen_volume", 0)),
             transaction_price=to_decimal(kwargs.get("transaction_price", 0)),
             transaction_volume=kwargs.get("transaction_volume", 0),
             remain=kwargs.get("remain", 0.0),

--- a/src/ginkgo/data/crud/order_record_crud.py
+++ b/src/ginkgo/data/crud/order_record_crud.py
@@ -157,7 +157,7 @@ class OrderRecordCRUD(BaseCRUD[MOrderRecord]):
             volume=kwargs.get("volume"),
             limit_price=to_decimal(kwargs.get("limit_price", 0)),
             frozen_money=to_decimal(kwargs.get("frozen_money", 0)),
-            frozen_volume=kwargs.get("frozen_volume", 0),
+            frozen_volume=int(kwargs.get("frozen_volume", 0)),
             transaction_price=to_decimal(kwargs.get("transaction_price", 0)),
             transaction_volume=kwargs.get("transaction_volume", 0),
             remain=to_decimal(kwargs.get("remain", 0)),

--- a/src/ginkgo/data/models/model_order.py
+++ b/src/ginkgo/data/models/model_order.py
@@ -180,8 +180,8 @@ class MOrder(MMysqlBase, MBacktestRecordBase):
         self.status = ORDERSTATUS_TYPES.validate_input(df["status"]) or -1
         self.volume = df["volume"]
         self.limit_price = to_decimal(df["limit_price"])
-        self.frozen_money = df["frozen_money"] if "frozen_money" in df else 0
-        self.frozen_volume = df["frozen_volume"] if "frozen_volume" in df else 0
+        self.frozen_money = to_decimal(df["frozen_money"] if "frozen_money" in df else df.get("frozen", 0))
+        self.frozen_volume = int(df["frozen_volume"] if "frozen_volume" in df else 0)
         self.transaction_price = to_decimal(df["transaction_price"])
         self.transaction_volume = df["transaction_volume"]
         self.remain = to_decimal(df["remain"])

--- a/src/ginkgo/data/models/model_order_record.py
+++ b/src/ginkgo/data/models/model_order_record.py
@@ -117,8 +117,8 @@ class MOrderRecord(MClickBase, MBacktestRecordBase, ModelConversion):
         self.status = ORDERSTATUS_TYPES.validate_input(df["status"]) or -1
         self.volume = df["volume"]
         self.limit_price = to_decimal(df["limit_price"])
-        self.frozen_money = df["frozen_money"] if "frozen_money" in df else 0
-        self.frozen_volume = df["frozen_volume"] if "frozen_volume" in df else 0
+        self.frozen_money = to_decimal(df["frozen_money"] if "frozen_money" in df else df.get("frozen", 0))
+        self.frozen_volume = int(df["frozen_volume"] if "frozen_volume" in df else 0)
         self.transaction_price = to_decimal(df["transaction_price"])
         self.transaction_volume = df["transaction_volume"]
         self.remain = to_decimal(df["remain"])

--- a/src/ginkgo/trading/risk_management/position_ratio_risk.py
+++ b/src/ginkgo/trading/risk_management/position_ratio_risk.py
@@ -157,9 +157,10 @@ class PositionRatioRisk(BaseRiskManagement):
             if adjusted_volume < to_decimal(order.volume):
                 GLOG.INFO(f"PositionRatioRisk: Adjusting order volume for single position ratio - {order.code}: {original_volume} → {int(adjusted_volume)} (from {float(expected_position_ratio):.2%} to {float(self._max_position_ratio):.2%})",
                 )
-                order.volume = int(adjusted_volume)
-                order.frozen_money = adjusted_volume * execution_price
-                order.frozen_volume = int(adjusted_volume)
+                truncated_volume = int(adjusted_volume)
+                order.volume = truncated_volume
+                order.frozen_money = to_decimal(truncated_volume) * execution_price
+                order.frozen_volume = truncated_volume
                 order.remain = order.frozen_money
 
         # 检查总持仓比例
@@ -195,9 +196,10 @@ class PositionRatioRisk(BaseRiskManagement):
             if adjusted_volume < to_decimal(order.volume):
                 GLOG.INFO(f"PositionRatioRisk: Adjusting order volume for total position ratio - {order.code}: {original_volume} → {int(adjusted_volume)} (from {float(expected_total_ratio):.2%} to {float(self._max_total_position_ratio):.2%})",
                 )
-                order.volume = int(adjusted_volume)
-                order.frozen_money = adjusted_volume * execution_price
-                order.frozen_volume = int(adjusted_volume)
+                truncated_volume = int(adjusted_volume)
+                order.volume = truncated_volume
+                order.frozen_money = to_decimal(truncated_volume) * execution_price
+                order.frozen_volume = truncated_volume
                 order.remain = order.frozen_money
 
         # 如果调整后的订单量为0，则拒绝订单

--- a/tests/unit/data/crud/test_order_crud_mock.py
+++ b/tests/unit/data/crud/test_order_crud_mock.py
@@ -376,3 +376,40 @@ class TestOrderBusinessMethods:
 
         crud_instance.count.assert_called_once_with({"portfolio_id": "portfolio-001"})
         assert result == 5
+
+
+@pytest.mark.tdd
+@pytest.mark.bug
+class TestOrderCRUDFrozenVolumeIntConversion:
+    """#6079: frozen_volume 应强制 int() 转换，防止 float 写入 Integer 列"""
+
+    @pytest.mark.unit
+    def test_frozen_volume_float_to_int(self, crud_instance):
+        """传入 float frozen_volume 应被转为 int"""
+        model = crud_instance._create_from_params(
+            portfolio_id="p1",
+            engine_id="e1",
+            code="000001.SZ",
+            direction=DIRECTION_TYPES.LONG,
+            order_type=ORDER_TYPES.LIMITORDER,
+            status=ORDERSTATUS_TYPES.NEW,
+            volume=100,
+            frozen_volume=484.03,
+        )
+        assert isinstance(model.frozen_volume, int)
+        assert model.frozen_volume == 484
+
+    @pytest.mark.unit
+    def test_frozen_volume_default_zero_is_int(self, crud_instance):
+        """默认值 0 应为 int 类型"""
+        model = crud_instance._create_from_params(
+            portfolio_id="p1",
+            engine_id="e1",
+            code="000001.SZ",
+            direction=DIRECTION_TYPES.LONG,
+            order_type=ORDER_TYPES.LIMITORDER,
+            status=ORDERSTATUS_TYPES.NEW,
+            volume=100,
+        )
+        assert isinstance(model.frozen_volume, int)
+        assert model.frozen_volume == 0

--- a/tests/unit/data/crud/test_order_record_crud_mock.py
+++ b/tests/unit/data/crud/test_order_record_crud_mock.py
@@ -216,3 +216,36 @@ class TestOrderRecordCRUDConstruction:
         assert order_record_crud._is_clickhouse is True
         assert order_record_crud._is_mysql is False
 
+
+@pytest.mark.tdd
+@pytest.mark.bug
+class TestOrderRecordCRUDFrozenVolumeIntConversion:
+    """#6079: frozen_volume 应强制 int() 转换"""
+
+    @pytest.mark.unit
+    def test_frozen_volume_float_to_int(self, order_record_crud):
+        """传入 float frozen_volume 应被转为 int"""
+        model = order_record_crud._create_from_params(
+            order_id="o1",
+            portfolio_id="p1",
+            engine_id="e1",
+            code="000001.SZ",
+            direction=DIRECTION_TYPES.LONG,
+            order_type=ORDER_TYPES.LIMITORDER,
+            status=ORDERSTATUS_TYPES.NEW,
+            volume=100,
+            frozen_volume=484.03,
+        )
+        assert isinstance(model.frozen_volume, int)
+        assert model.frozen_volume == 484
+
+    @pytest.mark.unit
+    def test_frozen_volume_default_zero_is_int(self, order_record_crud):
+        """默认值 0 应为 int 类型"""
+        model = order_record_crud._create_from_params(
+            order_id="o1",
+            portfolio_id="p1",
+        )
+        assert isinstance(model.frozen_volume, int)
+        assert model.frozen_volume == 0
+

--- a/tests/unit/data/models/test_order_model_frozen_split.py
+++ b/tests/unit/data/models/test_order_model_frozen_split.py
@@ -84,3 +84,135 @@ class TestMOrderRecordFrozenSplit:
         """MOrderRecord 应有 frozen_volume 列"""
         m = MOrderRecord()
         assert hasattr(m, "frozen_volume")
+
+
+class TestMOrderUpdateSeriesFrozenMoney:
+    """#6079: update(Series) 中 frozen_money 应使用 to_decimal()"""
+
+    @pytest.mark.unit
+    def test_frozen_money_to_decimal_from_float(self):
+        """update(Series) 传入 float frozen_money 应转为 Decimal"""
+        import pandas as pd
+        from decimal import Decimal
+
+        df = pd.DataFrame([{
+            "uuid": "test-uuid",
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "r1",
+            "code": "000001.SZ",
+            "direction": 1,
+            "order_type": 1,
+            "status": 1,
+            "volume": 100,
+            "limit_price": 10.33,
+            "frozen_money": 1549.50,
+            "frozen_volume": 150,
+            "transaction_price": 0,
+            "transaction_volume": 0,
+            "remain": 0,
+            "fee": 0,
+            "timestamp": "2024-01-15 10:00:00",
+            "business_timestamp": "2024-01-15 10:00:00",
+        }])
+        m = MOrder()
+        m.update(df.iloc[0])
+        assert isinstance(m.frozen_money, Decimal)
+        assert m.frozen_money == Decimal("1549.50")
+
+    @pytest.mark.unit
+    def test_frozen_volume_int_from_series(self):
+        """update(Series) 传入 float frozen_volume 应转为 int"""
+        import pandas as pd
+
+        df = pd.DataFrame([{
+            "uuid": "test-uuid",
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "r1",
+            "code": "000001.SZ",
+            "direction": 1,
+            "order_type": 1,
+            "status": 1,
+            "volume": 100,
+            "limit_price": 10.0,
+            "frozen_money": 1000.0,
+            "frozen_volume": 150.7,
+            "transaction_price": 0,
+            "transaction_volume": 0,
+            "remain": 0,
+            "fee": 0,
+            "timestamp": "2024-01-15 10:00:00",
+            "business_timestamp": "2024-01-15 10:00:00",
+        }])
+        m = MOrder()
+        m.update(df.iloc[0])
+        assert isinstance(m.frozen_volume, int)
+        assert m.frozen_volume == 150
+
+    @pytest.mark.unit
+    def test_backward_compat_legacy_frozen_column(self):
+        """旧 DataFrame 只有 frozen 列时，应拆分到 frozen_money"""
+        import pandas as pd
+        from decimal import Decimal
+
+        df = pd.DataFrame([{
+            "uuid": "test-uuid",
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "r1",
+            "code": "000001.SZ",
+            "direction": 1,
+            "order_type": 1,
+            "status": 1,
+            "volume": 100,
+            "limit_price": 10.0,
+            "frozen": 1000.0,
+            "transaction_price": 0,
+            "transaction_volume": 0,
+            "remain": 0,
+            "fee": 0,
+            "timestamp": "2024-01-15 10:00:00",
+            "business_timestamp": "2024-01-15 10:00:00",
+        }])
+        m = MOrder()
+        m.update(df.iloc[0])
+        # frozen_money 应从旧 frozen 列继承
+        assert isinstance(m.frozen_money, Decimal)
+        assert m.frozen_money == Decimal("1000.0")
+
+
+class TestMOrderRecordUpdateSeriesFrozenMoney:
+    """#6079: MOrderRecord update(Series) 中 frozen_money 应使用 to_decimal()"""
+
+    @pytest.mark.unit
+    def test_frozen_money_to_decimal_from_float(self):
+        """update(Series) 传入 float frozen_money 应转为 Decimal"""
+        import pandas as pd
+        from decimal import Decimal
+
+        df = pd.DataFrame([{
+            "uuid": "test-uuid",
+            "order_id": "o1",
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "r1",
+            "code": "000001.SZ",
+            "direction": 1,
+            "order_type": 1,
+            "status": 1,
+            "volume": 100,
+            "limit_price": 10.33,
+            "frozen_money": 1549.50,
+            "frozen_volume": 150,
+            "transaction_price": 0,
+            "transaction_volume": 0,
+            "remain": 0,
+            "fee": 0,
+            "timestamp": "2024-01-15 10:00:00",
+            "business_timestamp": "2024-01-15 10:00:00",
+        }])
+        m = MOrderRecord()
+        m.update(df.iloc[0])
+        assert isinstance(m.frozen_money, Decimal)
+        assert m.frozen_money == Decimal("1549.50")

--- a/tests/unit/trading/strategy/risk_managements/test_position_ratio_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_position_ratio_risk.py
@@ -225,3 +225,55 @@ class TestPositionRatioRiskPerformance:
             r.cal(info, order)
         elapsed = time.perf_counter() - start
         assert elapsed < 30.0
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.bug
+class TestPositionRatioRiskFrozenConsistency:
+    """#6079: frozen_money 必须等于 volume × price（截断后一致）"""
+
+    def test_frozen_money_equals_volume_times_price_after_single_adjustment(self):
+        """单股持仓比例调整后，frozen_money == volume × price"""
+        from decimal import Decimal
+
+        r = PositionRatioRisk(max_position_ratio=0.1, max_total_position_ratio=0.9)
+        pos = _make_position(code="000001.SZ", volume=500, price=10.0, market_value=5000)
+        order = _make_order(volume=600, limit_price=10.33, code="000001.SZ")
+        info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
+        result = r.cal(info, order)
+
+        if result is not None and result.frozen_money is not None:
+            expected = Decimal(str(result.volume)) * Decimal(str(result.limit_price))
+            assert result.frozen_money == expected, (
+                f"frozen_money={result.frozen_money} != volume({result.volume}) × price({result.limit_price}) = {expected}"
+            )
+
+    def test_frozen_money_equals_volume_times_price_after_total_adjustment(self):
+        """总仓位比例调整后，frozen_money == volume × price"""
+        from decimal import Decimal
+
+        r = PositionRatioRisk(max_position_ratio=0.5, max_total_position_ratio=0.2)
+        pos = _make_position(code="000001.SZ", volume=500, price=10.0, market_value=5000)
+        order = _make_order(volume=2000, limit_price=10.33, code="000002.SZ")
+        info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
+        result = r.cal(info, order)
+
+        if result is not None and result.frozen_money is not None:
+            expected = Decimal(str(result.volume)) * Decimal(str(result.limit_price))
+            assert result.frozen_money == expected, (
+                f"frozen_money={result.frozen_money} != volume({result.volume}) × price({result.limit_price}) = {expected}"
+            )
+
+    def test_frozen_volume_equals_volume_after_adjustment(self):
+        """调整后 frozen_volume == volume"""
+        r = PositionRatioRisk(max_position_ratio=0.1, max_total_position_ratio=0.9)
+        pos = _make_position(code="000001.SZ", volume=500, price=10.0, market_value=5000)
+        order = _make_order(volume=600, limit_price=10.33, code="000001.SZ")
+        info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
+        result = r.cal(info, order)
+
+        if result is not None:
+            assert result.frozen_volume == result.volume, (
+                f"frozen_volume={result.frozen_volume} != volume={result.volume}"
+            )


### PR DESCRIPTION
## Summary

修复 PR #6056 frozen 拆分为 `frozen_money` + `frozen_volume` 后的 4 处遗留问题：

| 优先级 | 问题 | 修复 |
|---|---|---|
| P1 | `position_ratio_risk.py` frozen_money 用未截断 Decimal 值计算，导致 frozen_money ≠ volume × price | 改用 `to_decimal(int(adjusted_volume)) * execution_price` |
| P2 | `order_crud.py` / `order_record_crud.py` frozen_volume 无 int() 转换，float 直接入 Integer 列 | 加 `int()` 包装 |
| P2 | `model_order.py` / `model_order_record.py` update(Series) frozen_money 无 to_decimal() | 加 `to_decimal()` 包装 |
| P3 | 旧 DataFrame 含 frozen 列但无 frozen_money，迁移过渡期丢失冻结金额 | fallback 到 `df.get("frozen", 0)` |

## 变更文件
- `src/ginkgo/trading/risk_management/position_ratio_risk.py` — 2 处 frozen_money 计算
- `src/ginkgo/data/crud/order_crud.py` — frozen_volume int() 转换
- `src/ginkgo/data/crud/order_record_crud.py` — frozen_volume int() 转换
- `src/ginkgo/data/models/model_order.py` — to_decimal() + 向后兼容
- `src/ginkgo/data/models/model_order_record.py` — to_decimal() + 向后兼容

## Test plan
- [x] 新增 11 个测试覆盖全部修复点
- [x] frozen_money == volume × price 一致性（单股+总仓位调整）
- [x] frozen_volume int() 转换（CRUD 层 + Model 层）
- [x] frozen_money to_decimal() 转换
- [x] 旧 frozen 列向后兼容
- [x] 67 个相关测试全通过，无回归

Closes #6079

🤖 Generated with [Claude Code](https://claude.com/claude-code)