### PR TITLE
refactor(#6107): 删 Order.deduct_remain 死方法收口 V5

### DIFF
--- a/src/ginkgo/entities/order.py
+++ b/src/ginkgo/entities/order.py
@@ -439,19 +439,6 @@ class Order(TimeMixin, Base):
         self._transaction_price = to_decimal(price)
         self._transaction_volume = int(volume)
 
-    def deduct_remain(self, amount) -> None:
-        """扣减剩余冻结资金，floor 0（ADR-010 V5）。
-
-        替代裸 ``order.remain = max(0, remain - cost)``（不动 transaction_volume，
-        区别于 settle 的成交累加）。用于 t1backtest LONG 分支的资金同步。
-        """
-        d = to_decimal(amount)
-        if d < 0:
-            raise ValueError("amount cannot be negative")
-        if self._remain is None:
-            self._remain = self._frozen_money
-        self._remain = max(Decimal("0"), self._remain - d)
-
     def normalize_freeze(self, places=2) -> None:
         """规整冻结资金精度并兜底 remain（下单前，ADR-010 V5）。
 

--- a/tests/unit/trading/entities/test_order.py
+++ b/tests/unit/trading/entities/test_order.py
@@ -2174,26 +2174,12 @@ class TestOrderFillBehavior:
 class TestOrderMoneyAdjust:
     """Order 资金调整方法测试（ADR-010 V5：t1backtest 迁移专用）。
 
-    deduct_remain：扣剩余冻结不动成交计数（保持 t1backtest:651 预存行为）。
     normalize_freeze：量化精度 + remain 兜底（t1backtest:361-365）。
     """
 
     def _make_order(self, volume=1000, frozen_money=10000, limit_price=10.0):
         return Order(portfolio_id="p", engine_id="e", task_id="t", code="000001.SZ",
                      volume=volume, limit_price=limit_price, frozen_money=frozen_money)
-
-    def test_deduct_remain_reduces_and_floors_zero(self):
-        o = self._make_order()
-        o.freeze(1000, 10000)  # remain=10000
-        o.deduct_remain(3000)
-        assert o.remain == 7000
-        o.deduct_remain(99999)  # 超额
-        assert o.remain == 0  # floor 0
-
-    def test_deduct_remain_rejects_negative(self):
-        o = self._make_order()
-        with pytest.raises((ValueError, TypeError)):
-            o.deduct_remain(-1)
 
     def test_normalize_freeze_quantizes_to_places(self):
         o = self._make_order(frozen_money=10000)

--- a/tests/unit/trading/portfolios/test_t1backtest.py
+++ b/tests/unit/trading/portfolios/test_t1backtest.py
@@ -696,7 +696,7 @@ class TestLongShortFillHandling:
     def test_long_partial_fill_remain_not_double_deducted(self):
         """LONG 部分成交 order.remain 应单扣 fill_cost（#6109）。
 
-        bug：settle(line624) 已扣 remain，deduct_remain(line640) 再扣 → 2×fill_cost，
+        bug：settle(line624) 已扣 remain，旧路径重复扣减 → 2×fill_cost，
         导致 is_final 时 unfreeze_remain 偏小，现金卡在 frozen 影响后续下单可用资金。
         """
         p = _make_portfolio()


### PR DESCRIPTION
## 背景
PR #6140（c014db85）标题"去 deduct_remain"实际只删了 t1backtest LONG 调用点（修双扣），但 `Order.deduct_remain` 方法定义留在 order.py，全 src 零调用成死代码。

## 改动
- 删 `Order.deduct_remain` 方法定义
- 删其 2 单测（test_deduct_remain_*）
- 更新 t1backtest 双扣回归测试注释去硬引用

## 验证
- deduct_remain 全仓零调用（grep 清零）→ 删除零运行时影响
- 波及域 order+position+t1backtest：200 passed（仅 activate 1 预存 failed，无关）
- 文件树：order.py -13 / test_order.py -14 / t1backtest +1/-1

收口 ADR-010 V5 字段封装。