### PR TITLE
fix: 批量修复 stockinfo 数据同步链路 (#6182 #6183 #6184)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -435,8 +435,13 @@ def sync(
             from ginkgo.data.containers import container
             stockinfo_service = container.stockinfo_service()
             console.print(":repeat: Syncing stock information...")
-            # TODO: Implement stockinfo sync
-            console.print(":information: Stock info sync not yet implemented")
+            result = stockinfo_service.sync()
+            if result and result.is_success():
+                console.print(f":white_check_mark: {result.message}")
+            else:
+                error_msg = result.message if result and hasattr(result, "message") else "unknown error"
+                console.print(f":x: Stock info sync failed: {error_msg}")
+                raise typer.Exit(1)
 
         elif data_type == "day":
             from ginkgo import service_hub

--- a/src/ginkgo/data/worker/worker.py
+++ b/src/ginkgo/data/worker/worker.py
@@ -298,8 +298,10 @@ class DataWorker(threading.Thread):
                     GLOG.ERROR(f"[DataWorker:{self._node_id}] Traceback: {traceback.format_exc()}")
                     with self._lock:
                         self._stats["errors"] += 1
-                    # 出错后短暂等待再继续
-                    time.sleep(5)
+                    # #6183: consumer 失效则重建（带退避），避免瞬时断连永久卡死
+                    if not self._rebuild_consumer():
+                        # 重建失败，退避后重试（而非死循环重试同一个 None）
+                        time.sleep(5)
 
         except KeyboardInterrupt:
             GLOG.WARN(f"[DataWorker:{self._node_id}] Worker received keyboard interrupt")
@@ -332,6 +334,35 @@ class DataWorker(threading.Thread):
         """
         with self._lock:
             return self._stats.copy()
+
+    def _rebuild_consumer(self) -> bool:
+        """检测 consumer 失效并重建（#6183）。
+
+        GinkgoConsumer 异常即置 self.consumer=None，run() 循环若只重试
+        同一个 None 会永久空转（错误计数无限增长）。此处检测失效后调
+        _init_consumer 重建；成功返回 True，重建失败返回 False（调用方
+        退避后再试），不 raise 以免拖垮 worker 线程。
+        """
+        if (
+            self._consumer is not None
+            and getattr(self._consumer, "consumer", None) is not None
+            and getattr(self._consumer, "is_connected", False)
+        ):
+            return True
+
+        GLOG.WARN(f"[DataWorker:{self._node_id}] Consumer lost or disconnected, rebuilding...")
+        try:
+            self._init_consumer()
+        except Exception as e:
+            GLOG.ERROR(f"[DataWorker:{self._node_id}] Consumer rebuild failed: {e}")
+            return False
+
+        if self._consumer is not None and getattr(self._consumer, "consumer", None) is not None:
+            GLOG.INFO(f"[DataWorker:{self._node_id}] Consumer rebuilt successfully")
+            return True
+
+        GLOG.ERROR(f"[DataWorker:{self._node_id}] Consumer rebuild yielded no usable consumer")
+        return False
 
     def _init_consumer(self):
         """初始化Kafka消费者"""

--- a/src/ginkgo/livecore/task_timer.py
+++ b/src/ginkgo/livecore/task_timer.py
@@ -838,13 +838,13 @@ class TaskTimer:
         try:
             from ginkgo import service_hub
 
-            stockinfo_service = service_hub.data.stockinfo_service
-            stocks = stockinfo_service.get_stockinfos()
+            stockinfo_service = service_hub.data.stockinfo_service()
+            result = stockinfo_service.get_stockinfos()
 
-            if not stocks:
-                return []
+            if result.is_success() and result.data:
+                return [stock.code for stock in result.data]
 
-            return [stock.code for stock in stocks]
+            return []
 
         except Exception as e:
             GLOG.ERROR(f"Failed to get stock codes: {e}")

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -267,13 +267,22 @@ class TestSync:
 
     @patch("ginkgo.data.containers.container")
     def test_sync_stockinfo_success(self, mock_container, cli_runner):
-        """同步 stockinfo 成功"""
+        """同步 stockinfo 成功：调用 service.sync() 并打印 success/total（非桩）"""
         mock_service = MagicMock()
+        mock_service.sync.return_value = ServiceResult.success(
+            data=MagicMock(),
+            message="Stock info sync completed: 5529 records processed",
+        )
         mock_container.stockinfo_service.return_value = mock_service
 
         result = cli_runner.invoke(data_cli.app, ["sync", "stockinfo"])
         assert result.exit_code == 0
         assert "Syncing stock information" in result.output
+        # 核心行为：必须真正调用 service.sync()，而不是桩
+        mock_service.sync.assert_called_once()
+        assert "not yet implemented" not in result.output
+        # 输出含 success/total，与 day/adjustfactor 同款
+        assert "5529" in result.output
 
     @patch("ginkgo.data.containers.container")
     def test_sync_stockinfo_service_exception(self, mock_container, cli_runner):

--- a/tests/unit/livecore/test_task_timer.py
+++ b/tests/unit/livecore/test_task_timer.py
@@ -96,3 +96,55 @@ class TestTaskTimerKafkaPublishing:
 
             topic = mock_producer.send.call_args.kwargs.get("topic") or mock_producer.send.call_args[0][0]
             assert topic == KafkaTopics.DATA_COMMANDS, f"Command '{cmd}' should route to DATA_COMMANDS"
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="TaskTimer not available")
+class TestGetAllStockCodes:
+    """#6182: _get_all_stock_codes 必须实例化 service（带 ()）并从 ServiceResult 取 .data。
+
+    旧实现把 dependency_injector 的 Singleton provider 对象当实例（漏调 ()），
+    且把 get_stockinfos() 返回的 ServiceResult 当 list 迭代，导致定时数据作业
+    永远 "No stocks found, skipping"，定时数据更新变空操作。
+    """
+
+    @patch("ginkgo.service_hub")
+    def test_returns_codes_from_service_result_data(self, mock_hub):
+        """ServiceResult.success(data=[StockInfo...]) -> 返回 [code...]，且 provider 必须被实例化。"""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        timer = TaskTimer()
+        mock_stocks = [MagicMock(code="000001.SZ"), MagicMock(code="600000.SH")]
+        mock_service = MagicMock()
+        mock_service.get_stockinfos.return_value = ServiceResult.success(data=mock_stocks)
+        mock_hub.data.stockinfo_service.return_value = mock_service
+
+        codes = timer._get_all_stock_codes()
+
+        assert codes == ["000001.SZ", "600000.SH"]
+        # provider 必须被实例化（带 ()），否则拿到的是 provider 对象非实例
+        mock_hub.data.stockinfo_service.assert_called_once()
+        mock_service.get_stockinfos.assert_called_once()
+
+    @patch("ginkgo.service_hub")
+    def test_returns_empty_when_no_data(self, mock_hub):
+        """ServiceResult 空 data -> 返回 []（不抛异常、不误返 ServiceResult 对象）。"""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        timer = TaskTimer()
+        mock_service = MagicMock()
+        mock_service.get_stockinfos.return_value = ServiceResult.success(data=[])
+        mock_hub.data.stockinfo_service.return_value = mock_service
+
+        assert timer._get_all_stock_codes() == []
+
+    @patch("ginkgo.service_hub")
+    def test_returns_empty_on_service_failure(self, mock_hub):
+        """ServiceResult.failure -> 返回 []。"""
+        from ginkgo.data.services.base_service import ServiceResult
+
+        timer = TaskTimer()
+        mock_service = MagicMock()
+        mock_service.get_stockinfos.return_value = ServiceResult.failure(message="db down")
+        mock_hub.data.stockinfo_service.return_value = mock_service
+
+        assert timer._get_all_stock_codes() == []

--- a/tests/unit/workers/test_data_worker.py
+++ b/tests/unit/workers/test_data_worker.py
@@ -1,0 +1,139 @@
+"""DataWorker consumer 自愈测试 -- #6183
+
+DataWorker.run() 长期运行时，Kafka 消费者遇异常会被置 None
+（GinkgoConsumer.__init__ 异常即 self.consumer=None），而 run() 的
+except 分支只 time.sleep(5) 重试同一个 None，导致一次瞬时断连即永久空转
+（错误计数无限增长）。修复：提取 _rebuild_consumer，consumer 失效时
+调 _init_consumer 重建（失败明确退避，不 raise）。
+"""
+import os
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+from unittest.mock import MagicMock, patch
+import pytest
+
+from ginkgo.data.worker import DataWorker
+
+
+def _make_worker():
+    """构造一个不连 Kafka 的 DataWorker（_consumer 延迟初始化）。"""
+    return DataWorker(bar_crud=MagicMock(), node_id="test-rebuild")
+
+
+def _healthy_consumer():
+    """一个健康 consumer mock：有底层 consumer、已连接。"""
+    c = MagicMock()
+    c.consumer = MagicMock()  # 底层 KafkaConsumer 对象存在
+    c.is_connected = True
+    return c
+
+
+class TestRebuildConsumer:
+    """#6183: _rebuild_consumer 检测失效并重建。"""
+
+    def test_rebuild_when_consumer_lost(self):
+        """consumer 为 None（失效）-> 调 _init_consumer 重建 -> 返回 True。"""
+        worker = _make_worker()
+        worker._consumer = None  # 失效（初始化失败置 None）
+
+        healthy = _healthy_consumer()
+
+        def fake_init():
+            worker._consumer = healthy
+
+        with patch.object(worker, "_init_consumer", side_effect=fake_init) as mock_init:
+            result = worker._rebuild_consumer()
+
+        assert result is True
+        mock_init.assert_called_once()
+
+    def test_rebuild_returns_false_on_init_failure(self):
+        """_init_consumer 抛异常时 _rebuild_consumer 不 raise，返回 False（调用方退避）。"""
+        worker = _make_worker()
+        worker._consumer = None
+
+        with patch.object(worker, "_init_consumer", side_effect=RuntimeError("kafka down")):
+            result = worker._rebuild_consumer()
+
+        assert result is False
+
+    def test_skip_rebuild_when_consumer_healthy(self):
+        """consumer 健康时不重建（不调 _init_consumer）。"""
+        worker = _make_worker()
+        worker._consumer = _healthy_consumer()
+
+        with patch.object(worker, "_init_consumer") as mock_init:
+            result = worker._rebuild_consumer()
+
+        assert result is True
+        mock_init.assert_not_called()
+
+
+class TestRunSelfHeal:
+    """#6183: run() 在 poll 异常且 consumer 失效时重建并恢复消费（端到端自愈）。
+
+    直接同步调用 worker.run()（它是 Thread.run 入口），通过 _stop_event
+    控制循环退出，避免起真实线程。
+    """
+
+    def test_run_rebuilds_and_resumes_after_disconnect(self):
+        """poll 抛异常（断连）-> 重建 -> 用新 consumer 恢复消费。"""
+        worker = _make_worker()
+
+        # 失效 consumer：底层 consumer 存在但已断连，poll 抛异常
+        broken = MagicMock()
+        broken.consumer = MagicMock()
+        broken.consumer.poll.side_effect = RuntimeError("broker gone")
+        broken.is_connected = False
+        worker._consumer = broken
+
+        # 重建后的健康 consumer：poll 返空，第二次后停止循环
+        healthy = _healthy_consumer()
+        poll_count = [0]
+
+        def healthy_poll(timeout_ms=1000):
+            poll_count[0] += 1
+            if poll_count[0] >= 2:
+                worker._stop_event.set()
+            return {}
+
+        healthy.consumer.poll.side_effect = healthy_poll
+
+        with patch.object(worker, "_init_consumer", side_effect=lambda: setattr(worker, "_consumer", healthy)):
+            worker.run()  # 同步执行 run 循环
+
+        # 重建发生：_consumer 从 broken 换成 healthy
+        assert worker._consumer is healthy
+        # 恢复消费：健康 consumer 的 poll 被调用
+        assert healthy.consumer.poll.call_count >= 2
+
+    def test_run_backs_off_when_rebuild_keeps_failing(self):
+        """重建持续失败时 run() 退避而非狂刷（验证不无限重建无节流）。"""
+        worker = _make_worker()
+
+        broken = MagicMock()
+        broken.consumer = MagicMock()
+        broken.consumer.poll.side_effect = RuntimeError("broker gone")
+        broken.is_connected = False
+        worker._consumer = broken
+
+        # _init_consumer 持续失败，且 _rebuild_consumer 内 _init_consumer 失败
+        # 不重建成功 -> run() 每次 except 走 sleep(5) 退避分支
+        rebuild_calls = [0]
+
+        real_rebuild = worker._rebuild_consumer
+
+        def counting_rebuild():
+            rebuild_calls[0] += 1
+            if rebuild_calls[0] >= 3:
+                worker._stop_event.set()
+            return real_rebuild()
+
+        # _init_consumer 始终失败 -> _rebuild_consumer 返 False -> run sleep(5)
+        with patch.object(worker, "_init_consumer", side_effect=RuntimeError("still down")), \
+             patch.object(worker, "_rebuild_consumer", side_effect=counting_rebuild), \
+             patch("ginkgo.data.worker.worker.time.sleep") as mock_sleep:
+            worker.run()
+
+        # 退避被调用（非死循环重试同一个 None）
+        assert mock_sleep.call_count >= 1


### PR DESCRIPTION
## Summary

批量修复 stockinfo 数据同步链路的三个断点（同模块、同链路，端到端验证）。三者根因各自独立，但同属 stockinfo 数据同步链路、共享 ServiceResult 解包模式。

| Issue | 角色 | 根因 | 修复 |
|---|---|---|---|
| #6184 | CLI 手动入口 | `data sync stockinfo` 打桩（`# TODO`）退出 | 接 `stockinfo_service.sync()`，输出 success/total，失败 `Exit(1)` |
| #6182 | 定时触发源 | `_get_all_stock_codes` 漏调 provider `()` + 把 ServiceResult 当 list | 带 `()` 实例化 service + 取 `result.data` |
| #6183 | 消费执行端 | consumer 失效后 `run()` 只 `sleep(5)` 重试同一个 None | 提取 `_rebuild_consumer`：失效检测→`_init_consumer` 重建→失败退避 |

## 调用链（修复前 → 修复后）

- **#6184**: `ginkgo data sync stockinfo` → ~~`# TODO: not yet implemented`~~ → `stockinfo_service.sync()` ✅
- **#6182**: 定时触发 → `task_timer._get_all_stock_codes` → ~~provider 漏 `()`、ServiceResult 当 list~~ → `service_hub.data.stockinfo_service()` + `result.data` ✅
- **#6183**: `DataWorker.run` poll 异常 → ~~`sleep(5)` 死循环重试 None~~ → `_rebuild_consumer()` 重建+退避 ✅

## Test plan

- [x] `tests/unit/client/test_data_cli.py::TestSync::test_sync_stockinfo_success` — #6184 强化原伪绿测试（断言 `sync()` 被调、非桩、含 success/total）
- [x] `tests/unit/livecore/test_task_timer.py::TestGetAllStockCodes` — #6182 三条路径（有数据/空/失败）+ 断言 provider 实例化
- [x] `tests/unit/workers/test_data_worker.py` — #6183 三个 `_rebuild_consumer` 单元 + 两个 `run()` 端到端自愈（断连重建恢复消费、重建持续失败退避非死循环）
- [x] 同模块回归（workers / livecore / client）：**55 passed**

变更文件覆盖率：`data_cli.py` / `task_timer.py` / `worker.py` 均有对应测试。

## ⚠️ 既有失败（非本 PR 引入）

`TestGetStockinfo::test_get_stockinfo_{with_filter,raw_mode,service_error}` 3 个测试在 **master 上同样失败**（已验证：主仓库 `origin/master` 跑同 3 个均失败）。属 `get` 命令测试与实现不同步（ADR-010 重构遗留），本 PR 未触及 `get` 命令，不负责修复。将另开 issue 跟进。

Closes #6184
Closes #6182
Closes #6183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
