### PR TITLE
fix(web-ui): 清理 Ant Design Vue <a-*> 标签残留 → shadcn-vue

### DIFF
--- a/web-ui/src/components/data/StatisticCard.vue
+++ b/web-ui/src/components/data/StatisticCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <a-card :class="['statistic-card', `card-${type}`]" :hoverable="hoverable" :bordered="bordered">
+  <Card :class="['statistic-card', `card-${type}`]">
     <div class="stat-header">
       <div v-if="icon || $slots.icon" class="stat-icon-wrapper" :style="{ backgroundColor: iconColor }">
         <slot name="icon">
@@ -33,10 +33,11 @@
         <span class="trend-value">{{ trendValue }}</span>
       </div>
     </div>
-  </a-card>
+  </Card>
 </template>
 
 <script setup lang="ts">
+import { Card } from '@/components/ui/card'
 
 type CardType = 'primary' | 'success' | 'warning' | 'danger' | 'info'
 type TrendType = 'up' | 'down' | 'flat'

--- a/web-ui/src/layouts/ComponentLayout.vue
+++ b/web-ui/src/layouts/ComponentLayout.vue
@@ -46,9 +46,9 @@
                   <span class="mr-3">{{ child.icon || '•' }}</span>
                   <span>{{ child.label }}</span>
                 </div>
-                <a-tag v-if="child.status" :color="getStatusColor(child.status)" size="small">
+                <Badge v-if="child.status" :variant="getStatusVariant(child.status)">
                   {{ getStatusLabel(child.status) }}
-                </a-tag>
+                </Badge>
               </router-link>
             </div>
           </div>
@@ -64,9 +64,9 @@
               <span class="text-lg mr-3">{{ item.icon }}</span>
               <span>{{ item.label }}</span>
             </div>
-            <a-tag v-if="item.status" :color="getStatusColor(item.status)" size="small">
+            <Badge v-if="item.status" :variant="getStatusVariant(item.status)">
               {{ getStatusLabel(item.status) }}
-            </a-tag>
+            </Badge>
           </router-link>
         </template>
       </nav>
@@ -115,6 +115,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue'
 import { useRoute } from 'vue-router'
+import { Badge } from '@/components/ui/badge'
 
 const route = useRoute()
 
@@ -230,17 +231,17 @@ const toggleMenu = (path: string) => {
   expandedMenus.value[path] = !expandedMenus.value[path]
 }
 
-// 获取状态颜色
-const getStatusColor = (status?: MenuItemStatus) => {
+// 获取状态徽章变体（映射到 shadcn-vue Badge 变体）
+const getStatusVariant = (status?: MenuItemStatus) => {
   switch (status) {
     case 'done':
-      return 'green'  // 绿色 - 已完成
+      return 'success'  // 绿色 - 已完成
     case 'pending-api':
-      return 'orange'  // 橙色 - 待API对接
+      return 'warning'  // 橙色 - 待API对接
     case 'todo':
-      return 'default'   // 灰色 - 未实现
+      return 'secondary'   // 灰色 - 未实现
     default:
-      return 'default'
+      return 'secondary'
   }
 }
 


### PR DESCRIPTION
## 背景

docs 对齐架构时发现 web-ui 仍残留 3 处 Ant Design Vue `<a-*>` 标签（依赖已在 `package.json` 移除，仅剩模板标签未替换）。本 PR 在独立分支（`origin/master` 基点）完成迁移到 shadcn-vue。

## 改动

| 文件 | 改动 |
|---|---|
| `ComponentLayout.vue` | 2× `<a-tag>` → `<Badge>`；`getStatusColor` → `getStatusVariant`（`green/orange/default` → Badge 的 `success/warning/secondary`） |
| `StatisticCard.vue` | `<a-card>` → `<Card>`；移除 ant-only 的 `:hoverable`/`:bordered` 绑定（已被 scoped CSS 架空为空操作） |

## 验证（隔离 worktree）

- 静态 grep：`.vue` 中 `<a-` 残留 **0**
- `vue-tsc` stash 对照：干净 master **33** 错 = 改动后 **33** 错 → **零新增类型错误**
- `vite build`：**2600 模块全部编译通过**（含两文件模板），完整构建成功

## 已知既有问题（非本 PR 范围）

master 基线 33 个 `vue-tsc` 错误源于 `web-ui/src/lib/utils.ts` 未提交（shadcn-vue 的 `cn()` 工具，本地有、仓库无）——属独立问题，建议另开 issue/PR 处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
