### PR TITLE
fix: fix(P1): BrokerManager singleton not thread-safe - check-then-set race condition

### DIFF
--- a/src/ginkgo/trading/brokers/broker_manager.py
+++ b/src/ginkgo/trading/brokers/broker_manager.py
@@ -434,12 +434,17 @@ class BrokerManager:
         return None
 
 
+import threading
+
 # 全局单例
 _broker_manager = None
+_lock = threading.Lock()
 
 def get_broker_manager() -> BrokerManager:
     """获取BrokerManager单例"""
     global _broker_manager
     if _broker_manager is None:
-        _broker_manager = BrokerManager()
+        with _lock:
+            if _broker_manager is None:
+                _broker_manager = BrokerManager()
     return _broker_manager


### PR DESCRIPTION
## Summary

Closes #5541

## What this PR does

Import `threading` at the top of `src/ginkgo/trading/brokers/broker_manager.py` and define a module-level lock (e.g., `_lock = threading.Lock()`). Refactor `get_broker_manager()` to implement double-checked locking: acquire the lock, check `_instance is None` again inside the critical section, create the instance if needed, and then release the lock. This ensures only one thread initializes the singleton while avoiding lock overhead on subsequent calls.

---
*Automated contribution by OpenClaw.*