### PR TITLE
docs: CLAUDE.md 增加架构决策记录(ADR)入口指引

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ ginkgo serve worker-backtest -id test2        # 回测 Worker
 
 ## 详细参考文档（按需查阅）
 - **开发模式/API/风控/日志/实盘** → `docs/claude-dev-reference.md`
+- **架构决策记录 (ADR)** → `docs/adr/README.md`（难逆转/反直觉/真实权衡的决策，触碰架构前先读）
 - **CLI 回测全链路操作指南** → 见下方
 
 ## CLI 回测全链路


### PR DESCRIPTION
## 改动
在 `CLAUDE.md` 的「详细参考文档」区新增一行，指向 `docs/adr/README.md`：

- **架构决策记录 (ADR)** → `docs/adr/README.md`（难逆转/反直觉/真实权衡的决策，触碰架构前先读）

## 背景
`docs/adr/`（ADR-001~010）已入库，记录了组件边界、分层架构、引擎二态、双实例 Debug、参数序列化、数据库角色分工、表结构驱动、策略框架能力、service_hub、Entity/ORM/DTO 分离等决策。但 `CLAUDE.md` 此前缺入口，agent 与新人难以发现这套决策记录。

## 价值
形成可发现链路：`CLAUDE.md` → `docs/adr/README.md` → 各 ADR → 代码引用。`improve-codebase-architecture` skill 会消费 `docs/adr/`，避免反复重开已定决策；决策不再是 Claude 私人记忆里的暗知识。

## 验证
- 改动仅 1 行（`git diff --stat master`: `CLAUDE.md | 1 +`）
- 基于最新 master（`3966ced2`），cherry-pick 自 `e6be81d2`，无冲突

🤖 Generated with [Claude Code](https://claude.com/claude-code)
