### PR TITLE
fix: 批量修复 auth/security 问题 (#5458 #5465 #5467)

### DIFF
--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -3,7 +3,7 @@
 """
 
 from fastapi import APIRouter, HTTPException, status, Request, Header
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from datetime import datetime, timedelta
 from typing import Optional
 import bcrypt
@@ -36,6 +36,9 @@ class LoginResponse(BaseModel):
 
 
 class RegisterRequest(BaseModel):
+    # #5458: email 不属于 MUser，靠 user_contacts 表解耦绑定；注册接口拒绝多余字段
+    model_config = ConfigDict(extra="forbid")
+
     username: str
     password: str
     display_name: Optional[str] = None

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -40,6 +40,15 @@ def hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
 
 
+def _require_admin(req: Request) -> None:
+    """#5467: 用户管理端点须管理员授权（中间件已注入 req.state.is_admin）"""
+    if not getattr(req.state, "is_admin", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Administrator privileges required",
+        )
+
+
 # ==================== 用户管理 ====================
 
 class UserSummary(BaseModel):
@@ -75,10 +84,12 @@ class UserUpdate(BaseModel):
 
 @router.get("/users")
 async def list_users(
+    req: Request,
     status: Optional[str] = None,
     search: Optional[str] = None
 ):
     """获取用户列表"""
+    _require_admin(req)  # #5467
     try:
         user_service = get_user_service()
 
@@ -143,8 +154,9 @@ async def list_users(
 
 
 @router.post("/users", status_code=201)
-async def create_user(data: UserCreate):
+async def create_user(req: Request, data: UserCreate):
     """创建用户"""
+    _require_admin(req)  # #5467
     try:
         user_service = get_user_service()
 
@@ -216,8 +228,9 @@ async def create_user(data: UserCreate):
 
 
 @router.put("/users/{uuid}")
-async def update_user(uuid: str, data: UserUpdate):
+async def update_user(req: Request, uuid: str, data: UserUpdate):
     """更新用户"""
+    _require_admin(req)  # #5467
     try:
         user_service = get_user_service()
 
@@ -323,8 +336,9 @@ async def reset_user_password(uuid: str, data: dict, req: Request):
 
 
 @router.delete("/users/{uuid}")
-async def delete_user(uuid: str):
+async def delete_user(req: Request, uuid: str):
     """删除用户"""
+    _require_admin(req)  # #5467
     try:
         user_service = get_user_service()
 

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -3,7 +3,7 @@
 """
 
 from fastapi import APIRouter, HTTPException, status, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from typing import List, Optional
 from datetime import datetime
 import bcrypt
@@ -65,8 +65,10 @@ class UserCreate(BaseModel):
 
 class UserUpdate(BaseModel):
     """更新用户请求"""
+    # #5458: email 不属于用户档案，由 contacts API 管理；拒绝多余字段
+    model_config = ConfigDict(extra="forbid")
+
     display_name: Optional[str] = None
-    email: Optional[str] = None
     roles: Optional[List[str]] = None
     status: Optional[str] = None
 
@@ -223,9 +225,6 @@ async def update_user(uuid: str, data: UserUpdate):
         updates = {}
         if data.display_name is not None:
             updates["display_name"] = data.display_name
-
-        if data.email is not None:
-            updates["email"] = data.email
 
         if data.status is not None:
             updates["is_active"] = (data.status == "active")

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -280,9 +280,15 @@ async def reset_user_password(uuid: str, data: dict, req: Request):
         )
 
     try:
-        user_service = get_user_service()
+        # #5465: new_password 必传——禁止默认弱密码（原默认 "123456"）
+        new_password = data.get("new_password")
+        if not new_password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="new_password is required",
+            )
 
-        new_password = data.get("new_password", "123456")
+        user_service = get_user_service()
         new_password_hash = hash_password(new_password)
 
         result = user_service.reset_password(uuid, new_password_hash)

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -41,8 +41,17 @@ def hash_password(password: str) -> str:
 
 
 def _require_admin(req: Request) -> None:
-    """#5467: 用户管理端点须管理员授权（中间件已注入 req.state.is_admin）"""
-    if not getattr(req.state, "is_admin", False):
+    """#5467+review: 管理员授权须 DB 校验 is_admin，不信任 JWT（与 #5899 /auth/verify 一致），DB 异常 fail-closed"""
+    user_uuid = getattr(req.state, "user_uuid", None)
+    is_admin = False
+    try:
+        credential = get_user_service().get_credential(user_uuid)
+        if credential is not None:
+            is_admin = credential.is_admin
+    except Exception as e:
+        logger.warning(f"#5467: DB query failed for is_admin, user={user_uuid}: {e}")
+        is_admin = False
+    if not is_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Administrator privileges required",

--- a/api/scripts/create_admin_user.py
+++ b/api/scripts/create_admin_user.py
@@ -39,10 +39,10 @@ def create_admin_user():
         print("  - 创建 users 记录...")
         session.execute(text("""
             INSERT INTO users (
-                uuid, name, username, display_name, email, description,
+                uuid, name, username, display_name, description,
                 user_type, is_active, source, meta, `desc`, create_at, update_at, is_del
             ) VALUES (
-                :uuid, :name, :username, :display_name, :email, :description,
+                :uuid, :name, :username, :display_name, :description,
                 :user_type, :is_active, :source, :meta, :desc, :create_at, :update_at, :is_del
             )
         """), {
@@ -50,7 +50,6 @@ def create_admin_user():
             "name": "admin",
             "username": "admin",
             "display_name": "Administrator",
-            "email": "admin@ginkgo.local",
             "description": "系统管理员账户",
             "user_type": 1,  # PERSON
             "is_active": True,

--- a/api/scripts/fix_admin_user.py
+++ b/api/scripts/fix_admin_user.py
@@ -33,7 +33,7 @@ def fix_admin_user():
             print(f"  - 找到 admin 用户 (UUID: {user_uuid[:8]}...)")
             session.execute(text("""
                 UPDATE users
-                SET username = 'admin', display_name = 'Administrator', email = 'admin@ginkgo.local'
+                SET username = 'admin', display_name = 'Administrator'
                 WHERE uuid = :uuid
             """), {"uuid": user_uuid})
             session.commit()
@@ -47,10 +47,10 @@ def fix_admin_user():
 
             session.execute(text("""
                 INSERT INTO users (
-                    uuid, name, username, display_name, email, description,
+                    uuid, name, username, display_name, description,
                     user_type, is_active, source, is_del, create_at, update_at
                 ) VALUES (
-                    :uuid, :name, :username, :display_name, :email, :description,
+                    :uuid, :name, :username, :display_name, :description,
                     :user_type, :is_active, :source, :is_del, :create_at, :update_at
                 )
             """), {
@@ -58,7 +58,6 @@ def fix_admin_user():
                 "name": "admin",
                 "username": "admin",
                 "display_name": "Administrator",
-                "email": "admin@ginkgo.local",
                 "description": "系统管理员账户",
                 "user_type": 1,  # PERSON
                 "is_active": True,

--- a/api/scripts/migrate_users_table.py
+++ b/api/scripts/migrate_users_table.py
@@ -129,7 +129,6 @@ def create_admin_user():
     user = MUser(
         username="admin",
         display_name="Administrator",
-        email="admin@ginkgo.local",
         description="系统管理员账户",
         user_type=USER_TYPES.PERSON,
         is_active=True,

--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -870,10 +870,10 @@ def _init_admin_user():
 
         session.execute(text("""
             INSERT INTO users (
-                uuid, name, username, display_name, email, description,
+                uuid, name, username, display_name, description,
                 user_type, is_active, is_del, source, create_at, update_at
             ) VALUES (
-                :uuid, :name, :username, :display_name, :email, :description,
+                :uuid, :name, :username, :display_name, :description,
                 :user_type, :is_active, :is_del, :source, :create_at, :update_at
             )
         """), {
@@ -881,7 +881,6 @@ def _init_admin_user():
             "name": "admin",
             "username": "admin",
             "display_name": "Administrator",
-            "email": "admin@ginkgo.local",
             "description": "Default system administrator account",
             "user_type": 1,  # PERSON
             "is_active": True,

--- a/src/ginkgo/data/models/model_user.py
+++ b/src/ginkgo/data/models/model_user.py
@@ -25,7 +25,6 @@ class MUser(MMysqlBase, ModelConversion):
         uuid: 用户唯一标识
         username: 登录用户名（唯一，用于登录认证）
         display_name: 显示名称（可重复，用于展示）
-        email: 邮箱地址
         description: 用户描述
         user_type: 用户类型 (PERSON/CHANNEL/ORGANIZATION)
         is_active: 是否激活
@@ -39,7 +38,6 @@ class MUser(MMysqlBase, ModelConversion):
     # 用户核心字段
     username: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True, comment="登录用户名（唯一）")
     display_name: Mapped[Optional[str]] = mapped_column(String(128), default="", comment="显示名称")
-    email: Mapped[Optional[str]] = mapped_column(String(128), default="", comment="邮箱地址")
     description: Mapped[Optional[str]] = mapped_column(String(512), default="")
     user_type: Mapped[int] = mapped_column(TINYINT, default=USER_TYPES.PERSON.value)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
@@ -54,7 +52,6 @@ class MUser(MMysqlBase, ModelConversion):
         self,
         username: Optional[str] = None,
         display_name: Optional[str] = None,
-        email: Optional[str] = None,
         description: Optional[str] = None,
         user_type=None,
         is_active: Optional[bool] = None,
@@ -67,7 +64,6 @@ class MUser(MMysqlBase, ModelConversion):
         Args:
             username: 登录用户名（唯一）
             display_name: 显示名称
-            email: 邮箱地址
             description: 用户描述
             user_type: 用户类型（枚举或整数）
             is_active: 是否激活
@@ -77,7 +73,6 @@ class MUser(MMysqlBase, ModelConversion):
 
         self.username = username or ""
         self.display_name = display_name or username or ""
-        self.email = email or ""
         self.description = description or ""
 
         # 处理 user_type 枚举转换
@@ -105,7 +100,6 @@ class MUser(MMysqlBase, ModelConversion):
         if not args and kwargs:
             username = kwargs.get('username')
             display_name = kwargs.get('display_name')
-            email = kwargs.get('email')
             description = kwargs.get('description')
             user_type = kwargs.get('user_type')
             is_active = kwargs.get('is_active')
@@ -116,9 +110,6 @@ class MUser(MMysqlBase, ModelConversion):
 
             if display_name is not None:
                 self.display_name = display_name
-
-            if email is not None:
-                self.email = email
 
             if description is not None:
                 self.description = description
@@ -153,7 +144,6 @@ class MUser(MMysqlBase, ModelConversion):
         self,
         username: str,
         display_name: Optional[str] = None,
-        email: Optional[str] = None,
         description: Optional[str] = None,
         user_type=None,
         is_active: Optional[bool] = None,
@@ -167,7 +157,6 @@ class MUser(MMysqlBase, ModelConversion):
         Args:
             username: 登录用户名
             display_name: 显示名称
-            email: 邮箱地址
             description: 用户描述
             user_type: 用户类型（枚举或整数）
             is_active: 是否激活
@@ -177,9 +166,6 @@ class MUser(MMysqlBase, ModelConversion):
 
         if display_name is not None:
             self.display_name = display_name
-
-        if email is not None:
-            self.email = email
 
         if description is not None:
             self.description = description
@@ -208,9 +194,6 @@ class MUser(MMysqlBase, ModelConversion):
 
         if 'display_name' in df.index and pd.notna(df['display_name']):
             self.display_name = str(df['display_name'])
-
-        if 'email' in df.index and pd.notna(df['email']):
-            self.email = str(df['email'])
 
         if 'description' in df.index and pd.notna(df['description']):
             self.description = str(df['description'])

--- a/tests/api/test_auth_security_batch.py
+++ b/tests/api/test_auth_security_batch.py
@@ -13,7 +13,9 @@ Auth/Security 批量修复测试
 - #5467: 4 个用户管理端点缺 admin 守卫（待定）
 """
 
+import asyncio
 import pytest
+from unittest.mock import MagicMock, patch
 
 
 pytestmark = pytest.mark.unit
@@ -65,3 +67,37 @@ class TestUpdateUserRejectsEmail:
         u = UserUpdate(display_name="Alice", roles=["admin"], status="active")
         assert u.display_name == "Alice"
         assert u.roles == ["admin"]
+
+
+# ============================================================
+# #5465: reset-password 不应默认弱密码 123456
+# ============================================================
+
+class TestResetPasswordNoDefault:
+    """#5465: 未传 new_password 必须拒绝，不可兜底成 123456"""
+
+    def _admin_req(self):
+        req = MagicMock()
+        req.state.user_uuid = "user-admin"
+        req.state.is_admin = True
+        return req
+
+    def test_reset_without_new_password_rejected(self):
+        """管理员未传 new_password 应返 400，而非默认 123456"""
+        from api.settings import reset_user_password
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(reset_user_password("user-target", {}, self._admin_req()))
+        assert exc_info.value.status_code == 400
+
+    def test_reset_does_not_call_service_with_default(self):
+        """被拒时 service.reset_password 不应被调用（防止任何默认值落库）"""
+        from api.settings import reset_user_password
+        from fastapi import HTTPException
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
+            with pytest.raises(HTTPException):
+                asyncio.run(reset_user_password("user-target", {}, self._admin_req()))
+            mock_svc.return_value.reset_password.assert_not_called()

--- a/tests/api/test_auth_security_batch.py
+++ b/tests/api/test_auth_security_batch.py
@@ -159,3 +159,54 @@ class TestUserMgmtAdminGuard:
             mock_svc.return_value.list_users.return_value = MagicMock(success=True, data={"users": []})
             # 不应抛 403；具体返回不限
             asyncio.run(list_users(req=self._req(True)))
+
+
+# ============================================================
+# #5467 review: _require_admin 须 DB 校验 is_admin（不信任 JWT，#5899 一致）
+# ============================================================
+
+class TestRequireAdminDbCheck:
+    """#5467 review: is_admin 以 DB 为准，旧 JWT 的 is_admin=true 不可绕过守卫"""
+
+    def test_demoted_admin_jwt_blocked_by_db(self):
+        """JWT is_admin=true 但 DB 已降权为 False → 必须 403"""
+        from api.settings import list_users
+        from fastapi import HTTPException
+
+        req = MagicMock()
+        req.state.is_admin = True   # 旧 JWT 仍声称管理员（降权后未过期）
+        req.state.user_uuid = "u-demoted"
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=False)
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(list_users(req=req))
+        assert exc_info.value.status_code == 403
+
+    def test_db_confirms_admin_passes(self):
+        """DB 确认 is_admin=True → 放行（DB 校验不误伤真管理员）"""
+        from api.settings import list_users
+
+        req = MagicMock()
+        req.state.is_admin = True
+        req.state.user_uuid = "u-admin"
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
+            mock_svc.return_value.list_users.return_value = MagicMock(success=True, data={"users": []})
+            asyncio.run(list_users(req=req))  # 不应抛 403
+
+    def test_db_exception_fail_closed(self):
+        """get_credential 抛异常 → fail-closed 403（DB 故障不可放行）"""
+        from api.settings import list_users
+        from fastapi import HTTPException
+
+        req = MagicMock()
+        req.state.is_admin = True
+        req.state.user_uuid = "u-1"
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.get_credential.side_effect = RuntimeError("db down")
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(list_users(req=req))
+        assert exc_info.value.status_code == 403

--- a/tests/api/test_auth_security_batch.py
+++ b/tests/api/test_auth_security_batch.py
@@ -101,3 +101,61 @@ class TestResetPasswordNoDefault:
             with pytest.raises(HTTPException):
                 asyncio.run(reset_user_password("user-target", {}, self._admin_req()))
             mock_svc.return_value.reset_password.assert_not_called()
+
+
+# ============================================================
+# #5467: 用户管理端点须 admin 守卫
+# ============================================================
+
+class TestUserMgmtAdminGuard:
+    """#5467: list/create/update/delete 用户须管理员，普通用户 → 403"""
+
+    def _req(self, is_admin):
+        req = MagicMock()
+        req.state.is_admin = is_admin
+        return req
+
+    def test_list_users_requires_admin(self):
+        """普通用户调 list_users 应返 403"""
+        from api.settings import list_users
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(list_users(req=self._req(False)))
+        assert exc_info.value.status_code == 403
+
+    def test_create_user_requires_admin(self):
+        """普通用户调 create_user 应返 403"""
+        from api.settings import create_user
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(create_user(self._req(False), MagicMock()))
+        assert exc_info.value.status_code == 403
+
+    def test_update_user_requires_admin(self):
+        """普通用户调 update_user 应返 403"""
+        from api.settings import update_user
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(update_user(self._req(False), "user-target", MagicMock()))
+        assert exc_info.value.status_code == 403
+
+    def test_delete_user_requires_admin(self):
+        """普通用户调 delete_user 应返 403"""
+        from api.settings import delete_user
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            asyncio.run(delete_user(self._req(False), "user-target"))
+        assert exc_info.value.status_code == 403
+
+    def test_admin_passes_guard(self):
+        """管理员调 list_users 不应被守卫拦截（守卫不误伤）"""
+        from api.settings import list_users
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.list_users.return_value = MagicMock(success=True, data={"users": []})
+            # 不应抛 403；具体返回不限
+            asyncio.run(list_users(req=self._req(True)))

--- a/tests/api/test_auth_security_batch.py
+++ b/tests/api/test_auth_security_batch.py
@@ -1,0 +1,67 @@
+# Issues: #5467, #5465, #5458, #5472
+# Upstream: api.api.auth, api.api.settings, src.ginkgo.data.models.model_user
+# Downstream: pytest
+# Role: Auth/Security 批量修复测试
+
+"""
+Auth/Security 批量修复测试
+
+覆盖 4 个 issue：
+- #5458: email 解耦 — 注册/更新接口拒绝 email（MUser 无 email 字段，靠 user_contacts 绑定）
+- #5472: 密码强度校验（待定）
+- #5465: reset-password 默认密码 123456（待定）
+- #5467: 4 个用户管理端点缺 admin 守卫（待定）
+"""
+
+import pytest
+
+
+pytestmark = pytest.mark.unit
+
+
+# ============================================================
+# #5458: email 解耦 — 注册接口拒绝 email
+# ============================================================
+
+class TestRegisterRejectsEmail:
+    """#5458: email 不属于 MUser，注册接口应拒绝 email 字段"""
+
+    def test_register_request_rejects_email(self):
+        """RegisterRequest 带 email 应抛 ValidationError"""
+        from pydantic import ValidationError
+        from api.auth import RegisterRequest
+
+        with pytest.raises(ValidationError):
+            RegisterRequest(username="alice", password="Secret123!", email="a@b.com")
+
+    def test_register_request_accepts_valid_fields(self):
+        """合法字段（无 email）应正常构造"""
+        from api.auth import RegisterRequest
+
+        req = RegisterRequest(username="alice", password="Secret123!", display_name="Alice")
+        assert req.username == "alice"
+        assert req.display_name == "Alice"
+
+
+# ============================================================
+# #5458: email 解耦 — update_user 不再处理 email（走 contacts API）
+# ============================================================
+
+class TestUpdateUserRejectsEmail:
+    """#5458: email 由 contacts API 管理，UserUpdate 不应接受 email 字段"""
+
+    def test_user_update_rejects_email(self):
+        """UserUpdate 带 email 应抛 ValidationError"""
+        from pydantic import ValidationError
+        from api.settings import UserUpdate
+
+        with pytest.raises(ValidationError):
+            UserUpdate(email="a@b.com")
+
+    def test_user_update_accepts_profile_fields(self):
+        """合法字段（display_name/roles/status，无 email）应正常构造"""
+        from api.settings import UserUpdate
+
+        u = UserUpdate(display_name="Alice", roles=["admin"], status="active")
+        assert u.display_name == "Alice"
+        assert u.roles == ["admin"]

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -219,11 +219,14 @@ class TestTokenBlacklistOnDeleteUser:
         """delete_user 应调用 token_blacklist.revoke_user 撤销旧 token"""
         from api.settings import delete_user
 
+        req = MagicMock()
+        req.state.is_admin = True  # #5467: delete_user 现需 admin 守卫
+
         with patch("api.settings.get_user_service") as mock_svc:
             mock_svc.return_value.delete_user.return_value = MagicMock(success=True)
 
             with patch("middleware.auth.token_blacklist") as mock_bl:
-                asyncio.run(delete_user("user-to-delete"))
+                asyncio.run(delete_user(req, "user-to-delete"))
 
                 mock_bl.revoke_user.assert_called_once_with("user-to-delete")
 

--- a/tests/api/test_settings_n_plus_1.py
+++ b/tests/api/test_settings_n_plus_1.py
@@ -41,13 +41,15 @@ class TestUsersN1Fix:
         from api.settings import list_users
 
         req = MagicMock()
-        req.state.is_admin = True  # #5467: list_users 现需 admin 守卫放行
+        req.state.user_uuid = "u-admin"  # #5467 review: 守卫按 DB 校验 is_admin
+        mock_service.get_credential.return_value = MagicMock(is_admin=True)
 
         with patch("api.settings.get_user_service", return_value=mock_service):
             result = run_async(list_users(req=req))
 
-        # 不应逐条调 get_credential（N+1）
-        mock_service.get_credential.assert_not_called()
+        # #5467 review: _require_admin 鉴权调 get_credential 恰 1 次（O(1)，非 N+1）；
+        # 业务层不得逐条查每个用户的凭证（N+1 才是问题）
+        assert mock_service.get_credential.call_count == 1
         # 不需要 get_all_credentials，service 已在 dict 中返回 is_admin
         mock_service.get_all_credentials.assert_not_called()
         # 验证返回数据包含 roles

--- a/tests/api/test_settings_n_plus_1.py
+++ b/tests/api/test_settings_n_plus_1.py
@@ -40,8 +40,11 @@ class TestUsersN1Fix:
 
         from api.settings import list_users
 
+        req = MagicMock()
+        req.state.is_admin = True  # #5467: list_users 现需 admin 守卫放行
+
         with patch("api.settings.get_user_service", return_value=mock_service):
-            result = run_async(list_users())
+            result = run_async(list_users(req=req))
 
         # 不应逐条调 get_credential（N+1）
         mock_service.get_credential.assert_not_called()


### PR DESCRIPTION
## Summary
批量修复 3 个 auth/security issue（#5472 wontfix 已关闭，本 PR 不含）。

- **#5458** email 解耦：MUser 无 email 列，注册/更新接口拒绝 email（`ConfigDict(extra="forbid")`），清 create_admin/fix_admin/migrate 脚本与 core_cli 残留
- **#5465** reset-password：删 `123456` 默认弱密码，缺失 `new_password` 返 400
- **#5467** 用户管理 4 端点（list/create/update/delete）加 `_require_admin` 守卫

## Test plan
- [x] `test_auth_security_batch.py` 11 passed
- [x] `test_jwt_security.py` 12 passed（含 delete_user 守卫适配）
- [x] `test_settings_n_plus_1.py` list_users 签名适配
- [x] `tests/api/` 全量：仅剩预存 saga/versioning 失败（与 origin/master 一致）

Closes #5458
Closes #5465
Closes #5467
