### PR TITLE
fix(#6174): 统一回测标识符边界 task_id/engine_id，闭合 baseline 恒空

### DIFF
--- a/docs/adrs/ADR-016-backtest-id-boundary.md
+++ b/docs/adrs/ADR-016-backtest-id-boundary.md
@@ -1,0 +1,77 @@
+# ADR-016: 回测标识符边界（task_id / engine_id / uuid）
+
+**Status:** Accepted
+**Date:** 2026-06-19
+
+## Context
+
+回测数据模型里**三个标识符**在记录与任务表上共存，语义长期漂移，最终在 baseline 管线静默断裂（#6174）：
+
+| 标识符 | 来源 | 注释意图（docstring） |
+|---|---|---|
+| `uuid` | 实体主键 | 永久唯一 |
+| `task_id` | `MBacktestRecordBase:42` / `MBacktestTask:52`（unique） | "执行会话ID"（动态，每次 run） |
+| `engine_id` | `MBacktestRecordBase:41` / `MBacktestTask:54` | "引擎装配ID"（稳定，配置驱动） |
+
+**实证（源组合 `bcc34af4` / 回测 `8b7b8cd8`）**：
+
+1. **记录侧两列同值**：analyzer/signal 记录 `engine_id = task_id = 8b7b8cd8`（= 回测 uuid）。非偶然——回测写入端普遍 `engine_id=task_id`：
+   - `backtest_orchestrator.py:123,169` `engine_id=task_id`
+   - `workers/backtest_worker/task_processor.py:200,387` `engine_id=self.task.task_uuid`
+2. **任务表 `engine_id` 系统性空**：47/50 completed 任务 `engine_id=''`；3 个非空值为旧格式 `engine_0`/`engine_f`（非 uuid）。`MBacktestTask` 创建默认 `""`（`backtest_task_crud.py:85`），`update_status(uuid, status, error_message, **result_fields)` 签名未暴露 engine_id 写入，完成路径从不回写。
+3. **管线混用**：`slice_data_manager.py:61` `get_by_task_id(task_id=engine_id)` 显式把 `engine_id` 当 `task_id` 喂查询。它"能查到"**纯靠回测不变量 `engine_id==task_id` 的偶然**；signal/order 的 `find(filters={"engine_id":...})`（`:70,:77`）同理。
+4. **断裂链**：`_generate_baseline_if_possible:871` 从 task 读空 `engine_id` → `evaluate_backtest_stability(engine_id='')` → `get_by_task_id(task_id='')` → analyzer 空 → `_validate_backtest_data:196` 判 `invalid_data` → `monitoring_baseline` 不产出 → worker `disabled`。
+
+**设计意图与现实的关系**：`base_engine.py:26-27` 注释把 `engine_id`（稳定装配）/`task_id`（动态会话）定为**二维**。live/paper 路径接近此意图（`trade_gateway_adapter.py:192-193` 默认 `'live_engine'`/`'live_run'` 占位串，二者独立）。但**回测路径一次回测 = 一次装配 = 一次执行**，二维天然坍缩成一维——这不是实现 bug，是回测的固有形态。强行让回测维护"独立的稳定 engine_id"会引入不存在的装配生命周期。
+
+## Decision
+
+### 边界定义
+
+| 标识符 | 语义 | 回测取值 | live/paper 取值 |
+|---|---|---|---|
+| **`task_id`** | 执行会话ID；**回测记录的主查询键** | `≡ MBacktestTask.uuid` | 每 session 新生成 |
+| **`engine_id`** | 引擎装配ID；标识"哪套装配跑的" | `≡ task_id`（坍缩，非偶然） | 稳定装配 id（跨 session） |
+| `uuid` | 实体主键 | task 表：`≡ task_id` | — |
+
+### 三条铁律
+
+1. **读回测记录一律按 `task_id`**（主键）。`engine_id` 仅用于"按装配聚合 / 跨 session 查询"，**禁止当 `task_id` 喂 `get_by_task_id`** 或作为单次回测数据的查询条件。
+2. **回测完成必须写 `task.engine_id = task.uuid`**，维持 `engine_id ≡ task_id` 不变量。`MBacktestTask.engine_id` 是真实查询维度（`get_tasks_by_engine`、service `get`/list filter），不得留空。
+3. **live/paper 路径 `engine_id` 与 `task_id` 独立**——本 ADR 不改变 live 语义，仅约束回测。当前 live 占位串 `'live_engine'`/`'live_run'` 的规整属后续独立工作。
+
+### 查询实体分界（决定用哪个 id）
+
+- 查 **`MEngine` / `MEnginePortfolioMapping`**（引擎装配实体）→ 用 `engine_id`（这些表的主键就是装配 id）。**正确用法，不在本 ADR 改动范围**。
+- 查 **回测记录**（analyzer/signal/order/position/signal_tracker/transfer）→ 用 `task_id`。
+
+## Rationale
+
+- **"主查询键"必须唯一确定一次执行的数据**：一次回测产出的全部记录共享一个 `task_id`，用 `engine_id` 查在 live 下会跨 session 串数据。`task_id` 天然是 per-run 边界，故为记录主键。
+- **回测坍缩是事实，强行展开二维是过度设计**：回测没有"同一装配多次运行"的生命周期（每次回测都重新 assemble），故 `engine_id` 在回测里没有独立于 `task_id` 的信息量。承认坍缩、维持不变量，比虚构装配 id 更诚实。
+- **混用是 bug 不是兼容层**：`get_by_task_id(task_id=engine_id)` 依赖不变量才工作，是脆弱耦合。边界明确后应消除，而非保留"碰巧能跑"。
+- **不抽共享 mixin / 不改 Base 类**（CLAUDE.md）：记录模型各自 `@update.register(str)` 重载补 `task_id` 形参即可，不触碰 `MBacktestRecordBase` 字段定义（字段本就两列都在）。
+
+## Consequences
+
+**正向**：baseline 管线（#6174）闭合；`get_tasks_by_engine` 等任务表 engine_id 消费者可用；记录查询语义一致。
+
+**本次落地范围**（PR #6174）：
+- W1 task 完成回写 `engine_id = task.uuid`（`progress_tracker._write_status_to_db` completed 分支，经 `update_status(**result_fields)` → CRUD `update_task_status` → `modify` 三层透传落库）
+- R1 `slice_data_manager` 形参 `engine_id→task_id`、内部查询全走 `task_id`
+- R2 `backtest_evaluator.evaluate_backtest_stability` 形参 `engine_id→task_id`
+- R3 `portfolio_cli._generate_baseline_if_possible` 传 `task_id`（已读取 `task.task_id`，却误传可能为空的 `engine_id`，即 #6174 直接病灶）
+- R4 `deviation_checker.get_baseline` 传 `task_id`（同 R3 模式）
+- 附带：`evaluation_cli` 两处 `evaluate_backtest_stability` 调用（死代码块内，防 `return` 移除后 `TypeError`）
+
+**W2 经实证撤销**：原计划"记录模型 `.update()` singledispatch 重载补 `task_id`"。实证发现：
+1. 记录真实写入路径是 CRUD `_create_from_params`（`base_crud:340` 调用），已设 `task_id=kwargs.get("task_id","")`；
+2. MAnalyzerRecord 等 `.update()` singledispatch（str 重载）全仓无调用方，为 vestigial 代码；
+3. `_convert_input_item` 亦未被 base 调用。
+故记录端一直正确，无需改动。改死代码会制造虚假完整性，违反 verify-before-implement。
+
+**不在本次范围**（独立 follow-up）：
+- live/paper 占位串 `'live_engine'`/`'live_run'` 规整
+- live 路径 engine_id 稳定装配 id 的真实落地（需引擎装配注册表，属 ADR-003 引擎双模式后续）
+
+**向后兼容**：历史数据 `MBacktestTask.engine_id` 多为空——W1 仅影响新完成回测；读点改 `task_id` 后，历史回测仍可查（`task_id` 一直正确填充）。无需数据迁移、无 schema 变更（字段已存在）。

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -28,6 +28,7 @@
 | ADR-013 | [Debug 模式改变 @retry 退避语义](ADR-013-debug-retry-backoff.md) | Accepted | 2026-06-19 |
 | ADR-014 | [core/database.py 半 gitignore + api 层禁裸 SQL](ADR-014-core-database-gitignored.md) | Accepted | 2026-06-19 |
 | ADR-015 | [web-ui 以 shadcn-vue 为唯一 UI 组件标准栈](ADR-015-webui-shadcn-vue.md) | Accepted | 2026-06-19 |
+| ADR-016 | [回测标识符边界（task_id / engine_id / uuid）](ADR-016-backtest-id-boundary.md) | Accepted | 2026-06-19 |
 
 ## 如何新增 / 修订
 

--- a/src/ginkgo/client/evaluation_cli.py
+++ b/src/ginkgo/client/evaluation_cli.py
@@ -223,7 +223,9 @@ def evaluate_stability(
         
         result = evaluator.evaluate_backtest_stability(
             portfolio_id=portfolio,
-            engine_id=engine,
+            # ADR-016: 回测记录按 task_id 查。--engine 传入值在此回测评估场景即 task_id；
+            # CLI flag 重命名待 #4639 实现本命令时一并处理。
+            task_id=engine,
             start_date=start_date,
             end_date=end_date
         )
@@ -269,7 +271,9 @@ def create_monitor(
         # Run evaluation to get baseline
         result = evaluator.evaluate_backtest_stability(
             portfolio_id=portfolio,
-            engine_id=engine,
+            # ADR-016: 回测记录按 task_id 查。--engine 传入值在此回测评估场景即 task_id；
+            # CLI flag 重命名待 #4639 实现本命令时一并处理。
+            task_id=engine,
             start_date=start_date,
             end_date=end_date
         )

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -868,7 +868,6 @@ def _generate_baseline_if_possible(paper_portfolio_id: str, source_portfolio_id:
 
         latest_task = tasks[0]
         task_id = getattr(latest_task, 'task_id', None)
-        engine_id = getattr(latest_task, 'engine_id', None)
 
         if not task_id:
             GLOG.WARN(f"[DEPLOY] Backtest task has no task_id, skipping baseline")
@@ -879,7 +878,7 @@ def _generate_baseline_if_possible(paper_portfolio_id: str, source_portfolio_id:
         evaluator = BacktestEvaluator()
         eval_result = evaluator.evaluate_backtest_stability(
             portfolio_id=source_portfolio_id,
-            engine_id=engine_id,
+            task_id=task_id,
         )
 
         if eval_result.get("status") != "success":

--- a/src/ginkgo/trading/analysis/evaluation/backtest_evaluator.py
+++ b/src/ginkgo/trading/analysis/evaluation/backtest_evaluator.py
@@ -53,31 +53,34 @@ class BacktestEvaluator:
         if candidate_periods:
             self.period_optimizer.candidate_periods = candidate_periods
             
-    def evaluate_backtest_stability(self, 
+    def evaluate_backtest_stability(self,
                                   portfolio_id: str,
-                                  engine_id: str,
+                                  task_id: str,
                                   start_date: Optional[str] = None,
                                   end_date: Optional[str] = None) -> Dict:
         """
         场景1：完整回测稳定性评估流程
-        
+
+        回测记录按 task_id（≡ 回测 uuid，ADR-016 主键）查询。task_id 由调用方从
+        MBacktestTask.task_id / uuid 提供，不得用 task.engine_id（#6174：可能空）。
+
         Args:
             portfolio_id: 投资组合ID
-            engine_id: 引擎ID
+            task_id: 执行会话ID（回测 uuid，记录主键）
             start_date: 开始日期
             end_date: 结束日期
-            
+
         Returns:
             Dict: 完整的评估结果
         """
-        GLOG.INFO(f"开始回测稳定性评估: portfolio={portfolio_id}, engine={engine_id}")
-        
+        GLOG.INFO(f"开始回测稳定性评估: portfolio={portfolio_id}, task_id={task_id}")
+
         try:
             # 1. 获取回测数据
             GLOG.INFO("步骤1: 获取回测数据")
             backtest_data = self.data_manager.get_backtest_data(
                 portfolio_id=portfolio_id,
-                engine_id=engine_id,
+                task_id=task_id,
                 start_date=start_date,
                 end_date=end_date
             )
@@ -123,7 +126,7 @@ class BacktestEvaluator:
                 'status': 'success',
                 'evaluation_time': clock_now().isoformat(),
                 'portfolio_id': portfolio_id,
-                'engine_id': engine_id,
+                'task_id': task_id,
                 'data_summary': {
                     'analyzer_records': len(backtest_data['analyzer_data']),
                     'signal_records': len(backtest_data['signal_data']),

--- a/src/ginkgo/trading/analysis/evaluation/deviation_checker.py
+++ b/src/ginkgo/trading/analysis/evaluation/deviation_checker.py
@@ -63,14 +63,13 @@ class DeviationChecker:
                 return None
             latest_task = tasks[0]
             task_id = getattr(latest_task, "task_id", None)
-            engine_id = getattr(latest_task, "engine_id", None)
             if not task_id:
                 return None
 
             from ginkgo.trading.analysis.evaluation.backtest_evaluator import BacktestEvaluator
             evaluator = BacktestEvaluator()
             eval_result = evaluator.evaluate_backtest_stability(
-                portfolio_id=source_id, engine_id=engine_id,
+                portfolio_id=source_id, task_id=task_id,
             )
             if eval_result.get("status") != "success":
                 return None

--- a/src/ginkgo/trading/analysis/evaluation/slice_data_manager.py
+++ b/src/ginkgo/trading/analysis/evaluation/slice_data_manager.py
@@ -33,32 +33,36 @@ class SliceDataManager:
         """初始化数据管理器"""
         self.cache = {}  # 数据缓存
         
-    def get_backtest_data(self, 
+    def get_backtest_data(self,
                          portfolio_id: str,
-                         engine_id: str,
+                         task_id: str,
                          start_date: Optional[str] = None,
                          end_date: Optional[str] = None) -> Dict[str, pd.DataFrame]:
         """
         获取回测的analyzer、signal、order数据
-        
+
+        回测记录主查询键为 task_id（≡ 回测 uuid，ADR-016）。三类记录一律按 task_id 查，
+        禁止以 engine_id 作为单次回测数据的查询条件（回测里 engine_id ≡ task_id 是
+        不变量，但 task 表 engine_id 可能空——见 #6174）。
+
         Args:
             portfolio_id: 投资组合ID
-            engine_id: 引擎ID
+            task_id: 执行会话ID（回测 uuid，记录主键）
             start_date: 开始日期
             end_date: 结束日期
-            
+
         Returns:
             Dict: 包含analyzer_data, signal_data, order_data的字典
         """
-        GLOG.INFO(f"获取回测数据: portfolio={portfolio_id}, engine={engine_id}")
-        
+        GLOG.INFO(f"获取回测数据: portfolio={portfolio_id}, task_id={task_id}")
+
         try:
             from ginkgo import services
 
             # 获取analyzer记录
             analyzer_crud = services.data.cruds.analyzer_record()
             analyzer_records = analyzer_crud.get_by_task_id(
-                task_id=engine_id,
+                task_id=task_id,
                 portfolio_id=portfolio_id,
                 page_size=100000,
             )
@@ -67,14 +71,14 @@ class SliceDataManager:
             # 获取信号记录
             signal_crud = services.data.cruds.signal()
             signal_records = signal_crud.find(
-                filters={"portfolio_id": portfolio_id, "engine_id": engine_id},
+                filters={"portfolio_id": portfolio_id, "task_id": task_id},
             )
             signal_data = signal_records if isinstance(signal_records, pd.DataFrame) else pd.DataFrame()
 
             # 获取订单记录
             order_crud = services.data.cruds.order_record()
             order_records = order_crud.find(
-                filters={"portfolio_id": portfolio_id, "engine_id": engine_id},
+                filters={"portfolio_id": portfolio_id, "task_id": task_id},
             )
             order_data = order_records if isinstance(order_records, pd.DataFrame) else pd.DataFrame()
             

--- a/src/ginkgo/workers/backtest_worker/progress_tracker.py
+++ b/src/ginkgo/workers/backtest_worker/progress_tracker.py
@@ -224,6 +224,9 @@ class ProgressTracker:
             # 完成状态时，设置结果字段和进度 100%
             if status == "completed":
                 result_fields["progress"] = 100
+                # ADR-016 铁律 2: 回测完成回写 engine_id = task_uuid（task_id 与 uuid 等价），
+                # 维持 engine_id ≡ task_id 不变量。baseline 管线 / get_tasks_by_engine 等依赖此列非空。
+                result_fields["engine_id"] = task_id
             if result:
                 result_fields.update({
                     "total_pnl": result.get("total_pnl", 0.0),

--- a/tests/unit/trading/analysis/test_backtest_evaluator.py
+++ b/tests/unit/trading/analysis/test_backtest_evaluator.py
@@ -41,7 +41,44 @@ class TestBacktestEvaluatorGLOG:
             "order_data": pd.DataFrame(),
         }
         with patch.object(evaluator.data_manager, "get_backtest_data", return_value=empty_data):
-            result = evaluator.evaluate_backtest_stability(portfolio_id="test", engine_id="test")
+            result = evaluator.evaluate_backtest_stability(portfolio_id="test", task_id="test")
 
         # Should return a failed result, NOT raise AttributeError
         assert result["status"] == "failed"
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestEvaluator not available")
+@pytest.mark.tdd
+class TestEvaluateBacktestStabilityTaskId:
+    """ADR-016: evaluate_backtest_stability 形参 task_id，透传给 get_backtest_data。
+
+    #6174 的核心混用点之一：调用方曾传 task.engine_id（可能空）→ 查不到记录。
+    形参改为 task_id 后，由调用方负责提供 task_id（= 回测 uuid），下游按 task_id 查。
+    """
+
+    def test_threads_task_id_to_data_manager(self):
+        """evaluate_backtest_stability(task_id=T) → get_backtest_data(task_id=T)。"""
+        import pandas as pd
+        from unittest.mock import patch, MagicMock
+
+        evaluator = BacktestEvaluator()
+        T = "8b7b8cd8d69444db9a59e01862e601d6"
+        P = "bcc34af44a074a95a9e56345d33b6d93"
+
+        empty_data = {
+            "analyzer_data": pd.DataFrame(columns=["timestamp", "name", "value"]),
+            "signal_data": pd.DataFrame(),
+            "order_data": pd.DataFrame(),
+        }
+        mock_dm = MagicMock()
+        mock_dm.get_backtest_data.return_value = empty_data
+        evaluator.data_manager = mock_dm
+
+        with patch.object(evaluator, "data_manager", mock_dm):
+            evaluator.evaluate_backtest_stability(portfolio_id=P, task_id=T)
+
+        # 断言：透传 task_id（非 engine_id）
+        kwargs = mock_dm.get_backtest_data.call_args.kwargs
+        assert "task_id" in kwargs, "应按 task_id 透传（ADR-016）"
+        assert kwargs["task_id"] == T
+        assert "engine_id" not in kwargs, "不应残留 engine_id 形参"

--- a/tests/unit/trading/analysis/test_evaluation_glog.py
+++ b/tests/unit/trading/analysis/test_evaluation_glog.py
@@ -24,7 +24,7 @@ class TestSliceDataManagerGLOG:
         mock_services.data.cruds.order_record.return_value = mock_crud
 
         with patch("ginkgo.services", mock_services):
-            result = mgr.get_backtest_data(portfolio_id="test", engine_id="test")
+            result = mgr.get_backtest_data(portfolio_id="test", task_id="test")
         # Should return dict with DataFrames, NOT crash on GLOG
         assert isinstance(result, dict)
 

--- a/tests/unit/trading/analysis/test_slice_data_manager.py
+++ b/tests/unit/trading/analysis/test_slice_data_manager.py
@@ -1,0 +1,80 @@
+"""Tests for SliceDataManager.get_backtest_data -- #6174 / ADR-016 task_id 边界。
+
+回测记录主查询键为 task_id（≡ 回测 uuid）。get_backtest_data 不得用 engine_id
+当 task_id 喂 get_by_task_id，也不得以 engine_id 作为 signal/order 的查询条件。
+crud mock 按 task_id 键敏感：实现若用错键（空 engine_id / engine_id 列）即返回空，
+断言失败——从而把 #6174 的"空 engine_id 查不到数据"固化成回归守卫。
+"""
+import pytest
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+try:
+    from ginkgo.trading.analysis.evaluation.slice_data_manager import SliceDataManager
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="SliceDataManager not available")
+@pytest.mark.tdd
+class TestGetBacktestDataTaskId:
+    """ADR-016: get_backtest_data 按 task_id 查回测记录。"""
+
+    @staticmethod
+    def _mock_services_keyed_on(expected_task_id):
+        """crud mock：仅当查询键 == expected_task_id 时返回数据，否则空（捕获键错配）。"""
+        analyzer_df = pd.DataFrame([
+            {"timestamp": "2025-01-%02d" % i, "name": "sharpe_ratio", "value": 1.0 + i * 0.1}
+            for i in range(1, 13)
+        ])
+        signal_df = pd.DataFrame([
+            {"timestamp": "2025-01-%02d" % i, "code": "000001"} for i in range(1, 6)
+        ])
+        order_df = pd.DataFrame([
+            {"timestamp": "2025-01-%02d" % i, "volume": 100} for i in range(1, 4)
+        ])
+
+        # 形参名必须叫 task_id，以接住 impl 的 task_id= 关键字实参
+        def _analyzer(task_id=None, **kw):
+            return analyzer_df if task_id == expected_task_id else pd.DataFrame()
+
+        def _find(df):
+            def _impl(filters=None, **kw):
+                return df if (filters and filters.get("task_id") == expected_task_id) else pd.DataFrame()
+            return _impl
+
+        mock = MagicMock()
+        mock.data.cruds.analyzer_record.return_value.get_by_task_id.side_effect = _analyzer
+        mock.data.cruds.signal.return_value.find.side_effect = _find(signal_df)
+        mock.data.cruds.order_record.return_value.find.side_effect = _find(order_df)
+        return mock
+
+    def test_get_backtest_data_returns_records_by_task_id(self):
+        """task_id=T 有记录 → 返回非空 analyzer/signal/order。"""
+        T = "8b7b8cd8d69444db9a59e01862e601d6"
+        P = "bcc34af44a074a95a9e56345d33b6d93"
+        mgr = SliceDataManager()
+        with patch("ginkgo.services", new=self._mock_services_keyed_on(T)):
+            result = mgr.get_backtest_data(portfolio_id=P, task_id=T)
+
+        assert len(result["analyzer_data"]) == 12
+        assert len(result["signal_data"]) == 5
+        assert len(result["order_data"]) == 3
+
+    def test_get_backtest_data_empty_when_no_records_under_task_id(self):
+        """task_id 查不到记录 → 三类全空。"""
+        T = "nonexistent_task_id"
+        P = "some_portfolio"
+        mgr = SliceDataManager()
+        # mock 仅对 TASK_X 返回数据；传 T 永远空
+        mock = MagicMock()
+        mock.data.cruds.analyzer_record.return_value.get_by_task_id.return_value = pd.DataFrame()
+        mock.data.cruds.signal.return_value.find.return_value = pd.DataFrame()
+        mock.data.cruds.order_record.return_value.find.return_value = pd.DataFrame()
+        with patch("ginkgo.services", new=mock):
+            result = mgr.get_backtest_data(portfolio_id=P, task_id=T)
+
+        assert result["analyzer_data"].empty
+        assert result["signal_data"].empty
+        assert result["order_data"].empty

--- a/tests/unit/workers/test_progress_tracker.py
+++ b/tests/unit/workers/test_progress_tracker.py
@@ -1,0 +1,42 @@
+"""Tests for ProgressTracker -- #6174 / ADR-016 W1.
+
+回测完成时必须回写 MBacktestTask.engine_id = task.uuid（ADR-016 铁律 2），
+维持 engine_id ≡ task_id 不变量。否则 baseline 管线读空 engine_id → 查不到记录。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+try:
+    from ginkgo.workers.backtest_worker.progress_tracker import ProgressTracker
+    from ginkgo.workers.backtest_worker.models import BacktestTask
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="ProgressTracker not available")
+@pytest.mark.tdd
+class TestReportCompletedWritesEngineId:
+    """ADR-016 W1: report_completed 回写 engine_id = task_uuid。"""
+
+    def test_completed_writes_engine_id_equals_task_uuid(self):
+        """完成时 update_status 的 result_fields 含 engine_id == task_uuid。"""
+        T = "8b7b8cd8d69444db9a59e01862e601d6"
+        task = BacktestTask(
+            task_uuid=T, portfolio_uuid="P", name="n", config=None,
+        )
+        task.completed_at = None  # report_completed 读 completed_at.isoformat()
+
+        task_service = MagicMock()
+        task_service.update_status.return_value = MagicMock(is_success=lambda: True)
+        producer = MagicMock()
+
+        tracker = ProgressTracker(worker_id="w1", kafka_producer=producer, task_service=task_service)
+
+        with patch("requests.post"):
+            tracker.report_completed(task, result={"total_pnl": 1.0})
+
+        kwargs = task_service.update_status.call_args.kwargs
+        assert kwargs.get("status") == "completed"
+        # ADR-016 铁律 2: engine_id ≡ task.uuid（task_id 与 uuid 等价）
+        assert kwargs.get("engine_id") == T, "完成时必须回写 engine_id = task_uuid"


### PR DESCRIPTION
## Summary

闭合 #6174（偏差检测 baseline 恒空）。根因：baseline 管线读端把 `engine_id` 当 `task_id` 喂查询，而 `MBacktestTask.engine_id` 系统性空（47/50）→ 查不到记录 → `monitoring_baseline` 不产出。

按 **ADR-012**（回测标识符边界）统一边界并修两类病灶：

**读端去混用（R1-R4）**
- `slice_data_manager.get_backtest_data`：形参 `engine_id→task_id`，analyzer/signal/order 三类全按 `task_id` 查，消除 `get_by_task_id(task_id=engine_id)` 脆弱耦合
- `backtest_evaluator.evaluate_backtest_stability`：形参→`task_id`，透传 + 结果 dict 键同步
- `portfolio_cli._generate_baseline_if_possible` / `deviation_checker.get_baseline`：已读 `task.task_id` 却误传可能空的 `engine_id`（#6174 直接病灶）→ 改传 `task_id`
- `evaluation_cli` 两处（死代码块内，防 `return` 移除后 `TypeError`）

**写端回写不变量（W1）**
- `progress_tracker._write_status_to_db` completed 分支回写 `engine_id = task_uuid`，经 `update_status(**result_fields)` → CRUD → modify 三层透传落库，维持 `engine_id ≡ task_id`

**W2 经实证撤销**：记录写入路径 `_create_from_params` 已正确设 `task_id`；model `.update()` singledispatch 全仓无调用（vestigial），改之无益——详见 ADR。

## Test plan
- [x] `test_slice_data_manager`：crud mock 按 task_id 键敏感，键错配即空（回归守卫）
- [x] `test_backtest_evaluator`：断言 `task_id` 透传 `get_backtest_data`
- [x] `test_progress_tracker`：完成时 `update_status` kwargs 含 `engine_id == task_uuid`
- [x] 7 改动模块 + `task_processor` import 冒烟全过
- [x] `ginkgo serve api` 启动到 socket 绑定（无 Traceback，对照 #6110 启动崩溃类）
- [ ] 手动：跑一次完整回测，确认完成回写 `engine_id` 后 baseline 非空、worker 进入 `enabled`

详见 `docs/adr/ADR-012-backtest-id-boundary.md`

Closes #6174
