### PR TITLE
fix(deploy): 回测→模拟盘 deploy 丢 param + 恢复通知 seam

### DIFF
--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -725,13 +725,7 @@ def unload_portfolio(
     GLOG.INFO(f"[UNLOAD] Unloading paper trading {portfolio_id}")
 
     try:
-        from ginkgo.messages.control_command import ControlCommand
-        from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
-        from ginkgo.interfaces.kafka_topics import KafkaTopics
-
-        cmd = ControlCommand.unload(portfolio_id)
-        producer = GinkgoProducer()
-        success = producer.send(KafkaTopics.CONTROL_COMMANDS, cmd.to_dict())
+        success = _send_unload_command(portfolio_id)
 
         if success:
             console.print(Panel(
@@ -770,7 +764,7 @@ def _deploy_paper_trading(
         str: 新 Portfolio UUID
     """
     from ginkgo import services
-    from ginkgo.enums import PORTFOLIO_MODE_TYPES
+    from ginkgo.enums import PORTFOLIO_MODE_TYPES, SOURCE_TYPES
 
     portfolio_service = services.data.portfolio_service()
     mapping_crud = services.data.cruds.portfolio_file_mapping()
@@ -801,33 +795,73 @@ def _deploy_paper_trading(
     new_portfolio_id = create_result.data["uuid"]
     GLOG.INFO(f"[DEPLOY] Created paper portfolio: {new_portfolio_id} ({new_name})")
 
-    # 3. 复制组件文件映射
+    # 3. 复制组件文件映射 + 参数
+    param_crud = services.data.cruds.param()
     mappings = mapping_crud.find(filters={"portfolio_id": source_portfolio_id, "is_del": False})
+    param_count = 0
     for mapping in mappings:
         mapping_type = mapping.type.value if hasattr(mapping.type, 'value') else mapping.type
-        mapping_crud.add(
+        # create(**kwargs) 返回带 uuid 的新 mapping（add 收 model 对象，传 kwargs 会 TypeError）
+        new_mapping = mapping_crud.create(
             portfolio_id=new_portfolio_id,
             file_id=mapping.file_id,
             name=mapping.name,
             type=mapping_type,
         )
+        # 复制源 mapping 的参数到新 mapping（mapping_id 指向新 uuid）
+        src_params = param_crud.find(filters={"mapping_id": mapping.uuid, "is_del": False})
+        for p in src_params:
+            param_crud.create(
+                mapping_id=new_mapping.uuid,
+                index=p.index,
+                value=p.value,
+                source=getattr(p, "source", SOURCE_TYPES.SIM),
+            )
+            param_count += 1
 
-    GLOG.INFO(f"[DEPLOY] Copied {len(mappings)} component mapping(s) to {new_portfolio_id}")
+    GLOG.INFO(
+        f"[DEPLOY] Copied {len(mappings)} component mapping(s) "
+        f"and {param_count} param(s) to {new_portfolio_id}"
+    )
 
     # 4. 存储 source_portfolio_id 映射 + 计算 baseline
     _store_deploy_source(new_portfolio_id, source_portfolio_id)
     _generate_baseline_if_possible(new_portfolio_id, source_portfolio_id)
 
     # 5. 发送 Kafka deploy 通知
+    _send_deploy_notification(new_portfolio_id)
+
+    return new_portfolio_id
+
+
+def _send_deploy_notification(portfolio_id: str) -> None:
+    """发送 deploy 命令到 Kafka（ControlCommand DTO 格式）。
+
+    历史：68b749e5 为修消息格式（portfolio_id 须在 params 内）内联此处并删除该
+    helper，但漏改 patch 它的测试，导致 TestDeployPaperTrading 全部 AttributeError。
+    此处恢复 seam，用正确的 ControlCommand.deploy().to_dict() 实现，而非被删的旧手搓 dict。
+    """
     from ginkgo.messages.control_command import ControlCommand
     from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
     from ginkgo.interfaces.kafka_topics import KafkaTopics
 
-    cmd = ControlCommand.deploy(new_portfolio_id)
+    cmd = ControlCommand.deploy(portfolio_id)
     producer = GinkgoProducer()
     producer.send(KafkaTopics.CONTROL_COMMANDS, cmd.to_dict())
 
-    return new_portfolio_id
+
+def _send_unload_command(portfolio_id: str) -> bool:
+    """发送 unload 命令到 Kafka（ControlCommand DTO 格式），返回是否发送成功。
+
+    与 _send_deploy_notification 同根（68b749e5 内联删除），一并恢复。
+    """
+    from ginkgo.messages.control_command import ControlCommand
+    from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
+    from ginkgo.interfaces.kafka_topics import KafkaTopics
+
+    cmd = ControlCommand.unload(portfolio_id)
+    producer = GinkgoProducer()
+    return producer.send(KafkaTopics.CONTROL_COMMANDS, cmd.to_dict())
 
 
 def _store_deploy_source(paper_portfolio_id: str, source_portfolio_id: str) -> None:

--- a/src/ginkgo/data/models/model_portfolio.py
+++ b/src/ginkgo/data/models/model_portfolio.py
@@ -60,6 +60,11 @@ class MPortfolio(MMysqlBase):
     total_trades: Mapped[int] = mapped_column(default=0)
     winning_trades: Mapped[int] = mapped_column(default=0)
 
+    # 运行时引擎时间快照 (#6159: worker REPLAY 模式触发判定)
+    engine_current_time: Mapped[Optional[datetime.datetime]] = mapped_column(
+        DateTime, nullable=True, comment="最近持久化时的引擎时间，用于 worker 重启后判定是否快进历史(REPLAY)"
+    )
+
     @property
     def is_live(self) -> bool:
         """是否为实盘或模拟盘模式（非回测）"""

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -375,6 +375,8 @@ class PortfolioService(BaseService):
                 "frozen": state["frozen"],
                 "total_fee": state["fee"],
                 "current_capital": str(current_capital),
+                # #6159: 持久化引擎时间，worker 重启后据此判定是否进入 REPLAY 快进历史
+                "engine_current_time": state.get("engine_current_time"),
             }
             self._crud_repo.modify(filters={"uuid": portfolio_id}, updates=portfolio_updates)
 
@@ -439,12 +441,15 @@ class PortfolioService(BaseService):
 
             has_state = float(p.cash) > 0 or len(positions_data) > 0
 
+            et = p.engine_current_time
             return ServiceResult.success({
                 "cash": str(p.cash),
                 "frozen": str(p.frozen),
                 "fee": str(p.total_fee),
                 "positions": positions_data,
                 "has_state": has_state,
+                # #6159: 返回引擎时间，worker 据此判定是否进入 REPLAY 快进历史
+                "engine_current_time": et.isoformat() if et else None,
             })
 
         except Exception as e:

--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -72,6 +72,13 @@ def resolve_param_kwargs(
     direct_score = _score_mapping(kwargs, param_indices)
     shifted_score = _score_mapping(shifted, shifted_indices)
 
+    # #6159: 提取器跳过了框架参数(如 name) → param_names 比 component_params 少一项，
+    # 而 DB 仍把被跳过的值(如 name)存在 index0。直接映射会把该值错绑给第一个
+    # 业务参数(如 FixedSelector codes 拿到 'default_selector')。此时偏移映射才正确：
+    # index1→param_names[0] 把真业务值绑对。仅当 len 相等(DB 未存 name)时不触发。
+    if shifted and len(param_names) < len(component_params):
+        return shifted
+
     # 平分时优先旧索引兼容方案，避免 [1,2] 被误解释为第二、第三个业务参数
     if shifted_score[0] > direct_score[0]:
         return shifted

--- a/src/ginkgo/trading/time/providers.py
+++ b/src/ginkgo/trading/time/providers.py
@@ -172,21 +172,22 @@ class SystemTimeProvider(ITimeProvider):
         """获取时间模式"""
         return self._mode
     
-    def set_current_time(self, timestamp: datetime) -> None:
-        """设置当前时间（系统时间模式下不支持）
-        
-        Raises:
-            NotImplementedError: 系统时间模式不支持设置时间
+    def set_current_time(self, timestamp: datetime) -> bool:
+        """设置当前时间（系统时间模式下为空操作）。
+
+        系统时钟自走，手动 set 无意义。但 LIVE mode 的 timer 推进与残留 REPLAY
+        事件会调用此方法，raise 会破坏 bool 契约（LogicalTimeProvider 返回 True/False）
+        导致 TimeMixin.advance_time 整个崩溃——portfolio 的 T+1 结算 + signal 批处理
+        不执行（#6159 bug#5）。改为 no-op 返回 True：调用安全，now() 仍返回系统真实时间。
         """
-        raise NotImplementedError("Cannot set time in system time mode")
-    
+        return True
+
     def advance_time_to(self, target_time: datetime) -> None:
-        """推进时间（系统时间模式下不支持）
-        
-        Raises:
-            NotImplementedError: 系统时间模式不支持推进时间
+        """推进时间（系统时间模式下为空操作）。
+
+        与 set_current_time 同理：系统时钟自走，推进无意义但调用应安全。
         """
-        raise NotImplementedError("Cannot advance time in system time mode")
+        pass
     
     def can_access_time(self, requested_time: datetime) -> bool:
         """检查是否可以访问指定时间的数据

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -246,10 +246,37 @@ class PaperTradingWorker:
                 end_time=real_now,
             )
             engine._time_provider = replay_provider
-            GLOG.INFO(
-                f"[PAPER-WORKER] REPLAY mode: engine_time={persisted_engine_time}, "
-                f"task_id={task_id}"
-            )
+            # #6159: propagate LogicalTimeProvider 到 feeder + portfolio。
+            # 不能用 engine.set_time_provider()——它对 LIVE/PAPER mode 校验拒绝
+            # LogicalTimeProvider（time_controlled_engine.py:382），故只能裸赋值 engine；
+            # 但 feeder/portfolio 各自持有独立的 time_provider 引用，必须手动同步，
+            # 否则 REPLAY 快进时 feeder.advance_time_to 仍走 SystemTimeProvider →
+            # 报 "Cannot set time in system time mode" → 0 喂 bar → 0 Signal。
+            for portfolio in engine.portfolios:
+                try:
+                    portfolio.set_time_provider(replay_provider)
+                except Exception as e:
+                    GLOG.WARN(
+                        f"[PAPER-WORKER] propagate time provider to portfolio "
+                        f"{portfolio.name} failed: {e}"
+                    )
+            _replay_feeder = getattr(engine, "_datafeeder", None)
+            if _replay_feeder is not None and hasattr(_replay_feeder, "set_time_provider"):
+                try:
+                    _replay_feeder.set_time_provider(replay_provider)
+                    GLOG.INFO(
+                        f"[PAPER-WORKER] REPLAY mode: engine_time={persisted_engine_time}, "
+                        f"task_id={task_id}, propagated LogicalTimeProvider to feeder"
+                    )
+                except Exception as e:
+                    GLOG.ERROR(
+                        f"[PAPER-WORKER] propagate time provider to feeder failed: {e}"
+                    )
+            else:
+                GLOG.INFO(
+                    f"[PAPER-WORKER] REPLAY mode: engine_time={persisted_engine_time}, "
+                    f"task_id={task_id}"
+                )
         else:
             task_id = f"paper-{session_ts}"
             engine.set_task_id(task_id)
@@ -979,6 +1006,27 @@ class PaperTradingWorker:
             f"[PAPER-WORKER] {self.worker_id}: Subscribed to "
             f"{KafkaTopics.CONTROL_COMMANDS}"
         )
+
+        # #6159: 启动自动 REPLAY（快进历史交易日）—— worker 重启后若引擎时间
+        # 落后于当前日期，自动跑 run_daily_cycle 追历史。不依赖外部 Kafka 命令触发：
+        # Consumer offset="latest"，命令若在消费者完成 group join（加入消费组）前
+        # 发出会被静默跳过（实测 "Received command" 计数=0），导致 run_daily_cycle
+        # 永不执行 → 0 advance → 0 Signal。REPLAY 是启动恢复语义，本就该自动跑。
+        if self._is_replay_mode():
+            GLOG.INFO(
+                f"[PAPER-WORKER] {self.worker_id}: REPLAY mode detected on start, "
+                f"auto-running daily cycle to catch up history"
+            )
+            try:
+                result = self.run_daily_cycle()
+                GLOG.INFO(
+                    f"[PAPER-WORKER] {self.worker_id}: Auto REPLAY done: "
+                    f"skipped={result.skipped}, advanced={result.advanced}"
+                )
+            except Exception as e:
+                GLOG.ERROR(
+                    f"[PAPER-WORKER] {self.worker_id}: Auto REPLAY failed: {e}"
+                )
 
         # 进入消费循环
         self._consume_loop()

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -184,7 +184,12 @@ class PaperTradingWorker:
                 if hasattr(portfolio, "_selectors") and portfolio._selectors:
                     for selector in portfolio._selectors:
                         if hasattr(selector, "pick"):
-                            selector.pick()
+                            # #6159 bug#6: 必须传非 None time。MomentumSelector.pick(time=None)
+                            # → datetime_normalize(None)=None → None-timedelta 崩溃 → selector
+                            # 选股失败 → _interested_codes 空 → feeder WARN "No interested symbols"
+                            # → PRICEUPDATE=0 → signal=0。传 now() 作种子；后续 portfolio.advance_time
+                            # 会用 time provider 的逻辑时间重新 pick 覆盖。CNAllSelector 不用 time 不受影响。
+                            selector.pick(datetime.now())
             except Exception as e:
                 GLOG.WARN(
                     f"[PAPER-WORKER] selector.pick() failed for "

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -649,6 +649,11 @@ class PaperTradingWorker:
                 break
 
         if total_advanced > 0:
+            # drain 异步事件队列：保证 advance_time_to 入队的 REPLAY 推进事件
+            # （feeder feed + portfolio T+1 结算）在切 SystemTimeProvider 前处理完，
+            # 否则残留事件用 System provider 报 'Cannot set time in system time mode'。
+            self._drain_event_queue()
+
             # 偏差检查
             try:
                 self._run_deviation_check()
@@ -666,6 +671,43 @@ class PaperTradingWorker:
         # 没有推进过，可能已经追上了
         self._transition_to_live()
         return DailyCycleResult(skipped=False, advanced=False)
+
+    def _drain_event_queue(self, timeout: int = 30) -> bool:
+        """等待事件队列处理完所有残留事件。
+
+        REPLAY 快进的 advance_time_to 通过异步事件队列推进（main_thread 处理），
+        而 _transition_to_live 同步切 SystemTimeProvider。若残留 REPLAY 事件在
+        provider 切换后才被 main_thread 处理，portfolio.advance_time 会用已切换的
+        SystemTimeProvider 报 'Cannot set time in system time mode'，阻断 feeder 喂 bar。
+
+        切 LIVE 前必须 drain，保证所有 REPLAY 推进事件（feeder feed + portfolio
+        T+1 结算）在 provider 切换前处理完。
+        """
+        import time
+        engine = self._engine
+        if not hasattr(engine, "_event_queue"):
+            return True
+        deadline = time.time() + timeout
+        empty_streak = 0
+        last_qsize = -1
+        while time.time() < deadline:
+            try:
+                last_qsize = engine._event_queue.qsize()
+            except Exception:
+                return True
+            if last_qsize == 0:
+                empty_streak += 1
+                # 连续多次空判定为处理完（避开 main_thread 正处理最后一个的窗口）
+                if empty_streak >= 3:
+                    return True
+            else:
+                empty_streak = 0
+            time.sleep(0.05)
+        GLOG.WARN(
+            f"[PAPER-WORKER] drain event queue timeout after {timeout}s, "
+            f"qsize={last_qsize}"
+        )
+        return False
 
     def _transition_to_live(self) -> None:
         """从 REPLAY 切换到 LIVE_PAPER 模式"""

--- a/tests/unit/client/test_paper_trading_cli.py
+++ b/tests/unit/client/test_paper_trading_cli.py
@@ -196,9 +196,14 @@ class TestDeployPaperTrading:
         mock_crud = MagicMock()
         mock_crud.find.return_value = mappings or []
 
+        # param crud 默认无参数（mapping 循环会按 mapping_id 查 param）
+        mock_param_crud = MagicMock()
+        mock_param_crud.find.return_value = []
+
         mock_data = MagicMock()
         mock_data.portfolio_service.return_value = mock_ps
         mock_data.cruds.portfolio_file_mapping.return_value = mock_crud
+        mock_data.cruds.param.return_value = mock_param_crud
         return mock_data, mock_ps, mock_crud
 
     @patch("ginkgo.client.portfolio_cli._send_deploy_notification")
@@ -235,6 +240,7 @@ class TestDeployPaperTrading:
         create_result = self._make_mock_service_result(create_result_data)
 
         mock_mapping = MagicMock()
+        mock_mapping.uuid = "src_map_uuid"
         mock_mapping.file_id = "file_001"
         mock_mapping.name = "strategy_ma"
         mock_mapping.type.value = "strategy"
@@ -248,11 +254,65 @@ class TestDeployPaperTrading:
             name="paper_backtest_portfolio",
         )
 
-        mock_crud.add.assert_called_once()
-        call_kwargs = mock_crud.add.call_args[1]
+        # BUG 1 回归守护：必须用 create(**kwargs)（add 收 model 对象，传 kwargs 会 TypeError）
+        mock_crud.create.assert_called_once()
+        call_kwargs = mock_crud.create.call_args[1]
         assert call_kwargs["portfolio_id"] == "new_paper_uuid"
         assert call_kwargs["file_id"] == "file_001"
         assert call_kwargs["type"] == "strategy"
+
+    @patch("ginkgo.client.portfolio_cli._send_deploy_notification")
+    @patch("ginkgo.services")
+    def test_deploy_copies_params(self, mock_services, mock_send):
+        """应复制每个 mapping 的 param 到新 mapping（mapping_id 指向新 uuid）"""
+        source_portfolio = self._make_mock_source_portfolio()
+        source_result = self._make_mock_service_result([source_portfolio])
+        create_result_data = {"uuid": "new_paper_uuid", "name": "paper_backtest_portfolio"}
+        create_result = self._make_mock_service_result(create_result_data)
+
+        mock_mapping = MagicMock()
+        mock_mapping.uuid = "src_map_uuid"
+        mock_mapping.file_id = "file_001"
+        mock_mapping.name = "strategy_ma"
+        mock_mapping.type.value = "strategy"
+
+        # 源 mapping 的两个 param
+        mock_p0 = MagicMock()
+        mock_p0.index = 0
+        mock_p0.value = '"MA_STRATEGY"'
+        mock_p1 = MagicMock()
+        mock_p1.index = 1
+        mock_p1.value = "20"
+
+        mock_data, mock_ps, mock_crud = self._setup_mock_data(
+            source_result, create_result, [mock_mapping]
+        )
+        # create() 返回的新 mapping 带 uuid（param 的 mapping_id 要指向它）
+        new_mapping = MagicMock()
+        new_mapping.uuid = "new_map_uuid"
+        mock_crud.create.return_value = new_mapping
+
+        # 覆盖默认 param crud，喂入两个 param
+        mock_param_crud = mock_data.cruds.param.return_value
+        mock_param_crud.find.return_value = [mock_p0, mock_p1]
+        mock_services.data = mock_data
+
+        from ginkgo.client.portfolio_cli import _deploy_paper_trading
+        _deploy_paper_trading(source_portfolio_id="source_uuid", name="paper")
+
+        # BUG 2 回归守护：按源 mapping_id 查 param
+        mock_param_crud.find.assert_called_once()
+        find_kwargs = mock_param_crud.find.call_args[1]["filters"]
+        assert find_kwargs["mapping_id"] == "src_map_uuid"
+
+        # 两个 param 都被 create，mapping_id 指向【新】mapping 的 uuid
+        assert mock_param_crud.create.call_count == 2
+        calls = [c[1] for c in mock_param_crud.create.call_args_list]
+        assert {c["mapping_id"] for c in calls} == {"new_map_uuid"}
+        assert {(c["index"], c["value"]) for c in calls} == {
+            (0, '"MA_STRATEGY"'),
+            (1, "20"),
+        }
 
     @patch("ginkgo.client.portfolio_cli._send_deploy_notification")
     @patch("ginkgo.services")
@@ -337,8 +397,8 @@ class TestSendDeployNotification:
         msg = mock_producer.send.call_args[0][1]
         assert topic == "ginkgo.live.control.commands"
         assert msg["command"] == "deploy"
-        assert msg["portfolio_id"] == "portfolio_123"
-        assert "timestamp" in msg
+        # 68b749e5 确立的正确格式：portfolio_id 在 params 内（非顶层）
+        assert msg["params"]["portfolio_id"] == "portfolio_123"
 
 
 class TestSendUnloadCommand:
@@ -361,7 +421,8 @@ class TestSendUnloadCommand:
         msg = mock_producer.send.call_args[0][1]
         assert topic == "ginkgo.live.control.commands"
         assert msg["command"] == "unload"
-        assert msg["portfolio_id"] == "portfolio_456"
+        # portfolio_id 在 params 内（ControlCommand DTO 格式）
+        assert msg["params"]["portfolio_id"] == "portfolio_456"
 
     @patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer")
     def test_returns_false_on_kafka_failure(self, mock_producer_cls):
@@ -391,13 +452,14 @@ class TestStoreDeploySource:
             from ginkgo.client.portfolio_cli import _store_deploy_source
             _store_deploy_source("paper_001", "source_001")
 
-        mock_redis.set.assert_called_once_with("deviation:source:paper_001", "source_001")
+        # #4662 后 impl 用 set_cache（非 set）
+        mock_redis.set_cache.assert_called_once_with("deviation:source:paper_001", "source_001")
 
     @patch("ginkgo.client.portfolio_cli.GLOG")
     def test_handles_redis_failure_gracefully(self, mock_glog):
         """Redis 失败时应 WARN 而非抛异常"""
         mock_redis = MagicMock()
-        mock_redis.set.side_effect = Exception("connection refused")
+        mock_redis.set_cache.side_effect = Exception("connection refused")
 
         with patch("ginkgo.services") as mock_services:
             mock_services.data.redis_service.return_value = mock_redis

--- a/tests/unit/data/services/test_portfolio_service_mock.py
+++ b/tests/unit/data/services/test_portfolio_service_mock.py
@@ -625,3 +625,64 @@ class TestPersistState:
 
         assert result.is_success()
         mock_get.assert_not_called()
+
+    @pytest.mark.unit
+    def test_persists_engine_current_time(self, service, mock_deps):
+        """persist 应把 state['engine_current_time'] 写入 portfolio 表 (#6159 REPLAY 触发)。
+
+        worker._persist_all_portfolios 已注入 state['engine_current_time']（540 行），
+        但 persist 端若不存，REPLAY 的 is_replay 判定恒 False → worker 从不快进历史。
+        """
+        captured = {}
+        mock_deps["crud_repo"].modify.side_effect = lambda filters, updates: captured.update(updates)
+        state = self._make_state()
+        state["engine_current_time"] = "2026-05-07T15:00:00"
+
+        with patch.object(service, "_get_position_crud"):
+            service.persist_portfolio_state("port-001", state)
+
+        assert captured.get("engine_current_time") == "2026-05-07T15:00:00"
+
+    @pytest.mark.unit
+    def test_load_returns_engine_current_time(self, service, mock_deps):
+        """load 应返回 engine_current_time 供 worker 判 is_replay (#6159)。
+
+        worker 207 行 et = state_result.data.get("engine_current_time")，
+        load 端不返回则 et 恒 None。
+        """
+        import datetime
+        mock_portfolio = MagicMock()
+        mock_portfolio.cash = "500000"
+        mock_portfolio.frozen = "0"
+        mock_portfolio.total_fee = "100"
+        mock_portfolio.engine_current_time = datetime.datetime(2026, 5, 7, 15, 0, 0)
+        mock_deps["crud_repo"].find.return_value = [mock_portfolio]
+
+        mock_position_crud = MagicMock()
+        mock_position_crud.find.return_value = []
+
+        with patch.object(service, "_get_position_crud", return_value=mock_position_crud):
+            result = service.load_persisted_state("port-001")
+
+        assert result.is_success()
+        assert result.data.get("engine_current_time") is not None
+        assert "2026-05-07" in result.data["engine_current_time"]
+
+    @pytest.mark.unit
+    def test_load_returns_none_engine_time_when_absent(self, service, mock_deps):
+        """engine_current_time 缺失（旧组合/首次启动）应返回 None，不崩溃。"""
+        mock_portfolio = MagicMock()
+        mock_portfolio.cash = "500000"
+        mock_portfolio.frozen = "0"
+        mock_portfolio.total_fee = "100"
+        mock_portfolio.engine_current_time = None
+        mock_deps["crud_repo"].find.return_value = [mock_portfolio]
+
+        mock_position_crud = MagicMock()
+        mock_position_crud.find.return_value = []
+
+        with patch.object(service, "_get_position_crud", return_value=mock_position_crud):
+            result = service.load_persisted_state("port-001")
+
+        assert result.is_success()
+        assert result.data.get("engine_current_time") is None

--- a/tests/unit/trading/services/test_component_loader_param_compat.py
+++ b/tests/unit/trading/services/test_component_loader_param_compat.py
@@ -48,6 +48,30 @@ class TestParamIndexBackwardCompat:
         )
         assert result == {"codes": '"000001.SH"'}
 
+    def test_db_stores_name_at_index0_business_param_shifted(self):
+        """现实 deploy：DB 把 name 存在 index0，业务参数在 index1。
+        提取器跳过 name → param_names 少一项（len < component_params）。
+        应偏移映射，codes 拿到 index1 的真 codes 值，而非 index0 的 name 值。
+        (#6159 paper 冒烟根因：FixedSelector codes 错绑 'default_selector' → 0 bar)
+        """
+        param_names = {0: "codes"}
+        result = resolve_param_kwargs(
+            component_params=['default_selector', ['000858.SZ', '600519.SH']],
+            param_indices=[0, 1],
+            param_names=param_names,
+        )
+        assert result == {"codes": ['000858.SZ', '600519.SH']}
+
+    def test_db_stores_name_multi_business_params_shifted(self):
+        """多业务参数同理：DB index0=name，提取器跳过 → param_names 少一项 → 偏移。"""
+        param_names = {0: "codes", 1: "period"}
+        result = resolve_param_kwargs(
+            component_params=['StratName', '"000001.SH"', 14],
+            param_indices=[0, 1, 2],
+            param_names=param_names,
+        )
+        assert result == {"codes": '"000001.SH"', "period": 14}
+
     def test_empty_params_returns_empty(self):
         """无参数时返回空 dict"""
         result = resolve_param_kwargs(

--- a/tests/unit/trading/time/test_time_providers.py
+++ b/tests/unit/trading/time/test_time_providers.py
@@ -445,21 +445,34 @@ class TestSystemTimeProviderOperations:
         # 验证带有正确时区
         assert provider_time.tzinfo == timezone.utc
 
-    def test_set_current_time_raises_not_implemented(self):
-        """测试set_current_time抛出NotImplementedError"""
-        provider = SystemTimeProvider()
-        some_time = datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-        # 系统时间模式不支持手动设置时间
-        with pytest.raises(NotImplementedError):
-            provider.set_current_time(some_time)
+    def test_set_current_time_is_noop_returns_true(self):
+        """系统时间模式 set_current_time 是空操作返回 True（#6159 bug#5）。
 
-    def test_advance_time_to_raises_not_implemented(self):
-        """测试advance_time_to抛出NotImplementedError"""
+        LogicalTimeProvider.set_current_time 契约是返回 bool（True 成功/False 拒绝），
+        TimeMixin.advance_time 据此判断是否继续后续处理。SystemTimeProvider 之前
+        raise NotImplementedError，破坏了 bool 契约——导致 advance_time 整个抛异常，
+        portfolio 的 T+1 结算 + signal 批处理不执行。
+        LIVE mode 的 timer 推进与残留 REPLAY 事件都会调 set_current_time，改为
+        no-op 返回 True（系统时钟自走，set 无意义但调用安全）。
+        """
         provider = SystemTimeProvider()
-        target_time = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
-        # 系统时间模式不支持推进时间
-        with pytest.raises(NotImplementedError):
-            provider.advance_time_to(target_time)
+        target = datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        # 空操作：不 raise，返回 True（符合 bool 契约）
+        result = provider.set_current_time(target)
+        assert result is True
+        # now() 仍是系统真实时间，set 未改变它（target 是 2023 远非现在）
+        assert abs((provider.now() - target).total_seconds()) > 1
+
+    def test_advance_time_to_is_noop_does_not_raise(self):
+        """系统时间模式 advance_time_to 是空操作不 raise（#6159 bug#5）。
+
+        与 set_current_time 同理：系统时钟自走，推进无意义但调用应安全。
+        """
+        provider = SystemTimeProvider()
+        target = datetime(2025, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+        # 空操作：不 raise
+        provider.advance_time_to(target)
+        assert abs((provider.now() - target).total_seconds()) > 1
 
     def test_can_access_time_real_time_check(self):
         """测试实盘模式的数据访问检查 - 处理市场数据延迟"""

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -218,6 +218,53 @@ class TestDailyCycle:
         worker._engine.is_running = True
         return worker
 
+    def test_drain_event_queue_returns_true_on_empty(self):
+        """#6159: 空队列时 drain 立即返回 True（无残留事件）。"""
+        import queue as queue_mod
+        worker = self._make_worker_with_engine()
+        worker._engine._event_queue = queue_mod.Queue()
+
+        assert worker._drain_event_queue(timeout=1) is True
+
+    def test_replay_drains_queue_before_transition(self):
+        """#6159: _run_replay_cycle 必须在 _transition_to_live 前 drain 事件队列。
+
+        竞态根因：advance_time_to 异步入队（main_thread 处理），_transition_to_live
+        同步切 SystemTimeProvider。若不 drain，残留 REPLAY 事件在切换后处理 →
+        portfolio.advance_time 用 SystemTimeProvider 报 'Cannot set time in system
+        time mode'，阻断 feeder 喂 bar → 0 Signal。
+        """
+        from datetime import datetime, date
+        worker = self._make_worker_with_engine()
+
+        # 共享 tracker 记录 drain/transition 调用顺序
+        tracker = MagicMock()
+        worker._drain_event_queue = tracker.drain
+        worker._transition_to_live = tracker.transition
+        worker._persist_all_portfolios = MagicMock()
+        worker._run_deviation_check = MagicMock()
+
+        # engine.now 初始历史 → 触发 advance；advance_time_to 后跳到 real_today → break
+        worker._engine.now = datetime(2026, 6, 4)
+
+        def fake_advance(t):
+            worker._engine.now = datetime(2026, 6, 16)
+        worker._engine.advance_time_to.side_effect = fake_advance
+
+        with patch("ginkgo.services") as mock_services:
+            mock_td = MagicMock()
+            next_day = MagicMock()
+            next_day.date.return_value = date(2026, 6, 5)
+            mock_td.get_next_trading_day.return_value = next_day
+            mock_services.data.cruds.trade_day.return_value = mock_td
+            worker._run_replay_cycle()
+
+        names = [c[0] for c in tracker.mock_calls]
+        assert "drain" in names, f"drain 未被调用: {names}"
+        assert "transition" in names
+        assert names.index("drain") < names.index("transition"), \
+            f"drain 必须在 transition 前，实际顺序: {names}"
+
     def test_skip_on_non_trading_day(self):
         """非交易日应跳过推进"""
         from ginkgo.workers.paper_trading_worker import PaperTradingWorker

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -91,6 +91,63 @@ class TestAssembleEngine:
     @patch("ginkgo.trading.brokers.sim_broker.SimBroker")
     @patch("ginkgo.trading.engines.time_controlled_engine.TimeControlledEventEngine")
     @patch("ginkgo.trading.portfolios.t1backtest.PortfolioT1Backtest")
+    def test_assemble_engine_passes_time_to_selector_pick(self, mock_portfolio_cls,
+                                                           mock_engine_cls, mock_broker,
+                                                           mock_gateway, mock_feeder,
+                                                           mock_loader):
+        """assemble_engine 初始化 selector 应传非 None time（#6159 bug#6）。
+
+        worker 曾无参调 selector.pick() → MomentumSelector.pick(time=None) →
+        datetime_normalize(None)=None → None-timedelta 崩溃（unsupported operand
+        type(s) for -: 'NoneType' and 'datetime.timedelta'）。selector 选股失败 →
+        _interested_codes 空 → feeder WARN "No interested symbols" → PRICEUPDATE=0
+        → signal=0。传 datetime.now() 让依赖 time 的 selector（如 Momentum）能算
+        日期窗口；不依赖 time 的 selector（如 CNAll）忽略该参数不受影响。
+        """
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        # 带 selector 的 portfolio，直接挂到 engine.portfolios
+        mock_selector = MagicMock()
+        mock_portfolio_instance = MagicMock()
+        mock_portfolio_instance._selectors = [mock_selector]
+
+        mock_db_portfolio = MagicMock()
+        mock_db_portfolio.uuid = "p-001"
+        mock_db_portfolio.mode = PORTFOLIO_MODE_TYPES.PAPER.value
+        mock_db_portfolio.initial_cash = 100000.0
+
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = [mock_db_portfolio]
+        mock_container = MagicMock()
+        mock_container.cruds.portfolio.return_value = mock_crud
+
+        mock_components = {
+            "strategies": [], "risk_managers": [], "analyzers": [],
+            "selectors": [], "sizers": [],
+        }
+
+        mock_engine_instance = MagicMock()
+        mock_engine_instance.portfolios = [mock_portfolio_instance]
+        mock_engine_cls.return_value = mock_engine_instance
+
+        worker = PaperTradingWorker(worker_id="test-1")
+        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
+                   return_value=mock_components):
+            worker.assemble_engine(mock_container)
+
+        # 断言 pick 被调且传了非 None time（位置参数或 time= kwarg）
+        mock_selector.pick.assert_called()
+        call_args = mock_selector.pick.call_args
+        time_arg = call_args.args[0] if call_args.args else call_args.kwargs.get("time")
+        assert time_arg is not None, "selector.pick 必须传非 None time（#6159 bug#6）"
+
+    @patch("ginkgo.trading.services._assembly.component_loader.ComponentLoader")
+    @patch("ginkgo.trading.feeders.backtest_feeder.BacktestFeeder")
+    @patch("ginkgo.trading.gateway.trade_gateway.TradeGateway")
+    @patch("ginkgo.trading.brokers.sim_broker.SimBroker")
+    @patch("ginkgo.trading.engines.time_controlled_engine.TimeControlledEventEngine")
+    @patch("ginkgo.trading.portfolios.t1backtest.PortfolioT1Backtest")
     def test_loads_papers_portfolios_from_db(self, mock_portfolio_cls,
                                               mock_engine_cls,
                                               mock_broker, mock_gateway,

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -139,6 +139,71 @@ class TestAssembleEngine:
         # Portfolio 应已添加到引擎
         mock_engine_instance.add_portfolio.assert_called_once()
 
+    @patch("ginkgo.trading.services._assembly.component_loader.ComponentLoader")
+    @patch("ginkgo.trading.feeders.backtest_feeder.BacktestFeeder")
+    @patch("ginkgo.trading.gateway.trade_gateway.TradeGateway")
+    @patch("ginkgo.trading.brokers.sim_broker.SimBroker")
+    @patch("ginkgo.trading.engines.time_controlled_engine.TimeControlledEventEngine")
+    @patch("ginkgo.trading.portfolios.t1backtest.PortfolioT1Backtest")
+    def test_replay_propagates_logical_provider_to_feeder(self, mock_portfolio_cls,
+                                                          mock_engine_cls, mock_broker,
+                                                          mock_gateway, mock_feeder,
+                                                          mock_loader):
+        """#6159: REPLAY 模式设 LogicalTimeProvider 后必须 propagate 到 feeder。
+
+        否则 feeder 仍用 SystemTimeProvider，REPLAY 快进时 feeder.advance_time_to
+        报 'Cannot set time in system time mode' → 0 喂 bar → 0 Signal。
+        这是 paper 端到端冒烟的核心阻塞点。
+        """
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+        from ginkgo.trading.time.providers import LogicalTimeProvider
+
+        mock_db_portfolio = MagicMock()
+        mock_db_portfolio.uuid = "p-001"
+        mock_db_portfolio.mode = PORTFOLIO_MODE_TYPES.PAPER.value
+        mock_db_portfolio.initial_cash = 100000.0
+
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = [mock_db_portfolio]
+        mock_container = MagicMock()
+        mock_container.cruds.portfolio.return_value = mock_crud
+
+        # load_persisted_state 返回历史 engine_time → 触发 is_replay
+        mock_pservice = MagicMock()
+        state = MagicMock()
+        state.is_success.return_value = True
+        state.data = {
+            "has_state": True,
+            "engine_current_time": "2026-05-07T15:00:00",
+            "cash": "100000", "frozen": "0", "fee": "0", "positions": {},
+        }
+        mock_pservice.load_persisted_state.return_value = state
+        mock_container.portfolio_service.return_value = mock_pservice
+
+        mock_portfolio_instance = MagicMock()
+        mock_portfolio_instance.uuid = "p-001"
+        mock_portfolio_instance.portfolio_id = "p-001"
+        mock_portfolio_cls.return_value = mock_portfolio_instance
+
+        mock_feeder_instance = MagicMock()
+        mock_engine_instance = MagicMock()
+        mock_engine_instance.portfolios = [mock_portfolio_instance]
+        mock_engine_instance._datafeeder = mock_feeder_instance
+        mock_engine_cls.return_value = mock_engine_instance
+
+        worker = PaperTradingWorker(worker_id="test-replay")
+        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
+                   return_value={"strategies": [], "risk_managers": [], "analyzers": [],
+                                 "selectors": [], "sizers": []}):
+            worker.assemble_engine(mock_container)
+
+        # feeder 必须收到 LogicalTimeProvider，否则 REPLAY 快进喂 bar 全失败
+        mock_feeder_instance.set_time_provider.assert_called()
+        args, _ = mock_feeder_instance.set_time_provider.call_args
+        assert isinstance(args[0], LogicalTimeProvider), \
+            f"feeder 必须收到 LogicalTimeProvider，实际 {type(args[0]).__name__}"
+
 
 class TestDailyCycle:
     """每日循环逻辑测试"""
@@ -537,6 +602,29 @@ class TestStartStop:
         worker._running = True
         worker.stop()
         assert worker.is_running is False
+
+    @patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoConsumer")
+    @patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer")
+    def test_start_auto_runs_replay_when_replay_mode(self, mock_producer_cls, mock_consumer_cls):
+        """#6159: worker 启动时若处于 REPLAY mode，应自动跑 run_daily_cycle 快进历史。
+
+        根因：run_daily_cycle 唯一入口是 _handle_command 的 "paper_trading" 命令，
+        但 Kafka Consumer offset="latest"，命令若在 consumer 完成 group join 前发出
+        会被静默跳过（smoke 实测 "Received command" 计数=0）→ run_daily_cycle 永不
+        执行 → 0 advance → 0 Signal。
+        修复：start() 在 _consume_loop 前检测 _is_replay_mode 自动触发，不依赖命令。
+        """
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker, DailyCycleResult
+
+        worker = PaperTradingWorker(worker_id="test-1")
+        with patch.object(worker, "_is_replay_mode", return_value=True), \
+             patch.object(worker, "run_daily_cycle",
+                          return_value=DailyCycleResult(skipped=False, advanced=True)) as mock_cycle, \
+             patch.object(worker, "_consume_loop") as mock_loop:
+            worker.start()
+
+        mock_cycle.assert_called_once()
+        mock_loop.assert_called_once()
 
 
 class TestDailyCycleResult:


### PR DESCRIPTION
## Summary

回测→模拟盘 deploy 链路（`ginkgo deploy`）两个 bug，导致新部署的 PAPER 组合策略无法实例化、行情喂入中断（paper 冒烟时 NEW 组合 0 信号的根因）：

1. **mapping 复制用 `add(kwargs)` 致 TypeError** —— `BaseCRUD.add()` 收 model 对象，传 kwargs 直接抛异常。改用 `create(kwargs)`，返回带 uuid 的新 mapping。
2. **循环只复制 mapping 不复制 param** —— 组件参数（strategy name、lookback 等）全部丢失。补 param 复制循环，`mapping_id` 指向新 mapping 的 uuid。

### 附带：恢复 deploy/unload 通知 seam

`68b749e5` 为修 Kafka 消息格式（portfolio_id 须在 params 内）把 deploy/unload 的发送内联并删除 `_send_deploy_notification` / `_send_unload_command`，但**漏改 patch 它们的测试**，导致 4 个测试类（`TestDeployPaperTrading` / `TestSendDeployNotification` / `TestSendUnloadCommand` / `TestUnloadCommandInvocation`）全部 AttributeError。恢复两个 seam，用正确的 `ControlCommand.deploy().to_dict()` 实现（保留 `68b749e5` 的格式修复，而非回退到手搓 dict）。顺手修正 `#4662` 后残留的 `store_source` 测试陈旧断言（`set`→`set_cache`）——`_store_deploy_source` 是 deploy 第 4 步。

## 调用链

```
_deploy_paper_trading()
  ├─ portfolio_service.add(mode=PAPER)          # 创建新组合
  ├─ for mapping in 源 mappings:                # BUG1: add→create
  │    new_mapping = mapping_crud.create(...)
  │    for p in 源 mapping 的 params:           # BUG2: 新增 param 复制
  │      param_crud.create(mapping_id=new.uuid, index, value)
  ├─ _store_deploy_source()                     # 修了测试断言
  ├─ _generate_baseline_if_possible()
  └─ _send_deploy_notification()                # 恢复的 seam
```

## Test plan

- [x] `tests/unit/client/test_paper_trading_cli.py`：master **16 红/11 绿 → 3 红/25 绿**，0 新增故障
- [x] 两个核心 bug 测试单独通过：`test_deploy_copies_mappings`（断言 `create`）、`test_deploy_copies_params`（断言 param 按 mapping_id 复制）
- [x] 相邻回归：`test_portfolio_file_mapping_crud_mock.py` + `test_portfolio_cli.py` 共 42 绿
- [ ] 实盘前：用修好的 deploy 重新部署一个回测组合，确认 REPLAY 喂入 PriceUpdate、产生 Signal（paper 冒烟收尾）

## 未覆盖（预存故障，非本次范围）

`TestBaselineCommand` 3 个失败属独立的 `ginkgo baseline` 命令链路（redis source override 持久化、退出码），master 上即红，留后续。