### PR TITLE
fix(serve-api): node_graph _file_type 绝对导入改包内相对 (#6147)

### DIFF
--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -37,7 +37,7 @@ def get_portfolio_mapping_service():
     return container.portfolio_mapping_service()
 
 
-from _file_type import _resolve_file_type  # noqa: F401 — 无副作用，可安全导入
+from ._file_type import _resolve_file_type  # noqa: F401 — 包内相对导入（#6110：app_dir=api/ 布局下绝对导入找不到包内模块）
 
 
 def get_file_service():

--- a/tests/unit/client/test_serve_cli.py
+++ b/tests/unit/client/test_serve_cli.py
@@ -212,3 +212,37 @@ class TestServeErrorHandling:
         assert result.exit_code == 1
         assert "npm" in result.output.lower()
         assert "Node.js" in result.output
+
+
+# ============================================================================
+# Serve API 启动路径 import 完整性（回归守护 #6110）
+# ============================================================================
+
+@pytest.mark.unit
+def test_serve_api_node_graph_imports_in_app_dir(monkeypatch):
+    """serve api 启动路径(app_dir=api/)下 node_graph 可被完整 import。
+
+    回归守护 #6110: node_graph.py:40 曾用绝对导入 ``from _file_type``，
+    但 _file_type.py 在 api/api/ 包内，app_dir=api/ 布局下不在 sys.path 顶层，
+    导致 ``ginkgo serve api`` 启动即 ``ModuleNotFoundError: No module named '_file_type'``。
+    正确写法是包内相对导入 ``from ._file_type``。
+    """
+    import importlib
+    from pathlib import Path
+
+    # 隔离 SECRET_KEY：core.config 在 import 时实例化 Settings(#5464 validator)
+    monkeypatch.setenv("SECRET_KEY", "import-guard-test-key")
+    api_dir = Path(__file__).parent.parent.parent.parent / "api"
+    monkeypatch.syspath_prepend(str(api_dir))
+    # 清除 api 包缓存，确保以 app_dir=api/ 布局重新导入
+    for m in list(sys.modules):
+        if m == "api" or m.startswith("api."):
+            del sys.modules[m]
+    try:
+        mod = importlib.import_module("api.node_graph")
+        assert hasattr(mod, "_resolve_file_type"), "node_graph 应暴露 _resolve_file_type"
+    finally:
+        # 清理本次 import 的 api.* 缓存，避免污染其他测试
+        for m in list(sys.modules):
+            if m == "api" or m.startswith("api."):
+                del sys.modules[m]


### PR DESCRIPTION
Fixes #6147

## 问题

`ginkgo serve api` 启动崩溃 `ModuleNotFoundError: No module named '_file_type'`，API 服务器无法启动。

## 根因（详见 #6147）

`api/api/node_graph.py:40` 绝对导入 `from _file_type`，但 `_file_type.py` 在 `api/api/` 包内。`serve_cli` 设 `app_dir=api/`，只把 `api/` 加入 sys.path 顶层，**包内模块不在顶层可寻址**。

潜伏三重盲区：api-server 在 docker-compose 被注释（从不跑）、单测 mock 绕过 `main.py` 全量 import、`test_node_graph_file_type.py` 用 sys.path hack 让功能测试"假绿"。

## 修复

`from _file_type` → `from ._file_type`（包内相对导入）

## 验证（三层）

| 层 | 结果 |
|---|---|
| TDD Red→Green | 守护测试 `test_serve_api_node_graph_imports_in_app_dir` FAIL(`ModuleNotFoundError`)→ PASS |
| 零回归 | test_serve_cli + test_node_graph_file_type **23 passed** |
| 真实启动 | `serve api` → `Application startup complete` + `GET /openapi.json → HTTP 200` |
