### PR TITLE
refactor(adjustfactor): 收敛三套转换器为一 + sync→calculate 全链路对齐

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -645,6 +645,17 @@ async def sync_data(request: DataUpdateRequest):
                     sync_svc.record_fail(uuid=rec.data["uuid"], error_message=str(e))
                 raise
 
+            # 同步成功后衔接 calculate（与 task_timer/worker 主力路径对齐）：
+            # sync 只落原始 adjustfactor，fore/back 占位 1.0，需 calculate 推导覆盖。
+            # 单 code 计算失败不阻断整体响应（原始因子已落库，可后续补算）。
+            for code in codes:
+                try:
+                    calc_result = adjustfactor_service.calculate(code)
+                    if not calc_result.is_success():
+                        logger.warning(f"Adjustfactor calculate failed for {code}: {calc_result.message}")
+                except Exception as e:
+                    logger.warning(f"Adjustfactor calculate exception for {code}: {e}")
+
             return ok(
                 data={"type": "adjustfactor", "codes": codes},
                 message=f"Adjust factors update completed for {len(codes)} codes"

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -583,7 +583,9 @@ def sync(
 
         elif data_type == "adjustfactor":
             from ginkgo.data.containers import container
-            from ginkgo.data import fetch_and_update_adjustfactor, recalculate_adjust_factors_for_code
+            # CLI → Service 直调（分层规则）。旧 import 的两个自由函数从未在 src/ 实现，
+            # 每次执行必 ImportError。sync 带 fast_mode 参数，full/force 语义无损透传。
+            adjustfactor_service = container.adjustfactor_service()
 
             # 确定同步哪些股票
             if code:
@@ -610,17 +612,17 @@ def sync(
 
                         if full:
                             if force:
-                                # 强制全量同步：直接pass参数，删除已有数据重新插入
+                                # 强制全量同步：fast_mode=False 重算覆盖
                                 console.print(f":information: Force full sync for {current_code} (overwrite existing)")
-                                result = fetch_and_update_adjustfactor(current_code, fast_mode=False)
+                                result = adjustfactor_service.sync(current_code, fast_mode=False)
                             else:
-                                # 全量同步：直接pass参数，跳过已有数据
+                                # 全量同步：fast_mode=True 跳过已有数据
                                 console.print(f":information: Full sync for {current_code} (skip existing)")
-                                result = fetch_and_update_adjustfactor(current_code, fast_mode=True)
+                                result = adjustfactor_service.sync(current_code, fast_mode=True)
                         else:
                             # 增量同步：从最新日期开始到当下
                             console.print(f":information: Incremental sync for {current_code} (from latest date)")
-                            result = fetch_and_update_adjustfactor(current_code, fast_mode=True)
+                            result = adjustfactor_service.sync(current_code, fast_mode=True)
 
                         # Check sync result - ServiceResult has success property, other results may not
                         sync_success = False
@@ -636,7 +638,7 @@ def sync(
 
                             # 同步完成后立即计算该股票的复权因子
                             console.print(f":information: Calculating adjustment factors for {current_code}...")
-                            calc_result = recalculate_adjust_factors_for_code(current_code)
+                            calc_result = adjustfactor_service.calculate(current_code)
                             if calc_result and hasattr(calc_result, 'success') and calc_result.success:
                                 console.print(f":white_check_mark: {current_code} adjustment factor calculation completed")
                             else:

--- a/src/ginkgo/data/fetching.py
+++ b/src/ginkgo/data/fetching.py
@@ -14,78 +14,17 @@ This module contains the core logic for fetching data from external sources (lik
 and persisting it into the database using the CRUD layer.
 """
 import pandas as pd
-import time
-from datetime import datetime, timedelta
 
 from ginkgo.data.sources import GinkgoTushare, GinkgoTDX
-from ginkgo.data.utils import get_crud, is_code_in_stocklist
+from ginkgo.data.utils import get_crud
 from ginkgo.libs import (
-    GCONF,
     GLOG,
     datetime_normalize,
-    to_decimal,
     RichProgress,
 )
-from ginkgo.data.models import MAdjustfactor, MBar, MStockInfo
+from ginkgo.data.models import MBar, MStockInfo
 from ginkgo.entities import Tick
 from ginkgo.enums import SOURCE_TYPES, FREQUENCY_TYPES, CURRENCY_TYPES, MARKET_TYPES, TICKDIRECTION_TYPES
-
-# --- Adjustfactor --- #
-def _get_adjustfactor_fetch_range(code: str, fast_mode: bool) -> tuple:
-    adjustfactor_crud = get_crud('adjustfactor')
-    start_date = datetime_normalize(GCONF.DEFAULTSTART)
-    if fast_mode:
-        latest = adjustfactor_crud.find(filters={"code": code}, page_size=1, desc_order=True)
-        if latest:
-            start_date = latest[0].timestamp + timedelta(days=1)
-    return start_date, datetime.now()
-
-def _prepare_adjustfactor_models(data: pd.DataFrame, code: str) -> list:
-    items = []
-    for _, r in data.iterrows():
-        if pd.notna(r["adj_factor"]) and r["adj_factor"] > 0:
-            items.append(
-                MAdjustfactor(
-                    code=code,
-                    foreadjustfactor=to_decimal(r["adj_factor"]),
-                    backadjustfactor=to_decimal(r["adj_factor"]),
-                    adjustfactor=to_decimal(r["adj_factor"]),
-                    timestamp=datetime_normalize(r["trade_date"]),
-                    source=SOURCE_TYPES.TUSHARE,
-                )
-            )
-    return items
-
-def _persist_adjustfactors(code: str, items: list, fast_mode: bool):
-    if not items:
-        return
-    adjustfactor_crud = get_crud('adjustfactor')
-    if not fast_mode:
-        min_date = min(item.timestamp for item in items)
-        max_date = max(item.timestamp for item in items)
-        adjustfactor_crud.remove(filters={"code": code, "timestamp__gte": min_date, "timestamp__lte": max_date})
-        time.sleep(0.2)
-    adjustfactor_crud.add_batch(items)
-    GLOG.DEBUG(f"Persisted {len(items)} adjustfactor records for {code}.")
-
-def process_adjustfactor_data(code: str, fast_mode: bool):
-    if not is_code_in_stocklist(code):
-        return
-
-    start_date, end_date = _get_adjustfactor_fetch_range(code, fast_mode)
-    GLOG.DEBUG(f"Fetching adjustfactors for {code} from {start_date.date()} to {end_date.date()}")
-
-    try:
-        raw_data = GinkgoTushare().fetch_cn_stock_adjustfactor(code=code, start_date=start_date, end_date=end_date)
-        if raw_data is None or raw_data.empty:
-            GLOG.DEBUG(f"No new adjustfactor data for {code}.")
-            return
-    except Exception as e:
-        GLOG.ERROR(f"Failed to fetch adjustfactors for {code}: {e}")
-        return
-
-    model_items = _prepare_adjustfactor_models(raw_data, code)
-    _persist_adjustfactors(code, model_items, fast_mode)
 
 # --- StockInfo --- #
 def _upsert_stock_info_batch(all_stocks_df: pd.DataFrame):

--- a/src/ginkgo/data/services/adjustfactor_service.py
+++ b/src/ginkgo/data/services/adjustfactor_service.py
@@ -102,7 +102,7 @@ class AdjustfactorService(BaseService):
 
             # Convert to models
             try:
-                adjustfactor_models = self._convert_to_adjustfactor_models(raw_data, code)
+                adjustfactor_models = mappers.dataframe_to_adjustfactor_models(raw_data, code)
             except Exception as e:
                 sync_result = DataSyncResult.create_for_entity(
                     entity_type="adjustfactors",
@@ -238,81 +238,6 @@ class AdjustfactorService(BaseService):
             return method(code, start_date, end_date)
         raise NotImplementedError("Adjustfactor data source not implemented")
 
-    def _convert_to_adjustfactor_models(self, raw_data: pd.DataFrame, code: str) -> List[Any]:
-        """
-        Convert raw adjustment factor data to standardized model objects list.
-
-        Args:
-            raw_data: Raw DataFrame data
-            code: Stock code
-
-        Returns:
-            List[Any]: Adjustment factor model objects list
-        """
-        # #5909 根因A2：旧 import 的模块 madjustfactor(类 MAdjustFactor) 根本不存在 → ImportError。
-        # 真实模型在 model_adjustfactor.MAdjustfactor，字段为 code/foreadjustfactor/backadjustfactor/adjustfactor。
-        from ginkgo.data.models.model_adjustfactor import MAdjustfactor
-
-        df = raw_data.copy()
-
-        # 日期列：Tushare 给 trade_date(YYYYMMDD)，Baostock/本库给 timestamp
-        if "trade_date" in df.columns:
-            df["timestamp"] = pd.to_datetime(df["trade_date"], format="%Y%m%d", errors="coerce")
-        elif "timestamp" in df.columns:
-            df["timestamp"] = pd.to_datetime(df["timestamp"], errors="coerce")
-
-        # 原始复权因子列：Tushare adj_factor / 本库 adjustfactor
-        if "adj_factor" in df.columns:
-            raw_col = "adj_factor"
-        elif "adjustfactor" in df.columns:
-            raw_col = "adjustfactor"
-        else:
-            raw_col = None
-
-        # 按日期升序，供 fore/back 推导（与 calculate() 同约定）
-        df = df.sort_values("timestamp").reset_index(drop=True)
-
-        # 仅当源只给原始因子时，按 calculate() 约定推导前/后复权：
-        #   fore = latest / raw ；back = raw / earliest
-        # 源若直接给 fore/back 列（如 Baostock），下方用源值覆盖，避免被推导值盖掉。
-        if raw_col is not None and len(df) > 0:
-            raws = df[raw_col].astype(float)
-            latest = float(raws.iloc[-1])
-            earliest = float(raws.iloc[0])
-            df["_fore"] = latest / raws
-            df["_back"] = raws / earliest
-
-        if "foreadjustfactor" not in df.columns:
-            df["foreadjustfactor"] = df.get("_fore")
-        if "backadjustfactor" not in df.columns:
-            df["backadjustfactor"] = df.get("_back")
-
-        # #5909 根因A3：旧代码读 timestamp/adjust_type/adjust_factor/before_price 等列，
-        # 全部错位 → 每行 KeyError 被 except 吞掉 → 返回空 models → 落库 0 条。
-        models = []
-        for _, row in df.iterrows():
-            try:
-                model = MAdjustfactor()
-                model.code = code
-                ts = row.get("timestamp")
-                model.timestamp = datetime_normalize(ts) if (ts is not None and pd.notna(ts)) else None
-
-                raw_val = row.get(raw_col) if raw_col else row.get("adjustfactor")
-                if raw_val is None:
-                    raw_val = 1.0
-
-                fore = row.get("foreadjustfactor")
-                back = row.get("backadjustfactor")
-                # 三列均 nullable=False，缺失则回退原始因子，保证落库不违约
-                model.adjustfactor = to_decimal(raw_val)
-                model.foreadjustfactor = to_decimal(fore if (fore is not None and pd.notna(fore)) else raw_val)
-                model.backadjustfactor = to_decimal(back if (back is not None and pd.notna(back)) else raw_val)
-                models.append(model)
-            except Exception as e:
-                self._logger.WARN(f"Failed to convert adjustfactor row to model: {e}")
-                continue
-
-        return models
 
     def get(self, code: str = None, start_date: datetime = None, end_date: datetime = None,
             adjust_type: str = None, limit: int = None,

--- a/tests/api/test_data_sync_adjustfactor.py
+++ b/tests/api/test_data_sync_adjustfactor.py
@@ -84,3 +84,28 @@ class TestSyncDataAdjustfactorAlias:
             run_async(sync_data(request))
 
         mock_svc.sync_batch.assert_called_once_with(["000001.SZ"])
+
+    @pytest.mark.unit
+    def test_sync_success_chains_calculate_per_code(self):
+        """收敛：API sync 成功后应衔接 calculate（与 task_timer/worker 主力路径对齐）
+
+        sync 只落原始 adjustfactor，fore/back 占位 1.0，需 calculate 推导覆盖。
+        当前 handler 仅 sync_batch 不调 calculate → 本测试红。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_batch.return_value = make_ok_result()
+        mock_svc.calculate.return_value = make_ok_result()
+
+        request = DataUpdateRequest(type="adjustfactor", codes=["000001.SZ", "000002.SZ"])
+
+        with patch("api.data.get_adjustfactor_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            run_async(sync_data(request))
+
+        mock_svc.sync_batch.assert_called_once_with(["000001.SZ", "000002.SZ"])
+        # sync 成功后，每个 code 都应衔接 calculate 推导 fore/back
+        assert mock_svc.calculate.call_count == 2
+        called_codes = {call.args[0] for call in mock_svc.calculate.call_args_list}
+        assert called_codes == {"000001.SZ", "000002.SZ"}

--- a/tests/unit/client/test_data_cli_adjustfactor.py
+++ b/tests/unit/client/test_data_cli_adjustfactor.py
@@ -1,0 +1,57 @@
+"""#5868/收敛: ginkgo data sync adjustfactor 应直调 service.sync+calculate
+
+旧代码 `from ginkgo.data import fetch_and_update_adjustfactor, recalculate_adjust_factors_for_code`
+→ 这两个函数在 src/ 零定义 → 每次 `ginkgo data sync adjustfactor` 必 ImportError → 命令死代码。
+收敛后：CLI 经 container 直调 adjustfactor_service.sync(code, fast_mode=...) + calculate(code)，
+与 timer/worker/API handler 全链路一致（sync 落原始因子 → calculate 推导 fore/back）。
+"""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client.data_cli import app
+
+runner = CliRunner()
+
+
+def _ok_result():
+    """构造一个 success 的 ServiceResult 替身"""
+    r = MagicMock()
+    r.success = True
+    r.is_success.return_value = True
+    r.message = "ok"
+    return r
+
+
+class TestSyncAdjustfactorWiring:
+    """CLI sync adjustfactor 直调 service（修复 ImportError 死代码）"""
+
+    @pytest.mark.unit
+    def test_sync_adjustfactor_calls_service_sync_then_calculate(self):
+        """ginkgo data sync adjustfactor --code X 应调 service.sync(X) 后 calculate(X)
+
+        RED: 旧代码 import 不存在的函数 → ImportError，sync/calculate 永不被调，
+        命令 exit_code != 0。
+        """
+        mock_svc = MagicMock()
+        mock_svc.sync.return_value = _ok_result()
+        mock_svc.calculate.return_value = _ok_result()
+
+        with patch("ginkgo.data.containers.container.adjustfactor_service", return_value=mock_svc):
+            result = runner.invoke(app, ["sync", "adjustfactor", "--code", "000001.SZ"])
+
+        # 命令不应因 ImportError 崩溃
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        mock_svc.sync.assert_called_once()
+        assert mock_svc.sync.call_args.args[0] == "000001.SZ"
+        # sync 成功后衔接 calculate（与 timer/worker/API handler 对齐）
+        mock_svc.calculate.assert_called_once_with("000001.SZ")

--- a/tests/unit/data/services/test_adjustfactor_service_mock.py
+++ b/tests/unit/data/services/test_adjustfactor_service_mock.py
@@ -128,6 +128,41 @@ class TestAdjustfactorServiceSync:
         assert result.success is True
         assert result.data.records_added == 1
 
+    @pytest.mark.unit
+    def test_sync_models_keep_raw_factor_placeholder_foreback(self, service, mock_deps):
+        """收敛契约：sync 入库只存原始 adjustfactor，fore/back 占位 1.0（交 calculate 推导）
+
+        前后复权推导是 calculate() 的职责（task_timer/worker 在 sync 后立即调 calculate
+        覆盖 fore/back）。sync 内推导属冗余的第三套逻辑，会与 calculate 漂移。
+        多行数据下旧 _convert 推导 fore=latest/raw(≠1.0) → 本测试红；
+        收敛为复用 mappers（fore/back 恒 1.0）后 → 本测试绿。
+        """
+        from decimal import Decimal
+
+        mock_deps["stockinfo_service"].exists.return_value = True
+        mock_deps["crud_repo"].find.return_value = []
+        mock_deps["crud_repo"].exists.return_value = False     # 走 add 分支
+        df = pd.DataFrame({
+            "trade_date": ["20240101", "20240102"],
+            "adj_factor": [1.5, 3.0],
+        })
+        mock_deps["data_source"].fetch_cn_stock_adjustfactor.return_value = df
+
+        result = service.sync(code="000001.SZ")
+
+        assert result.success is True
+        added = [call.args[0] for call in mock_deps["crud_repo"].add.call_args_list]
+        assert len(added) == 2
+        raw_expected = {Decimal("1.5"), Decimal("3.0")}
+        for m in added:
+            # adjustfactor 保留原始因子
+            assert m.adjustfactor in raw_expected
+            # fore/back 占位 1.0，交 calculate 推导
+            assert m.foreadjustfactor == Decimal("1.0"), \
+                f"foreadjustfactor 应占位 1.0（交 calculate），实际 {m.foreadjustfactor}"
+            assert m.backadjustfactor == Decimal("1.0"), \
+                f"backadjustfactor 应占位 1.0（交 calculate），实际 {m.backadjustfactor}"
+
 
 # ============================================================
 # get 方法测试


### PR DESCRIPTION
## Summary

承接已合并的 **#6094**（adjustfactor 同步链 5 层断链修复）。本轮做**收敛式精炼**：把全仓 3 套复权因子（adjustfactor）转换器合一，并补齐 `sync → calculate` 全链路对齐。

> #6094 已 squash 合并进 master（`a9050161`），无法再追加提交，故本 PR 作为后续独立提交。本分支经 `rebase --onto a9050161` 剥离了已合并的 #6094 提交，净 diff 仅含本轮收敛改动。

### 背景：为什么要收敛三套转换器

#6094 修复"链断了不落库"后，发现同一份原始复权因子 → `MAdjustfactor` 模型的转换逻辑在全仓**并存三套**，行为不一致（fore/back 推导规则各异）：

| # | 位置 | fore/back 处理 | 状态 |
|---|---|---|---|
| ① | `mappers.dataframe_to_adjustfactor_models` | 存 1.0 占位，adjustfactor 落原始值 | **保留为唯一规范版** |
| ② | `fetching._prepare_adjustfactor_models` | 全字段=原始值 | 本 PR **删除**（零外部引用，孤儿） |
| ③ | `service._convert_to_adjustfactor_models` | 推导 fore=latest/raw | 本 PR **删除**（死代码） |

关键洞见：`sync()` 之后 `calculate()`（timer/worker 紧耦合触发）会立即重算并覆盖 fore/back，因此在 sync 内推导 fore/back 是无效的死代码。统一为"**sync 只落原始 adjustfactor + fore/back 占位 1.0，推导全部下放给 calculate**"。

## 改动（4 层）

| 层 | 文件 | 改动 |
|---|---|---|
| **1** | `adjustfactor_service.py` | `sync` 直接复用 `mappers.dataframe_to_adjustfactor_models`；删除第三套转换 `_convert_to_adjustfactor_models`；`existing_filters` 唯一键回归 `(code, timestamp)` |
| **2** | `api/api/data.py` | `sync_batch` 成功后逐 code 衔接 `adjustfactor_service.calculate(code)`，与 `task_timer`/`worker` 主力路径对齐；单 code 计算失败不阻断整体响应（原始因子已落库，可后续补算）|
| **3a** | `data_cli.py` | **修复 ImportError 死命令**：原 `from ginkgo.data import fetch_and_update_adjustfactor, recalculate_adjust_factors_for_code`（src 零定义 → 每次执行必崩）→ 改经 `container` 直调 `adjustfactor_service.sync(code, fast_mode=...)` + `calculate(code)`。`sync` 带 `fast_mode`，CLI 零损失透传 |
| **3b** | `fetching.py` | 删除第 2 套转换死代码（`_get_adjustfactor_fetch_range` / `_prepare_adjustfactor_models` / `_persist_adjustfactors` / `process_adjustfactor_data`），仅保留 stockinfo 相关函数 |

净 −6 行（7 文件，+140 / −146），收敛式重构（越改越短）。

## Test plan

- [x] **Layer 1** `tests/unit/data/services/test_adjustfactor_service_mock.py` — 21 passed（含 TDD 红→绿：多层因子 `[1.5, 3.0]` 下 `adjustfactor` 保持原始值、fore/back == 1.0）
- [x] **Layer 2** `tests/api/test_data_sync_adjustfactor.py` — 3 passed（含 `test_sync_success_chains_calculate_per_code`：sync 成功后对每个 code 调 calculate）
- [x] **Layer 3a** `tests/unit/client/test_data_cli_adjustfactor.py` — 1 passed（TDD 红→绿：原 ImportError exit=1 → 直调 service exit=0，sync+calculate 各调一次）
- [x] **Layer 3b** `fetching.py` 干净导入冒烟通过（`PYTHONPATH=src python -c "from ginkgo.data import fetching"` ✓，唯一公开函数 `process_stockinfo_data`）

> 已知预存问题（非本 PR 引入，#6094 body 已记载）：`tests/api/` 与非 api 测试同会话运行时触发 `core` 命名空间污染（`No module named 'core.logging'`），api 测试需单独 / 在 api 子树内运行（已按此验证 3 passed）。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
