### PR TITLE
fix(#5578): node-graphs file_type 支持 snake_case 归一化（risk_manager → RISKMANAGER）

### DIFF
--- a/api/api/_file_type.py
+++ b/api/api/_file_type.py
@@ -6,7 +6,7 @@ file_type 参数解析工具
 
 
 def _resolve_file_type(raw):
-    """解析 file_type 参数：支持整数、数字字符串、枚举名、别名 (#5774)"""
+    """解析 file_type 参数：支持整数、数字字符串、枚举名、别名、snake_case (#5774 #5578)"""
     from ginkgo.enums import FILE_TYPES
 
     if isinstance(raw, int):
@@ -32,8 +32,10 @@ def _resolve_file_type(raw):
     if upper in alias_map:
         return alias_map[upper]
 
-    # 枚举名匹配
+    # 枚举名匹配（含 snake_case 归一化重试：risk_manager → RISKMANAGER，#5578）
     result = FILE_TYPES.enum_convert(s)
+    if result is None and "_" in upper:
+        result = FILE_TYPES.enum_convert(upper.replace("_", ""))
     if result is None:
         raise ValueError(f"Unknown file_type: {s}")
     return result

--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -426,6 +426,12 @@ async def add_file_to_portfolio(
 ):
     """
     添加文件到投资组合（自动同步到图结构）
+
+    file_type 命名（统一归一化解析，见 _resolve_file_type #5774 #5578）：
+      - 枚举名/大小写：strategy / STRATEGY / Strategy
+      - 风控别名：risk / riskmanager / risk_manager / RISK 均映射为 RISKMANAGER
+      - 整数/数字串：6 / "6"（FILE_TYPES 整数值）
+    支持类型：ANALYZER / INDEX / RISKMANAGER / SELECTOR / SIZER / STRATEGY
     """
     try:
         from ginkgo.enums import FILE_TYPES

--- a/tests/api/test_node_graph_file_type.py
+++ b/tests/api/test_node_graph_file_type.py
@@ -60,6 +60,16 @@ class TestFileTypeParsing:
         assert _resolve_file_type("RISK") == FILE_TYPES.RISKMANAGER
 
     @pytest.mark.unit
+    def test_risk_manager_snake_case(self):
+        """snake_case 'risk_manager' → RISKMANAGER (#5578)"""
+        assert _resolve_file_type("risk_manager") == FILE_TYPES.RISKMANAGER
+
+    @pytest.mark.unit
+    def test_riskmanager_compact_compat(self):
+        """连写 'riskmanager' → RISKMANAGER（兼容，回归守护 #5578 ③）"""
+        assert _resolve_file_type("riskmanager") == FILE_TYPES.RISKMANAGER
+
+    @pytest.mark.unit
     def test_mixed_case(self):
         """混合大小写 'Strategy' → STRATEGY"""
         assert _resolve_file_type("Strategy") == FILE_TYPES.STRATEGY


### PR DESCRIPTION
## Summary

修复 #5578：`POST /api/v1/node-graphs/{pid}/files?file_type=risk_manager` 返回 500。

**验证发现**：主症状 `file_type=risk` 已由 #5774 的别名表修复；但验收要求的 snake_case `risk_manager` 仍抛 `ValueError: Unknown file_type: risk_manager`。

**根因**：`_resolve_file_type` 的枚举名匹配（`cls[string.upper()]`）不归一化下划线，枚举成员是 CamelCase 连写 `RISKMANAGER`，故 `RISK_MANAGER` 无法匹配。

**修复**：`api/api/_file_type.py` 在 `enum_convert` 失败后增加去下划线归一化重试（`upper().replace("_","")`），通用覆盖 snake_case，而非逐个加别名。仅当 `"_" in upper` 时触发，零侵入原有整数/大小写/别名路径。

### 验收对照

| 验收项 | 输入 | 结果 |
|---|---|---|
| ① risk 绑定 | `risk` | ✅ RISKMANAGER |
| ② risk_manager 绑定 | `risk_manager` | ✅ RISKMANAGER |
| ③ riskmanager 兼容 | `riskmanager` | ✅ RISKMANAGER |
| ④ 命名文档 | 端点 docstring | ✅ 已补 |
| 无效拒绝 | `foo_bar` | ✅ 仍 ValueError |

## Test plan

- [x] `tests/api/test_node_graph_file_type.py` 新增 2 用例（snake_case + 连写兼容），共 12 passed
- [x] `_resolve_file_type` 功能冒烟：①②③ + 别名 + 对照全过，无效输入仍拒绝
- [x] `py_compile` 两文件（docstring 无语法问题）

## 改动文件

- `api/api/_file_type.py` — snake_case 归一化重试（+4 行）
- `api/api/node_graph.py` — 端点 docstring 补 file_type 命名说明（验收④）
- `tests/api/test_node_graph_file_type.py` — +2 测试

Closes #5578
