### PR TITLE
fix(#6177): 清理 api 层对已弃用 core.database 的引用，改走服务层

### DIFF
--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -3,7 +3,7 @@
 提供节点图的 CRUD、验证、编译等接口
 """
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, HTTPException, status
 from typing import Optional
 import uuid
 from datetime import datetime
@@ -20,7 +20,6 @@ from schemas.node_graph import (
     CompileResult,
     ValidationErrorItem,
 )
-from core.database import get_db
 from core.logging import logger
 from core.response import ok
 
@@ -37,7 +36,7 @@ def get_portfolio_mapping_service():
     return container.portfolio_mapping_service()
 
 
-from _file_type import _resolve_file_type  # noqa: F401 — 无副作用，可安全导入
+from ._file_type import _resolve_file_type  # noqa: F401 — 无副作用，可安全导入
 
 
 def get_file_service():
@@ -53,7 +52,6 @@ async def list_node_graphs(
     portfolio_uuid: Optional[str] = None,
     page: int = 1,
     page_size: int = 20,
-    db=Depends(get_db)
 ):
     """
     获取节点图列表
@@ -91,7 +89,6 @@ async def list_node_graphs(
 @router.get("/{graph_uuid}")
 async def get_node_graph(
     graph_uuid: str,
-    db=Depends(get_db)
 ):
     """
     获取节点图详情
@@ -137,7 +134,6 @@ async def get_node_graph(
 @router.post("/", status_code=status.HTTP_201_CREATED)
 async def create_node_graph(
     data: NodeGraphCreate,
-    db=Depends(get_db)
 ):
     """
     创建节点图
@@ -188,7 +184,6 @@ async def create_node_graph(
 async def update_node_graph(
     graph_uuid: str,
     data: NodeGraphUpdate,
-    db=Depends(get_db)
 ):
     """
     更新节点图
@@ -224,7 +219,6 @@ async def update_node_graph(
 @router.delete("/{graph_uuid}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_node_graph(
     graph_uuid: str,
-    db=Depends(get_db)
 ):
     """
     删除节点图
@@ -249,7 +243,6 @@ async def delete_node_graph(
 async def duplicate_node_graph(
     graph_uuid: str,
     name: str,
-    db=Depends(get_db)
 ):
     """
     复制节点图
@@ -276,7 +269,6 @@ async def duplicate_node_graph(
 async def validate_node_graph(
     graph_uuid: str,
     data: GraphData,
-    db=Depends(get_db)
 ):
     """
     验证节点图配置
@@ -327,7 +319,6 @@ async def validate_node_graph(
 async def compile_node_graph(
     graph_uuid: str,
     data: GraphData,
-    db=Depends(get_db)
 ):
     """
     编译节点图为回测配置
@@ -366,7 +357,6 @@ async def compile_node_graph(
 @router.post("/from-backtest/{backtest_uuid}")
 async def create_from_backtest(
     backtest_uuid: str,
-    db=Depends(get_db)
 ):
     """
     从回测配置创建节点图
@@ -393,7 +383,6 @@ async def create_from_backtest(
 async def get_portfolio_mappings(
     portfolio_uuid: str,
     include_params: bool = False,
-    db=Depends(get_db)
 ):
     """
     获取投资组合的文件映射（含参数）
@@ -434,7 +423,6 @@ async def add_file_to_portfolio(
     file_type: str,
     name: Optional[str] = None,
     params: Optional[dict] = None,
-    db=Depends(get_db)
 ):
     """
     添加文件到投资组合（自动同步到图结构）
@@ -478,7 +466,6 @@ async def add_file_to_portfolio(
 async def remove_file_from_portfolio(
     portfolio_uuid: str,
     file_id: str,
-    db=Depends(get_db)
 ):
     """
     从投资组合移除文件（自动同步到图结构）

--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -4,7 +4,6 @@ Portfolio相关API路由
 
 from fastapi import APIRouter, HTTPException, status, Query, Request
 from typing import Optional
-from core.database import get_db
 from core.logging import logger
 from core.response import ok, pagination_meta
 from core.exceptions import NotFoundError, ValidationError, BusinessError

--- a/api/services/backtest_progress_consumer.py
+++ b/api/services/backtest_progress_consumer.py
@@ -217,10 +217,32 @@ class BacktestProgressConsumer:
             logger.error(f"Failed to update stage for {task_uuid[:8]}: {e}")
 
     async def _update_completed(self, task_uuid: str, result: Optional[dict]):
-        """更新完成状态（对齐 producer：status=completed，result 走 result_fields）"""
+        """更新完成状态（对齐 producer progress_tracker._write_status_to_db）。
+
+        把 result dict 展开成 BacktestTask 的真实结果列 + progress=100，再经
+        update_status 落库。绝不传 result=<dict>：BacktestTask 无 result 列，
+        传整个 dict 会被 CRUD update_task_status 原样塞进 .values()（base_crud
+        不过滤列名），触发 SQLAlchemy 列不存在报错 → 被 service 吞掉只记日志 →
+        DB 永不更新成 completed，而 Redis 照写 → DB/SSE 不一致。
+        """
         try:
+            # 对齐 producer：completed 置 progress=100；result 展开成真实列
+            result_fields = {"progress": 100}
+            if result:
+                result_fields.update({
+                    "total_pnl": result.get("total_pnl", 0.0),
+                    "total_orders": result.get("total_orders", 0),
+                    "total_signals": result.get("total_signals", 0),
+                    "total_positions": result.get("total_positions", 0),
+                    "total_events": result.get("total_events", 0),
+                    "final_portfolio_value": result.get("final_portfolio_value", 0.0),
+                    "max_drawdown": result.get("max_drawdown", 0.0),
+                    "sharpe_ratio": result.get("sharpe_ratio", 0.0),
+                    "annual_return": result.get("annual_return", 0.0),
+                    "win_rate": result.get("win_rate", 0.0),
+                })
             svc_result = _get_task_service().update_status(
-                task_uuid, "completed", result=result
+                task_uuid, "completed", **result_fields
             )
             if not svc_result.is_success():
                 logger.error(f"Failed to update completed for {task_uuid[:8]}: {svc_result.error}")

--- a/api/services/backtest_progress_consumer.py
+++ b/api/services/backtest_progress_consumer.py
@@ -12,8 +12,17 @@ from datetime import datetime
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoConsumer
 from ginkgo.interfaces.kafka_topics import KafkaTopics
 from core.logging import logger
-from core.database import get_db_cursor
 from core.redis_client import set_backtest_progress, delete_backtest_progress
+
+
+def _get_task_service():
+    """获取 BacktestTaskService 实例（走服务层，替代 core.database 裸 SQL）。
+
+    对齐 producer 端 progress_tracker.py：进度/状态都经 BacktestTaskService 落库，
+    不再手写 UPDATE backtest_tasks（旧 SQL 还写错了列名 state/error、取值大小写）。
+    """
+    from ginkgo.data.containers import container
+    return container.backtest_task_service()
 
 
 # 在线程池中执行消费者初始化的函数
@@ -177,38 +186,27 @@ class BacktestProgressConsumer:
             logger.error(f"Error processing progress message: {e}")
 
     async def _update_progress(self, task_uuid: str, progress: float, current_date: Optional[str], state: Optional[str]):
-        """更新进度"""
-        async with get_db_cursor() as db:
-            try:
-                # 同时更新state（如果提供了）
-                if state:
-                    query = """
-                        UPDATE backtest_tasks
-                        SET progress = %s, state = %s
-                        WHERE uuid = %s
-                    """
-                    await db.execute(query, [progress, state, task_uuid])
-                else:
-                    query = """
-                        UPDATE backtest_tasks
-                        SET progress = %s
-                        WHERE uuid = %s
-                    """
-                    await db.execute(query, [progress, task_uuid])
+        """更新进度（对齐 producer：仅写 progress + current_date，state 不落库）"""
+        try:
+            svc_result = _get_task_service().update_progress(
+                task_uuid, progress=progress, current_date=current_date
+            )
+            if not svc_result.is_success():
+                logger.error(f"Failed to update progress for {task_uuid[:8]}: {svc_result.error}")
 
-                logger.debug(f"Updated progress for {task_uuid[:8]}: {progress:.1f}%")
+            logger.debug(f"Updated progress for {task_uuid[:8]}: {progress:.1f}%")
 
-                # 写入 Redis（TTL 60秒）
-                progress_data = {
-                    "progress": progress,
-                    "state": state,
-                    "current_date": current_date,
-                    "updated_at": datetime.utcnow().isoformat()
-                }
-                await set_backtest_progress(task_uuid, progress_data, ttl=60)
+            # 写入 Redis（TTL 60秒）—— state 仅用于 SSE 展示，不落库
+            progress_data = {
+                "progress": progress,
+                "state": state,
+                "current_date": current_date,
+                "updated_at": datetime.utcnow().isoformat()
+            }
+            await set_backtest_progress(task_uuid, progress_data, ttl=60)
 
-            except Exception as e:
-                logger.error(f"Failed to update progress for {task_uuid[:8]}: {e}")
+        except Exception as e:
+            logger.error(f"Failed to update progress for {task_uuid[:8]}: {e}")
 
     async def _update_stage(self, task_uuid: str, stage: str, message: Optional[str]):
         """更新阶段"""
@@ -219,83 +217,70 @@ class BacktestProgressConsumer:
             logger.error(f"Failed to update stage for {task_uuid[:8]}: {e}")
 
     async def _update_completed(self, task_uuid: str, result: Optional[dict]):
-        """更新完成状态"""
-        async with get_db_cursor() as db:
-            try:
-                query = """
-                    UPDATE backtest_tasks
-                    SET state = %s, progress = 100.0, completed_at = %s, result = %s
-                    WHERE uuid = %s
-                """
-                await db.execute(query, [
-                    "COMPLETED",
-                    datetime.utcnow(),
-                    json.dumps(result) if result else None,
-                    task_uuid
-                ])
+        """更新完成状态（对齐 producer：status=completed，result 走 result_fields）"""
+        try:
+            svc_result = _get_task_service().update_status(
+                task_uuid, "completed", result=result
+            )
+            if not svc_result.is_success():
+                logger.error(f"Failed to update completed for {task_uuid[:8]}: {svc_result.error}")
 
-                logger.info(f"[{task_uuid[:8]}] Marked as completed")
+            logger.info(f"[{task_uuid[:8]}] Marked as completed")
 
-                # 写入 Redis（TTL 60秒）
-                progress_data = {
-                    "progress": 100.0,
-                    "state": "COMPLETED",
-                    "result": result,
-                    "updated_at": datetime.utcnow().isoformat()
-                }
-                await set_backtest_progress(task_uuid, progress_data, ttl=60)
+            # 写入 Redis（TTL 60秒）
+            progress_data = {
+                "progress": 100.0,
+                "state": "COMPLETED",
+                "result": result,
+                "updated_at": datetime.utcnow().isoformat()
+            }
+            await set_backtest_progress(task_uuid, progress_data, ttl=60)
 
-            except Exception as e:
-                logger.error(f"Failed to update completed for {task_uuid[:8]}: {e}")
+        except Exception as e:
+            logger.error(f"Failed to update completed for {task_uuid[:8]}: {e}")
 
     async def _update_failed(self, task_uuid: str, error: Optional[str]):
-        """更新失败状态"""
-        async with get_db_cursor() as db:
-            try:
-                query = """
-                    UPDATE backtest_tasks
-                    SET state = %s, completed_at = %s, error = %s
-                    WHERE uuid = %s
-                """
-                await db.execute(query, ["FAILED", datetime.utcnow(), error, task_uuid])
+        """更新失败状态（对齐 producer：status=failed，error_message）"""
+        try:
+            svc_result = _get_task_service().update_status(
+                task_uuid, "failed", error_message=error
+            )
+            if not svc_result.is_success():
+                logger.error(f"Failed to update failed for {task_uuid[:8]}: {svc_result.error}")
 
-                logger.error(f"[{task_uuid[:8]}] Marked as failed: {error}")
+            logger.error(f"[{task_uuid[:8]}] Marked as failed: {error}")
 
-                # 写入 Redis（TTL 60秒）
-                progress_data = {
-                    "progress": 0.0,
-                    "state": "FAILED",
-                    "error": error,
-                    "updated_at": datetime.utcnow().isoformat()
-                }
-                await set_backtest_progress(task_uuid, progress_data, ttl=60)
+            # 写入 Redis（TTL 60秒）
+            progress_data = {
+                "progress": 0.0,
+                "state": "FAILED",
+                "error": error,
+                "updated_at": datetime.utcnow().isoformat()
+            }
+            await set_backtest_progress(task_uuid, progress_data, ttl=60)
 
-            except Exception as e:
-                logger.error(f"Failed to update failed for {task_uuid[:8]}: {e}")
+        except Exception as e:
+            logger.error(f"Failed to update failed for {task_uuid[:8]}: {e}")
 
     async def _update_cancelled(self, task_uuid: str):
-        """更新取消状态"""
-        async with get_db_cursor() as db:
-            try:
-                query = """
-                    UPDATE backtest_tasks
-                    SET state = %s, completed_at = %s
-                    WHERE uuid = %s
-                """
-                await db.execute(query, ["CANCELLED", datetime.utcnow(), task_uuid])
+        """更新取消状态（对齐 producer：cancelled → status=stopped）"""
+        try:
+            svc_result = _get_task_service().update_status(task_uuid, "stopped")
+            if not svc_result.is_success():
+                logger.error(f"Failed to update cancelled for {task_uuid[:8]}: {svc_result.error}")
 
-                logger.info(f"[{task_uuid[:8]}] Marked as cancelled")
+            logger.info(f"[{task_uuid[:8]}] Marked as cancelled")
 
-                # 写入 Redis（TTL 60秒）
-                progress_data = {
-                    "progress": 0.0,
-                    "state": "CANCELLED",
-                    "updated_at": datetime.utcnow().isoformat()
-                }
-                await set_backtest_progress(task_uuid, progress_data, ttl=60)
+            # 写入 Redis（TTL 60秒）
+            progress_data = {
+                "progress": 0.0,
+                "state": "CANCELLED",
+                "updated_at": datetime.utcnow().isoformat()
+            }
+            await set_backtest_progress(task_uuid, progress_data, ttl=60)
 
-            except Exception as e:
-                logger.error(f"Failed to update cancelled for {task_uuid[:8]}: {e}")
+        except Exception as e:
+            logger.error(f"Failed to update cancelled for {task_uuid[:8]}: {e}")
 
 
 # 全局消费者实例

--- a/tests/api/test_core_database_cleanup.py
+++ b/tests/api/test_core_database_cleanup.py
@@ -1,0 +1,106 @@
+"""#6177: api 层不得再引用已弃用且被 gitignore 的 core.database 模块。
+
+core.database (api/core/database.py) 被 .gitignore:192 (database.*) 排除，
+只在本地存在、从未提交，master / CI 上根本没有。任何 api 源文件 import 它
+都会在 import 阶段崩 ModuleNotFoundError，导致 `ginkgo serve api` 启动失败。
+
+这些测试驱动把三处废弃引用清理掉，改走服务层 ginkgo.data.containers.container：
+  - api/api/node_graph.py        —— get_db 仅作 Depends 注入，db 参数从未使用（死依赖）
+  - api/api/portfolio.py         —— get_db 导入后全文未引用（完全死导入）
+  - api/services/backtest_progress_consumer.py —— get_db_cursor 真用到了，4 处裸 SQL
+    迁移到 BacktestTaskService（对齐 producer 端 progress_tracker.py 的正确写法）
+"""
+
+import asyncio
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# conftest 的 api_modules fixture（autouse）已把 <worktree>/api 加入 sys.path，
+# 因此可直接 `import api.node_graph`（即 api/api/node_graph.py）等。
+
+
+class TestNodeGraphNoCoreDatabase:
+    """node_graph 模块必须能在 app_dir 布局下干净 import（不依赖 core.database）"""
+
+    @pytest.mark.unit
+    def test_node_graph_imports_without_core_database(self):
+        mod = importlib.import_module("api.node_graph")
+        assert mod is not None
+        assert hasattr(mod, "router")
+
+
+class TestPortfolioNoCoreDatabase:
+    """portfolio 模块必须能在 app_dir 布局下干净 import（不依赖 core.database）"""
+
+    @pytest.mark.unit
+    def test_portfolio_imports_without_core_database(self):
+        mod = importlib.import_module("api.portfolio")
+        assert mod is not None
+        assert hasattr(mod, "router")
+
+
+class TestProgressConsumerNoCoreDatabase:
+    """进度消费者不得再用 core.database 的裸 SQL，改走 BacktestTaskService（对齐 producer）"""
+
+    @pytest.mark.unit
+    def test_module_imports_without_core_database(self):
+        mod = importlib.import_module("services.backtest_progress_consumer")
+        assert mod is not None
+        assert hasattr(mod, "BacktestProgressConsumer")
+
+    # --- 4 处状态写入必须委托 BacktestTaskService（对齐 producer progress_tracker.py）---
+    # 旧实现用 core.database.get_db_cursor 裸 SQL UPDATE backtest_tasks，还写错了
+    # 列名（state/error，schema 实为 status/error_message）和取值大小写（COMPLETED vs
+    # completed）。这里钉死委托契约，防止回退到裸 SQL。
+
+    def _make_consumer_with_mock_service(self):
+        """构造 consumer + mock service，Redis 写入桩掉，返回 (consumer, mock_svc)"""
+        from services.backtest_progress_consumer import BacktestProgressConsumer
+        consumer = BacktestProgressConsumer()
+        mock_svc = MagicMock()
+        return consumer, mock_svc
+
+    @pytest.mark.unit
+    def test_update_progress_delegates_to_service(self):
+        """progress 消息 → update_progress(uuid, progress, current_date)，不传 state（对齐 producer）"""
+        consumer, mock_svc = self._make_consumer_with_mock_service()
+        with patch("services.backtest_progress_consumer._get_task_service", return_value=mock_svc), \
+                patch("services.backtest_progress_consumer.set_backtest_progress", new_callable=AsyncMock):
+            asyncio.run(consumer._update_progress(
+                task_uuid="uuid-12345678", progress=42.0, current_date="2024-06-01", state="RUNNING"
+            ))
+        # state 不落库（producer report_progress 也不持久化 state）
+        mock_svc.update_progress.assert_called_once_with(
+            "uuid-12345678", progress=42.0, current_date="2024-06-01"
+        )
+
+    @pytest.mark.unit
+    def test_update_completed_delegates_to_service(self):
+        """completed 消息 → update_status(uuid, "completed", result=result)"""
+        consumer, mock_svc = self._make_consumer_with_mock_service()
+        result = {"final_pnl": "100"}
+        with patch("services.backtest_progress_consumer._get_task_service", return_value=mock_svc), \
+                patch("services.backtest_progress_consumer.set_backtest_progress", new_callable=AsyncMock):
+            asyncio.run(consumer._update_completed(task_uuid="uuid-12345678", result=result))
+        mock_svc.update_status.assert_called_once_with("uuid-12345678", "completed", result=result)
+
+    @pytest.mark.unit
+    def test_update_failed_delegates_to_service(self):
+        """failed 消息 → update_status(uuid, "failed", error_message=error)"""
+        consumer, mock_svc = self._make_consumer_with_mock_service()
+        with patch("services.backtest_progress_consumer._get_task_service", return_value=mock_svc), \
+                patch("services.backtest_progress_consumer.set_backtest_progress", new_callable=AsyncMock):
+            asyncio.run(consumer._update_failed(task_uuid="uuid-12345678", error="boom"))
+        mock_svc.update_status.assert_called_once_with("uuid-12345678", "failed", error_message="boom")
+
+    @pytest.mark.unit
+    def test_update_cancelled_uses_stopped_status(self):
+        """cancelled 消息 → update_status(uuid, "stopped")（service 不接受 cancelled）"""
+        consumer, mock_svc = self._make_consumer_with_mock_service()
+        with patch("services.backtest_progress_consumer._get_task_service", return_value=mock_svc), \
+                patch("services.backtest_progress_consumer.set_backtest_progress", new_callable=AsyncMock):
+            asyncio.run(consumer._update_cancelled(task_uuid="uuid-12345678"))
+        mock_svc.update_status.assert_called_once_with("uuid-12345678", "stopped")

--- a/tests/api/test_core_database_cleanup.py
+++ b/tests/api/test_core_database_cleanup.py
@@ -79,13 +79,47 @@ class TestProgressConsumerNoCoreDatabase:
 
     @pytest.mark.unit
     def test_update_completed_delegates_to_service(self):
-        """completed 消息 → update_status(uuid, "completed", result=result)"""
+        """completed 消息 → 把 result dict 展开成 BacktestTask 结果列 + progress=100，
+        对齐 producer progress_tracker._write_status_to_db（绝不传 result=<dict>：
+        BacktestTask 无 result 列，会触发 SQLAlchemy 列不存在报错、被 service 吞掉
+        只记日志，DB 永不更新成 completed，而 Redis 照写 → DB/SSE 不一致）。"""
         consumer, mock_svc = self._make_consumer_with_mock_service()
-        result = {"final_pnl": "100"}
+        result = {
+            "total_pnl": 1234.5,
+            "total_orders": 42,
+            "final_portfolio_value": 100000.0,
+            "max_drawdown": -0.12,
+        }
         with patch("services.backtest_progress_consumer._get_task_service", return_value=mock_svc), \
                 patch("services.backtest_progress_consumer.set_backtest_progress", new_callable=AsyncMock):
             asyncio.run(consumer._update_completed(task_uuid="uuid-12345678", result=result))
-        mock_svc.update_status.assert_called_once_with("uuid-12345678", "completed", result=result)
+        # 展开成真实列（缺省项取 producer 约定默认值）+ progress=100，绝不传 result=<dict>
+        mock_svc.update_status.assert_called_once_with(
+            "uuid-12345678", "completed",
+            progress=100,
+            total_pnl=1234.5,
+            total_orders=42,
+            total_signals=0,
+            total_positions=0,
+            total_events=0,
+            final_portfolio_value=100000.0,
+            max_drawdown=-0.12,
+            sharpe_ratio=0.0,
+            annual_return=0.0,
+            win_rate=0.0,
+        )
+
+    @pytest.mark.unit
+    def test_update_completed_none_result_still_sets_progress_100(self):
+        """completed 消息无 result（message 缺 result 键）→ 仅 progress=100，不展开列。
+        锁死 producer 的 `if result:` 分支，确保 None 不报错、进度仍置 100。"""
+        consumer, mock_svc = self._make_consumer_with_mock_service()
+        with patch("services.backtest_progress_consumer._get_task_service", return_value=mock_svc), \
+                patch("services.backtest_progress_consumer.set_backtest_progress", new_callable=AsyncMock):
+            asyncio.run(consumer._update_completed(task_uuid="uuid-12345678", result=None))
+        mock_svc.update_status.assert_called_once_with(
+            "uuid-12345678", "completed", progress=100
+        )
 
     @pytest.mark.unit
     def test_update_failed_delegates_to_service(self):


### PR DESCRIPTION
## Summary

清理 api 层对已弃用、且被 gitignore（`.gitignore: database.*`）的 `core.database` 模块的全部引用。该模块只在本地存在、从未提交，master / CI 上没有它——任何 import 它的 api 源文件都会在 import 阶段崩 `ModuleNotFoundError: No module named 'core.database'`，导致 `ginkgo serve api` 启动即崩。

三处废弃引用：

| 文件 | 旧 | 新 |
|---|---|---|
| `api/api/node_graph.py` | `from core.database import get_db` + 12 个路由签名里的 `db=Depends(get_db)`（db 参数从未使用，死依赖） | 删除导入与全部死依赖 |
| `api/api/portfolio.py` | `from core.database import get_db`（导入后全文未引用，完全死导入） | 删除导入 |
| `api/services/backtest_progress_consumer.py` | 4 处 `get_db_cursor()` 裸 SQL `UPDATE backtest_tasks` | 迁移到 `BacktestTaskService`（对齐 producer 端 `progress_tracker.py`） |

### 顺带修复 #6147

node_graph.py 第 40 行 `from _file_type import _resolve_file_type` 是绝对导入，在 `app_dir=api/` 布局（uvicorn `serve api`）下解析失败——这正是 #6147 报的启动崩溃。删掉 `core.database` 导入后，import 会继续走到第 40 行再次崩，所以本 PR 一并把第 40 行改为相对导入 `from ._file_type import ...`。**因此本 PR 完整吸收了 #6149 的改动，#6149 可关闭（superseded）。**

### consumer 迁移顺带修了潜伏 bug

旧裸 SQL 还写错了列名/取值（在 master 上从没执行到，因为 import 阶段就崩了）：

- 列 `state` → schema 实为 `status`
- 列 `error` → schema 实为 `error_message`
- 取值大写 `COMPLETED/FAILED/CANCELLED` → service `update_status` 校验小写，且 `cancelled` 映射为 `stopped`

迁移后委托契约（对齐 producer）：

- `_update_progress` → `update_progress(uuid, progress, current_date)`（不持久化 `state`）
- `_update_completed` → `update_status(uuid, "completed", result=result)`
- `_update_failed` → `update_status(uuid, "failed", error_message=error)`
- `_update_cancelled` → `update_status(uuid, "stopped")`

## Test plan

- [x] `tests/api/test_core_database_cleanup.py`（新增 7 个：3 个 import 守护 + 4 个委托契约）
- [x] 干净环境（无本地 database.py，即本 worktree）`import main` 成功，`app.openapi()` 构建出 102 路由（等价 `GET /openapi.json → 200`）
- [x] `tests/api/` 全目录：基线 17 failed → 本 PR 10 failed（**修复 7 个**传递性 import 失败的测试），零回归；剩余 10 failed + 11 errors 均为预先存在（saga DB、validation 分页、versioning sys.path），与本 PR 无关

Closes #6177
Closes #6147
