### PR TITLE
refactor(#6110): Base.uuid 创建后只读（删 setter + set_uuid，ADR-010 V10）

### DIFF
--- a/src/ginkgo/entities/base.py
+++ b/src/ginkgo/entities/base.py
@@ -52,18 +52,8 @@ class Base(object):
     def uuid(self, *args, **kwargs) -> str:
         return self._uuid
 
-    @uuid.setter
-    def uuid(self, uuid: str, *args, **kwargs) -> str:
-        if not isinstance(uuid, str):
-            raise ValueError("UUID must be a string.")
-        self._uuid = uuid
-        return self._uuid
-
-    def set_uuid(self, uuid: str, *args, **kwargs) -> str:
-        if not isinstance(uuid, str):
-            raise ValueError("UUID must be a string.")
-        self._uuid = uuid
-        return self._uuid
+    # uuid 创建后只读（ADR-010 §5：身份不变量）。删 @uuid.setter + set_uuid，
+    # 构造注入走 Base.__init__(uuid=...)。运行时 .uuid= 会 AttributeError（封装落地）。
 
     def _get_component_prefix(self, component_type: COMPONENT_TYPES) -> str:
         """

--- a/tests/unit/data/services/test_signal_tracking_service.py
+++ b/tests/unit/data/services/test_signal_tracking_service.py
@@ -62,9 +62,9 @@ def sample_signal(unique_id):
         engine_id=unique_id,
         task_id=unique_id,
         code="000001.SZ",
-        direction=DIRECTION_TYPES.LONG
+        direction=DIRECTION_TYPES.LONG,
+        uuid=unique_id,
     )
-    signal.uuid = unique_id
     signal.price = 10.50
     signal.volume = 1000
     signal.strategy_id = unique_id
@@ -146,9 +146,9 @@ class TestSignalTrackingServiceCRUD:
             engine_id=unique_id,
             task_id=unique_id,
             code="000001.SZ",
-            direction=direction
+            direction=direction,
+            uuid=unique_id,
         )
-        signal.uuid = unique_id
 
         result = signal_tracking_service.create(
             signal=signal,
@@ -213,9 +213,9 @@ class TestSignalTrackingLifecycle:
             engine_id=unique_id,
             task_id=unique_id,
             code="000001.SZ",
-            direction=DIRECTION_TYPES.LONG
+            direction=DIRECTION_TYPES.LONG,
+            uuid=unique_id,
         )
-        signal.uuid = unique_id
         signal.price = 10.50
         signal.volume = 1000
 
@@ -248,9 +248,9 @@ class TestSignalTrackingLifecycle:
             engine_id=unique_id,
             task_id=unique_id,
             code="000002.SZ",
-            direction=DIRECTION_TYPES.SHORT
+            direction=DIRECTION_TYPES.SHORT,
+            uuid=unique_id,
         )
-        signal.uuid = unique_id
         signal.price = 15.20
         signal.volume = 2000
 
@@ -274,9 +274,9 @@ class TestSignalTrackingLifecycle:
             engine_id=unique_id,
             task_id=unique_id,
             code="000003.SZ",
-            direction=DIRECTION_TYPES.LONG
+            direction=DIRECTION_TYPES.LONG,
+            uuid=unique_id,
         )
-        signal.uuid = unique_id
         signal.price = 12.80
         signal.volume = 1500
 
@@ -365,9 +365,9 @@ class TestSignalTrackingServiceBusinessLogic:
                 engine_id=unique_id,
                 task_id=unique_id,
                 code=f"00000{i}.SZ",
-                direction=DIRECTION_TYPES.LONG if i % 2 == 0 else DIRECTION_TYPES.SHORT
+                direction=DIRECTION_TYPES.LONG if i % 2 == 0 else DIRECTION_TYPES.SHORT,
+                uuid=f"{unique_id}_{i}",
             )
-            signal.uuid = f"{unique_id}_{i}"
             signal.price = 10.0 + i
             signal.volume = 1000
 
@@ -387,9 +387,9 @@ class TestSignalTrackingServiceBusinessLogic:
             engine_id=unique_id,
             task_id=unique_id,
             code="000004.SZ",
-            direction=DIRECTION_TYPES.LONG
+            direction=DIRECTION_TYPES.LONG,
+            uuid=unique_id,
         )
-        signal.uuid = unique_id
         signal.price = 18.60
         signal.volume = 1200
 
@@ -435,9 +435,9 @@ class TestSignalTrackingServiceEdgeCases:
             engine_id=unique_id,
             task_id=unique_id,
             code="000005.SZ",
-            direction=DIRECTION_TYPES.LONG
+            direction=DIRECTION_TYPES.LONG,
+            uuid=unique_id,
         )
-        signal.uuid = unique_id
         signal.price = price
         signal.volume = volume
 
@@ -460,9 +460,9 @@ class TestSignalTrackingServiceEdgeCases:
                 engine_id=unique_id,
                 task_id=unique_id,
                 code=code,
-                direction=DIRECTION_TYPES.LONG
+                direction=DIRECTION_TYPES.LONG,
+                uuid=f"{unique_id}_{i}",
             )
-            signal.uuid = f"{unique_id}_{i}"
             signal.price = 10.0
             signal.volume = 1000
 

--- a/tests/unit/entities/test_base_uuid_readonly.py
+++ b/tests/unit/entities/test_base_uuid_readonly.py
@@ -1,0 +1,33 @@
+"""Base.uuid 只读保护测试（ADR-010 §5 V10：身份不变量创建后只读）。
+
+删 Base.uuid.setter + set_uuid 后，运行时 ``.uuid=`` 抛 AttributeError；
+uuid 走 ``Base.__init__(uuid=...)`` 构造注入，未传时自动生成（带 prefix）。
+"""
+import pytest
+
+from ginkgo.entities.base import Base
+
+
+class TestBaseUuidReadonly:
+    """Base.uuid 创建后只读（ADR-010 V10 身份不变量）。"""
+
+    def test_uuid_setter_removed(self):
+        """运行时 .uuid= 抛 AttributeError（封装落地）。"""
+        b = Base()
+        with pytest.raises(AttributeError):
+            b.uuid = "should-fail"
+
+    def test_set_uuid_method_removed(self):
+        """set_uuid() 已删（业务零调用，ADR-010 §5）。"""
+        b = Base()
+        assert not hasattr(b, "set_uuid"), "set_uuid 应已删除"
+
+    def test_uuid_constructor_injection(self):
+        """uuid 走构造注入（Base.__init__ uuid 参数）。"""
+        b = Base(uuid="injected-uuid-123")
+        assert b.uuid == "injected-uuid-123"
+
+    def test_uuid_auto_generated_when_not_provided(self):
+        """未传 uuid 时 Base.__init__ 自动生成（带 prefix，非空）。"""
+        b = Base()
+        assert b.uuid and len(b.uuid) > 0


### PR DESCRIPTION
## ADR-010 §5 V10：uuid 身份不变量只读

**关联**：主 issue #6106（架构评审总览）；V10 实质属 #6112（entities 不变量）。
> 注：commit 标题的 `#6110` 关联有误（#6110 实为 deviation mock），实际归属 ADR-010 §5 / #6106。

删 `Base.uuid.setter` + `set_uuid()`，保留构造注入 + 自动生成 + getter。

**验证**：
- src `set_uuid()` 0 调用。
- review 发现 `test_signal_tracking_service` 9 处真实 Signal `signal.uuid=` 回归（master 22 passed → 10 failed + 6 errors），已迁移构造注入修复（commit 87e349f2），恢复 22 passed + 1 skipped。
- 全局核查：tests/ 其余 `.uuid=` 写赋值（lab/conftest 全 Mock、account/pos/task/r 不继承 Base）无回归。

保护测试 `test_base_uuid_readonly`（运行时 `.uuid=` 抛 AttributeError）。

ADR-010 §5 line 79 授权，不触及 ORM 层 / BaseCRUD/BaseService。

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
