### PR TITLE
ADR-011 信号发射 seam 统一（Strategy + Risk）+ source 语义厘清

### DIFF
--- a/docs/adr/ADR-011-signal-emission-seam.md
+++ b/docs/adr/ADR-011-signal-emission-seam.md
@@ -1,0 +1,56 @@
+# ADR-011: 信号发射统一 Seam（Strategy + Risk）
+
+**Status:** Accepted
+**Date:** 2026-06-15（初稿 2026-06-14，落地前范围由 Strategy 扩至含 Risk）
+
+## Context
+
+`create_signal` 在代码库有**两份独立定义**，二者各自静默漂移：
+
+- `BaseStrategy.create_signal`（strategy_base.py:33）—— 15 策略
+- `RiskBase.create_signal`（risk_base.py:105）—— 8 Risk 类；RiskBase **不继承** BaseStrategy，是平行同名方法
+
+两份都只填 portfolio/engine/task_id 后构造 Signal，三个跨切关注点漂移：
+
+| 关注点 | Strategy 侧 | Risk 侧 |
+|---|---|---|
+| ClickHouse 日志 | 4/15 策略调 `blog.signal` | **0/8 记日志** |
+| `source` | 1/15 设 STRATEGY，14 掉 OTHER（signal.py:36） | **8/8 全掉 OTHER** |
+| `business_timestamp` | 8 用 `portfolio_info["now"]`、1（Random）用 `provider.now()`；同源（portfolio_base.py:919）冗余 | 各类各异 |
+
+后果：同样"产生一个信号"，日志完整度与 `source` 字段因来源不同而不可靠——**静默数据质量漂移**。此外 `finalize()`/`on_data_updated()` 经 grep 无策略侧调用方（死方法），`validate_parameters()` 基类恒 `True`（仅 RandomSignalStrategy 覆写，#24 绑定时校验）。
+
+## Decision
+
+把两份 `create_signal` 统一深化为**信号发射 seam**——单一入口，背后藏 4 件事，调用方只见业务参数：
+
+1. **构造** Signal（现状）—— 自动填 portfolio/engine/task_id
+2. **`business_timestamp`** —— 缺省 `self.get_time_provider().now()`；provider 为 None 时**留 None**（全链路契约支持，见 Rationale）；调用方可覆盖
+3. **`source`** —— 按角色缺省：Strategy→`SOURCE_TYPES.STRATEGY`，Risk→**新增 `SOURCE_TYPES.RISK`**；调用方可覆盖
+4. **ClickHouse 日志** —— 无条件调 `self.blog.signal(...)`；Strategy 传 `strategy_id=self.uuid`，Risk 传 `risk_id=self.uuid`
+
+配套：删除死方法 `finalize()`/`on_data_updated()`；收敛 4 个手写 blog 的策略（6 处）与 RandomSignalStrategy 的后置 `set_source`；`validate_parameters()` 留 hook + 默认 `True`（待类型化参数注入收编）。
+
+**两份 seam 同结构、不同参数**：Strategy 与 Risk 共享"构造 / 时间 / source / 日志"四件事，仅 source 缺省值与日志 id 字段按角色分叉。**不抽共享 mixin**——BaseStrategy/RiskBase 继承链已分，禁改 Base 类 norm（CLAUDE.md）下强行抽 mixin 牵动面更大，且收益（省一份 ~10 行样板）抵不过耦合成本。
+
+## Rationale
+
+- **"值归谁"决定可不可覆盖**：`source`/`timestamp` 是组件**拥有的值**（缺省 + 可覆盖）；日志是框架**拥有的基础设施**（11 策略 + 8 Risk 不记是 bug，无条件）。这条线挡住"日志也加开关"的滑坡。
+- **provider=None 留 None 有三层契约支撑**：entity 默认 `business_timestamp=None`（signal.py:42）、ORM `nullable=True`（model_signal.py:40）、下游 `signal.business_timestamp or signal.timestamp` 兜底（signal_tracking_service.py:63）。"可缺时间戳"是系统既有设计，非新引入风险。seam 拿不到 event（签名只有 code/direction/reason），无法照搬 Random 的 event 兜底。
+- **加 `SOURCE_TYPES.RISK` 免 ALTER**：source 列是 `Int8`（model_clickbase.py:53），非 ClickHouse Enum16——枚举值只活在 Python 语义层，DB 层即 int，加值零成本，不触碰 ADR-007 禁手动 ALTER。
+- **不退回显式两段（create + emit）**：那正是当前 RandomSignalStrategy 只 create 不 log 的漂移根源。
+- **timestamp 取 `get_time_provider()`**：portfolio_base.py:919 证明 `portfolio_info["now"]` 与之同源，且两份 create_signal 所在类经 TimeMixin 已持 provider → seam 无需 `portfolio_info`，接口保持业务参数，深度最大。
+
+## Consequences
+
+- **行为变更（难逆转）**：23 个子类（15 Strategy + 8 Risk）将统一记 ClickHouse 信号日志；`source` 默认由 OTHER 变 STRATEGY（Strategy）/ RISK（Risk），均可覆盖。
+- **新增枚举值**：`SOURCE_TYPES.RISK`（建议 =22），Int8 列免 ALTER。
+- **验证方式**：一次回测前后对比 ClickHouse 信号行——修复前仅 4 策略有日志、source 混乱、Risk 完全无日志；修复后齐日志、source 按角色分明。比单测更能证明 drift 修好。
+- **交叉引用**：ADR-001（组件单向流，`cal()`/`generate_signals()` 契约不变）、ADR-008（框架能力边界机制层细化）、ADR-010（Signal 是 Entity，发射 seam 耦合构造与观测）、ADR-007（Int8 列使加 source 值不破"Model 驱动建表"）。
+- **未决（与本 ADR 正交，单独处理）**：4 处 `isinstance(event, EventPriceUpdate)` guard 多半死防御（需先确认 portfolio handler 注册的事件类型再删）；`initialize()` 签名错配（strategy_adapter.py:156 传 `**kwargs`、基类收 `context: Dict`）。
+
+## 判定标准自检
+
+- ① **难逆转**：23 子类依赖，但被其简化（回退需重加样板）——中等。
+- ② **反直觉**：`create_signal` 顺带写 ClickHouse、且两份同名方法不同 source 缺省——未来必被质疑——满足。
+- ③ **真实权衡**：A Strategy-only / B 两份统一（**本 ADR**）/ C 抽共享 mixin——选 B——满足。

--- a/docs/adr/ADR-011-signal-emission-seam.md
+++ b/docs/adr/ADR-011-signal-emission-seam.md
@@ -45,9 +45,9 @@
 
 ## Consequences
 
-- **行为变更（难逆转）**：23 个子类（15 Strategy + 8 Risk）将统一记 ClickHouse 信号日志；`source` 默认由 OTHER 变 STRATEGY（Strategy）/ RISK（Risk），均可覆盖。
+- **行为变更（难逆转）**：23 个子类（15 Strategy + 8 Risk）将统一记 ClickHouse 信号日志（ginkgo_logs_backtest 的 SIGNALGENERATION 行）；Signal 实体的 `source` 默认由 OTHER 变 STRATEGY（Strategy）/ RISK（Risk），均可覆盖。
 - **新增枚举值**：`SOURCE_TYPES.RISK`（建议 =22），Int8 列免 ALTER。
-- **验证方式**：一次回测前后对比 ClickHouse 信号行——修复前仅 4 策略有日志、source 混乱、Risk 完全无日志；修复后齐日志、source 按角色分明。比单测更能证明 drift 修好。
+- **验证方式**：drift 修复落在两个独立观测面——(1) **齐日志**：组件经 seam 调 `blog.signal()` → ginkgo_logs_backtest 的 SIGNALGENERATION 行齐全（注意：该行 `source` 是引擎级 BACKTEST，由 `engine_ctx.source_type` 注入，与信号角色无关，非 drift）；(2) **source 按角色分明**：指 Signal 实体的 `source`（STRATEGY/RISK，seam 缺省设，单元测试验证），Signal 是事件流内存对象，不落 ClickHouse signal 表/MySQL signal_tracker（两者本环境均 0 行）。
 - **交叉引用**：ADR-001（组件单向流，`cal()`/`generate_signals()` 契约不变）、ADR-008（框架能力边界机制层细化）、ADR-010（Signal 是 Entity，发射 seam 耦合构造与观测）、ADR-007（Int8 列使加 source 值不破"Model 驱动建表"）。
 - **未决（与本 ADR 正交，单独处理）**：4 处 `isinstance(event, EventPriceUpdate)` guard 多半死防御（需先确认 portfolio handler 注册的事件类型再删）；`initialize()` 签名错配（strategy_adapter.py:156 传 `**kwargs`、基类收 `context: Dict`）。
 

--- a/docs/adr/ADR-011-signal-emission-seam.md
+++ b/docs/adr/ADR-011-signal-emission-seam.md
@@ -29,11 +29,11 @@
 1. **构造** Signal（现状）—— 自动填 portfolio/engine/task_id
 2. **`business_timestamp`** —— 缺省 `self.get_time_provider().now()`；provider 为 None 时**留 None**（全链路契约支持，见 Rationale）；调用方可覆盖
 3. **`source`** —— 按角色缺省：Strategy→`SOURCE_TYPES.STRATEGY`，Risk→**新增 `SOURCE_TYPES.RISK`**；调用方可覆盖
-4. **ClickHouse 日志** —— 无条件调 `self.blog.signal(...)`；Strategy 传 `strategy_id=self.uuid`，Risk 传 `risk_id=self.uuid`
+4. **ClickHouse 日志** —— 无条件调 `self.blog.signal(...)`；Strategy/Risk 均传 `strategy_id=self.uuid`（参数名历史沿用，两 seam 共用，日志行结构一致；来源区分由 `Signal.source` 承担，见第 50 行）
 
 配套：收敛 4 个手写 blog 的策略（6 处）与 RandomSignalStrategy 的后置 `set_source`；`validate_parameters()` 留 hook + 默认 `True`（待类型化参数注入收编）。
 
-**两份 seam 同结构、不同参数**：Strategy 与 Risk 共享"构造 / 时间 / source / 日志"四件事，仅 source 缺省值与日志 id 字段按角色分叉。**不抽共享 mixin**——BaseStrategy/RiskBase 继承链已分，禁改 Base 类 norm（CLAUDE.md）下强行抽 mixin 牵动面更大，且收益（省一份 ~10 行样板）抵不过耦合成本。
+**两份 seam 同结构、不同参数**：Strategy 与 Risk 共享“构造 / 时间 / source / 日志”四件事，仅 source 缺省值按角色分叉（日志 id 字段共用 `strategy_id`，参数名历史沿用）。**不抽共享 mixin**——BaseStrategy/RiskBase 继承链已分，禁改 Base 类 norm（CLAUDE.md）下强行抽 mixin 牵动面更大，且收益（省一份 ~10 行样板）抵不过耦合成本。
 
 ## Rationale
 

--- a/docs/adr/ADR-011-signal-emission-seam.md
+++ b/docs/adr/ADR-011-signal-emission-seam.md
@@ -18,7 +18,9 @@
 | `source` | 1/15 设 STRATEGY，14 掉 OTHER（signal.py:36） | **8/8 全掉 OTHER** |
 | `business_timestamp` | 8 用 `portfolio_info["now"]`、1（Random）用 `provider.now()`；同源（portfolio_base.py:919）冗余 | 各类各异 |
 
-后果：同样"产生一个信号"，日志完整度与 `source` 字段因来源不同而不可靠——**静默数据质量漂移**。此外 `finalize()`/`on_data_updated()` 经 grep 无策略侧调用方（死方法），`validate_parameters()` 基类恒 `True`（仅 RandomSignalStrategy 覆写，#24 绑定时校验）。
+后果：同样"产生一个信号"，日志完整度与 `source` 字段因来源不同而不可靠——**静默数据质量漂移**。`validate_parameters()` 基类恒 `True`（仅 RandomSignalStrategy 覆写，#24 绑定时校验）。
+
+**已排除（非死代码）**：`finalize()`/`on_data_updated()` 虽无运行时调用方，但受 `StrategyProtocol`（interfaces/protocols/strategy.py:179/240）声明 + `test_strategy_protocol.py` 断言 `callable(...)` 双重守护，是接口契约占位（基类 stub 满足 protocol 返回类型）。删除会破 protocol 契约 + 红测试，不在本 ADR 范围——是否从协议移除策略生命周期概念属独立设计决策。
 
 ## Decision
 
@@ -29,7 +31,7 @@
 3. **`source`** —— 按角色缺省：Strategy→`SOURCE_TYPES.STRATEGY`，Risk→**新增 `SOURCE_TYPES.RISK`**；调用方可覆盖
 4. **ClickHouse 日志** —— 无条件调 `self.blog.signal(...)`；Strategy 传 `strategy_id=self.uuid`，Risk 传 `risk_id=self.uuid`
 
-配套：删除死方法 `finalize()`/`on_data_updated()`；收敛 4 个手写 blog 的策略（6 处）与 RandomSignalStrategy 的后置 `set_source`；`validate_parameters()` 留 hook + 默认 `True`（待类型化参数注入收编）。
+配套：收敛 4 个手写 blog 的策略（6 处）与 RandomSignalStrategy 的后置 `set_source`；`validate_parameters()` 留 hook + 默认 `True`（待类型化参数注入收编）。
 
 **两份 seam 同结构、不同参数**：Strategy 与 Risk 共享"构造 / 时间 / source / 日志"四件事，仅 source 缺省值与日志 id 字段按角色分叉。**不抽共享 mixin**——BaseStrategy/RiskBase 继承链已分，禁改 Base 类 norm（CLAUDE.md）下强行抽 mixin 牵动面更大，且收益（省一份 ~10 行样板）抵不过耦合成本。
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@
 | ADR-008 | [策略框架能力边界](ADR-008-strategy-framework-capacity.md) | Accepted | 2026-06-03 |
 | ADR-009 | [全局服务容器 service_hub](ADR-009-global-service-hub.md) | Accepted | 2026-06-13 |
 | ADR-010 | [数据对象三层角色分离 Entity/ORM/DTO](ADR-010-entity-orm-dto-separation.md) | Accepted | 2026-06-13 |
+| ADR-011 | [信号发射统一 Seam（Strategy + Risk）](ADR-011-signal-emission-seam.md) | Accepted | 2026-06-15 |
 
 ## 如何新增 / 修订
 

--- a/src/ginkgo/enums.py
+++ b/src/ginkgo/enums.py
@@ -156,6 +156,7 @@ class SOURCE_TYPES(EnumBase):
     PAPER_LIVE = 19     # 实盘模拟（真实市场数据）
     MANUAL = 20         # 手动录入
     OKX = 21            # OKX 交易所
+    RISK = 22           # 风控组件（RiskBase.create_signal 信号源）
 
 
 class DIRECTION_TYPES(EnumBase):

--- a/src/ginkgo/trading/bases/risk_base.py
+++ b/src/ginkgo/trading/bases/risk_base.py
@@ -19,6 +19,7 @@ from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
 from ginkgo.entities.mixins import EngineBindableMixin
 from ginkgo.entities.mixins import NamedMixin
+from ginkgo.enums import SOURCE_TYPES
 
 if TYPE_CHECKING:
     from ginkgo.entities import Order
@@ -105,15 +106,47 @@ class RiskBase(TimeMixin, ContextMixin, EngineBindableMixin, NamedMixin, Base):
     def create_signal(self, code: str, direction, reason: str = "",
                       volume: int = 0, weight: float = 0.0,
                       strength: float = 0.5, confidence: float = 0.5,
+                      business_timestamp=None, source=None,
                       **kwargs):
         """
-        创建带有完整上下文的风控信号。
+        信号发射 seam（ADR-011, #6160）：单一入口背后藏四件事，调用方只见业务参数。
 
-        自动填充 portfolio_id、engine_id、task_id，风控组件只需关注业务参数。
+        1. 构造 Signal —— 自动填 portfolio/engine/task_id
+        2. business_timestamp —— 缺省 get_time_provider().now()；provider 未绑定留 None；
+           调用方传值时覆盖（不查 provider）
+        3. source —— 缺省 SOURCE_TYPES.RISK；调用方可覆盖
+        4. ClickHouse 日志 —— 无条件 blog.signal(strategy_id=self.uuid)
+           注：strategy_id 参数名历史沿用，泛指信号生成组件 uuid（Strategy/Risk 共用）；
+           来源区分由 Signal.source（STRATEGY/RISK）承担。
+
+        Args:
+            code: 股票代码
+            direction: 交易方向 (DIRECTION_TYPES)
+            reason: 信号原因
+            volume: 建议交易量
+            weight: 信号权重
+            strength: 信号强度
+            confidence: 信号置信度
+            business_timestamp: 业务时间戳；None 时取 provider.now()，provider 未绑定留 None
+            source: 信号来源；None 时缺省 RISK
+            **kwargs: 其他 Signal 参数
+
+        Returns:
+            Signal: 带完整上下文、source、时间戳的信号对象
         """
         from ginkgo.entities import Signal
 
-        return Signal(
+        # source：组件拥有的值，缺省 RISK，可覆盖（值归组件原则）
+        if source is None:
+            source = SOURCE_TYPES.RISK
+
+        # business_timestamp：provider 有则取 now()，无则留 None（三层契约支撑）
+        if business_timestamp is None:
+            provider = self.get_time_provider()
+            if provider is not None:
+                business_timestamp = provider.now()
+
+        signal = Signal(
             portfolio_id=self.portfolio_id or "",
             engine_id=self.engine_id or "",
             task_id=self.task_id or "",
@@ -124,5 +157,17 @@ class RiskBase(TimeMixin, ContextMixin, EngineBindableMixin, NamedMixin, Base):
             weight=weight,
             strength=strength,
             confidence=confidence,
+            source=source,
+            business_timestamp=business_timestamp,
             **kwargs,
         )
+
+        # ClickHouse 信号日志：框架拥有的基础设施，无条件（ADR-011）
+        self.blog.signal(
+            symbol=code,
+            direction=direction.value if hasattr(direction, 'value') else str(direction),
+            signal_reason=reason,
+            strategy_id=self.uuid,
+            msg=reason,
+        )
+        return signal

--- a/src/ginkgo/trading/strategies/mean_reversion.py
+++ b/src/ginkgo/trading/strategies/mean_reversion.py
@@ -245,14 +245,6 @@ class MeanReversion(BaseStrategy, StrategyDataMixin):
                 business_timestamp=business_timestamp,
             )
 
-            self.blog.signal(
-                symbol=code,
-                direction=direction.value if hasattr(direction, 'value') else str(direction),
-                signal_reason=signal.reason,
-                strategy_id=self.uuid,
-                msg=f"均值回归信号: {signal.reason}",
-            )
-
         return [signal] if signal else None
 
     def reset_state(self) -> None:

--- a/src/ginkgo/trading/strategies/momentum.py
+++ b/src/ginkgo/trading/strategies/momentum.py
@@ -158,14 +158,6 @@ class Momentum(BaseStrategy, StrategyDataMixin):
             )
             signals.append(signal)
 
-            self.blog.signal(
-                symbol=code,
-                direction=DIRECTION_TYPES.LONG.value,
-                signal_reason=signal.reason,
-                strategy_id=self.uuid,
-                msg=f"动量买入: {code} 动量={momentum:.4f}",
-            )
-
         elif momentum < -self.momentum_threshold and has_position:
             signal = self.create_signal(
                 code=code,
@@ -174,14 +166,6 @@ class Momentum(BaseStrategy, StrategyDataMixin):
                 business_timestamp=current_time,
             )
             signals.append(signal)
-
-            self.blog.signal(
-                symbol=code,
-                direction=DIRECTION_TYPES.SHORT.value,
-                signal_reason=signal.reason,
-                strategy_id=self.uuid,
-                msg=f"动量卖出: {code} 动量={momentum:.4f}",
-            )
 
         return signals
 

--- a/src/ginkgo/trading/strategies/moving_average_crossover.py
+++ b/src/ginkgo/trading/strategies/moving_average_crossover.py
@@ -292,15 +292,6 @@ class MovingAverageCrossover(BaseStrategy, StrategyDataMixin):
 
             GLOG.INFO(f"{self.name}: {code} {signal.reason}")
 
-            # 记录信号事件到ClickHouse（使用快捷访问）
-            self.blog.signal(
-                symbol=code,
-                direction=direction.value if hasattr(direction, 'value') else str(direction),
-                signal_reason=signal.reason,
-                strategy_id=self.uuid,
-                msg=f"MA交叉信号: {signal.reason}",
-            )
-
         return [signal] if signal else None
 
     def reset_state(self) -> None:

--- a/src/ginkgo/trading/strategies/random_signal_strategy.py
+++ b/src/ginkgo/trading/strategies/random_signal_strategy.py
@@ -27,7 +27,7 @@ from ginkgo.libs import GLOG
 from ginkgo.trading.strategies.strategy_base import BaseStrategy
 from ginkgo.entities import Signal
 from ginkgo.trading.events.price_update import EventPriceUpdate
-from ginkgo.enums import DIRECTION_TYPES, SOURCE_TYPES
+from ginkgo.enums import DIRECTION_TYPES
 
 
 class RandomSignalStrategy(BaseStrategy):
@@ -230,10 +230,6 @@ class RandomSignalStrategy(BaseStrategy):
                 reason=reason,
                 business_timestamp=timestamp      # 使用TimeProvider的业务时间
             )
-
-            # 设置信号来源
-            if hasattr(signal, 'set_source'):
-                signal.set_source(SOURCE_TYPES.STRATEGY)
 
             return signal
 

--- a/src/ginkgo/trading/strategies/strategy_base.py
+++ b/src/ginkgo/trading/strategies/strategy_base.py
@@ -15,6 +15,7 @@ from ginkgo.entities.base import Base
 from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
 from ginkgo.entities.mixins import NamedMixin
+from ginkgo.enums import SOURCE_TYPES
 
 
 class BaseStrategy(ContextMixin, TimeMixin, NamedMixin, Base):
@@ -39,12 +40,18 @@ class BaseStrategy(ContextMixin, TimeMixin, NamedMixin, Base):
         weight: float = 0.0,
         strength: float = 0.5,
         confidence: float = 0.5,
+        business_timestamp=None,
+        source=None,
         **kwargs
     ):
         """
-        创建带有完整上下文的交易信号
+        信号发射 seam（ADR-011）：单一入口背后藏四件事，调用方只见业务参数。
 
-        自动填充 portfolio_id、engine_id、task_id，策略只需关注业务参数。
+        1. 构造 Signal —— 自动填 portfolio/engine/task_id
+        2. business_timestamp —— 缺省 get_time_provider().now()；provider 未绑定留 None；
+           调用方传值时覆盖（不查 provider）
+        3. source —— 缺省 SOURCE_TYPES.STRATEGY；调用方可覆盖
+        4. ClickHouse 日志 —— 无条件 blog.signal(strategy_id=self.uuid)
 
         Args:
             code: 股票代码
@@ -54,12 +61,24 @@ class BaseStrategy(ContextMixin, TimeMixin, NamedMixin, Base):
             weight: 信号权重
             strength: 信号强度
             confidence: 信号置信度
-            **kwargs: 其他 Signal 参数 (如 business_timestamp)
+            business_timestamp: 业务时间戳；None 时取 provider.now()，provider 未绑定留 None
+            source: 信号来源；None 时缺省 STRATEGY
+            **kwargs: 其他 Signal 参数
 
         Returns:
-            Signal: 带有完整上下文的信号对象
+            Signal: 带完整上下文、source、时间戳的信号对象
         """
-        return Signal(
+        # source：组件拥有的值，缺省 STRATEGY，可覆盖（值归组件原则）
+        if source is None:
+            source = SOURCE_TYPES.STRATEGY
+
+        # business_timestamp：provider 有则取 now()，无则留 None（三层契约支撑）
+        if business_timestamp is None:
+            provider = self.get_time_provider()
+            if provider is not None:
+                business_timestamp = provider.now()
+
+        signal = Signal(
             portfolio_id=self.portfolio_id,
             engine_id=self.engine_id,
             task_id=self.task_id,
@@ -70,8 +89,20 @@ class BaseStrategy(ContextMixin, TimeMixin, NamedMixin, Base):
             weight=weight,
             strength=strength,
             confidence=confidence,
+            source=source,
+            business_timestamp=business_timestamp,
             **kwargs
         )
+
+        # ClickHouse 信号日志：框架拥有的基础设施，无条件（ADR-011）
+        self.blog.signal(
+            symbol=code,
+            direction=direction.value if hasattr(direction, 'value') else str(direction),
+            signal_reason=reason,
+            strategy_id=self.uuid,
+            msg=reason,
+        )
+        return signal
     def cal(self, portfolio_info, event, *args, **kwargs) -> List[Signal]:
         """
         策略计算方法

--- a/src/ginkgo/trading/strategies/trend_reverse.py
+++ b/src/ginkgo/trading/strategies/trend_reverse.py
@@ -198,14 +198,6 @@ class TrendFollow(BaseStrategy, StrategyDataMixin):
                 )
                 signals.append(signal)
 
-                self.blog.signal(
-                    symbol=code,
-                    direction=direction.value if hasattr(direction, 'value') else str(direction),
-                    signal_reason=signal.reason,
-                    strategy_id=self.uuid,
-                    msg=f"趋势反转信号: {signal.reason}",
-                )
-
             # 从看多 变为 非看多（看空） → 卖出
             elif prev_bullish is not None and prev_bullish and is_bearish:
                 direction = DIRECTION_TYPES.SHORT
@@ -224,14 +216,6 @@ class TrendFollow(BaseStrategy, StrategyDataMixin):
                     business_timestamp=portfolio_info.get("now"),
                 )
                 signals.append(signal)
-
-                self.blog.signal(
-                    symbol=code,
-                    direction=direction.value if hasattr(direction, 'value') else str(direction),
-                    signal_reason=signal.reason,
-                    strategy_id=self.uuid,
-                    msg=f"趋势反转信号: {signal.reason}",
-                )
 
             # 更新状态：True=看多排列, False=其他
             self._prev_alignment[code] = is_bullish

--- a/tests/unit/trading/strategies/test_trend_reverse.py
+++ b/tests/unit/trading/strategies/test_trend_reverse.py
@@ -128,7 +128,8 @@ class TestTrendFollowCal:
         portfolio_info = _make_portfolio_info()
         event = _make_event("000001.SZ")
 
-        # Mock engine_id and task_id as they are read-only properties from context
+        # Mock context properties (read-only) so create_signal can build a Signal
+        type(strategy).portfolio_id = PropertyMock(return_value="portfolio-001")
         type(strategy).engine_id = PropertyMock(return_value="engine-001")
         type(strategy).task_id = PropertyMock(return_value="run-001")
         event = _make_event("000001.SZ")
@@ -166,6 +167,7 @@ class TestTrendFollowCal:
         portfolio_info = _make_portfolio_info()
         event = _make_event("000001.SZ")
 
+        type(strategy).portfolio_id = PropertyMock(return_value="portfolio-001")
         type(strategy).engine_id = PropertyMock(return_value="engine-001")
         type(strategy).task_id = PropertyMock(return_value="run-001")
         event = _make_event("000001.SZ")

--- a/tests/unit/trading/strategy/risk_managements/test_capital_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_capital_risk.py
@@ -84,7 +84,11 @@ class TestCapitalRiskUtilizationControl:
 
     def test_utilization_warning_level(self):
         r = CapitalRisk(max_capital_usage_ratio=0.9, single_trade_max_ratio=0.1)
-        r._context = type('C', (), {'engine_id': 'test_engine'})()
+        r._context = type('C', (), {
+            'engine_id': 'test_engine',
+            'portfolio_id': 'test_portfolio',
+            'task_id': 'test_task',
+        })()
         signals = r.generate_signals(
             _make_portfolio_info(capital_info={"used_ratio": 0.85}),
             _make_bar()
@@ -148,7 +152,11 @@ class TestCapitalRiskCashReserve:
 
     def test_cash_reserve_warning_mechanism(self):
         r = CapitalRisk(max_capital_usage_ratio=0.9)
-        r._context = type('C', (), {'engine_id': 'test_engine'})()
+        r._context = type('C', (), {
+            'engine_id': 'test_engine',
+            'portfolio_id': 'test_portfolio',
+            'task_id': 'test_task',
+        })()
         signals = r.generate_signals(
             _make_portfolio_info(capital_info={"used_ratio": 0.82}),
             _make_bar()
@@ -235,7 +243,11 @@ class TestCapitalRiskOrderProcessing:
 class TestCapitalRiskSignalGeneration:
     def test_high_utilization_signal(self):
         r = CapitalRisk(max_capital_usage_ratio=0.9)
-        r._context = type('C', (), {'engine_id': 'test_engine'})()
+        r._context = type('C', (), {
+            'engine_id': 'test_engine',
+            'portfolio_id': 'test_portfolio',
+            'task_id': 'test_task',
+        })()
         signals = r.generate_signals(
             _make_portfolio_info(capital_info={"used_ratio": 0.85}),
             _make_bar()
@@ -246,7 +258,11 @@ class TestCapitalRiskSignalGeneration:
 
     def test_cash_reserve_depletion_signal(self):
         r = CapitalRisk(max_capital_usage_ratio=0.9)
-        r._context = type('C', (), {'engine_id': 'test_engine'})()
+        r._context = type('C', (), {
+            'engine_id': 'test_engine',
+            'portfolio_id': 'test_portfolio',
+            'task_id': 'test_task',
+        })()
         signals = r.generate_signals(
             _make_portfolio_info(capital_info={"used_ratio": 0.5}),
             _make_bar()
@@ -255,7 +271,11 @@ class TestCapitalRiskSignalGeneration:
 
     def test_allocation_imbalance_signal(self):
         r = CapitalRisk(max_capital_usage_ratio=0.9)
-        r._context = type('C', (), {'engine_id': 'test_engine'})()
+        r._context = type('C', (), {
+            'engine_id': 'test_engine',
+            'portfolio_id': 'test_portfolio',
+            'task_id': 'test_task',
+        })()
         signals = r.generate_signals(
             _make_portfolio_info(capital_info={"used_ratio": 0.91}),
             _make_bar()

--- a/tests/unit/trading/strategy/test_create_signal_seam.py
+++ b/tests/unit/trading/strategy/test_create_signal_seam.py
@@ -1,0 +1,128 @@
+"""
+BaseStrategy.create_signal 信号发射 seam 测试（ADR-011, #6159）
+
+验证深化后的 seam 背后四件事：
+- 构造 Signal（填 portfolio/engine/task_id）—— 契约不变
+- business_timestamp：缺省 get_time_provider().now()，provider 未绑定留 None，
+  调用方传值时覆盖（不查 provider）
+- source：缺省 SOURCE_TYPES.STRATEGY，可覆盖
+- ClickHouse 日志：无条件 blog.signal(strategy_id=self.uuid)，恰调一次
+"""
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from ginkgo.trading.strategies.strategy_base import BaseStrategy
+from ginkgo.entities.signal import Signal
+from ginkgo.entities.mixins.context_mixin import ContextMixin
+from ginkgo.enums import DIRECTION_TYPES, SOURCE_TYPES
+
+
+def _make_strategy():
+    """构造一个带上下文 ID、无 time_provider 的 BaseStrategy。"""
+    s = BaseStrategy(name="SeamTest")
+    s._context = type('C', (), {
+        'engine_id': 'e', 'portfolio_id': 'p', 'task_id': 't',
+    })()
+    return s
+
+
+@pytest.mark.unit
+class TestCreateSignalSeamSource:
+    """source 字段：缺省 STRATEGY，可覆盖（值归组件原则）。"""
+
+    def test_source_defaults_to_strategy(self):
+        s = _make_strategy()
+        sig = s.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert sig.source == SOURCE_TYPES.STRATEGY
+
+    def test_source_overridable(self):
+        s = _make_strategy()
+        sig = s.create_signal(
+            code="000001", direction=DIRECTION_TYPES.LONG, reason="r",
+            source=SOURCE_TYPES.SELECTOR,
+        )
+        assert sig.source == SOURCE_TYPES.SELECTOR
+
+
+@pytest.mark.unit
+class TestCreateSignalSeamTimestamp:
+    """business_timestamp：provider 缺省、None 留 None、调用方覆盖优先。"""
+
+    def test_timestamp_none_when_no_provider(self):
+        s = _make_strategy()
+        assert s._time_provider is None
+        sig = s.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        # provider 未绑定 → 留 None（全链路契约支持，不崩）
+        assert sig.business_timestamp is None
+
+    def test_timestamp_from_provider_when_set(self):
+        s = _make_strategy()
+        fixed = datetime(2025, 6, 14, 10, 0)
+        provider = MagicMock()
+        provider.now.return_value = fixed
+        s._time_provider = provider
+        sig = s.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert sig.business_timestamp == fixed
+        provider.now.assert_called_once()
+
+    def test_timestamp_overridable_beats_provider(self):
+        s = _make_strategy()
+        provider = MagicMock()
+        provider.now.return_value = datetime(2025, 6, 14)
+        s._time_provider = provider
+        override = datetime(2024, 1, 1)
+        sig = s.create_signal(
+            code="000001", direction=DIRECTION_TYPES.LONG, reason="r",
+            business_timestamp=override,
+        )
+        assert sig.business_timestamp == override
+        provider.now.assert_not_called()
+
+
+@pytest.mark.unit
+class TestCreateSignalSeamBlog:
+    """无条件 ClickHouse 信号日志（框架基础设施，ADR-011）。"""
+
+    def test_blog_signal_called_once_with_strategy_id(self, monkeypatch):
+        mock_blog = MagicMock()
+        monkeypatch.setattr(ContextMixin, 'blog', mock_blog)
+        s = _make_strategy()
+        s.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="buy")
+        mock_blog.signal.assert_called_once()
+        kwargs = mock_blog.signal.call_args.kwargs
+        assert kwargs['strategy_id'] == s.uuid
+
+    def test_blog_signal_receives_symbol_direction_reason(self, monkeypatch):
+        mock_blog = MagicMock()
+        monkeypatch.setattr(ContextMixin, 'blog', mock_blog)
+        s = _make_strategy()
+        s.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="momentum")
+        kwargs = mock_blog.signal.call_args.kwargs
+        assert kwargs['symbol'] == "000001"
+        assert kwargs['direction'] == DIRECTION_TYPES.LONG.value
+        assert kwargs['signal_reason'] == "momentum"
+
+
+@pytest.mark.unit
+class TestCreateSignalSeamContract:
+    """构造契约不变：上下文 ID 填充 + 业务参数透传 + 返回 Signal。"""
+
+    def test_signal_carries_context_ids(self):
+        s = _make_strategy()
+        sig = s.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert isinstance(sig, Signal)
+        assert sig.portfolio_id == 'p'
+        assert sig.engine_id == 'e'
+        assert sig.task_id == 't'
+
+    def test_business_params_propagated(self):
+        s = _make_strategy()
+        sig = s.create_signal(
+            code="000001", direction=DIRECTION_TYPES.SHORT,
+            reason="r", volume=100, weight=0.5, strength=0.8, confidence=0.9,
+        )
+        assert sig.volume == 100
+        assert sig.weight == 0.5
+        assert sig.strength == 0.8
+        assert sig.confidence == 0.9

--- a/tests/unit/trading/strategy/test_create_signal_seam_risk.py
+++ b/tests/unit/trading/strategy/test_create_signal_seam_risk.py
@@ -1,0 +1,130 @@
+"""
+RiskBase.create_signal 信号发射 seam 测试（ADR-011, #6160）
+
+验证深化后的 Risk seam（镜像 Strategy S1）：
+- 构造 Signal（填 portfolio/engine/task_id）—— 契约不变
+- business_timestamp：缺省 get_time_provider().now()，provider 未绑定留 None，
+  调用方传值时覆盖（不查 provider）
+- source：缺省 SOURCE_TYPES.RISK，可覆盖（值归组件原则）
+- ClickHouse 日志：无条件 blog.signal(strategy_id=self.uuid) 恰调一次
+  注：blog 的 strategy_id 参数名历史沿用，语义泛指"信号生成组件 uuid"（Strategy/Risk 共用）；
+  Strategy 与 Risk 的来源区分由 Signal.source（STRATEGY/RISK）承担。
+"""
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from ginkgo.trading.bases.risk_base import RiskBase
+from ginkgo.entities.signal import Signal
+from ginkgo.entities.mixins.context_mixin import ContextMixin
+from ginkgo.enums import DIRECTION_TYPES, SOURCE_TYPES
+
+
+def _make_risk():
+    """构造一个带上下文 ID、无 time_provider 的 RiskBase。"""
+    r = RiskBase(name="RiskSeamTest")
+    r._context = type('C', (), {
+        'engine_id': 'e', 'portfolio_id': 'p', 'task_id': 't',
+    })()
+    return r
+
+
+@pytest.mark.unit
+class TestCreateSignalRiskSource:
+    """source 字段：缺省 RISK，可覆盖（值归组件原则）。"""
+
+    def test_source_defaults_to_risk(self):
+        r = _make_risk()
+        sig = r.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert sig.source == SOURCE_TYPES.RISK
+
+    def test_source_overridable(self):
+        r = _make_risk()
+        sig = r.create_signal(
+            code="000001", direction=DIRECTION_TYPES.LONG, reason="r",
+            source=SOURCE_TYPES.STRATEGY,
+        )
+        assert sig.source == SOURCE_TYPES.STRATEGY
+
+
+@pytest.mark.unit
+class TestCreateSignalRiskTimestamp:
+    """business_timestamp：provider 缺省留 None、有则取 now()、调用方覆盖优先。"""
+
+    def test_timestamp_none_when_no_provider(self):
+        r = _make_risk()
+        assert r._time_provider is None
+        sig = r.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert sig.business_timestamp is None
+
+    def test_timestamp_from_provider_when_set(self):
+        r = _make_risk()
+        fixed = datetime(2025, 6, 14, 10, 0)
+        provider = MagicMock()
+        provider.now.return_value = fixed
+        r._time_provider = provider
+        sig = r.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert sig.business_timestamp == fixed
+        provider.now.assert_called_once()
+
+    def test_timestamp_overridable_beats_provider(self):
+        r = _make_risk()
+        provider = MagicMock()
+        provider.now.return_value = datetime(2025, 6, 14)
+        r._time_provider = provider
+        override = datetime(2024, 1, 1)
+        sig = r.create_signal(
+            code="000001", direction=DIRECTION_TYPES.LONG, reason="r",
+            business_timestamp=override,
+        )
+        assert sig.business_timestamp == override
+        provider.now.assert_not_called()
+
+
+@pytest.mark.unit
+class TestCreateSignalRiskBlog:
+    """无条件 ClickHouse 信号日志（框架基础设施，ADR-011）。"""
+
+    def test_blog_signal_called_once_with_component_uuid(self, monkeypatch):
+        mock_blog = MagicMock()
+        monkeypatch.setattr(ContextMixin, 'blog', mock_blog)
+        r = _make_risk()
+        r.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="block")
+        mock_blog.signal.assert_called_once()
+        kwargs = mock_blog.signal.call_args.kwargs
+        # strategy_id 参数名历史沿用，泛指信号生成组件 uuid（Risk 复用）
+        assert kwargs['strategy_id'] == r.uuid
+
+    def test_blog_signal_receives_symbol_direction_reason(self, monkeypatch):
+        mock_blog = MagicMock()
+        monkeypatch.setattr(ContextMixin, 'blog', mock_blog)
+        r = _make_risk()
+        r.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="stop_loss")
+        kwargs = mock_blog.signal.call_args.kwargs
+        assert kwargs['symbol'] == "000001"
+        assert kwargs['direction'] == DIRECTION_TYPES.LONG.value
+        assert kwargs['signal_reason'] == "stop_loss"
+
+
+@pytest.mark.unit
+class TestCreateSignalRiskContract:
+    """构造契约不变：上下文 ID 填充 + 业务参数透传 + 返回 Signal。"""
+
+    def test_signal_carries_context_ids(self):
+        r = _make_risk()
+        sig = r.create_signal(code="000001", direction=DIRECTION_TYPES.LONG, reason="r")
+        assert isinstance(sig, Signal)
+        assert sig.portfolio_id == 'p'
+        assert sig.engine_id == 'e'
+        assert sig.task_id == 't'
+
+    def test_business_params_propagated(self):
+        r = _make_risk()
+        sig = r.create_signal(
+            code="000001", direction=DIRECTION_TYPES.SHORT,
+            reason="r", volume=100, weight=0.5, strength=0.8, confidence=0.9,
+        )
+        assert sig.volume == 100
+        assert sig.weight == 0.5
+        assert sig.strength == 0.8
+        assert sig.confidence == 0.9


### PR DESCRIPTION
## 概述

ADR-011 信号发射 seam 统一：Strategy + Risk 的 `create_signal` 深化为单一入口，消除 drift（修复前 14/15 策略 source 掉 OTHER、11 策略 + 8 Risk 不记 ClickHouse 日志）。

## 改动

### S1 (#6159) — Strategy seam
- `BaseStrategy.create_signal` 深化：source 缺省 STRATEGY、business_timestamp 缺省 provider.now()、无条件 `blog.signal()`
- 5 子类删旧样板（mean_reversion / momentum / moving_average_crossover / random_signal / trend_reverse）
- 新增 `test_create_signal_seam.py`（9 测试）

### S2 (#6160) — Risk seam
- `RiskBase.create_signal` 同步深化：source 缺省 RISK
- 新增 `SOURCE_TYPES.RISK=22`（Int8 列免 ALTER，不触碰 ADR-007）
- 新增 `test_create_signal_seam_risk.py`（9 测试）
- 修 `test_capital_risk.py` 5 处 mock context（task_id AttributeError 预存红）

### S4 (#6162) — 端到端验证 + source 语义厘清
- grep 确证 **26 真实组件走 seam**（12 Strategy + 14 Risk），**0 drift** 残留
- 厘清 source 双链路：blog 日志 `source`=引擎级 BACKTEST（`engine_ctx.source_type` 注入，logger.py:190）；Signal 实体 `source`=组件级 STRATEGY/RISK（不落 ClickHouse signal 表 / MySQL signal_tracker）
- ADR-011 行 48/50 措辞修订消除歧义

### 文档
- `docs/adr/ADR-011-signal-emission-seam.md`（58 行）+ README 索引

## 验证

- ✅ `tests/unit/trading/strategy/test_create_signal_seam.py`（9）
- ✅ `tests/unit/trading/strategy/test_create_signal_seam_risk.py`（9）
- ✅ `test_capital_risk.py` 预存红修复
- ✅ grep：26 组件走 seam，0 直接 `Signal(` 绕过

## 端到端 follow-up

CLI 端到端回测验证时发现 **random_signal 产生 0 信号**（portfolio/feeder 数据流断裂，与 seam 正交）→ #6167 单独跟踪。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
