### PR TITLE
fix(#6107): ConcentrationRisk Decimal 混算修复

### DIFF
--- a/src/ginkgo/trading/risk_management/concentration_risk.py
+++ b/src/ginkgo/trading/risk_management/concentration_risk.py
@@ -276,7 +276,7 @@ class ConcentrationRisk(BaseRiskManagement):
         if total_value <= 0:
             return 0.0
 
-        return (position.market_value / total_value) * 100
+        return float((position.market_value / total_value) * 100)
 
     def _calculate_projected_ratio(self, portfolio_info: Dict, order: Order) -> float:
         """计算下单后的预计持仓比例"""
@@ -300,7 +300,7 @@ class ConcentrationRisk(BaseRiskManagement):
         projected_position_value = positions.get(order.code).market_value if positions.get(order.code) else 0
         projected_position_value += order_value
 
-        return (projected_position_value / projected_total) * 100
+        return float((projected_position_value / projected_total) * 100)
 
     def _calculate_projected_industry_ratio(self, portfolio_info: Dict, order: Order, industry: str) -> float:
         """计算下单后的预计行业持仓比例"""
@@ -310,8 +310,8 @@ class ConcentrationRisk(BaseRiskManagement):
         if total_value <= 0:
             return 100.0
 
-        # 计算当前行业价值
-        current_industry_value = 0.0
+        # 计算当前行业价值（Decimal(0)：market_value 为 Decimal，float 初值会与 Decimal 混算抛 TypeError）
+        current_industry_value = Decimal(0)
         for code, position in positions.items():
             if position and position.market_value > 0:
                 stock_industry = self._stock_industry_map.get(code, "未知行业")
@@ -327,7 +327,7 @@ class ConcentrationRisk(BaseRiskManagement):
         projected_industry_value = current_industry_value + order_value
         projected_total = total_value + order_value
 
-        return (projected_industry_value / projected_total) * 100
+        return float((projected_industry_value / projected_total) * 100)
 
     def update_stock_classification(self, code: str, industry: str = None, concepts: List[str] = None):
         """

--- a/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
@@ -379,3 +379,43 @@ class TestConcentrationRiskPerformance:
         for _ in range(1000):
             r._calculate_concentrations(_make_portfolio_info())
         assert time.perf_counter() - start < 1.0
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
+class TestConcentrationRiskDecimalCompatibility:
+    """V5 后 Position.market_value / order.limit_price 均为 Decimal 的混算兼容性守护。
+
+    既有 helper 用 int market_value / float limit_price，靠 order_value 恰好 Decimal 才触发崩溃；
+    Decimal 显式输入更贴近生产，并直接暴露 float 初值与 Decimal 的算术 TypeError。
+    """
+
+    def test_cal_decimal_market_value_and_limit_price_no_typeerror(self):
+        """Decimal market_value + Decimal limit_price 经 cal() 不抛 TypeError。
+
+        修复前 current_industry_value=0.0 在累加 market_value(Decimal) 时即崩
+        （float+Decimal 算术 TypeError；int+Decimal 合法是既有用例的巧合触发）。
+        """
+        r = ConcentrationRisk(max_single_position_ratio=5, max_industry_ratio=30)
+        r.update_stock_classification("000001.SZ", industry="银行")
+        order = _make_order(volume=100, code="000001.SZ", limit_price=Decimal("10.0"))
+        pos = _make_position(code="000001.SZ", market_value=Decimal("90000"))
+        info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
+        result = r.cal(info, order)
+        assert isinstance(result, Order)
+
+    def test_generate_signals_decimal_market_value_no_typeerror(self):
+        """Decimal market_value 经 generate_signals→_calculate_concentrations 不抛。
+
+        证伪'_calculate_concentrations 会 Decimal>float 崩'：Python 3.2+ 起比较合法（返回 bool），
+        sum/累加初值为 int 0（0+Decimal 合法）。仅算术混算 float+Decimal 才崩。
+        """
+        r = ConcentrationRisk(max_single_position_ratio=5)
+        _set_context(r)
+        r.update_stock_classification("000001.SZ", industry="银行")
+        pos = _make_position(code="000001.SZ", market_value=Decimal("90000"))
+        info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
+        event = EventPriceUpdate(payload=_make_bar())
+        signals = r.generate_signals(info, event)
+        assert isinstance(signals, list)


### PR DESCRIPTION
## 问题
V5(ADR-010)后 `order.limit_price` 与 `Position.market_value` 均为 Decimal。`_calculate_projected_industry_ratio` 的 `current_industry_value` 初值 `0.0`(float) 与 `order_value`(Decimal) 在 L327 相加抛 TypeError。

## 根因
Python Decimal 仅对 int 定义 __radd__（int+Decimal 合法），对 float 没有（float+Decimal 崩）。`0.0` 初值是炸弹。

## 修复
- L314: `current_industry_value = 0.0` → `Decimal(0)`
- L279/L303/L330: 出口 float() 包装（保 -> float 签名 + float 阈值比较）

## 验证
trading 18→16 failed(-2 即 concentration)，2872 passed；concentration 单独 35 passed。剩余 16 均环境问题(OKX/analyzer/DB/activate)，零 V5 回归。