### PR TITLE
fix: find_by_live_status(True) 返回 PAPER+LIVE 对齐 is_live 语义 (#6144)

### DIFF
--- a/src/ginkgo/data/crud/portfolio_crud.py
+++ b/src/ginkgo/data/crud/portfolio_crud.py
@@ -220,22 +220,28 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
 
     def find_by_live_status(self, is_live: bool) -> List[MPortfolio]:
         """
-        [已废弃] 按实盘状态查询投资组合
+        [已废弃] 按"是否在盘"查询投资组合。
+
+        语义对齐 MPortfolio.is_live property：is_live 即 mode >= PAPER（PAPER + LIVE）。
+        三态化前的旧实现把 True 二值映射成 LIVE，会漏掉 PAPER 组合（#6144）。
 
         .. deprecated::
-            此方法已废弃，请使用 find_by_mode() 替代。
+            此方法已废弃，新代码请用 find_by_mode() 按单模式查询。
 
             迁移示例:
                 旧: find_by_live_status(is_live=True)
-                新: find_by_mode(PORTFOLIO_MODE_TYPES.LIVE)
+                新: find_paper_portfolios() + find_live_portfolios()  # PAPER + LIVE
+                    或 find_by_mode(PORTFOLIO_MODE_TYPES.LIVE)        # 仅 LIVE
 
         Args:
-            is_live: True=实盘, False=回测
+            is_live: True=PAPER+LIVE（在盘），False=BACKTEST（回测）
 
         Returns:
             符合条件的投资组合列表
         """
         GLOG.WARN("find_by_live_status is deprecated, use find_by_mode instead")
-        mode = PORTFOLIO_MODE_TYPES.LIVE if is_live else PORTFOLIO_MODE_TYPES.BACKTEST
-        return self.find_by_mode(mode)
+        if is_live:
+            # is_live property 语义：mode >= PAPER → PAPER + LIVE（与 plan_manager 双模式查询一致）
+            return self.find_paper_portfolios() + self.find_live_portfolios()
+        return self.find_by_mode(PORTFOLIO_MODE_TYPES.BACKTEST)
 

--- a/tests/integration/data/crud/test_portfolio_crud.py
+++ b/tests/integration/data/crud/test_portfolio_crud.py
@@ -323,6 +323,62 @@ class TestPortfolioCRUDQuery:
             print(f"✗ 实盘状态查询失败: {e}")
             raise
 
+    def test_find_by_live_status_includes_paper(self):
+        """find_by_live_status(True) 必须返回所有 is_live 组合（PAPER + LIVE）。
+
+        对齐 MPortfolio.is_live property 语义：mode >= PAPER 即"活的"。
+        回归 #6144：旧的 True→LIVE 二值映射会漏掉 PAPER 组合。
+        """
+        print("\n" + "=" * 60)
+        print("开始测试: find_by_live_status(True) 包含 PAPER 组合")
+        print("=" * 60)
+
+        portfolio_crud = PortfolioCRUD()
+        prefix = "test_find_live_status_6144_"
+        inserted = [
+            MPortfolio(name=f"{prefix}paper", mode=PORTFOLIO_MODE_TYPES.PAPER.value,
+                       state=PORTFOLIO_RUNSTATE_TYPES.RUNNING.value, source=SOURCE_TYPES.TEST),
+            MPortfolio(name=f"{prefix}live", mode=PORTFOLIO_MODE_TYPES.LIVE.value,
+                       state=PORTFOLIO_RUNSTATE_TYPES.RUNNING.value, source=SOURCE_TYPES.TEST),
+            MPortfolio(name=f"{prefix}backtest", mode=PORTFOLIO_MODE_TYPES.BACKTEST.value,
+                       state=PORTFOLIO_RUNSTATE_TYPES.INITIALIZED.value, source=SOURCE_TYPES.TEST),
+        ]
+
+        try:
+            portfolio_crud.add_batch(inserted)
+            print(f"✓ 插入 3 个测试组合: PAPER / LIVE / BACKTEST")
+
+            # is_live=True → PAPER + LIVE（对齐 is_live property: mode >= PAPER）
+            live_result = portfolio_crud.find_by_live_status(True)
+            live_names = {p.name for p in live_result}
+            print(f"→ find_by_live_status(True) 命中: {sorted(n for n in live_names if n.startswith(prefix))}")
+
+            assert f"{prefix}paper" in live_names, "PAPER 组合应被 find_by_live_status(True) 返回"
+            assert f"{prefix}live" in live_names, "LIVE 组合应被 find_by_live_status(True) 返回"
+            assert f"{prefix}backtest" not in live_names, "BACKTEST 组合不应被 find_by_live_status(True) 返回"
+
+            # is_live=False → 仅 BACKTEST
+            backtest_result = portfolio_crud.find_by_live_status(False)
+            backtest_names = {p.name for p in backtest_result}
+            print(f"→ find_by_live_status(False) 命中: {sorted(n for n in backtest_names if n.startswith(prefix))}")
+
+            assert f"{prefix}backtest" in backtest_names, "BACKTEST 组合应被 find_by_live_status(False) 返回"
+            assert f"{prefix}paper" not in backtest_names, "PAPER 组合不应被 find_by_live_status(False) 返回"
+            assert f"{prefix}live" not in backtest_names, "LIVE 组合不应被 find_by_live_status(False) 返回"
+
+            print("✓ find_by_live_status 语义对齐 is_live property 验证通过")
+
+        except Exception as e:
+            print(f"✗ 查询失败: {e}")
+            raise
+        finally:
+            # 清理本测试插入的行，避免污染
+            try:
+                for p in portfolio_crud.find(filters={"name__like": prefix, "source": SOURCE_TYPES.TEST.value}):
+                    portfolio_crud.delete(p.uuid)
+            except Exception as cleanup_err:
+                print(f"⚠ 清理失败: {cleanup_err}")
+
     def test_find_by_time_range(self):
         """测试根据创建时间范围查询Portfolio"""
         print("\n" + "="*60)


### PR DESCRIPTION
## Summary

修复 `PortfolioCRUD.find_by_live_status(True)` 漏掉 PAPER 组合的问题（#6144）。

**根因**：旧的二值映射 `True→LIVE` 与 `MPortfolio.is_live` property（`mode >= PAPER`，即 PAPER 或 LIVE）语义矛盾，导致 PAPER 模式组合被排除，Scheduler 无法发现模拟盘组合。

**修复**（`portfolio_crud.py` 单处）：
- `True` → PAPER + LIVE（复用 `find_paper_portfolios()` + `find_live_portfolios()`）
- `False` → BACKTEST
- 与 `plan_manager._get_all_portfolios` 双模式查询保持一致

> #4661（Scheduler 发现路径）此前已由 PR #4686 修复；本 PR 补齐 `find_by_live_status` 方法本身的语义缺陷（验收标准 #1）。

## Test plan

- [x] 新增 `test_find_by_live_status_includes_paper`：插入 PAPER/LIVE/BACKTEST 三组合，断言 `True` 含 PAPER+LIVE 排除 BACKTEST、`False` 仅 BACKTEST
- [x] RED→GREEN：修复前 PAPER 断言失败，修复后通过
- [x] `tests/integration/data/crud/test_portfolio_crud.py` 全套 20 测试通过（无回归）

Closes #6144
