### PR TITLE
fix(#6102): data_preparer risk 组件类型判定 7→3 修复

### DIFF
--- a/src/ginkgo/trading/services/_assembly/data_preparer.py
+++ b/src/ginkgo/trading/services/_assembly/data_preparer.py
@@ -171,7 +171,7 @@ class DataPreparer:
                         selectors.append(mapping)
                     elif file_type == 5:  # SIZER
                         sizers.append(mapping)
-                    elif file_type == 7:  # RISK_MANAGER
+                    elif file_type == 3:  # RISK_MANAGER (FILE_TYPES.RISKMANAGER=3) #6102 曾误用 7(ENGINE)
                         risk_managers.append(mapping)
                     elif file_type == 1:  # ANALYZER (FILE_TYPES.ANALYZER = 1)
                         analyzers.append(mapping)

--- a/tests/unit/trading/services/test_data_preparer_risk_bucket.py
+++ b/tests/unit/trading/services/test_data_preparer_risk_bucket.py
@@ -1,0 +1,51 @@
+"""
+#6102: data_preparer._get_portfolio_components 的 risk 类型分桶回归
+
+file_type == FILE_TYPES.RISKMANAGER (3) 的 mapping 应进 risk_managers。
+历史 bug：判定写成 7（ENGINE），导致 risk 组件落入 else 警告分支被静默丢弃。
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.enums import FILE_TYPES
+
+
+def _make_mapping(file_type, name="m"):
+    """构造带 .type/.name 的 mapping 对象（模拟 portfolio_file_mapping 记录）"""
+    return SimpleNamespace(type=file_type, name=name)
+
+
+@pytest.mark.unit
+class TestGetPortfolioComponentsRiskBucket:
+    """risk 组件(type=RISKMANAGER=3)应被正确分到 risk_managers，不落空"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_risk_manager_bucketed_correctly(self, mock_container):
+        """type=3(RISKMANAGER) 进 risk_managers；type=6(STRATEGY) 进 strategies 作对照"""
+        from ginkgo.trading.services._assembly.data_preparer import DataPreparer
+
+        mappings = [
+            _make_mapping(FILE_TYPES.RISKMANAGER.value, "risk-1"),
+            _make_mapping(FILE_TYPES.STRATEGY.value, "strat-1"),
+        ]
+        # _get_portfolio_components 内: container.cruds.portfolio_file_mapping().find(...)
+        mock_container.cruds.portfolio_file_mapping.return_value.find.return_value = mappings
+
+        preparer = DataPreparer()
+        components = preparer._get_portfolio_components("pf-1")
+
+        # risk 组件不再丢失
+        assert len(components["risk_managers"]) == 1
+        assert components["risk_managers"][0].name == "risk-1"
+        # 对照：strategy 正常分桶
+        assert len(components["strategies"]) == 1
+        assert components["strategies"][0].name == "strat-1"


### PR DESCRIPTION
## 修复

`data_preparer._get_portfolio_components` 用 `file_type == 7` 判定 risk 组件，但 `FILE_TYPES.RISKMANAGER == 3`、`7 == ENGINE`，risk 分支永不命中 → risk 组件落入 `else` 警告被静默丢弃（影响 `prepare_engine_data` / YAML 装配路径）。

## 改动

- `data_preparer.py:174` `7` → `3`
- 补回归测试 `test_data_preparer_risk_bucket.py`：`type=3` 进 `risk_managers`，`type=6` 进 `strategies` 作对照

## 验证

TDD：RED（`type=3` 落 else，日志 `Unknown file type: 3`）→ GREEN（正确进 `risk_managers`）。`data_preparer` 冒烟 7 passed。

## 关联

- Fixes #6102
- 来源：PR #6101 review non-blocking follow-up（与 #6098 路径统一无关）
