### PR TITLE
fix: Paper Trading 状态读取与前端 API URL 修复 (#5392 #5401 #5605)

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -63,25 +63,39 @@ def _get_portfolio_service():
     return container.portfolio_service()
 
 
-async def _get_pt_status(account_id: str) -> str:
-    """查询模拟盘账户实际运行状态
+def _map_pt_status(portfolio) -> str:
+    """根据 DB portfolio.state 返回前端账户状态字符串。
 
-    优先从 Redis 缓存查询 Worker 上报的状态，
-    如果无法获取则返回 'stopped'。
+    Paper account 即 mode=PAPER 的 Portfolio，运行状态由 Worker 在
+    deploy/unload 时写入 portfolio.state（RUNNING/STOPPED/...）。
 
-    TODO: Paper Trading Worker 需要在启动/停止时写入 Redis key
-          `pt:status:{account_id}`，当前无生产者，始终走 fallback。
+    #5392 #5401: 早期实现 _get_pt_status 读 Redis key pt:status:{id}，但该
+    key 从无生产者写入，导致状态永远 fallback 为 "stopped"。改为直接读已持有的
+    portfolio.state（list/detail 端点均已持有 portfolio 对象，无需额外查询）。
     """
-    try:
-        from core.redis_client import get_redis
-        redis = await get_redis()
-        if redis:
-            status = await redis.get(f"pt:status:{account_id}")
-            if status:
-                return status if isinstance(status, str) else status.decode()
-    except Exception:
-        pass
-    return "stopped"
+    from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+    state = getattr(portfolio, "state", None)
+
+    # 规范化：DB 枚举字段可能以裸 int 返回（参考 _map_order_status）
+    if isinstance(state, int) and not hasattr(state, 'value'):
+        try:
+            state = PORTFOLIO_RUNSTATE_TYPES(state)
+        except ValueError:
+            return "error"
+
+    return {
+        # 运行中（含过渡态：暂停/停止中/重载/迁移，账户仍在 worker 内）
+        PORTFOLIO_RUNSTATE_TYPES.RUNNING: "running",
+        PORTFOLIO_RUNSTATE_TYPES.PAUSED: "running",
+        PORTFOLIO_RUNSTATE_TYPES.STOPPING: "running",
+        PORTFOLIO_RUNSTATE_TYPES.RELOADING: "running",
+        PORTFOLIO_RUNSTATE_TYPES.MIGRATING: "running",
+        # 未运行
+        PORTFOLIO_RUNSTATE_TYPES.VOID: "stopped",
+        PORTFOLIO_RUNSTATE_TYPES.INITIALIZED: "stopped",
+        PORTFOLIO_RUNSTATE_TYPES.STOPPED: "stopped",
+        PORTFOLIO_RUNSTATE_TYPES.OFFLINE: "stopped",
+    }.get(state, "error")
 
 
 def _get_result_service():
@@ -171,7 +185,7 @@ async def list_paper_accounts():
                 "total_asset": cash,   # TODO: 现金 + 持仓市值
                 "today_pnl": 0,
                 "total_pnl": 0,
-                "status": await _get_pt_status(p.uuid),
+                "status": _map_pt_status(p),
                 "created_at": _format_datetime(getattr(p, 'create_at', None)),
             })
 
@@ -261,7 +275,7 @@ async def get_paper_account(account_id: str):
                 "total_asset": cash,
                 "today_pnl": 0,
                 "total_pnl": 0,
-                "status": await _get_pt_status(account_id),
+                "status": _map_pt_status(p),
                 "created_at": _format_datetime(getattr(p, 'create_at', None)),
                 "positions": positions,
                 "active_orders": orders,
@@ -285,7 +299,7 @@ async def start_paper_trading(account_id: str, data: StartPaperTradingRequest = 
         from ginkgo.interfaces.kafka_topics import KafkaTopics
 
         # 验证 portfolio 存在
-        _require_portfolio(account_id)
+        portfolio = _require_portfolio(account_id)
 
         # 发送 Kafka deploy 命令
         producer = _get_kafka_producer()
@@ -297,9 +311,11 @@ async def start_paper_trading(account_id: str, data: StartPaperTradingRequest = 
 
         logger.info(f"Start paper trading command sent for {account_id}")
 
+        # #5401: 即发即忘——Kafka 命令已投递，但 worker 异步处理，状态不会立即变
+        # RUNNING。返回当前真实状态 + 诚实消息，避免前端误以为已启动。
         return ok(
-            data={"success": True},
-            message="Paper trading start command sent"
+            data={"success": True, "current_status": _map_pt_status(portfolio)},
+            message="Deploy command sent. Worker starts asynchronously; status will update shortly."
         )
 
     except NotFoundError:

--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -300,6 +300,10 @@ async def start_paper_trading(account_id: str, data: StartPaperTradingRequest = 
 
         # 验证 portfolio 存在
         portfolio = _require_portfolio(account_id)
+        # #6095 review: _require_portfolio 经 PortfolioService.get → _crud_repo.find 返回 list，
+        # 与 get_paper_account(L258) 一致地解包取首元素，否则 _map_pt_status 收到 list → 恒为 "error"
+        if isinstance(portfolio, list):
+            portfolio = portfolio[0]
 
         # 发送 Kafka deploy 命令
         producer = _get_kafka_producer()

--- a/tests/api/test_backtest_api_fixes.py
+++ b/tests/api/test_backtest_api_fixes.py
@@ -232,9 +232,15 @@ class TestAnalyzerCatalog:
 class TestPaperTradingStatus:
     """Paper Trading status 应从实际状态查询，不应硬编码"""
 
-    def test_account_status_queries_redis(self):
-        """list_paper_accounts 应从 Redis/Worker 查询 status，而非硬编码 stopped"""
+    def test_account_status_reflects_db_state(self):
+        """list_paper_accounts 的 status 应反映 DB portfolio.state，而非硬编码 stopped
+
+        #5392 #5401: 早期 _get_pt_status 读死 Redis 导致永远 stopped；现由
+        _map_pt_status 读 portfolio.state 映射。此处通过给 mock portfolio 设
+        RUNNING 状态，验证端点正确产出 'running'。
+        """
         from api.trading import list_paper_accounts
+        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
 
         mock_portfolio = MagicMock()
         mock_portfolio.uuid = "pt-1"
@@ -242,6 +248,8 @@ class TestPaperTradingStatus:
         mock_portfolio.initial_capital = 100000
         mock_portfolio.cash = 95000
         mock_portfolio.create_at = None
+        # worker deploy 时写入的运行状态；_map_pt_status 据此映射
+        mock_portfolio.state = PORTFOLIO_RUNSTATE_TYPES.RUNNING
 
         mock_svc = MagicMock()
         result_mock = MagicMock()
@@ -249,14 +257,12 @@ class TestPaperTradingStatus:
         result_mock.data = [mock_portfolio]
         mock_svc.get.return_value = result_mock
 
-        with patch("api.trading._get_portfolio_service", return_value=mock_svc), \
-             patch("api.trading._get_pt_status") as mock_status:
-            mock_status.return_value = "running"
+        with patch("api.trading._get_portfolio_service", return_value=mock_svc):
             result = run_async(list_paper_accounts())
 
         accounts = result["data"]
         assert len(accounts) == 1
-        # status 不应是硬编码的 "stopped"
+        # status 不应是硬编码的 "stopped"，应反映 RUNNING
         assert accounts[0]["status"] == "running"
 
 

--- a/tests/api/test_paper_trading_status.py
+++ b/tests/api/test_paper_trading_status.py
@@ -1,0 +1,99 @@
+# Issue: #5392 #5401 #5605
+# Upstream: api.api.trading, ginkgo.enums
+# Downstream: pytest
+# Role: Paper Trading 账户状态读取修复 — 状态必须反映 DB portfolio.state，而非永远 "stopped"
+
+"""
+Paper Trading 状态读取测试
+
+根因：_get_pt_status 读从不写入的 Redis key pt:status:{id}，永远 fallback "stopped"，
+与 DB portfolio.state（worker deploy/unload 时更新）完全脱节。
+
+修复：list/detail 端点改为读已持有的 portfolio.state，映射 RUNSTATE→前端字符串。
+"""
+
+import pytest
+from types import SimpleNamespace
+
+
+class TestMapPtStatus:
+    """验证 portfolio.state → 前端 status 字符串的映射"""
+
+    def test_running_state_returns_running(self):
+        """#5392 #5401: portfolio 处于 RUNNING 时，status 必须是 'running'（不再永远 stopped）"""
+        from api.trading import _map_pt_status
+        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+
+        portfolio = SimpleNamespace(state=PORTFOLIO_RUNSTATE_TYPES.RUNNING)
+        assert _map_pt_status(portfolio) == "running"
+
+    def test_stopped_state_returns_stopped(self):
+        """#5392 #5401: STOPPED/INITIALIZED/OFFLINE 等终态必须映射为 'stopped'"""
+        from api.trading import _map_pt_status
+        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+
+        for terminal in (PORTFOLIO_RUNSTATE_TYPES.STOPPED,
+                         PORTFOLIO_RUNSTATE_TYPES.INITIALIZED,
+                         PORTFOLIO_RUNSTATE_TYPES.OFFLINE):
+            assert _map_pt_status(SimpleNamespace(state=terminal)) == "stopped"
+
+    def test_transition_states_still_running(self):
+        """PAUSED/STOPPING/RELOADING 等过渡态：账户仍在 worker 内，对前端是 'running'"""
+        from api.trading import _map_pt_status
+        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+
+        for trans in (PORTFOLIO_RUNSTATE_TYPES.PAUSED,
+                      PORTFOLIO_RUNSTATE_TYPES.STOPPING,
+                      PORTFOLIO_RUNSTATE_TYPES.MIGRATING):
+            assert _map_pt_status(SimpleNamespace(state=trans)) == "running"
+
+    def test_unknown_state_returns_error(self):
+        """None 或未识别状态必须 fail-fast 返回 'error'，而非静默 'stopped'（掩盖 bug）"""
+        from api.trading import _map_pt_status
+
+        assert _map_pt_status(SimpleNamespace(state=None)) == "error"
+        assert _map_pt_status(SimpleNamespace()) == "error"
+
+    def test_int_state_value_normalized(self):
+        """DB 枚举字段常以裸 int 返回（如 1=RUNNING），必须规范化后映射，否则端点层永远 error"""
+        from api.trading import _map_pt_status
+        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+
+        running_int = PORTFOLIO_RUNSTATE_TYPES.RUNNING.value
+        assert isinstance(running_int, int)
+        assert _map_pt_status(SimpleNamespace(state=running_int)) == "running"
+
+
+class TestStartReturnsCurrentStatus:
+    """#5401: start 即发即忘，返回必须含当前真实状态，避免前端误判已启动"""
+
+    def test_start_returns_current_status_not_running(self, monkeypatch):
+        """worker 尚未处理 deploy，state 仍 INITIALIZED；返回应诚实反映 stopped，而非假装 running"""
+        import asyncio
+        from api import trading
+        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
+
+        portfolio = SimpleNamespace(uuid="acc-1",
+                                    state=PORTFOLIO_RUNSTATE_TYPES.INITIALIZED)
+
+        class FakeResult:
+            data = portfolio
+            def is_success(self): return True
+
+        class FakeSvc:
+            def get(self, portfolio_id): return FakeResult()
+
+        class FakeProducer:
+            def send(self, *a, **k): return True
+
+        monkeypatch.setattr(trading, "_get_portfolio_service", lambda: FakeSvc())
+        monkeypatch.setattr(trading, "_get_kafka_producer", lambda: FakeProducer())
+
+        resp = asyncio.run(trading.start_paper_trading("acc-1", None))
+
+        assert resp["code"] == 0
+        assert resp["data"]["success"] is True
+        # 关键：current_status 反映 DB 真实状态（INITIALIZED→stopped），非误导性 "running"
+        assert resp["data"]["current_status"] == "stopped"
+        # 消息必须诚实说明异步性，不再宣称"已启动"
+        assert "asynchronously" in resp["message"].lower()

--- a/tests/api/test_paper_trading_status.py
+++ b/tests/api/test_paper_trading_status.py
@@ -76,8 +76,11 @@ class TestStartReturnsCurrentStatus:
         portfolio = SimpleNamespace(uuid="acc-1",
                                     state=PORTFOLIO_RUNSTATE_TYPES.INITIALIZED)
 
+        # #6095 review: 真实 PortfolioService.get 经 _crud_repo.find 返回的是 list，
+        # FakeResult.data 必须是 list 形状，否则测试退化成"测 mock"而非"测生产契约"。
+        # 旧实现 FakeResult.data = portfolio（单对象）掩盖了 start 端点未解包 list 的 bug。
         class FakeResult:
-            data = portfolio
+            data = [portfolio]
             def is_success(self): return True
 
         class FakeSvc:

--- a/web-ui/src/api/modules/trading.ts
+++ b/web-ui/src/api/modules/trading.ts
@@ -124,7 +124,7 @@ export function getPaperAccount(accountId: string) {
     active_orders: Order[]
     today_trades: Order[]
   }>>({
-    url: `/v1/paper-trading/accounts/${accountId}`,
+    url: `/api/v1/paper-trading/accounts/${accountId}`,
     method: 'GET'
   })
 }
@@ -134,7 +134,7 @@ export function getPaperAccount(accountId: string) {
  */
 export function startPaperTrading(accountId: string, strategyIds: string[]) {
   return request<APIResponse<void>>({
-    url: `/v1/paper-trading/${accountId}/start`,
+    url: `/api/v1/paper-trading/${accountId}/start`,
     method: 'POST',
     data: { strategy_ids: strategyIds }
   })
@@ -145,7 +145,7 @@ export function startPaperTrading(accountId: string, strategyIds: string[]) {
  */
 export function stopPaperTrading(accountId: string) {
   return request<APIResponse<void>>({
-    url: `/v1/paper-trading/${accountId}/stop`,
+    url: `/api/v1/paper-trading/${accountId}/stop`,
     method: 'POST'
   })
 }
@@ -155,7 +155,7 @@ export function stopPaperTrading(accountId: string) {
  */
 export function getPaperPositions(accountId: string) {
   return request<APIResponse<Position[]>>({
-    url: `/v1/paper-trading/${accountId}/positions`,
+    url: `/api/v1/paper-trading/${accountId}/positions`,
     method: 'GET'
   })
 }
@@ -165,7 +165,7 @@ export function getPaperPositions(accountId: string) {
  */
 export function getPaperOrders(accountId: string, status?: OrderStatus[]) {
   return request<APIResponse<Order[]>>({
-    url: `/v1/paper-trading/${accountId}/orders`,
+    url: `/api/v1/paper-trading/${accountId}/orders`,
     method: 'GET',
     params: { status }
   })
@@ -176,7 +176,7 @@ export function getPaperOrders(accountId: string, status?: OrderStatus[]) {
  */
 export function cancelPaperOrder(accountId: string, orderId: string) {
   return request<APIResponse<void>>({
-    url: `/v1/paper-trading/${accountId}/orders/${orderId}`,
+    url: `/api/v1/paper-trading/${accountId}/orders/${orderId}`,
     method: 'DELETE'
   })
 }
@@ -192,7 +192,7 @@ export function getPaperReport(accountId: string, date: string) {
     trades_count: number
     positions_count: number
   }>>({
-    url: `/v1/paper-trading/${accountId}/report/daily`,
+    url: `/api/v1/paper-trading/${accountId}/report/daily`,
     method: 'GET',
     params: { date }
   })
@@ -215,7 +215,7 @@ export function getLiveAccounts() {
  */
 export function connectBroker(accountId: string) {
   return request<APIResponse<void>>({
-    url: `/v1/live-trading/accounts/${accountId}/connect`,
+    url: `/api/v1/live-trading/accounts/${accountId}/connect`,
     method: 'POST'
   })
 }
@@ -225,7 +225,7 @@ export function connectBroker(accountId: string) {
  */
 export function disconnectBroker(accountId: string) {
   return request<APIResponse<void>>({
-    url: `/v1/live-trading/accounts/${accountId}/disconnect`,
+    url: `/api/v1/live-trading/accounts/${accountId}/disconnect`,
     method: 'POST'
   })
 }
@@ -235,7 +235,7 @@ export function disconnectBroker(accountId: string) {
  */
 export function getLivePositions(accountId: string) {
   return request<APIResponse<Position[]>>({
-    url: `/v1/live-trading/${accountId}/positions`,
+    url: `/api/v1/live-trading/${accountId}/positions`,
     method: 'GET'
   })
 }
@@ -245,7 +245,7 @@ export function getLivePositions(accountId: string) {
  */
 export function getLiveActiveOrders(accountId: string) {
   return request<APIResponse<Order[]>>({
-    url: `/v1/live-trading/${accountId}/active-orders`,
+    url: `/api/v1/live-trading/${accountId}/active-orders`,
     method: 'GET'
   })
 }
@@ -255,7 +255,7 @@ export function getLiveActiveOrders(accountId: string) {
  */
 export function cancelLiveOrder(accountId: string, orderId: string) {
   return request<APIResponse<void>>({
-    url: `/v1/live-trading/${accountId}/orders/${orderId}`,
+    url: `/api/v1/live-trading/${accountId}/orders/${orderId}`,
     method: 'DELETE'
   })
 }
@@ -271,7 +271,7 @@ export function getLiveCapital(accountId: string) {
     frozen_cash: number
     today_pnl: number
   }>>({
-    url: `/v1/live-trading/${accountId}/capital`,
+    url: `/api/v1/live-trading/${accountId}/capital`,
     method: 'GET'
   })
 }
@@ -281,7 +281,7 @@ export function getLiveCapital(accountId: string) {
  */
 export function getRiskStatus(accountId: string) {
   return request<APIResponse<RiskStatus>>({
-    url: `/v1/live-trading/${accountId}/risk/status`,
+    url: `/api/v1/live-trading/${accountId}/risk/status`,
     method: 'GET'
   })
 }
@@ -291,7 +291,7 @@ export function getRiskStatus(accountId: string) {
  */
 export function triggerCircuitBreaker(accountId: string) {
   return request<APIResponse<void>>({
-    url: `/v1/live-trading/${accountId}/risk/circuit-breaker`,
+    url: `/api/v1/live-trading/${accountId}/risk/circuit-breaker`,
     method: 'POST'
   })
 }


### PR DESCRIPTION
## Summary

修复 Paper Trading 关联簇 3 个 issue（调用链分析后定位 3 个根因，合并修复）。

### 根因 A — 状态永远显示 "stopped" (#5392 #5401)
`_get_pt_status` 读取**从不被写入**的 Redis key `pt:status:{id}`，永远 fallback `"stopped"`，与 worker 在 deploy/unload 时更新的 DB `portfolio.state` 完全脱节。

改为 `_map_pt_status(portfolio)` 直接读已持有的 `portfolio.state` 并映射为前端状态字符串（RUNNING/PAUSED/STOPPING 等过渡态→`running`，STOPPED/INITIALIZED/OFFLINE→`stopped`，未知→`error` fail-fast）。list/detail 端点本就持有 portfolio 对象，无需额外查询。

### 根因 B — start 返回误导性成功 (#5401)
`start_paper_trading` 即发即忘返回 `success:true`，但 Kafka 命令投递后 worker 异步处理，状态不会立即变 RUNNING。前端看到 success 却状态 stopped 会困惑。

改为返回 `current_status`（投递瞬间的真实 DB 状态）+ 诚实消息说明异步性。

### 根因 C — 前端 API URL 缺 /api 前缀 (#5605)
`web-ui/src/api/modules/trading.ts` 中 15 个端点 URL 写成 `/v1/...` 而非 `/api/v1/...`，导致前端请求 404。`getPaperAccounts`/`createPaperAccount`/`getLiveAccounts` 已正确，其余 paper-trading 7 个 + live-trading 8 个统一修正。

## Test plan
- [x] `pytest tests/api/test_paper_trading_status.py` — 6 个新测试（映射全分支 + int 规范化 + start 诚实返回）
- [x] `pytest tests/api/test_backtest_api_fixes.py` — 回归适配（旧测试 patch 已删的 `_get_pt_status`，改为数据驱动 `mock_portfolio.state`）
- [x] 基线对比：`tests/api/` 的 10 failed / 11 errors **全部 pre-existing**（master 上同样失败），本次零回归
- [ ] 前端 `trading.ts` URL 由 E2E 覆盖（纯字符串机械改动，无逻辑分支）

Closes #5392
Closes #5401
Closes #5605
