### PR TITLE
fix: MaxDrawdownRisk 防御性加固+减仓副本隔离 (#5486 #5495)

### DIFF
--- a/src/ginkgo/trading/risk_management/max_drawdown_risk.py
+++ b/src/ginkgo/trading/risk_management/max_drawdown_risk.py
@@ -20,6 +20,7 @@
 - 自动减仓机制
 """
 
+import copy
 from typing import List, Dict
 from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
@@ -54,8 +55,22 @@ class MaxDrawdownRisk(BaseRiskManagement):
             max_drawdown(float): 最大允许回撤，百分比（例如：15.0表示15%）
             warning_drawdown(float): 预警回撤阈值，百分比
             critical_drawdown(float): 严重回撤阈值，百分比
+
+        Constraint:
+            critical_drawdown 必须 > max_drawdown。减仓分支仅在
+            max_drawdown < drawdown <= critical_drawdown 区间生效，
+            若 critical <= max 则该区间为空，参数无意义。
         """
         super().__init__(name, *args, **kwargs)
+
+        # 参数语义校验：critical 必须严格大于 max，否则减仓区间为空、减仓分支不可达
+        if critical_drawdown <= max_drawdown:
+            raise ValueError(
+                f"critical_drawdown({critical_drawdown}) must be strictly greater than "
+                f"max_drawdown({max_drawdown}); otherwise the reduction band "
+                f"(max_drawdown, critical_drawdown] is empty and reduction never triggers."
+            )
+
         self._max_drawdown = float(max_drawdown)
         self._warning_drawdown = float(warning_drawdown)
         self._critical_drawdown = float(critical_drawdown)
@@ -101,9 +116,14 @@ class MaxDrawdownRisk(BaseRiskManagement):
                 return None
             elif current_drawdown > self._max_drawdown:
                 # 超过最大回撤，减少开仓规模
-                reduction_factor = (self._critical_drawdown - current_drawdown) / (self._critical_drawdown - self._max_drawdown)
-                order.volume = int(order.volume * max(reduction_factor, 0.1))
+                # 分母 floor 防御 (#5486)：构造器已保证 critical>max 使分母恒正，此处为纵深保护
+                denominator = max(self._critical_drawdown - self._max_drawdown, 0.001)
+                reduction_factor = (self._critical_drawdown - current_drawdown) / denominator
+                # 返回副本而非原地修改 (#5495)：避免多风险链共享同一 order 引用导致过度缩减与状态污染
+                reduced_order = copy.deepcopy(order)
+                reduced_order.volume = int(reduced_order.volume * max(reduction_factor, 0.1))
                 GLOG.WARN(f"MaxDrawdownRisk: Reducing position size due to drawdown {current_drawdown:.1f}%")
+                return reduced_order
 
         # 卖出订单允许通过（减仓）
         return order

--- a/tests/unit/trading/strategy/risk_managements/test_max_drawdown_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_max_drawdown_risk.py
@@ -81,6 +81,13 @@ class TestMaxDrawdownRiskConstruction:
         assert r.warning_drawdown == 10.0
         assert r.critical_drawdown == 20.0
 
+    def test_constructor_rejects_critical_le_max(self):
+        """critical_drawdown 必须严格大于 max_drawdown，否则减仓区间(max<dd<=critical)无意义"""
+        with pytest.raises(ValueError):
+            MaxDrawdownRisk(max_drawdown=15, critical_drawdown=15)
+        with pytest.raises(ValueError):
+            MaxDrawdownRisk(max_drawdown=20, critical_drawdown=15)
+
 
 @pytest.mark.tdd
 @pytest.mark.risk
@@ -158,6 +165,35 @@ class TestMaxDrawdownRiskOrderProcessing:
         result = r.cal(info, order)
         if result is not None:
             assert isinstance(result.volume, int)
+
+    def test_reduction_returns_copy_original_order_unchanged(self):
+        """减仓时返回新 Order 副本，原 order 对象的 volume 保持不变（#5495）"""
+        r = MaxDrawdownRisk(max_drawdown=10, critical_drawdown=20)
+        r._portfolio_peak = Decimal("100000")
+        order = _make_order(volume=1000)
+        original_volume = order.volume
+        info = _make_portfolio_info(worth=85000)  # dd=15%, 落在(10,20]减仓区间
+        result = r.cal(info, order)
+        assert result is not None
+        assert result is not order  # 返回副本，非原对象
+        assert result.volume < original_volume  # 副本被缩减
+        assert order.volume == original_volume  # 原对象保持不变
+
+    def test_multi_risk_chain_does_not_mutate_original(self):
+        """多风险链串联：原 order 经历整条链后仍不变，后续 manager 拒绝时可回退（#5495）"""
+        r1 = MaxDrawdownRisk(max_drawdown=10, critical_drawdown=20)
+        r2 = MaxDrawdownRisk(max_drawdown=10, critical_drawdown=20)
+        r1._portfolio_peak = Decimal("100000")
+        r2._portfolio_peak = Decimal("100000")
+        order = _make_order(volume=1000)
+        original_volume = order.volume
+        info = _make_portfolio_info(worth=85000)  # dd=15%, 触发减仓
+        after_r1 = r1.cal(info, order)
+        after_r2 = r2.cal(info, after_r1)
+        # 原 order 在整条链后保持不变（后续若 reject 可安全回退）
+        assert order.volume == original_volume
+        assert after_r1 is not order
+        assert after_r1.volume < original_volume
 
 
 @pytest.mark.tdd


### PR DESCRIPTION
## Summary

批量修复 `MaxDrawdownRisk` 的两个关联问题（同根因簇，改同一文件同一方法）。

### #5486 — ZeroDivisionError 防御（降级为防御性加固）
- **根因**：`cal()` 减仓分支分母 `(critical - max)` 在 `critical == max` 时为 0。经追踪调用链确认，line 113 的 `critical` 守卫 (`return None`) 先于减仓分支执行，故**实际崩溃路径不可达**——P0 前提不成立。
- **修复**：构造器强制校验 `critical > max`（抛 ValueError），消除参数配置陷阱；`cal()` 分母 `max(..., 0.001)` 作为纵深保护。这是把「靠守卫顺序侥幸不崩」变成「参数层就不可能崩」。

### #5495 — 多风险链过度缩减
- **根因**：`cal()` 减仓分支 `order.volume = int(...)` 原地修改传入的 order 对象。多 risk manager 串联时，r1 把 1000→500，r2 在 500 上再缩减→250；若后续 manager reject，volume 已被永久污染无法回退。
- **修复**：`copy.deepcopy(order)` 返回副本，原 order 在整条风险链中保持不变。

## 调用链分析

```
Strategy.on_signal → 多个 Risk.cal(order) 串联 → 💥 #5495: 后者在前者原地修改结果上再算
                                      ↓
                          #5486: 分母=(critical-max)，配置错误时为0（被守卫顺序掩盖）
```

两 issue 物理交织在 `cal()` 同一 elif 分支，单独提交任一会产生不可运行中间态，故合并为一个 commit。

## Test plan

- [x] `test_constructor_rejects_critical_le_max`：critical<=max 抛 ValueError（#5486）
- [x] `test_reduction_returns_copy_original_order_unchanged`：返回副本，原 order volume 不变（#5495）
- [x] `test_multi_risk_chain_does_not_mutate_original`：双 risk 串联，原 order 整链不变（#5495）
- [x] `test_max_drawdown_risk.py` 全套 29 passed

**冒烟隔离证明**：`risk_managements/` 目录有 7 个预存失败（capital_risk/concentration_risk/position_ratio_risk），经 `git stash` 隔离确认在 origin/master 裸状态同样失败，与本 PR 无关。

## 审计发现（#5495 验收#4，待后续处理）

审计确认其他 risk manager 存在**相同的原地修改模式**：`margin_risk` / `volatility_risk` / `position_ratio_risk` / `profit_target_risk` / `liquidity_risk` / `concentration_risk`。建议后续统一修复（可另开 issue），本 PR 不扩大范围以保持 TDD 聚焦。

Closes #5486
Closes #5495

🤖 Generated with [Claude Code](https://claude.com/claude-code)