### PR TITLE
fix: data 驱动层 cursorclass 字符串 + ClickHouse 流式连接泄漏 (#5502 #5505)

### DIFF
--- a/src/ginkgo/data/drivers/ginkgo_mysql.py
+++ b/src/ginkgo/data/drivers/ginkgo_mysql.py
@@ -10,6 +10,7 @@
 import time
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
+from pymysql.cursors import SSCursor
 
 from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.libs.utils.health_check import check_mysql_ready
@@ -109,7 +110,7 @@ class GinkgoMysql(DatabaseDriverBase):
                 "use_unicode": True,
                 "charset": "utf8mb4",
                 "autocommit": False,  # 流式查询需要禁用自动提交
-                "cursorclass": "SSCursor",  # 服务器端游标类
+                "cursorclass": SSCursor,  # 服务器端游标类（必须传类引用，字符串名会让 pymysql 执行期抛 TypeError）
                 "max_allowed_packet": 10485760  # 10MB - 合理的BLOB大小限制
             }
         )

--- a/src/ginkgo/data/streaming/engines/clickhouse_streaming_engine.py
+++ b/src/ginkgo/data/streaming/engines/clickhouse_streaming_engine.py
@@ -53,6 +53,10 @@ class ClickHouseStreamingEngine(BaseStreamingEngine):
         """
         super().__init__(connection, config)
 
+        # 借出的池连接：_create_streaming_cursor 从池借出，_cleanup_cursor 归还
+        # 引擎只借出，不拥有底层 dbapi 连接，无权销毁它（#5505）
+        self._borrowed_connection = None
+
         # ClickHouse专用配置
         self._cursor_type = CursorType.NATIVE_STREAMING
         self._use_native_streaming = True
@@ -90,8 +94,10 @@ class ClickHouseStreamingEngine(BaseStreamingEngine):
             ClickHouse流式查询游标对象
         """
         try:
-            # 获取原生ClickHouse连接
+            # 获取原生ClickHouse连接（从 SQLAlchemy 池借出的代理）
             raw_connection = self.connection.raw_connection()
+            # 记录借出的连接，供 _cleanup_cursor 归还（归还 ≠ 销毁底层连接）#5505
+            self._borrowed_connection = raw_connection
 
             # ClickHouse使用标准游标但配置为流式模式
             cursor = raw_connection.cursor()
@@ -279,9 +285,10 @@ class ClickHouseStreamingEngine(BaseStreamingEngine):
                 # 关闭游标
                 cursor.close()
 
-                # 关闭底层连接
-                if hasattr(cursor, "connection") and cursor.connection:
-                    cursor.connection.close()
+                # 归还借出的池连接（对池代理 close = 归还，而非销毁底层 dbapi 连接）#5505
+                if self._borrowed_connection is not None:
+                    self._borrowed_connection.close()
+                    self._borrowed_connection = None
 
                 GLOG.DEBUG("ClickHouse streaming cursor cleaned up successfully")
 

--- a/src/ginkgo/data/streaming/engines/mysql_streaming_engine.py
+++ b/src/ginkgo/data/streaming/engines/mysql_streaming_engine.py
@@ -54,6 +54,10 @@ class MySQLStreamingEngine(BaseStreamingEngine):
         """
         super().__init__(connection, config)
 
+        # 借出的池连接：_create_streaming_cursor 从池借出，_cleanup_cursor 归还
+        # 引擎只借出，不拥有底层 dbapi 连接，无权销毁它（#5505）
+        self._borrowed_connection = None
+
         # MySQL专用配置
         self._cursor_type = CursorType.SERVER_SIDE
         self._use_buffered = False
@@ -83,8 +87,10 @@ class MySQLStreamingEngine(BaseStreamingEngine):
             MySQL服务器端游标对象
         """
         try:
-            # 获取原生MySQL连接
+            # 获取原生MySQL连接（从 SQLAlchemy 池借出的代理）
             raw_connection = self.connection.raw_connection()
+            # 记录借出的连接，供 _cleanup_cursor 归还（归还 ≠ 销毁底层连接）#5505
+            self._borrowed_connection = raw_connection
 
             # 创建服务器端游标 (SSCursor)
             cursor = raw_connection.cursor(pymysql.cursors.SSCursor)
@@ -212,9 +218,10 @@ class MySQLStreamingEngine(BaseStreamingEngine):
                 # 关闭游标
                 cursor.close()
 
-                # 关闭底层连接
-                if hasattr(cursor, "connection") and cursor.connection:
-                    cursor.connection.close()
+                # 归还借出的池连接（对池代理 close = 归还，而非销毁底层 dbapi 连接）#5505
+                if self._borrowed_connection is not None:
+                    self._borrowed_connection.close()
+                    self._borrowed_connection = None
 
                 GLOG.DEBUG("MySQL streaming cursor cleaned up successfully")
 

--- a/tests/unit/data/drivers/test_mysql_driver_comprehensive.py
+++ b/tests/unit/data/drivers/test_mysql_driver_comprehensive.py
@@ -492,3 +492,28 @@ class TestMySQLDriverErrorHandling:
         call_kwargs = mock_create.call_args[1]
         assert call_kwargs['pool_pre_ping'] is True
         assert call_kwargs['pool_recycle'] == 3600
+
+
+@pytest.mark.unit
+@pytest.mark.database
+class TestMySQLStreamingCursorConfig:
+    """流式引擎游标配置 (#5502)
+
+    cursorclass 必须是类引用。传字符串名时，pymysql 在构造期静默接受，
+    直到真实流式查询执行 cursor 才抛 TypeError —— 缺陷会潜伏到生产。
+    """
+
+    def test_streaming_cursorclass_is_sscursor_class_reference(self):
+        """流式引擎 connect_args.cursorclass 应为 SSCursor 类本身，而非字符串名"""
+        import pymysql.cursors
+
+        mock_engine = Mock()
+        with patch(
+            "ginkgo.data.drivers.ginkgo_mysql.create_engine", return_value=mock_engine
+        ) as mock_create:
+            with patch.object(GinkgoMysql, "_create_engine", return_value=Mock()):
+                driver = GinkgoMysql("user", "pwd", "localhost", "3306", "testdb")
+            driver._create_streaming_engine()
+
+        connect_args = mock_create.call_args.kwargs["connect_args"]
+        assert connect_args["cursorclass"] is pymysql.cursors.SSCursor

--- a/tests/unit/data/streaming/engines/test_clickhouse_streaming_engine.py
+++ b/tests/unit/data/streaming/engines/test_clickhouse_streaming_engine.py
@@ -1,0 +1,80 @@
+"""
+ClickHouse 流式引擎连接生命周期测试 (#5505)
+
+验证流式游标清理时归还借出的池连接，而非销毁底层 dbapi 连接。
+缺陷表象：池连接被 _cleanup_cursor 通过 cursor.connection.close() 物理销毁，
+         每次流式查询消耗一个池连接，pool_size 次后系统挂起。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[5]
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.streaming.engines.clickhouse_streaming_engine import ClickHouseStreamingEngine
+
+# NOTE: config 用 MagicMock 而非真实 StreamingConfig，隔离 engine/config 字段不同步问题
+# （engine 引用的 enable_column_optimization 等字段在 PerformanceConfig 中不存在），
+# 让测试聚焦 #5505 的连接生命周期行为本身。
+
+
+@pytest.mark.unit
+@pytest.mark.database
+class TestClickHouseStreamingConnectionLifecycle:
+    """ClickHouse 流式引擎连接生命周期 (#5505)"""
+
+    def _make_engine(self):
+        """构造带分身 mock 的引擎：池代理与底层 dbapi 连接分离"""
+        fake_underlying = MagicMock(name="underlying_dbapi_conn")
+        fake_cursor = MagicMock(name="streaming_cursor")
+        fake_cursor.connection = fake_underlying  # cursor.connection 穿透到底层
+        fake_raw = MagicMock(name="pooled_raw_connection")  # 池代理（close=归还）
+        fake_raw.cursor.return_value = fake_cursor
+        fake_engine = MagicMock(name="sqlalchemy_engine")
+        fake_engine.raw_connection.return_value = fake_raw
+        engine = ClickHouseStreamingEngine(fake_engine, MagicMock(name="streaming_config"))
+        return engine, fake_raw, fake_cursor, fake_underlying
+
+    def test_cleanup_returns_borrowed_connection_instead_of_destroying_underlying(self):
+        """清理游标时应归还借出的池连接，而非销毁底层 dbapi 连接"""
+        engine, fake_raw, fake_cursor, fake_underlying = self._make_engine()
+
+        cursor = engine._create_streaming_cursor("SELECT 1")
+        engine._cleanup_cursor(cursor)
+
+        # 归还：借出的池代理连接被关闭（SQLAlchemy 池语义下 close = 归还）
+        fake_raw.close.assert_called_once()
+        # 不销毁：底层 dbapi 连接（cursor.connection）未被物理关闭
+        fake_underlying.close.assert_not_called()
+
+    def test_repeated_queries_return_every_borrowed_connection(self):
+        """多次流式查询：每次借出的池连接都被归还，池不会耗尽 (#5505)"""
+        borrowed = []
+
+        def lend_raw():
+            raw = MagicMock(name="pooled_raw")
+            cursor = MagicMock(name="streaming_cursor")
+            cursor.connection = MagicMock(name="underlying")
+            raw.cursor.return_value = cursor
+            borrowed.append(raw)
+            return raw
+
+        fake_engine = MagicMock(name="sqlalchemy_engine")
+        fake_engine.raw_connection.side_effect = lend_raw
+
+        engine = ClickHouseStreamingEngine(fake_engine, MagicMock(name="streaming_config"))
+
+        # 连续 5 次流式查询（超过典型 pool_size 的压力）
+        for _ in range(5):
+            cursor = engine._create_streaming_cursor("SELECT 1")
+            engine._cleanup_cursor(cursor)
+
+        # 5 次借出，5 次归还，无一泄漏（否则第 pool_size+1 次查询会因池耗尽而挂起）
+        assert len(borrowed) == 5
+        for raw in borrowed:
+            raw.close.assert_called_once()

--- a/tests/unit/data/streaming/engines/test_mysql_streaming_engine.py
+++ b/tests/unit/data/streaming/engines/test_mysql_streaming_engine.py
@@ -1,0 +1,80 @@
+"""
+MySQL 流式引擎连接生命周期测试 (#5505)
+
+验证流式游标清理时归还借出的池连接，而非销毁底层 dbapi 连接。
+缺陷表象：池连接被 _cleanup_cursor 通过 cursor.connection.close() 物理销毁，
+         每次流式查询消耗一个池连接，pool_size 次后系统挂起。
+         （与 ClickHouse 引擎同根因，#5505 镜像缺陷）
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+project_root = Path(__file__).resolve().parents[5]
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.streaming.engines.mysql_streaming_engine import MySQLStreamingEngine
+
+# NOTE: config 用 MagicMock 而非真实 StreamingConfig，隔离 engine/config 字段不同步问题，
+# 让测试聚焦 #5505 的连接生命周期行为本身。
+
+
+@pytest.mark.unit
+@pytest.mark.database
+class TestMySQLStreamingConnectionLifecycle:
+    """MySQL 流式引擎连接生命周期 (#5505 镜像缺陷)"""
+
+    def _make_engine(self):
+        """构造带分身 mock 的引擎：池代理与底层 dbapi 连接分离"""
+        fake_underlying = MagicMock(name="underlying_dbapi_conn")
+        fake_cursor = MagicMock(name="streaming_cursor")
+        fake_cursor.connection = fake_underlying  # cursor.connection 穿透到底层
+        fake_raw = MagicMock(name="pooled_raw_connection")  # 池代理（close=归还）
+        fake_raw.cursor.return_value = fake_cursor
+        fake_engine = MagicMock(name="sqlalchemy_engine")
+        fake_engine.raw_connection.return_value = fake_raw
+        engine = MySQLStreamingEngine(fake_engine, MagicMock(name="streaming_config"))
+        return engine, fake_raw, fake_cursor, fake_underlying
+
+    def test_cleanup_returns_borrowed_connection_instead_of_destroying_underlying(self):
+        """清理游标时应归还借出的池连接，而非销毁底层 dbapi 连接"""
+        engine, fake_raw, fake_cursor, fake_underlying = self._make_engine()
+
+        cursor = engine._create_streaming_cursor("SELECT 1")
+        engine._cleanup_cursor(cursor)
+
+        # 归还：借出的池代理连接被关闭（SQLAlchemy 池语义下 close = 归还）
+        fake_raw.close.assert_called_once()
+        # 不销毁：底层 dbapi 连接（cursor.connection）未被物理关闭
+        fake_underlying.close.assert_not_called()
+
+    def test_repeated_queries_return_every_borrowed_connection(self):
+        """多次流式查询：每次借出的池连接都被归还，池不会耗尽 (#5505)"""
+        borrowed = []
+
+        def lend_raw():
+            raw = MagicMock(name="pooled_raw")
+            cursor = MagicMock(name="streaming_cursor")
+            cursor.connection = MagicMock(name="underlying")
+            raw.cursor.return_value = cursor
+            borrowed.append(raw)
+            return raw
+
+        fake_engine = MagicMock(name="sqlalchemy_engine")
+        fake_engine.raw_connection.side_effect = lend_raw
+
+        engine = MySQLStreamingEngine(fake_engine, MagicMock(name="streaming_config"))
+
+        # 连续 5 次流式查询（MySQL driver pool_size=5，超过即池耗尽）
+        for _ in range(5):
+            cursor = engine._create_streaming_cursor("SELECT 1")
+            engine._cleanup_cursor(cursor)
+
+        # 5 次借出，5 次归还，无一泄漏（否则第 pool_size+1 次查询会因池耗尽而挂起）
+        assert len(borrowed) == 5
+        for raw in borrowed:
+            raw.close.assert_called_once()


### PR DESCRIPTION
## Summary
批量修复 data 驱动层两个**确定的、自包含的** P0 缺陷（同一 worktree，分两次提交）。

### #5502 MySQL 流式引擎 cursorclass 传了字符串
`ginkgo_mysql.py::_create_streaming_engine` 的 `connect_args.cursorclass` 传的是字符串 `"SSCursor"`，而 pymysql 期望**类引用**。字符串名在构造期静默通过，真实流式查询执行期才抛 `TypeError`，缺陷潜伏到生产。改为 `pymysql.cursors.SSCursor`。

### #5505 ClickHouse 流式引擎连接泄漏
`clickhouse_streaming_engine._cleanup_cursor` 误对 `cursor.connection`（底层 dbapi 连接）调 `.close()`，**物理销毁**池连接而非归还。每次流式查询消耗一个池连接，`pool_size` 次后池耗尽、系统挂起。
修复：`_create_streaming_cursor` 记录借出的 `raw_connection`（池代理）；`_cleanup_cursor` 改为归还它（对池代理 `close` = 归还），不再越权销毁底层连接。

## 调用链与根因
- **#5505**: `_streaming.py:83` 注入 `self._engine`(SQLAlchemy Engine) → `execute_stream` finally → `_cleanup_cursor` → 原 `cursor.connection.close()` 💥 销毁底层 dbapi 连接
- **根因**: 混淆"SQLAlchemy 池代理（raw_connection，close=归还）"与"底层 dbapi 连接（cursor.connection，close=销毁）"，越权关闭了引擎并不拥有的资源

## 附带发现（未在本次修复，建议单独 issue）
`clickhouse_streaming_engine.__init__` 引用了 `config.performance.enable_column_optimization / adaptive_batch_size / enable_shard_awareness`，但 `PerformanceConfig` 实际只有 `default/min/max_batch_size / auto_adjust_batch_size`——engine 与 config 字段不同步，真实 `StreamingConfig()` 构造的引擎会直接 `AttributeError`。

## Test plan
- [x] `test_streaming_cursorclass_is_sscursor_class_reference`（#5502，`cursorclass is SSCursor` 类）
- [x] `test_cleanup_returns_borrowed_connection_instead_of_destroying_underlying`（#5505，归还借出、不销毁底层）
- [x] `test_repeated_queries_return_every_borrowed_connection`（#5505，多次查询不耗尽池）
- [x] 回归：`tests/unit/data/drivers/test_mysql_driver_comprehensive.py` + streaming engine 共 **50 passed**

Closes #5502
Closes #5505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
