### PR TITLE
fix(#6080): 补全 RED 测试缺失实现 — get_order_summary + cal() fail-closed

### DIFF
--- a/src/ginkgo/data/crud/order_crud.py
+++ b/src/ginkgo/data/crud/order_crud.py
@@ -551,6 +551,61 @@ class OrderCRUD(BaseCRUD[MOrder]):
             filters["portfolio_id"] = portfolio_id
         return self.count(filters)
 
+    def get_order_summary(self, portfolio_id: str) -> Dict:
+        """
+        Business helper: 订单统计摘要。
+
+        #6080: RED 测试要求无订单时返回全零统计。
+
+        Returns:
+            Dict: total_orders / pending_orders / filled_orders / cancelled_orders /
+                  total_volume / avg_price / total_fees（无订单时全 0）。
+        """
+        orders = self.find({"portfolio_id": portfolio_id}) or []
+
+        pending_states = {
+            ORDERSTATUS_TYPES.NEW.value,
+            ORDERSTATUS_TYPES.SUBMITTED.value,
+            ORDERSTATUS_TYPES.PARTIAL_FILLED.value,
+        }
+        cancelled_states = {
+            ORDERSTATUS_TYPES.CANCELED.value,
+            ORDERSTATUS_TYPES.REJECTED.value,
+        }
+
+        pending = filled = cancelled = 0
+        total_volume = 0
+        filled_volume = 0
+        filled_value = to_decimal(0)
+        total_fees = to_decimal(0)
+
+        for o in orders:
+            status = getattr(o, "status", None)
+            total_volume += int(getattr(o, "volume", 0) or 0)
+            total_fees += to_decimal(getattr(o, "fee", 0) or 0)
+
+            if status == ORDERSTATUS_TYPES.FILLED.value:
+                filled += 1
+                tv = int(getattr(o, "transaction_volume", 0) or 0)
+                filled_volume += tv
+                filled_value += to_decimal(getattr(o, "transaction_price", 0) or 0) * tv
+            elif status in pending_states:
+                pending += 1
+            elif status in cancelled_states:
+                cancelled += 1
+
+        avg_price = float(filled_value) / filled_volume if filled_volume > 0 else 0
+
+        return {
+            "total_orders": len(orders),
+            "pending_orders": pending,
+            "filled_orders": filled,
+            "cancelled_orders": cancelled,
+            "total_volume": total_volume,
+            "avg_price": avg_price,
+            "total_fees": float(total_fees),
+        }
+
     def get_all_codes(self) -> List[str]:
         """
         Business helper: Get all distinct stock codes with orders.

--- a/src/ginkgo/data/crud/order_crud.py
+++ b/src/ginkgo/data/crud/order_crud.py
@@ -563,14 +563,17 @@ class OrderCRUD(BaseCRUD[MOrder]):
         """
         orders = self.find({"portfolio_id": portfolio_id}) or []
 
+        # 注意：find() 返回的订单经 _convert_output_items 转换后，
+        # status 为 ORDERSTATUS_TYPES 枚举实例（非 int），故须按枚举比较，而非 .value。
+        # 关联 #6092
         pending_states = {
-            ORDERSTATUS_TYPES.NEW.value,
-            ORDERSTATUS_TYPES.SUBMITTED.value,
-            ORDERSTATUS_TYPES.PARTIAL_FILLED.value,
+            ORDERSTATUS_TYPES.NEW,
+            ORDERSTATUS_TYPES.SUBMITTED,
+            ORDERSTATUS_TYPES.PARTIAL_FILLED,
         }
         cancelled_states = {
-            ORDERSTATUS_TYPES.CANCELED.value,
-            ORDERSTATUS_TYPES.REJECTED.value,
+            ORDERSTATUS_TYPES.CANCELED,
+            ORDERSTATUS_TYPES.REJECTED,
         }
 
         pending = filled = cancelled = 0
@@ -584,7 +587,7 @@ class OrderCRUD(BaseCRUD[MOrder]):
             total_volume += int(getattr(o, "volume", 0) or 0)
             total_fees += to_decimal(getattr(o, "fee", 0) or 0)
 
-            if status == ORDERSTATUS_TYPES.FILLED.value:
+            if status == ORDERSTATUS_TYPES.FILLED:
                 filled += 1
                 tv = int(getattr(o, "transaction_volume", 0) or 0)
                 filled_volume += tv

--- a/src/ginkgo/trading/risk_management/position_ratio_risk.py
+++ b/src/ginkgo/trading/risk_management/position_ratio_risk.py
@@ -114,7 +114,8 @@ class PositionRatioRisk(BaseRiskManagement):
 
         if execution_price <= 0:
             GLOG.WARN(f"PositionRatioRisk: Invalid execution price {execution_price} for {order.code}, order type: {order.order_type}, limit_price: {order.limit_price}")
-            return order
+            # fail-closed: 无法定价则拒绝，不让未风控订单漏网 (#6080)
+            return None
 
         # 计算订单执行后的预期持仓价值
         order_value = to_decimal(order.volume) * execution_price

--- a/tests/unit/data/crud/test_order_crud_mock.py
+++ b/tests/unit/data/crud/test_order_crud_mock.py
@@ -369,6 +369,37 @@ class TestOrderBusinessMethods:
         assert summary['total_fees'] == 0
 
     @pytest.mark.unit
+    def test_get_order_summary_non_empty_buckets(self, crud_instance):
+        """get_order_summary 非空时应按状态正确分桶（status 为枚举实例，模拟 find 经 _convert_output_items 转换后的真实形态）。关联 #6092"""
+        def mk(status, volume, tv=0, tp=0, fee=0):
+            o = MagicMock()
+            o.status = status
+            o.volume = volume
+            o.transaction_volume = tv
+            o.transaction_price = tp
+            o.fee = fee
+            return o
+
+        orders = [
+            mk(ORDERSTATUS_TYPES.NEW, volume=100, fee=1),       # pending
+            mk(ORDERSTATUS_TYPES.SUBMITTED, volume=200, fee=2),  # pending
+            mk(ORDERSTATUS_TYPES.FILLED, volume=300, tv=300, tp=10.5, fee=3),  # filled
+            mk(ORDERSTATUS_TYPES.CANCELED, volume=400, fee=4),   # cancelled
+            mk(ORDERSTATUS_TYPES.REJECTED, volume=500, fee=5),   # cancelled
+        ]
+        crud_instance.find = MagicMock(return_value=orders)
+
+        summary = crud_instance.get_order_summary("portfolio-001")
+
+        assert summary['total_orders'] == 5
+        assert summary['pending_orders'] == 2      # NEW + SUBMITTED
+        assert summary['filled_orders'] == 1
+        assert summary['cancelled_orders'] == 2    # CANCELED + REJECTED
+        assert summary['total_volume'] == 1500     # 100+200+300+400+500
+        assert summary['avg_price'] == 10.5        # 成交加权 (10.5*300)/300
+        assert summary['total_fees'] == 15         # 1+2+3+4+5
+
+    @pytest.mark.unit
     def test_count_by_portfolio(self, crud_instance):
         """count_by_portfolio 应调用 count 并传入正确的 filters"""
         crud_instance.count = MagicMock(return_value=5)


### PR DESCRIPTION
## Summary

冒烟测试发现 **#6080** (commit `5a100495`) 提交了 2 个 RED 测试，但遗漏了对应 GREEN 实现，导致 master `a56b473d` 实际为红（2 failed）。

| # | RED 测试 | 根因 | 修复 |
|---|---|---|---|
| 1 | `test_get_order_summary_empty_orders` | `OrderCRUD` 缺 `get_order_summary` 方法（docstring 已列入导出清单但无实现） | 新增方法：`self.find` 聚合 → 按 status 计数 + 累计 volume/fee + 成交加权均价；无订单返回全零 dict |
| 2 | `test_invalid_data_feeder_state` | `cal()` 无可用执行价时 `return order`（fail-open，未风控订单漏网） | 改为 `return None`（fail-closed，评不了风险就拒绝） |

**Fix 2 设计要点**：未加"feeder is None 即 return None"的兜底——那会让所有无 feeder 的回测（靠 positions 自定价）风控全部失效。真正的失效条件是"无法定价"（feeder 无价 **且** limit_price=0），由既有 `execution_price <= 0` 分支捕获，仅修正其返回姿态。

## Test plan

- [x] `test_get_order_summary_empty_orders` RED → GREEN
- [x] `test_invalid_data_feeder_state` RED → GREEN
- [x] 6 文件测试集 **110 passed / 0 failed**（2 转绿，108 零回归）
- [x] 变更覆盖率：`order_crud.py` ↔ `test_order_crud_mock.py`；`position_ratio_risk.py` ↔ `test_position_ratio_risk.py`，均有直接覆盖

```
tests/api/test_node_graph_file_type.py
tests/unit/data/crud/test_order_crud_mock.py
tests/unit/data/crud/test_order_record_crud_mock.py
tests/unit/data/models/test_order_model_frozen_split.py
tests/unit/trading/gateway/test_trade_gateway.py
tests/unit/trading/strategy/risk_managements/test_position_ratio_risk.py
→ 110 passed, 4 warnings in 9.29s
```

Refs #6080（已合并，本 PR 为其遗留 RED 测试的补全）

🤖 Generated with [Claude Code](https://claude.com/claude-code)