### PR TITLE
fix(#5756): Monte Carlo 净值无波动时显式报错，避免全零伪结果

### DIFF
--- a/src/ginkgo/data/services/validation_service.py
+++ b/src/ginkgo/data/services/validation_service.py
@@ -372,6 +372,15 @@ class ValidationService(BaseService):
                 return ServiceResult.error("数据不足：net_value 记录少于 10 条")
 
             returns = self._records_to_returns(records)
+
+            # fix(#5756): 收益率恒定（净值无波动，如无交易回测）时 bootstrap 退化，
+            # 所有模拟结果相同 → VaR/CVaR/loss_probability 全零、分布塌成单 bin，
+            # 伪装成有效结果会误导风险分析。应明确报错而非吐零。
+            if float(np.std(returns)) == 0.0:
+                return ServiceResult.error(
+                    "净值曲线无波动（日收益率恒定），蒙特卡洛模拟无意义；请确认回测是否产生了实际交易"
+                )
+
             actual_return = float(np.prod(1 + returns) - 1)
 
             # Bootstrap：有放回抽样

--- a/tests/unit/test_validation_service.py
+++ b/tests/unit/test_validation_service.py
@@ -79,8 +79,15 @@ class TestSegmentStability:
         records = _make_net_value_records("2024-01-02", daily_returns, task_id="test-task")
         mock_get_records.return_value = records
 
-        svc = ValidationService.__new__(ValidationService)
-        result = svc.segment_stability(task_id="test-task", portfolio_id="pf-001", n_segments_list=[2, 4])
+        # fix(#5756): 用真 __init__ 构造；analyzer_crud 的全量查询(L257)也返回同一批记录；
+        # records 全是 net_value，故 metrics 取 ["net_value"] 使数据自洽
+        mock_crud = MagicMock()
+        mock_crud.get_by_task_id.return_value = records
+        svc = ValidationService(analyzer_record_crud=mock_crud, validation_result_crud=None)
+        result = svc.segment_stability(
+            task_id="test-task", portfolio_id="pf-001",
+            n_segments_list=[2, 4], metrics=["net_value"],
+        )
 
         assert result.is_success()
         data = result.data
@@ -101,7 +108,8 @@ class TestMonteCarlo:
         records = _make_net_value_records("2024-01-02", daily_returns, task_id="test-task")
         mock_get_records.return_value = records
 
-        svc = ValidationService.__new__(ValidationService)
+        # fix(#5756): 用真 __init__ 构造，_result_crud=None 跳过持久化分支
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
         result = svc.monte_carlo(
             task_id="test-task",
             portfolio_id="pf-001",
@@ -118,6 +126,52 @@ class TestMonteCarlo:
         assert "loss_probability" in data
         assert 0 <= data["percentile"] <= 100
         assert data["loss_probability"] >= 0
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_monte_carlo_flat_equity_returns_error(self, mock_get_records):
+        """fix(#5756): 净值无波动（收益率恒定）时，应返回明确错误，而非全零伪结果"""
+        from ginkgo.data.services.validation_service import ValidationService
+        # 恒定净值（如无交易回测）→ 收益率全零
+        records = _make_net_value_records("2024-01-02", [0.0] * 100, task_id="test-task")
+        mock_get_records.return_value = records
+
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.monte_carlo(
+            task_id="test-task",
+            portfolio_id="pf-001",
+            n_simulations=1000,
+            confidence=0.95,
+        )
+
+        # 关键：不能返回"成功 + 全零"——那是误导用户的风险体检结果
+        assert not result.is_success()
+        assert result.error  # 必须有明确错误信息
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_monte_carlo_volatile_produces_meaningful_distribution(self, mock_get_records):
+        """fix(#5756): 波动净值必须产出非零 VaR/CVaR 且分布跨多 bin（非全零/单 bin 退化）"""
+        from ginkgo.data.services.validation_service import ValidationService
+        np.random.seed(42)  # 稳定 bootstrap 抽样，保证断言可复现
+        daily_returns = [0.005] * 50 + [-0.003] * 50
+        records = _make_net_value_records("2024-01-02", daily_returns, task_id="test-task")
+        mock_get_records.return_value = records
+
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.monte_carlo(
+            task_id="test-task",
+            portfolio_id="pf-001",
+            n_simulations=1000,
+            confidence=0.95,
+        )
+
+        assert result.is_success()
+        data = result.data
+        # 波动数据 → VaR/CVaR 必须非零（全零即 #5756 退化）；CVaR ≤ VaR 恒成立
+        assert data["var"] != 0
+        assert data["cvar"] <= data["var"]
+        # 1000 次模拟应分散到多个 bin，不能塌成单 bin（=模拟全相同）
+        counts = data["distribution"]["counts"]
+        assert sum(1 for c in counts if c > 0) > 1
 
     def test_monte_carlo_var_cvar(self):
         """VaR 应小于 CVaR（绝对值）"""


### PR DESCRIPTION
## Summary

**根因**：`ValidationService.monte_carlo` 在日收益率恒定（如**无交易的回测**）时，bootstrap 有放回抽样退化为单点分布 —— 所有模拟结果相同，导致 `VaR / CVaR / loss_probability` 全为 0.0、`distribution` 塌成单个 bin。算法本身正确（`_calc_monte_carlo_stats` 用合理数据可产出非零指标），问题在于**对退化输入沉默地吐零**，伪装成有效的风险体检结果。

**修复**（`validation_service.py`）：在 `returns = _records_to_returns(records)` 后加守卫 —— `np.std(returns) == 0.0` 时显式返回 `ServiceResult.error`，提示用户「净值曲线无波动，模拟无意义；请确认回测是否产生了实际交易」，而非吐全零。

## Test plan

TDD（RED→GREEN），`tests/unit/test_validation_service.py`：

| 测试 | 验证 |
|---|---|
| `test_monte_carlo_flat_equity_returns_error`（新增，核心 bug） | 恒定净值 → `is_success()==False` + 有错误信息 |
| `test_monte_carlo_volatile_produces_meaningful_distribution`（新增，硬化） | 波动净值 → VaR≠0、CVaR≤VaR、分布跨多 bin |
| `test_monte_carlo_basic` / `test_segment_stability_multi_window` | 修复 `__new__` 绕过 `__init__` 的测试构造坏味道（`_result_crud` 未设） |

```
pytest tests/unit/test_validation_service.py  →  10 passed
```

注：`tests/api/test_validation_pagination.py` 的 2 个失败为 **pre-existing**（master 上 stash 验证同样失败，属该测试自身的 `sys.path`/环境问题），与本次改动无关。

Closes #5756