### PR TITLE
fix(web-ui): 锚定 .gitignore lib/ 规则，纳入 src/lib 源码，解锁构建

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/      # 锚定仓库根：仅忽略 Python 构建产物，勿误伤 web-ui/src/lib（shadcn-vue 源码）
+/lib64/
 parts/
 sdist/
 var/

--- a/web-ui/src/lib/animations.ts
+++ b/web-ui/src/lib/animations.ts
@@ -1,0 +1,241 @@
+/**
+ * MagicUI 风格动画预设
+ * 基于 @vueuse/motion 和 Vue 3 Transition API
+ */
+
+// TransitionProps re-exported for external consumers
+export type { TransitionProps } from 'vue'
+
+// 基础过渡配置类型
+export interface MagicTransition {
+  name?: string
+  enterActiveClass?: string
+  leaveActiveClass?: string
+  enterFromClass?: string
+  enterToClass?: string
+  leaveFromClass?: string
+  leaveToClass?: string
+}
+
+// ==================== 基础动画 ====================
+
+/**
+ * 淡入淡出动画
+ */
+export const fadeIn: MagicTransition = {
+  enterActiveClass: 'transition-opacity duration-300 ease-out',
+  leaveActiveClass: 'transition-opacity duration-200 ease-in',
+  enterFromClass: 'opacity-0',
+  enterToClass: 'opacity-100',
+  leaveFromClass: 'opacity-100',
+  leaveToClass: 'opacity-0',
+}
+
+/**
+ * 滑入动画
+ */
+export const slideIn: MagicTransition = {
+  enterActiveClass: 'transition-all duration-300 ease-out',
+  leaveActiveClass: 'transition-all duration-200 ease-in',
+  enterFromClass: 'opacity-0 translate-y-4',
+  enterToClass: 'opacity-100 translate-y-0',
+  leaveFromClass: 'opacity-100 translate-y-0',
+  leaveToClass: 'opacity-0 translate-y-4',
+}
+
+/**
+ * 缩放动画
+ */
+export const scaleIn: MagicTransition = {
+  enterActiveClass: 'transition-all duration-300 ease-out',
+  leaveActiveClass: 'transition-all duration-200 ease-in',
+  enterFromClass: 'opacity-0 scale-95',
+  enterToClass: 'opacity-100 scale-100',
+  leaveFromClass: 'opacity-100 scale-100',
+  leaveToClass: 'opacity-0 scale-95',
+}
+
+// ==================== MagicUI 风格动画 ====================
+
+/**
+ * Magic Reveal - 魔法揭示效果
+ * 类似于 MagicUI 的 reveal 动画
+ */
+export const magicReveal: MagicTransition = {
+  enterActiveClass: 'transition-all duration-500 ease-out',
+  leaveActiveClass: 'transition-all duration-200 ease-in',
+  enterFromClass: 'opacity-0 scale-95 translate-y-4',
+  enterToClass: 'opacity-100 scale-100 translate-y-0',
+  leaveFromClass: 'opacity-100 scale-100 translate-y-0',
+  leaveToClass: 'opacity-0 scale-95 translate-y-4',
+}
+
+/**
+ * Border Beam - 边框光束效果
+ * 使用 CSS 动画实现流动的边框光效
+ */
+export const borderBeam = {
+  className: 'relative overflow-hidden',
+  // 需要配合 CSS 使用，参考下面样式定义
+}
+
+/**
+ * Marquee - 滚动文字效果
+ */
+export const marquee = {
+  className: 'flex overflow-hidden',
+  // 需要配合 CSS 动画使用
+}
+
+/**
+ * Sparkles - 闪烁效果
+ */
+export const sparkles: MagicTransition = {
+  enterActiveClass: 'transition-all duration-500 ease-out',
+  leaveActiveClass: 'transition-all duration-300 ease-in',
+  enterFromClass: 'opacity-0 scale-0 rotate-180',
+  enterToClass: 'opacity-100 scale-100 rotate-0',
+  leaveFromClass: 'opacity-100 scale-100 rotate-0',
+  leaveToClass: 'opacity-0 scale-0 rotate-180',
+}
+
+/**
+ * Shimmer - 微光效果
+ */
+export const shimmer = {
+  className: 'animate-shimmer',
+  // 需要配合 CSS @keyframes shimmer 使用
+}
+
+// ==================== 列表动画 ====================
+
+/**
+ * 列表项逐个显示动画
+ * 用于列表渲染时的渐入效果
+ */
+export const listStagger: MagicTransition = {
+  enterActiveClass: 'transition-all duration-300 ease-out',
+  leaveActiveClass: 'transition-all duration-200 ease-in',
+  enterFromClass: 'opacity-0 translate-x-[-20px]',
+  enterToClass: 'opacity-100 translate-x-0',
+  leaveFromClass: 'opacity-100 translate-x-0',
+  leaveToClass: 'opacity-0 translate-x-[20px]',
+}
+
+// ==================== 模态框动画 ====================
+
+/**
+ * 模态框淡入
+ */
+export const modalFadeIn: MagicTransition = {
+  enterActiveClass: 'transition-all duration-300 ease-out',
+  leaveActiveClass: 'transition-all duration-200 ease-in',
+  enterFromClass: 'opacity-0 scale-95',
+  enterToClass: 'opacity-100 scale-100',
+  leaveFromClass: 'opacity-100 scale-100',
+  leaveToClass: 'opacity-0 scale-95',
+}
+
+/**
+ * 遮罩层淡入
+ */
+export const overlayFadeIn: MagicTransition = {
+  enterActiveClass: 'transition-opacity duration-300 ease-out',
+  leaveActiveClass: 'transition-opacity duration-200 ease-in',
+  enterFromClass: 'opacity-0',
+  enterToClass: 'opacity-100',
+  leaveFromClass: 'opacity-100',
+  leaveToClass: 'opacity-0',
+}
+
+// ==================== 按钮动画 ====================
+
+/**
+ * 按钮按下效果
+ */
+export const buttonPress = {
+  className: 'active:scale-95 transition-transform duration-100',
+}
+
+/**
+ * 按钮悬停效果
+ */
+export const buttonHover = {
+  className: 'hover:scale-105 transition-transform duration-200',
+}
+
+// ==================== 页面过渡 ====================
+
+/**
+ * 页面滑动过渡
+ */
+export const pageSlide: MagicTransition = {
+  enterActiveClass: 'transition-all duration-300 ease-out',
+  leaveActiveClass: 'transition-all duration-200 ease-in',
+  enterFromClass: 'opacity-0 translate-x-8',
+  enterToClass: 'opacity-100 translate-x-0',
+  leaveFromClass: 'opacity-100 translate-x-0',
+  leaveToClass: 'opacity-0 -translate-x-8',
+}
+
+// ==================== 工具函数 ====================
+
+/**
+ * 创建带延迟的列表动画
+ * @param index 列表项索引
+ * @param baseDelay 基础延迟(ms)
+ * @param delayIncrement 每项增加的延迟(ms)
+ */
+export function createStaggerDelay(
+  index: number,
+  baseDelay: number = 0,
+  delayIncrement: number = 50
+): string {
+  return `${baseDelay + index * delayIncrement}ms`
+}
+
+/**
+ * 获取动画样式对象
+ * @param transition 动画配置
+ * @param delay 可选的延迟时间
+ */
+export function getAnimationStyle(
+  _transition: MagicTransition,
+  delay?: string | number
+): Record<string, string> {
+  const style: Record<string, string> = {}
+
+  if (delay) {
+    style.transitionDelay = typeof delay === 'number' ? `${delay}ms` : delay
+  }
+
+  return style
+}
+
+// ==================== Tailwind 动画扩展 ====================
+
+/**
+ * Tailwind 配置中需要添加的自定义动画
+ *
+ * 在 tailwind.config.js 的 theme.extend 中添加:
+ *
+ * keyframes: {
+ *   shimmer: {
+ *     '0%': { backgroundPosition: '-1000px 0' },
+ *     '100%': { backgroundPosition: '1000px 0' }
+ *   },
+ *   marquee: {
+ *     '0%': { transform: 'translateX(0%)' },
+ *     '100%': { transform: 'translateX(-100%)' }
+ *   },
+ *   'border-beam': {
+ *     '0%': { offsetDistance: '0%' },
+ *     '100%': { offsetDistance: '100%' }
+ *   }
+ * },
+ * animation: {
+ *   shimmer: 'shimmer 2s linear infinite',
+ *   marquee: 'marquee 25s linear infinite',
+ *   'border-beam': 'border-beam 2s linear infinite'
+ * }
+ */

--- a/web-ui/src/lib/utils.ts
+++ b/web-ui/src/lib/utils.ts
@@ -1,0 +1,68 @@
+import { type ClassValue, clsx } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+/**
+ * 合并 Tailwind CSS 类名的工具函数
+ * 使用 clsx 处理条件类名，然后用 tailwind-merge 解决冲突
+ *
+ * @param inputs - 类名或类名数组
+ * @returns 合并后的类名字符串
+ *
+ * @example
+ * cn('px-2', 'py-1', someCondition && 'bg-blue-500')
+ * // => 'px-2 py-1 bg-blue-500' (当 someCondition 为 true)
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}
+
+/**
+ * 格式化日期时间为本地字符串
+ *
+ * @param dateTime - 日期时间字符串或Date对象
+ * @returns 格式化后的日期时间字符串
+ */
+export function formatDateTime(dateTime: string | Date | null | undefined): string {
+  if (!dateTime) return '-'
+  return new Date(dateTime).toLocaleString('zh-CN')
+}
+
+/**
+ * 获取状态对应的颜色
+ *
+ * @param status - 状态字符串
+ * @returns Tailwind 颜色类名
+ */
+export function getStatusColor(status: string): string {
+  const colorMap: Record<string, string> = {
+    enabled: 'text-green-600',
+    disabled: 'text-gray-400',
+    connecting: 'text-blue-600',
+    connected: 'text-green-600',
+    disconnected: 'text-yellow-600',
+    error: 'text-red-600',
+    active: 'text-green-600',
+    inactive: 'text-gray-400',
+  }
+  return colorMap[status] || 'text-gray-600'
+}
+
+/**
+ * 获取状态对应的背景色
+ *
+ * @param status - 状态字符串
+ * @returns Tailwind 背景颜色类名
+ */
+export function getStatusBgColor(status: string): string {
+  const colorMap: Record<string, string> = {
+    enabled: 'bg-green-100',
+    disabled: 'bg-gray-100',
+    connecting: 'bg-blue-100',
+    connected: 'bg-green-100',
+    disconnected: 'bg-yellow-100',
+    error: 'bg-red-100',
+    active: 'bg-green-100',
+    inactive: 'bg-gray-100',
+  }
+  return colorMap[status] || 'bg-gray-100'
+}


### PR DESCRIPTION
## 问题

干净克隆 / CI / 新 worktree 中 web-ui **无法构建**：
- `vue-tsc`：25 处 `Cannot find module '@/lib/utils'`（所有 shadcn-vue ui 组件 + 多个 view）
- `vite build`：模块加载阶段 `ENOENT .../src/lib/utils`

## 根因

`.gitignore:20` 的 `lib/`（GitHub Python 打包模板条目）**未锚定**，匹配任意深度的 `lib` 目录，误伤了 `web-ui/src/lib/`（shadcn-vue 源码）。结果 `utils.ts` 被静默忽略、从未入库；本地因文件存在照常工作，问题完全沉默。

## 改动

| 文件 | 改动 |
|---|---|
| `.gitignore` | `lib/` `lib64/` → `/lib/` `/lib64/`（锚定仓库根）。Python 侧零影响：`build/lib` 已被 `build/` 覆盖、`.venv/lib` 已被 `.venv` 覆盖，仓库无顶层 `lib/` |
| `web-ui/src/lib/utils.ts` | 纳入。导出 `cn()`（Tailwind 类名合并，25 处引用）+ `formatDateTime` / `getStatusColor` / `getStatusBgColor` |
| `web-ui/src/lib/animations.ts` | 纳入。shadcn 动画工具，当前 0 引用（保留，非本次删改范围） |

## 验证（隔离 worktree，`origin/master` 基点）

- `vue-tsc`：**33 错 → 8 错**（25 处 `@/lib/utils` 错全部消除；剩 8 为无关基线类型债）
- `vite build`：**完整构建成功**（6.58s，无需手动补任何文件）

## 关联

解锁后，PR #6163（Ant 标签清理）的隔离验证将不再需要手动拷贝 lib/utils。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
