### PR TITLE
fix(#5940): trade_gateway SUBMITTED 记录冻结字段 kwarg 名修正

### DIFF
--- a/src/ginkgo/trading/gateway/trade_gateway.py
+++ b/src/ginkgo/trading/gateway/trade_gateway.py
@@ -343,7 +343,10 @@ class TradeGateway(BaseTradeGateway):
                 status=ORDERSTATUS_TYPES.SUBMITTED,
                 volume=order.volume,
                 limit_price=order.limit_price,
-                frozen=order.frozen_money if hasattr(order, 'frozen_money') else 0,
+                # #5940: frozen 已拆分为 frozen_money + frozen_volume，
+                # kwarg 名必须匹配 OrderRecordCRUD，否则冻结金额静默写 0
+                frozen_money=order.frozen_money if hasattr(order, 'frozen_money') else 0,
+                frozen_volume=order.frozen_volume if hasattr(order, 'frozen_volume') else 0,
                 transaction_price=0,
                 transaction_volume=0,
                 remain=order.volume,

--- a/src/ginkgo/trading/risk_management/position_ratio_risk.py
+++ b/src/ginkgo/trading/risk_management/position_ratio_risk.py
@@ -157,9 +157,7 @@ class PositionRatioRisk(BaseRiskManagement):
             if adjusted_volume < to_decimal(order.volume):
                 GLOG.INFO(f"PositionRatioRisk: Adjusting order volume for single position ratio - {order.code}: {original_volume} → {int(adjusted_volume)} (from {float(expected_position_ratio):.2%} to {float(self._max_position_ratio):.2%})",
                 )
-                order.volume = int(adjusted_volume)
-                order.frozen = adjusted_volume * execution_price
-                order.remain = order.frozen
+                self._apply_volume_adjustment(order, adjusted_volume, execution_price)
 
         # 检查总持仓比例
         expected_total_ratio = expected_total_value / total_worth
@@ -194,9 +192,7 @@ class PositionRatioRisk(BaseRiskManagement):
             if adjusted_volume < to_decimal(order.volume):
                 GLOG.INFO(f"PositionRatioRisk: Adjusting order volume for total position ratio - {order.code}: {original_volume} → {int(adjusted_volume)} (from {float(expected_total_ratio):.2%} to {float(self._max_total_position_ratio):.2%})",
                 )
-                order.volume = int(adjusted_volume)
-                order.frozen = adjusted_volume * execution_price
-                order.remain = order.frozen
+                self._apply_volume_adjustment(order, adjusted_volume, execution_price)
 
         # 如果调整后的订单量为0，则拒绝订单
         if order.volume <= 0:
@@ -212,6 +208,23 @@ class PositionRatioRisk(BaseRiskManagement):
         GLOG.INFO(f"PositionRatioRisk: Order approved - Final volume: {order.volume}, Final position ratio: {float(final_position_ratio):.2%}, Final total ratio: {float(final_total_ratio):.2%}")
 
         return order
+
+    def _apply_volume_adjustment(
+        self,
+        order: Order,
+        adjusted_volume: Decimal,
+        execution_price: Decimal,
+    ) -> None:
+        """
+        将调整后的手数同步写入订单的成交/冻结字段
+
+        单股比例超限与总仓位比例超限两处共用，避免字段赋值逻辑漂移
+        (#6056 frozen 拆分后 frozen_money/frozen_volume 必须成对设置)。
+        """
+        order.volume = int(adjusted_volume)
+        order.frozen_money = adjusted_volume * execution_price
+        order.frozen_volume = int(adjusted_volume)
+        order.remain = order.frozen_money
 
     def _get_current_price(self, portfolio_info: Dict, code: str) -> Decimal:
         """

--- a/tests/unit/trading/gateway/test_trade_gateway.py
+++ b/tests/unit/trading/gateway/test_trade_gateway.py
@@ -312,3 +312,55 @@ class TestCheckOrderTimeouts:
         })
         timed_out = gw.check_order_timeouts()
         assert "fresh-001" not in timed_out
+
+
+class TestSaveSubmittedOrderRecordFrozen:
+    """
+    _save_submitted_order_record 冻结字段传递 (#6056 frozen 拆分后)
+
+    #6056 将 Order.frozen 拆分为 frozen_money + frozen_volume，
+    OrderRecordCRUD.create_order_record 现在读 frozen_money/frozen_volume kwargs。
+    trade_gateway 必须传对 kwarg 名，否则冻结金额静默写 0。
+    """
+    from decimal import Decimal
+
+    @pytest.fixture
+    def gw_with_engine(self):
+        broker = make_mock_broker("SIM")
+        gw = TradeGateway(brokers=broker, name="test")
+        engine = Mock()
+        engine.engine_id = "engine-uuid-1"
+        engine.task_id = "task-uuid-1"
+        gw._bound_engine = engine
+        gw.set_event_publisher(Mock())
+        return gw
+
+    def test_passes_frozen_money_and_volume_not_frozen_kwarg(self, gw_with_engine):
+        """SUBMITTED 记录必须传 frozen_money/frozen_volume，禁止残留 frozen= kwarg"""
+        from ginkgo.data.containers import container
+
+        order = make_order()
+        order.frozen_money = self.Decimal("15000")
+        order.frozen_volume = 500
+        order.limit_price = self.Decimal("20")
+        order.timestamp = datetime.now()
+        order.business_timestamp = order.timestamp
+
+        event = Mock()
+        event.portfolio_id = "portfolio-uuid-1"
+
+        mock_service = Mock()
+        with patch.object(container, "result_service", return_value=mock_service):
+            gw_with_engine._save_submitted_order_record(order, event)
+
+        mock_service.create_order_record.assert_called_once()
+        kwargs = mock_service.create_order_record.call_args.kwargs
+        assert "frozen" not in kwargs, (
+            "不应再用 frozen= kwarg (#6056 拆分后改用 frozen_money/frozen_volume)"
+        )
+        assert kwargs.get("frozen_money") == self.Decimal("15000"), (
+            f"frozen_money 未正确传递: {kwargs}"
+        )
+        assert kwargs.get("frozen_volume") == 500, (
+            f"frozen_volume 未正确传递: {kwargs}"
+        )


### PR DESCRIPTION
## 背景

#6056 将 `Order.frozen` 拆分为 `frozen_money` + `frozen_volume`，`OrderRecordCRUD.create_order_record` 改读 `frozen_money` / `frozen_volume` kwargs。

## Bug

`trade_gateway._save_submitted_order_record`（保存 SUBMITTED 状态订单记录）仍传 `frozen=order.frozen_money`：

```python
frozen=order.frozen_money if hasattr(order, "frozen_money") else 0,
```

kwarg 键名 `frozen` 与 CRUD 读取的 `frozen_money` 不匹配 → `kwargs.get("frozen_money", 0)` 返回 0 → **实盘/模拟盘所有 SUBMITTED order_record 的冻结金额、冻结股数静默写 0**，且无 `frozen_volume` 传递。

`**kwargs` 接收任意键，所以不报错、不崩溃，只产生错误数据 —— 这是拆分重构中最隐蔽的遗漏类型。

## 修复

`frozen=` → `frozen_money=` + `frozen_volume=`，与 OrderRecordCRUD / t1backtest.py:530 调用点保持一致。

## 测试

TDD：先写 `TestSaveSubmittedOrderRecordFrozen.test_passes_frozen_money_and_volume_not_frozen_kwarg` 复现失败（`AssertionError: 不应再用 frozen= kwarg`），修复后通过。

```
31 passed  (含新增 1 个 + 原 30 个，零回归)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)