### PR TITLE
fix(#6109): LONG 部分成交剩余冻结资金未释放（settle 兜底 + 去 deduct_remain）

### DIFF
--- a/src/ginkgo/entities/order.py
+++ b/src/ginkgo/entities/order.py
@@ -416,7 +416,9 @@ class Order(TimeMixin, Base):
         if qty <= 0:
             raise ValueError("qty must be positive")
         fill_cost = to_decimal(price) * qty + to_decimal(fee)
-        if self._remain is None:
+        # remain 兜底：构造默认 0（无人调 order.freeze() 初始化），首次 settle
+        # 从 frozen_money 起扣（与 normalize_freeze 的 `None or ==0` 模式一致，#6109）
+        if self._remain is None or self._remain == 0:
             self._remain = self._frozen_money
         self._remain = max(Decimal("0"), self._remain - fill_cost)
         self._transaction_volume = min(self._volume, self._transaction_volume + qty)

--- a/src/ginkgo/trading/portfolios/t1backtest.py
+++ b/src/ginkgo/trading/portfolios/t1backtest.py
@@ -633,11 +633,8 @@ class PortfolioT1Backtest(PortfolioBase):
                 # 如果不是最终成交，不解冻剩余资金；如果是最终成交，解冻所有剩余资金
                 unfreeze_remain = order.remain if is_final else Decimal("0")
 
-                # 从冻结资金中扣除成交成本
+                # 从冻结资金中扣除成交成本（settle 已扣 order.remain，此处仅 portfolio 侧同步）
                 self.deduct_from_frozen(cost=fill_cost, unfreeze_remain=unfreeze_remain)
-
-                # 同步扣减订单剩余冻结（ADR-010 V5：deduct_remain，保持预存资金同步语义）
-                order.deduct_remain(fill_cost)
                 if is_final:
                     order.release_frozen()
 

--- a/tests/unit/trading/entities/test_order.py
+++ b/tests/unit/trading/entities/test_order.py
@@ -2146,6 +2146,16 @@ class TestOrderFillBehavior:
         order.settle(100, 10.0, 0)  # fill_cost=1000
         assert order.remain == 0
 
+    def test_settle_init_remain_from_frozen_when_construct_zero(self):
+        """settle 在 remain 为构造默认 0 时从 frozen_money 兜底起扣（#6109）。
+        真实成交流程无人调 order.freeze()，remain 走构造默认 0；settle 首次调用须
+        从 frozen_money 起扣，否则 is_final 时 unfreeze_remain 恒 0，剩余冻结
+        资金不释放回 cash。与 normalize_freeze 的 `None or ==0` 模式一致。"""
+        order = self._make_order(volume=100, frozen_money=1000)
+        # 不调 freeze()，模拟真实流程（构造默认 remain=0）
+        order.settle(30, 10.0, 0)  # fill_cost = 30*10+0 = 300
+        assert order.remain == 700  # 0 → 兜底 frozen_money=1000 → 1000-300
+
     def test_release_frozen_zeroes_remain(self):
         """release_frozen 清零剩余冻结"""
         order = self._make_order()

--- a/tests/unit/trading/portfolios/test_t1backtest.py
+++ b/tests/unit/trading/portfolios/test_t1backtest.py
@@ -693,6 +693,33 @@ class TestLongShortFillHandling:
         assert pos.volume == 100
         assert pos.cost == Decimal("10.0")
 
+    def test_long_partial_fill_remain_not_double_deducted(self):
+        """LONG 部分成交 order.remain 应单扣 fill_cost（#6109）。
+
+        bug：settle(line624) 已扣 remain，deduct_remain(line640) 再扣 → 2×fill_cost，
+        导致 is_final 时 unfreeze_remain 偏小，现金卡在 frozen 影响后续下单可用资金。
+        """
+        p = _make_portfolio()
+        _setup_portfolio(p)
+        p.add_cash(Decimal("100000"))
+        p.freeze(Decimal("1000"))
+        _set_context_ids(p)
+        order = _make_order(volume=100, frozen_money=Decimal("1000"))
+        event = EventOrderPartiallyFilled(
+            order=order, filled_quantity=30, fill_price=Decimal("10.0"),
+            commission=Decimal("0"), portfolio_id="pid",
+            engine_id="eid", task_id="rid",
+        )
+        with patch('ginkgo.trading.portfolios.t1backtest.GLOG'), \
+             patch('ginkgo.trading.portfolios.t1backtest.container'), \
+             patch.object(p, 'is_event_from_future', return_value=False), \
+             patch.object(p, 'update_worth'), \
+             patch.object(p, 'update_profit'):
+            p.on_order_partially_filled(event)
+        # fill_cost = 30*10+0 = 300；单扣 remain=1000-300=700（双扣 bug 得 400）
+        assert order.remain == Decimal("700"), \
+            f"remain 被双扣: 期望 700, 实际 {order.remain}"
+
     def test_short_filled_position_reduction(self):
         p = _make_portfolio()
         _setup_portfolio(p)


### PR DESCRIPTION
## 根因
- `order.remain` 构造默认 0，`settle` 兜底 `if self._remain is None` 不触发（0≠None）→ 成交后 remain 恒 0
- `on_order_partially_filled` 又调 `deduct_remain` 二次扣
- 叠加导致 `is_final` 时 `unfreeze_remain=0`，剩余冻结资金不释放回 cash（资金守恒断裂）

## 修复
- `order.settle` 兜底改 `if None or ==0`（与 `normalize_freeze` 一致），首次 settle 从 frozen_money 起扣，多次 settle 正确累减
- `on_order_partially_filled` 删 `deduct_remain` 调用（settle 已扣），与死方法 `deal_long_filled` 的 event 权威语义对齐

## 测试
- order 层：`test_settle_init_remain_from_frozen_when_construct_zero`
- portfolio 层：`test_long_partial_fill_remain_not_double_deducted`
- 回归：test_order 78 passed，t1backtest 44 passed（1 预存 FAIL 见 #6139，与本 PR 无关）

🤖 Generated with [Claude Code](https://claude.com/claude-code)