### PR TITLE
feat(cli): 回测进度回调透传，运行中实时更新进度

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -171,12 +171,29 @@ def run_task(
             ),
         )
 
+        def _progress_callback(progress: float, current_date: str):
+            service.update_progress(
+                task.uuid,
+                progress=progress,
+                current_stage="RUNNING",
+                current_date=current_date,
+            )
+
         if bg:
             def _run_in_thread():
                 result = orchestrator.run(
-                    task_id=task.uuid, config=config, portfolio_id=portfolio_uuid,
+                    task_id=task.uuid,
+                    config=config,
+                    portfolio_id=portfolio_uuid,
+                    progress_callback=_progress_callback,
                 )
                 if result.is_success():
+                    service.update_progress(
+                        task.uuid,
+                        progress=100,
+                        current_stage="FINALIZING",
+                        current_date=str(config.end_date),
+                    )
                     console.print(f":white_check_mark: Backtest completed: {task.uuid[:12]}")
                 else:
                     console.print(f":x: Backtest failed: {result.error}")
@@ -186,12 +203,22 @@ def run_task(
             console.print(f":hourglass: Backtest running in background (thread)")
         else:
             result = orchestrator.run(
-                task_id=task.uuid, config=config, portfolio_id=portfolio_uuid,
+                task_id=task.uuid,
+                config=config,
+                portfolio_id=portfolio_uuid,
+                progress_callback=_progress_callback,
             )
 
             if not result.is_success():
                 console.print(f":x: Backtest failed: {result.error}")
                 raise typer.Exit(1)
+
+            service.update_progress(
+                task.uuid,
+                progress=100,
+                current_stage="FINALIZING",
+                current_date=str(config.end_date),
+            )
 
             # 灌入日志到 ClickHouse（静默降级）
             try:

--- a/src/ginkgo/trading/services/backtest_orchestrator.py
+++ b/src/ginkgo/trading/services/backtest_orchestrator.py
@@ -41,7 +41,7 @@ class BacktestOrchestrator:
         self._result_aggregator = result_aggregator
 
     def run(self, task_id: str, config, portfolio_id: str,
-            timeout: float = 3600.0) -> OrchestratorResult:
+            timeout: float = 3600.0, progress_callback=None) -> OrchestratorResult:
         """
         执行完整回测链路。
 
@@ -63,7 +63,7 @@ class BacktestOrchestrator:
 
             # 3. 装配引擎
             engine = self._assemble_engine(task_id, config, portfolio_id,
-                                           portfolio_data, components)
+                                           portfolio_data, components, progress_callback)
 
             # 4. 运行引擎
             engine.start()
@@ -104,7 +104,7 @@ class BacktestOrchestrator:
         return load_portfolio_components(portfolio_id)
 
     def _assemble_engine(self, task_id, config, portfolio_id,
-                         portfolio_data, components):
+                         portfolio_data, components, progress_callback=None):
         """构建引擎装配参数并调用 EngineAssemblyService。"""
         from ginkgo.workers.backtest_worker.task_helpers import (
             build_engine_data,
@@ -125,6 +125,7 @@ class BacktestOrchestrator:
             portfolio_mappings=[mapping],
             portfolio_configs={portfolio_id: portfolio_config},
             portfolio_components={portfolio_id: components},
+            progress_callback=progress_callback,
         )
 
         if not result.success:

--- a/tests/unit/trading/services/test_backtest_orchestrator.py
+++ b/tests/unit/trading/services/test_backtest_orchestrator.py
@@ -157,6 +157,44 @@ class TestOrchestratorHappyPath:
         assert agg_kwargs["task_id"] == task_id
         assert agg_kwargs["portfolio_id"] == portfolio_id
 
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_run_passes_progress_callback_to_assembly(
+        self,
+        mock_load_components,
+        orchestrator,
+        mock_assembly_service,
+        mock_portfolio_service,
+        mock_aggregator,
+    ):
+        config = _make_config()
+        portfolio_id = "portfolio-001"
+        task_id = "task-001"
+        engine = _make_engine_mock()
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True,
+            data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True,
+            data=engine,
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        progress_callback = MagicMock()
+        result = orchestrator.run(
+            task_id=task_id,
+            config=config,
+            portfolio_id=portfolio_id,
+            progress_callback=progress_callback,
+        )
+
+        assert result.is_success()
+        call_kwargs = mock_assembly_service.assemble_backtest_engine.call_args.kwargs
+        assert call_kwargs["progress_callback"] is progress_callback
+
 
 class TestOrchestratorPortfolioLoading:
     """Verify portfolio loading is lightweight - no component binding."""


### PR DESCRIPTION
## 背景

`docs/cli-quant-research-report` 点出 CLI 回测链路阻塞之一：长回测运行期间无任何进度反馈，看起来像卡死。

## 改动

- `backtest_cli`：定义 `_progress_callback(progress, current_date)`，前台/后台两条路径均透传给 `orchestrator.run`，结束时置 `100% / FINALIZING`。
- `backtest_orchestrator`：`run` / `_assemble_engine` 接收并下传 `progress_callback` 到 `EngineAssemblyService`。

## 测试

新增 `test_run_passes_progress_callback_to_assembly`。本地 `test_backtest_orchestrator` 6 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)