### PR TITLE
fix(#5955): param 索引平局优先偏移映射（边界加固）

### DIFF
--- a/src/ginkgo/data/services/component_parameter_extractor.py
+++ b/src/ginkgo/data/services/component_parameter_extractor.py
@@ -167,6 +167,11 @@ class ComponentParameterExtractor:
 
         return {}
 
+    @staticmethod
+    def _normalize_component_name(name: str) -> str:
+        """统一类名/文件名比较，兼容 snake_case 与 CamelCase。"""
+        return "".join(ch for ch in str(name).lower() if ch.isalnum())
+
     def _extract_from_file(self, file_path: str, component_name: str) -> Dict[int, str]:
         """从Python文件中提取参数信息"""
         try:
@@ -201,7 +206,7 @@ class ComponentParameterExtractor:
             for attr_name in dir(module):
                 attr = getattr(module, attr_name)
                 if (inspect.isclass(attr) and
-                    component_name.lower().replace('_', '') in attr_name.lower().replace('_', '')):
+                    self._normalize_component_name(component_name) in self._normalize_component_name(attr_name)):
                     component_class = attr
                     break
 
@@ -251,7 +256,9 @@ class ComponentParameterExtractor:
             for node in ast.walk(tree):
                 if isinstance(node, ast.ClassDef):
                     class_name = node.name.lower()
-                    if (component_name.lower() in class_name or
+                    normalized_class_name = self._normalize_component_name(node.name)
+                    normalized_component_name = self._normalize_component_name(component_name)
+                    if (normalized_component_name in normalized_class_name or
                         any(keyword in class_name for keyword in
                            ['strategy', 'selector', 'sizer', 'risk', 'analyzer'])):
                         component_class = node
@@ -305,7 +312,9 @@ class ComponentParameterExtractor:
             for node in ast.walk(tree):
                 if isinstance(node, ast.ClassDef):
                     class_name = node.name.lower()
-                    if (component_name.lower() in class_name or
+                    normalized_class_name = self._normalize_component_name(node.name)
+                    normalized_component_name = self._normalize_component_name(component_name)
+                    if (normalized_component_name in normalized_class_name or
                         any(keyword in class_name for keyword in
                            ['strategy', 'selector', 'sizer', 'risk', 'analyzer'])):
                         component_class = node
@@ -420,10 +429,12 @@ class ComponentParameterExtractor:
 
     @staticmethod
     def _find_component_class(tree: ast.AST, component_name: str) -> Optional[ast.ClassDef]:
+        normalized_component_name = ComponentParameterExtractor._normalize_component_name(component_name)
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 class_name = node.name.lower()
-                if (component_name.lower() in class_name or
+                normalized_class_name = ComponentParameterExtractor._normalize_component_name(node.name)
+                if (normalized_component_name in normalized_class_name or
                     any(kw in class_name for kw in ['strategy', 'selector', 'sizer', 'risk', 'analyzer'])):
                     return node
         return None

--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -27,7 +27,12 @@ def resolve_param_kwargs(
     - 新组合（#5955 后创建）：索引从 0 开始，name 已跳过
     - 旧组合（#5955 前创建）：索引从 1 开始（0=name）
 
-    策略：先尝试直接匹配，若全部失败则尝试整体偏移 -1。
+    策略（两轮打分择优）：
+    1. 直接匹配：param_indices[i] → param_names[该索引]。当全部命中且
+       min(param_indices)==0（确属新组合 0 起始）时立即返回。
+    2. 偏移匹配：整体 -1（name 曾占 index 0）。
+    选择规则：按 _score_mapping 的「命中数」优先；命中数相同时，若为多参数
+    旧组合（min>0）则偏好偏移方案，避免 [1,2] 被误读为第二、第三业务参数。
     """
     if not component_params or not param_indices:
         return {}

--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -32,30 +32,51 @@ def resolve_param_kwargs(
     if not component_params or not param_indices:
         return {}
 
+    def _score_mapping(mapped_kwargs: Dict[str, Any], source_indices: List[int]) -> tuple[int, int, int]:
+        """给候选映射打分，优先保留业务参数映射更完整、索引起点更合理的方案。"""
+        mapped_count = len(mapped_kwargs)
+        if not source_indices:
+            return (mapped_count, 0, 0)
+
+        min_index = min(source_indices)
+        # 更偏向 0 起始的新索引；旧索引在平分时由调用方显式选择
+        zero_based_bonus = 1 if min_index == 0 else 0
+        contiguous_bonus = 1 if source_indices == list(range(min_index, min_index + len(source_indices))) else 0
+        return (mapped_count, zero_based_bonus, contiguous_bonus)
+
     # 第一轮：直接匹配（新组合）
     kwargs: Dict[str, Any] = {}
-    mapped = 0
     for i, val in enumerate(component_params):
         orig_idx = param_indices[i]
         if orig_idx in param_names:
             kwargs[param_names[orig_idx]] = val
-            mapped += 1
 
-    if mapped == len(component_params):
+    if len(kwargs) == len(component_params) and (not param_indices or min(param_indices) == 0):
         return kwargs
 
     # 第二轮：旧组合，索引整体偏移 -1（name 曾在 index 0）
     shifted: Dict[str, Any] = {}
-    shifted_mapped = 0
+    shifted_indices: List[int] = []
     for i, val in enumerate(component_params):
         orig_idx = param_indices[i]
         shifted_idx = orig_idx - 1
         if shifted_idx >= 0 and shifted_idx in param_names:
             shifted[param_names[shifted_idx]] = val
-            shifted_mapped += 1
+            shifted_indices.append(shifted_idx)
 
-    # 选择匹配更多的方案
-    if shifted_mapped > mapped:
+    direct_score = _score_mapping(kwargs, param_indices)
+    shifted_score = _score_mapping(shifted, shifted_indices)
+
+    # 平分时优先旧索引兼容方案，避免 [1,2] 被误解释为第二、第三个业务参数
+    if shifted_score[0] > direct_score[0]:
+        return shifted
+    if (
+        shifted_score[0] == direct_score[0]
+        and shifted
+        and param_indices
+        and len(component_params) > 1
+        and min(param_indices) > 0
+    ):
         return shifted
 
     return kwargs

--- a/tests/unit/data/services/test_parameter_extractor_skip_name.py
+++ b/tests/unit/data/services/test_parameter_extractor_skip_name.py
@@ -93,3 +93,18 @@ class SimpleStrategy:
         )
         # period + threshold = 2 (not 3 with name)
         assert len(result) == 2
+
+    def test_snake_case_component_name_matches_camel_case_class(self):
+        """组件名来自文件名时，snake_case 也应匹配 CamelCase 类名。"""
+        code = '''
+class MovingAverageCrossover:
+    def __init__(self, name="MovingAverageCrossover", short_period=20, long_period=60, **kwargs):
+        self.short_period = short_period
+        self.long_period = long_period
+'''
+        result = get_component_parameter_names(
+            "moving_average_crossover",
+            file_content=code,
+            component_type="strategy",
+        )
+        assert result == {0: "short_period", 1: "long_period"}

--- a/tests/unit/services/smoke/test_component_parameter_extractor_smoke.py
+++ b/tests/unit/services/smoke/test_component_parameter_extractor_smoke.py
@@ -36,8 +36,8 @@ class FixedSelector:
         )
         assert isinstance(result, dict)
         assert 0 in result
-        assert result[0] == "name"
-        assert result[1] == "codes"
+        assert result[0] == "codes"
+        assert "name" not in result.values()
 
     def test_get_parameter_info_callable(self):
         ext = ComponentParameterExtractor()

--- a/tests/unit/trading/services/test_component_loader_param_compat.py
+++ b/tests/unit/trading/services/test_component_loader_param_compat.py
@@ -87,3 +87,13 @@ class TestParamIndexBackwardCompat:
             param_names=param_names,
         )
         assert result == {"codes": '"000001.SH"', "period": 20, "threshold": 0.8}
+
+    def test_old_style_indices_prefer_shifted_mapping_on_tie(self):
+        """旧组合 [1,2] 与新索引都能“匹配”时，应优先选择偏移后的业务参数。"""
+        param_names = {0: "short_period", 1: "long_period", 2: "frequency"}
+        result = resolve_param_kwargs(
+            component_params=[5, 20],
+            param_indices=[1, 2],
+            param_names=param_names,
+        )
+        assert result == {"short_period": 5, "long_period": 20}


### PR DESCRIPTION
## 背景

#5955 主因（`--param` 索引 0 误映射到 name 导致回测 0 交易）已在先前 PR 修复并关闭。此 PR 补一个**平局边界场景**的遗漏。

## 问题

旧组合用索引 `[1,2]` 指业务参数（旧约定 name 占 index 0）。新组件定义索引从 0 起算后，直接匹配与偏移匹配**都能全中**：

```
直接: 1→param[1], 2→param[2]   # 匹配数=2，但语义错位
偏移: 1→param[0], 2→param[1]   # 匹配数=2，保留旧组合原意
```

原逻辑 `if shifted_mapped > mapped`（严格大于）在平局时走直接匹配，把"第二业务参数的值"静默塞进"第三位置"，回测跑错但不报错。

## 修复

- `component_loader.resolve_param_kwargs`：引入 `_score_mapping=(匹配数, zero_based_bonus, contiguous_bonus)`，平局 + 多参数 + `min_index>0` 时显式 `return shifted`。
- `component_parameter_extractor._normalize_component_name`：文件名(snake_case)与类名(CamelCase)统一小写+去非字母数字后比较，修复 import 路径用 `replace('_','')` 而 AST 路径用裸 `lower()` 的不一致。

## 测试

新增/强化测试：
- `test_old_style_indices_prefer_shifted_mapping_on_tie`
- `test_snake_case_component_name_matches_camel_case_class`

本地 param 相关 18 passed。全量测试因已知 OOM（~20GB）未跑，仅验证改动子集。

Refs #5955

🤖 Generated with [Claude Code](https://claude.com/claude-code)