### PR TITLE
fix: adjustfactor 同步链 5 层全断修复 (#5868 #5909)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -621,14 +621,16 @@ async def sync_data(request: DataUpdateRequest):
                 message=f"Ticks update completed for {len(codes)} codes"
             )
 
-        elif request.type == "adjustfactor":
+        elif request.type in ("adjustfactor", "adjustfactors"):
+            # #5868: GET 端点用复数 /adjustfactors，sync type 接受单复数双别名，归一化为单数
+            sync_type = "adjustfactor"
             codes = request.codes or []
             if not codes:
                 raise HTTPException(status_code=400, detail="Codes are required for adjust factors update")
 
             adjustfactor_service = get_adjustfactor_service()
             # 批量同步复权因子，整体记录
-            rec = sync_svc.record_start(sync_type="adjustfactor", code=",".join(codes))
+            rec = sync_svc.record_start(sync_type=sync_type, code=",".join(codes))
             started_at = _time.time()
             try:
                 result = adjustfactor_service.sync_batch(codes)

--- a/src/ginkgo/data/services/adjustfactor_service.py
+++ b/src/ginkgo/data/services/adjustfactor_service.py
@@ -125,11 +125,11 @@ class AdjustfactorService(BaseService):
 
             for i, model in enumerate(adjustfactor_models):
                 try:
-                    # Check if record exists
+                    # Check if record exists. 真实模型唯一键为 (code, timestamp)，
+                    # 不存在 adjust_type 维度（前/后复权是同一行的不同列）。
                     existing_filters = {
                         'code': model.code,
                         'timestamp': model.timestamp,
-                        'adjust_type': model.adjust_type
                     }
 
                     if self._crud_repo and self._crud_repo.exists(filters=existing_filters):
@@ -228,12 +228,15 @@ class AdjustfactorService(BaseService):
         Returns:
             pd.DataFrame: 包含复权因子数据
         """
-        # This would integrate with actual data source (e.g., Tushare, etc.)
-        # For now, return empty DataFrame to be implemented
-        if hasattr(self._data_source, 'get_adjustfactor_data'):
-            return self._data_source.get_adjustfactor_data(code, start_date, end_date)
-        else:
-            raise NotImplementedError("Adjustfactor data source not implemented")
+        # 数据源方法名不统一：Tushare 暴露 fetch_cn_stock_adjustfactor，tdx 暴露 fetch_adjustfactor。
+        # 按优先级探测首个可用方法。#5909 根因A：旧代码探测不存在的 get_adjustfactor_data，
+        # 而真实源只有 fetch_cn_stock_adjustfactor → 永远 NotImplementedError → 永远落不了库。
+        for method_name in ("fetch_cn_stock_adjustfactor", "fetch_adjustfactor", "get_adjustfactor_data"):
+            method = getattr(self._data_source, method_name, None)
+            if method is None:
+                continue
+            return method(code, start_date, end_date)
+        raise NotImplementedError("Adjustfactor data source not implemented")
 
     def _convert_to_adjustfactor_models(self, raw_data: pd.DataFrame, code: str) -> List[Any]:
         """
@@ -246,20 +249,64 @@ class AdjustfactorService(BaseService):
         Returns:
             List[Any]: Adjustment factor model objects list
         """
-        from ginkgo.data.models.madjustfactor import MAdjustFactor
+        # #5909 根因A2：旧 import 的模块 madjustfactor(类 MAdjustFactor) 根本不存在 → ImportError。
+        # 真实模型在 model_adjustfactor.MAdjustfactor，字段为 code/foreadjustfactor/backadjustfactor/adjustfactor。
+        from ginkgo.data.models.model_adjustfactor import MAdjustfactor
 
+        df = raw_data.copy()
+
+        # 日期列：Tushare 给 trade_date(YYYYMMDD)，Baostock/本库给 timestamp
+        if "trade_date" in df.columns:
+            df["timestamp"] = pd.to_datetime(df["trade_date"], format="%Y%m%d", errors="coerce")
+        elif "timestamp" in df.columns:
+            df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
+
+        # 原始复权因子列：Tushare adj_factor / 本库 adjustfactor
+        if "adj_factor" in df.columns:
+            raw_col = "adj_factor"
+        elif "adjustfactor" in df.columns:
+            raw_col = "adjustfactor"
+        else:
+            raw_col = None
+
+        # 按日期升序，供 fore/back 推导（与 calculate() 同约定）
+        df = df.sort_values("timestamp").reset_index(drop=True)
+
+        # 仅当源只给原始因子时，按 calculate() 约定推导前/后复权：
+        #   fore = latest / raw ；back = raw / earliest
+        # 源若直接给 fore/back 列（如 Baostock），下方用源值覆盖，避免被推导值盖掉。
+        if raw_col is not None and len(df) > 0:
+            raws = df[raw_col].astype(float)
+            latest = float(raws.iloc[-1])
+            earliest = float(raws.iloc[0])
+            df["_fore"] = latest / raws
+            df["_back"] = raws / earliest
+
+        if "foreadjustfactor" not in df.columns:
+            df["foreadjustfactor"] = df.get("_fore")
+        if "backadjustfactor" not in df.columns:
+            df["backadjustfactor"] = df.get("_back")
+
+        # #5909 根因A3：旧代码读 timestamp/adjust_type/adjust_factor/before_price 等列，
+        # 全部错位 → 每行 KeyError 被 except 吞掉 → 返回空 models → 落库 0 条。
         models = []
-        for _, row in raw_data.iterrows():
+        for _, row in df.iterrows():
             try:
-                model = MAdjustFactor()
+                model = MAdjustfactor()
                 model.code = code
-                model.timestamp = datetime_normalize(row['timestamp'])
-                model.adjust_type = row.get('adjust_type', 'fore')  # Default to fore adjustment
-                model.adjust_factor = to_decimal(row.get('adjust_factor', 1.0))
-                model.before_price = to_decimal(row.get('before_price', 0))
-                model.after_price = to_decimal(row.get('after_price', 0))
-                model.dividend = to_decimal(row.get('dividend', 0))
-                model.split_ratio = to_decimal(row.get('split_ratio', 1.0))
+                ts = row.get("timestamp")
+                model.timestamp = datetime_normalize(ts) if (ts is not None and pd.notna(ts)) else None
+
+                raw_val = row.get(raw_col) if raw_col else row.get("adjustfactor")
+                if raw_val is None:
+                    raw_val = 1.0
+
+                fore = row.get("foreadjustfactor")
+                back = row.get("backadjustfactor")
+                # 三列均 nullable=False，缺失则回退原始因子，保证落库不违约
+                model.adjustfactor = to_decimal(raw_val)
+                model.foreadjustfactor = to_decimal(fore if (fore is not None and pd.notna(fore)) else raw_val)
+                model.backadjustfactor = to_decimal(back if (back is not None and pd.notna(back)) else raw_val)
                 models.append(model)
             except Exception as e:
                 self._logger.WARN(f"Failed to convert adjustfactor row to model: {e}")
@@ -521,7 +568,9 @@ class AdjustfactorService(BaseService):
         for i, code in enumerate(codes):
             try:
                 result = self.sync(code=code, start_date=start_date, end_date=end_date, fast_mode=fast_mode)
-                sync_results.append(result.data if result.success else result)
+                # 始终收集 DataSyncResult（result.data 即是），让失败 code 的 records_failed
+                # 也进入统计；旧代码失败时收集的是 ServiceResult 本身，无 records_* 属性 → 被求和忽略。
+                sync_results.append(result.data if result.data is not None else result)
             except Exception as e:
                 error_result = DataSyncResult.create_for_entity(
                     entity_type="adjustfactors",
@@ -539,13 +588,25 @@ class AdjustfactorService(BaseService):
         total_records_updated = sum(r.records_updated for r in sync_results if hasattr(r, 'records_updated'))
         total_records_failed = sum(r.records_failed for r in sync_results if hasattr(r, 'records_failed'))
 
+        # #5909 根因B：旧代码无条件 success=True，吞掉全部逐 code 失败 → handler 误报 200。
+        # 诚实规则：请求了 code 却一条都没落库（added+updated==0）即视为失败，
+        # 让 handler/history 诚实报错；空 code 列表不算错误。
+        any_persisted = (total_records_added + total_records_updated) > 0
+        batch_success = (total_codes == 0) or any_persisted
+        if batch_success:
+            message = f"Batch adjustfactor sync completed: {total_records_added} added, {total_records_updated} updated, {total_records_failed} failed"
+        else:
+            message = f"Batch adjustfactor sync failed: 0 records persisted across {total_codes} codes ({total_records_failed} failed)"
+
         batch_result = ServiceResult(
-            success=True,
-            message=f"Batch adjustfactor sync completed: {total_records_added} added, {total_records_updated} updated, {total_records_failed} failed",
+            success=batch_success,
+            message=message,
             data=sync_results
         )
         batch_result.set_metadata("total_codes", total_codes)
         batch_result.set_metadata("total_records_processed", total_records_processed)
+        batch_result.set_metadata("total_records_added", total_records_added)
+        batch_result.set_metadata("total_records_failed", total_records_failed)
         batch_result.set_metadata("batch_duration", time.time() - start_time)
 
         return batch_result

--- a/tests/api/test_data_sync_adjustfactor.py
+++ b/tests/api/test_data_sync_adjustfactor.py
@@ -1,0 +1,86 @@
+# Upstream: api.api.data.sync_data (POST /api/v1/data/sync)
+# Downstream: AdjustfactorService.sync_batch, DataSyncRecordService
+# Role: 验证 sync_data 的 type 分发接受 adjustfactor/adjustfactors 双别名 (#5868)
+"""
+sync_data type 别名测试
+
+#5868: GET /api/v1/data/adjustfactors 用复数，但 POST /sync 的 type 分发只认
+单数 adjustfactor → 客户端传 adjustfactors 报 "Unsupported data type"。
+本测试锁定 type 别名路由：单数/复数都应进入 adjustfactor 分支并调用 sync_batch。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi import HTTPException
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_ok_result():
+    """构造一个 is_success 的 ServiceResult 替身"""
+    r = MagicMock()
+    r.is_success.return_value = True
+    r.success = True
+    r.message = "ok"
+    r.data = None
+    r.metadata = {}
+    return r
+
+
+def make_sync_record_mock():
+    """构造 DataSyncRecordService + record_start 返回值的替身"""
+    svc = MagicMock()
+    rec = MagicMock()
+    rec.is_success.return_value = True
+    rec.data = {"uuid": "rec-uuid-1"}
+    svc.record_start.return_value = rec
+    return svc
+
+
+class TestSyncDataAdjustfactorAlias:
+    """#5868: type 单复数别名路由"""
+
+    @pytest.mark.unit
+    def test_plural_type_routes_to_adjustfactor_branch(self):
+        """type='adjustfactors' (复数) 应路由到 adjustfactor 分支并调 sync_batch
+
+        RED 状态：旧代码只匹配单数 'adjustfactor'，复数落到 else →
+        HTTPException(400, 'Unsupported data type: adjustfactors')。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_batch.return_value = make_ok_result()
+
+        request = DataUpdateRequest(type="adjustfactors", codes=["000001.SZ"])
+
+        with patch("api.data.get_adjustfactor_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            try:
+                run_async(sync_data(request))
+            except HTTPException as e:
+                pytest.fail(
+                    f"type='adjustfactors' 应回 adjustfactor 分支，却抛 HTTPException: {e.detail}"
+                )
+
+        mock_svc.sync_batch.assert_called_once_with(["000001.SZ"])
+
+    @pytest.mark.unit
+    def test_singular_type_still_routes(self):
+        """type='adjustfactor' (单数) 回归保护：仍应调 sync_batch"""
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_batch.return_value = make_ok_result()
+
+        request = DataUpdateRequest(type="adjustfactor", codes=["000001.SZ"])
+
+        with patch("api.data.get_adjustfactor_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            run_async(sync_data(request))
+
+        mock_svc.sync_batch.assert_called_once_with(["000001.SZ"])

--- a/tests/unit/data/services/test_adjustfactor_service_mock.py
+++ b/tests/unit/data/services/test_adjustfactor_service_mock.py
@@ -88,7 +88,7 @@ class TestAdjustfactorServiceSync:
         """数据源返回空数据时返回成功，提示无新数据"""
         mock_deps["stockinfo_service"].exists.return_value = True
         mock_deps["crud_repo"].find.return_value = []
-        mock_deps["data_source"].get_adjustfactor_data.return_value = pd.DataFrame()
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.return_value = pd.DataFrame()
 
         result = service.sync(code="000001.SZ")
 
@@ -100,12 +100,33 @@ class TestAdjustfactorServiceSync:
         """数据源抛出异常时返回失败"""
         mock_deps["stockinfo_service"].exists.return_value = True
         mock_deps["crud_repo"].find.return_value = []
-        mock_deps["data_source"].get_adjustfactor_data.side_effect = Exception("网络超时")
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.side_effect = Exception("网络超时")
 
         result = service.sync(code="000001.SZ")
 
         assert result.success is False
         assert "Failed to fetch data from source" in result.message
+
+    @pytest.mark.unit
+    def test_sync_fetches_and_persists_via_real_source_method(self, service, mock_deps):
+        """sync 应通过真实方法 fetch_cn_stock_adjustfactor 拉数据并落库 (#5909 根因A/A2/A3)
+
+        真实数据源（Tushare/Baostock）只提供 fetch_cn_stock_adjustfactor，旧代码调
+        不存在的 get_adjustfactor_data → 永远 NotImplementedError → 永远落不了库。
+        """
+        mock_deps["stockinfo_service"].exists.return_value = True
+        mock_deps["crud_repo"].find.return_value = []          # _get_fetch_start_date 走默认窗口
+        mock_deps["crud_repo"].exists.return_value = False     # 记录不存在 → 走 add 分支
+        df = pd.DataFrame({"trade_date": ["20240101"], "adj_factor": [1.5]})
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.return_value = df
+
+        result = service.sync(code="000001.SZ")
+
+        # 必须调真实方法（而非 get_adjustfactor_data）
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.assert_called_once()
+        # 数据成功落库：success + added=1
+        assert result.success is True
+        assert result.data.records_added == 1
 
 
 # ============================================================
@@ -285,3 +306,51 @@ class TestAdjustfactorServiceCalculate:
 
         assert result.success is False
         assert "复权因子计算失败" in result.message
+
+
+# ============================================================
+# sync_batch 方法测试
+# ============================================================
+
+
+class TestAdjustfactorServiceSyncBatch:
+    """sync_batch 批量同步方法测试（#5909 根因B：诚实传播失败）"""
+
+    @pytest.mark.unit
+    def test_sync_batch_propagates_failure_when_all_codes_fail(self, service, mock_deps):
+        """所有 code 拉取都失败时，sync_batch 必须 success=False
+
+        旧代码 L589 无条件 success=True，吞掉逐 code 失败 → handler 误报 200，
+        history 写 0，无数据落库。这正是 #5909 "返回成功但无效果" 的根因。
+        """
+        mock_deps["stockinfo_service"].exists.return_value = True
+        mock_deps["crud_repo"].find.return_value = []
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.side_effect = Exception("source down")
+
+        result = service.sync_batch(codes=["000001.SZ", "000002.SZ"])
+
+        assert result.success is False
+        assert result.metadata["total_codes"] == 2
+
+    @pytest.mark.unit
+    def test_sync_batch_success_when_at_least_one_code_persists(self, service, mock_deps):
+        """至少一个 code 成功落库时，sync_batch success=True（允许部分失败）"""
+        mock_deps["stockinfo_service"].exists.return_value = True
+        mock_deps["crud_repo"].find.return_value = []
+        mock_deps["crud_repo"].exists.return_value = False
+        df = pd.DataFrame({"trade_date": ["20240101"], "adj_factor": [1.5]})
+
+        # 逐 code 返回不同结果：第一个正常，第二个抛错
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.side_effect = [df, Exception("boom")]
+
+        result = service.sync_batch(codes=["000001.SZ", "000002.SZ"])
+
+        assert result.success is True
+
+    @pytest.mark.unit
+    def test_sync_batch_empty_codes_returns_success(self, service, mock_deps):
+        """空 code 列表不算错误，返回 success=True"""
+        result = service.sync_batch(codes=[])
+
+        assert result.success is True
+        assert result.metadata["total_codes"] == 0


### PR DESCRIPTION
## Summary

修复 adjustfactor 数据同步整条链的 5 层缺陷。修复前 `POST /api/v1/data/sync {"type":"adjustfactors"}` 报 "Unsupported data type"，且即便用单数 `adjustfactor` 也永远落不了库却返回成功——是一条从未真正工作过的脚手架。

调用链：`sync_data(adjustfactor)` → `sync_batch` → 逐 code `sync` → `_fetch_adjustfactor_data` → `_convert_to_adjustfactor_models` → CRUD 落库。5 层缺陷叠加导致全程零数据落库、handler 误报 200。

| 层 | 位置 | 缺陷 → 修复 |
|---|---|---|
| A | `adjustfactor_service.py` `_fetch_adjustfactor_data` | 调不存在的 `get_adjustfactor_data`（真实为 `fetch_cn_stock_adjustfactor`）→ 按优先级探测真实方法 |
| A2 | `_convert_to_adjustfactor_models` | import 不存在的 `madjustfactor.MAdjustFactor` → 改 `model_adjustfactor.MAdjustfactor` |
| A3 | `_convert_to_adjustfactor_models` | 读 `timestamp/adjust_type/adjust_factor/before_price` 等错位列 → 映射 `trade_date→timestamp`、`adj_factor→adjustfactor`，fore/back 按 `calculate()` 同约定推导（兼容 Baostock 直给 fore/back） |
| A3 涟漪 | `sync` 主循环 `existing_filters` | 引用真实模型不存在的 `adjust_type` → 唯一键回归 `(code, timestamp)` |
| B | `sync_batch` | 无条件 `success=True` 吞掉全部逐 code 失败 → 始终收集 `DataSyncResult`，诚实 success（请求了 code 却 0 条落库即 False） |
| C | `data.py` `sync_data` | type 只认单数 `adjustfactor`，GET 端点用复数 → 接受 `adjustfactor`/`adjustfactors` 双别名 |

## Test plan

- [x] `tests/unit/data/services/test_adjustfactor_service_mock.py`：修正 2 个 mock 错方法名的旧用例 + 新增 tracer bullet（真实方法拉取并落库 `records_added==1`）+ 3 个 `sync_batch` 诚实传播用例（全失败→False、部分成功→True、空 code→True）。**20 passed**
- [x] `tests/api/test_data_sync_adjustfactor.py`：锁定 `type=adjustfactors`/`adjustfactor` 都路由到 adjustfactor 分支并调用 `sync_batch`。**2 passed**
- [x] service 层全量冒烟 `tests/unit/data/services/`：**572 passed**；既有失败（`portfolio_service`/`stockinfo_service`）与本变更无关（未触及模块，错误签名 TypeError/KeyError 与复权无关），属 master 既有破损。
- [x] api 层冒烟 `tests/api/`：adjustfactor/sync 相关全绿；既有失败（`test_api_versioning` 的 `ImportError: cannot import 'app'`）与本变更无关。

> 注：`tests/api/` 与 `tests/unit/data/test_init_adjustment_apis.py` 同会话运行时会触发预先存在的 `core` 命名空间污染（`No module named 'core.logging'`），影响所有 api 测试（含既有的 `test_data_pagination.py`），非本 PR 引入。两个 api 测试文件单独/在 api 子树内运行均通过。

Closes #5868
Closes #5909

🤖 Generated with [Claude Code](https://claude.com/claude-code)
