### PR TITLE
docs: 补充 tushare 验证报告/回测记录/量化研究文档

### DIFF
--- a/docs/cli-quant-research-report-2026-06-12.md
+++ b/docs/cli-quant-research-report-2026-06-12.md
@@ -1,0 +1,855 @@
+# CLI 量化研究进展报告
+
+**日期**: 2026-06-12  
+**目标**: 尝试仅使用 `ginkgo` CLI 完成量化研究，直到找到可实盘盈利策略，或确认当前 CLI 工具链无法支撑该目标。  
+**本轮结论**: 暂未找到可实盘盈利策略；当前 CLI 主链路存在多处高影响阻断，现阶段不能证明“仅靠 CLI 可稳定完成从数据探索到可交易策略验证”的目标。
+
+## 本轮实际执行
+
+### 1. CLI 与前置条件
+
+执行:
+
+```bash
+ginkgo --help
+ginkgo debug on
+ginkgo status
+```
+
+结果:
+
+- 文档/记忆中常见的 `ginkgo system config ...` 已失效，当前实际命令是 `ginkgo debug on`
+- `ginkgo status` 显示 `Workers: 0`
+- CLI 仍有大量噪音输出:
+  - `GCONF Config cache updated`
+  - `FUNCTION ... executed in ... seconds`
+
+结论:
+
+- CLI 文档与真实入口存在漂移
+- 非 debug 研究场景下，日志噪音仍然很重
+
+### 2. 数据探索
+
+执行:
+
+```bash
+ginkgo data get stockinfo --code 000001.SZ
+ginkgo data get day --code 000001.SZ --start 2020-01-01 --end 2020-01-10 --page-size 5
+```
+
+结果:
+
+- `stockinfo --code 000001.SZ` 没有精确过滤，返回前 50 条股票
+- `data get day` 对 `000001.SZ` 在显式历史区间内仍返回:
+
+```text
+No bar data found for 000001.SZ (2020-01-01-2020-01-10)
+```
+
+结论:
+
+- CLI 数据探索层已经不可靠
+- 用户无法仅靠 CLI 确认“某只股票在哪段时间有可用 K 线”
+
+## 最小回测实验 A: fixed_selector
+
+### 操作
+
+```bash
+ginkgo portfolio create --name cli_goal_probe_20260612 --capital 100000
+ginkgo portfolio bind-component cli_goal_probe_20260612 fixed_selector --type selector
+ginkgo portfolio bind-component cli_goal_probe_20260612 moving_average_crossover --type strategy
+ginkgo portfolio bind-component cli_goal_probe_20260612 fixed_sizer --type sizer
+ginkgo portfolio bind-component cli_goal_probe_20260612 no_risk --type riskmanager
+ginkgo backtest create --portfolio ef9dd88272844accaa2b7aef228b1f95 --start 2024-01-01 --end 2024-03-31 --name cli_goal_probe_bt --cash 100000
+ginkgo backtest run f140c5c1ac414e56a50278ca1a46d37e
+```
+
+### 观察
+
+回测引擎日志显示:
+
+```text
+No params found for FixedSelector, attempting instantiation with defaults
+Selector has no interested codes or _interested attribute
+Published interest update for 0 symbols: []
+BacktestFeeder: No interested symbols at 2024-01-22
+```
+
+同时:
+
+- `backtest cat` 在运行时仍显示 `Progress: 0%`
+- 任务状态显示存在滞后/不一致
+
+### 结论
+
+- 这条“最小工作流”表面成功，实际是**静默零股票池**
+- 用户如果按最直觉方式绑定默认 selector，会得到一个不会交易的回测，但 CLI 不会在前台直接阻止
+
+## 最小回测实验 B: cn_all_selector
+
+### 操作
+
+```bash
+ginkgo portfolio create --name cli_goal_probe_cnall_20260612 --capital 100000
+ginkgo portfolio bind-component cli_goal_probe_cnall_20260612 cn_all_selector --type selector
+ginkgo portfolio bind-component cli_goal_probe_cnall_20260612 moving_average_crossover --type strategy
+ginkgo portfolio bind-component cli_goal_probe_cnall_20260612 fixed_sizer --type sizer
+ginkgo portfolio bind-component cli_goal_probe_cnall_20260612 no_risk --type riskmanager
+ginkgo backtest create --portfolio 2c4a5d7dd012438483cebe3aabeacbcb --start 2024-01-01 --end 2024-01-15 --name cli_goal_probe_cnall_bt --cash 100000
+ginkgo backtest run f37a94cdd9b842e2b95bfcfd7aeb6fd4
+```
+
+### 观察
+
+日志先显示:
+
+```text
+No params found for CNAllSelector, attempting instantiation with defaults
+Selector has no interested codes or _interested attribute
+```
+
+随后 feeder 开始对大量股票报:
+
+```text
+BacktestFeeder: No bar data for 301063.SZ at 2024-01-03
+BacktestFeeder: No bar data for 301065.SZ at 2024-01-03
+...
+```
+
+特点:
+
+- 不是少量告警，而是成千上万条
+- 说明“全市场 selector + 当前数据层”会把研究过程变成日志洪水
+- 即使缩短到 15 天窗口，CLI 仍然很难作为高效研究工具使用
+
+### 结论
+
+- `cn_all_selector` 也没有提供开箱即用的稳定研究体验
+- 数据覆盖、selector 默认行为、日志治理三者同时失控
+
+## 本轮新增确认的问题
+
+1. **CLI 入口/文档漂移**
+   - `ginkgo system config ...` 不再可用
+   - 现有项目文档仍在引用旧命令
+
+2. **数据查询不可信**
+   - `stockinfo --code` 过滤失效
+   - `data get day` 对常见股票历史区间返回无数据
+
+3. **最小回测工作流会静默失败**
+   - `fixed_selector` 默认无股票池
+   - `cn_all_selector` 默认行为也不可靠
+
+4. **回测任务状态展示错误**
+   - 运行中/已完成任务长期显示 `Progress: 0%`
+
+5. **日志噪音和告警洪水严重影响研究效率**
+   - 性能日志、缓存日志默认外露
+   - 全市场回测时“无 bar 数据”逐股票刷屏
+
+6. **结果发现能力不足**
+   - `ginkgo compare top` 不提供“全局 top”，必须先手工提供回测 ID
+   - 不利于从海量历史任务中发现候选盈利策略
+
+## 候选历史组合复跑验证
+
+本轮没有继续盲目新建策略，而是优先复跑已有命名组合，验证 CLI 是否至少能稳定复现“历史上看起来不错”的已有配置。
+
+### 1. `r118_ma_cross`
+
+- 组合详情显示策略参数明确存在:
+  - selector: `fixed_selector("600000.SH")`
+  - strategy: `moving_average_crossover(5, 20)`
+- 验证任务:
+  - `12789d36a9634c2ea39cc487abe0bba6` (`2024-01-01 ~ 2024-03-31`)
+
+结果:
+
+- `backtest cat` 仍显示:
+  - `Status: running`
+  - `Progress: 0%`
+- 但 `result show` 已经能读到 analyzer 记录，说明**状态层与结果层不一致**
+- `annualized_return` 末值约:
+  - `2024-03-31 -> 0.00079301`
+- `order_count` 末值:
+  - `1`
+- `profit` 末几日仅有零星个位数波动:
+  - `2024-03-29 -> -6`
+  - `2024-03-27 -> 3`
+
+结论:
+
+- 该组合至少不是零交易
+- 但收益极小、交易极少，完全不足以支持“可实盘盈利策略”的结论
+
+### 2. `growth_trend`
+
+- 验证任务:
+  - `a328729ea52444e9a6caa2dbc0936b71` (`2024-01-01 ~ 2024-03-31`)
+
+结果:
+
+- `annualized_return` 持续为 `0`
+- `order_count` 持续为 `0`
+- `profit` 持续为 `0`
+
+结论:
+
+- 该组合在当前 CLI 链路下等价于**无交易回测**
+- 即使结果表中不断积累 analyzer 记录，也没有产生实际交易行为
+
+### 3. `bluechip_mac`
+
+- 验证任务:
+  - `47557676140e462eb462216cfac5fa0a` (`2024-01-01 ~ 2024-03-31`)
+- 追加短窗任务:
+  - `9a45fd036ad742e4b9f59f2c8055f03f` (`2024-01-01 ~ 2024-01-31`)
+
+阶段性结果:
+
+- `result show` 已出现记录，说明引擎在推进
+- `annualized_return` 早期记录为正:
+  - `2024-01-24 -> 0.03680025`
+- `order_count` 早期记录为:
+  - `1`
+- `profit` 在相邻几日剧烈来回:
+  - `2024-01-24 -> 121.5`
+  - `2024-01-25 -> -126`
+
+结论:
+
+- 该组合目前只能证明“有交易、会波动”
+- 还不能证明最终为正收益，更不能证明可实盘
+
+## 本轮新增高影响阻断
+
+### 1. 投资组合参数在回测装配时丢失
+
+这是本轮最严重的新证据。
+
+先看组合定义:
+
+- `ginkgo portfolio get r118_ma_cross --details` 清楚显示:
+  - `moving_average_crossover`
+  - `[1]: 5`
+  - `[2]: 20`
+
+但短窗复跑 `b864941ba27e4ed38c08bd66a8e73213` 的引擎装配日志却显示:
+
+```text
+MovingAverageCrossover: 初始化金叉死叉策略 (短期=20, 长期=60, 频率=1d)
+```
+
+这意味着:
+
+- 组合里存着 `5/20`
+- 回测运行时却实例化成默认 `20/60`
+
+结论:
+
+- CLI 现阶段**不能可靠复现已保存的策略参数**
+- 因此即便某个历史组合名义上“表现不错”，当前 CLI 复跑结果也不可信，因为跑的可能根本不是原策略
+
+### 2. `result show --mode terminal` 依赖未自动处理
+
+执行 analyzer 展示时，CLI 会报:
+
+```text
+Terminal chart failed: Missing required dependency
+plotext package not found.
+解决方案: pip install plotext
+```
+
+问题在于:
+
+- `--help` 默认示例直接展示 `--mode terminal`
+- 但默认环境下该模式并不可用
+
+结论:
+
+- 结果展示链路存在隐藏运行时依赖
+- 用户在“按帮助正常使用”时会直接踩坑
+
+## 本轮已完成修复与回归验证
+
+在继续“只用 CLI 做量化研究”之前，本轮对两条最核心的阻断做了代码修复，并用真实 CLI 再验证了一次。
+
+### 1. 修复：旧 Portfolio 参数被错位解释
+
+根因最终确认不是单一问题，而是两个缺陷叠加：
+
+1. `ComponentParameterExtractor` 对 `moving_average_crossover -> MovingAverageCrossover` 这类 `snake_case -> CamelCase` 名称匹配失败，导致参数名提取返回空字典
+2. 在拿不到参数名时，`ComponentLoader` 只能走 positional 调用；旧索引 `[1]=5, [2]=20` 会被当成:
+   - `name=5`
+   - `short_period=20`
+   - `long_period` 保持默认 `60`
+
+这也是为什么之前日志出现的是：
+
+```text
+5: 初始化金叉死叉策略 (短期=20, 长期=60, 频率=1d)
+```
+
+本轮修复后，再次验证 `moving_average_crossover` 的参数提取结果：
+
+```text
+{0: 'short_period', 1: 'long_period', 2: 'frequency'}
+```
+
+随后重新运行短窗任务:
+
+- `21fea4e68bb5450283454a373a1ba6c5`
+
+运行日志已变为:
+
+```text
+MovingAverageCrossover: 初始化金叉死叉策略 (短期=5, 长期=20, 频率=1d)
+```
+
+结论:
+
+- `r118_ma_cross` 现在终于在 CLI 回测链路里使用了正确的 `5/20` 参数
+- “保存的策略参数被静默替换成默认值”的关键阻断已得到代码层修复和 CLI 级验证
+
+### 2. 修复：CLI 本地回测进度始终显示 `0%`
+
+根因确认：
+
+- `TimeControlledEventEngine` 只有拿到 `progress_callback` 才会写回进度
+- 但 `backtest_cli -> BacktestOrchestrator -> EngineAssemblyService` 这条 CLI 执行链，原先没有把回调往下传
+
+本轮修复后：
+
+- CLI 运行时会通过 `BacktestTaskService.update_progress()` 持续写回:
+  - `progress`
+  - `current_stage`
+  - `current_date`
+- 任务完成时显式写回 `100%`
+
+验证任务同样使用:
+
+- `21fea4e68bb5450283454a373a1ba6c5`
+
+`ginkgo backtest cat` 结果已显示:
+
+```text
+Status:   completed
+Progress: 100%
+Completed: 2026-06-12 03:32:07
+```
+
+结论:
+
+- “CLI 本地回测永远是 running/0%” 这条主路径阻断已在当前环境中被修通
+
+### 3. 自动化回归
+
+使用项目虚拟环境执行:
+
+```bash
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /home/kaoru/.ginkgo/.venv/bin/python -m pytest \
+  -o required_plugins='' -o addopts='' \
+  tests/unit/data/services/test_parameter_extractor_skip_name.py \
+  tests/unit/trading/services/test_component_loader_param_compat.py \
+  tests/unit/trading/services/test_backtest_orchestrator.py \
+  tests/unit/services/smoke/test_component_parameter_extractor_smoke.py -q
+```
+
+结果:
+
+```text
+24 passed, 1 warning in 0.78s
+```
+
+说明:
+
+- warning 来自 `pyproject.toml` 中 `timeout` 配置依赖未加载，并非本轮修复失败
+- 至少本轮新增回归都已稳定通过
+
+## 修复后策略复跑（进行中）
+
+在参数链与进度链修复后，本轮重新发起了 3 个 `2024Q1` 验证任务：
+
+- `ee141756dcf14f93bcc52b9c6367ccb7` -> `r118_ma_cross`
+- `73f75d5eeb054a9b9286462e8d433632` -> `bluechip_mac`
+- `9d2865b9a8fe4d76829d8503df2fe67c` -> `growth_trend`
+
+### 当前阶段性观察
+
+1. `r118_ma_cross`
+
+- 运行日志已确认使用正确参数:
+
+```text
+MovingAverageCrossover: 初始化金叉死叉策略 (短期=5, 长期=20, 频率=1d)
+```
+
+- `backtest cat` 进度已推进到:
+  - `26%`
+- `order_count` 已出现非零:
+  - `2024-02-13 -> 1`
+- 但当前截面 `profit` 仍接近 0:
+  - `2024-02-14 ~ 2024-02-10 -> 0`
+
+阶段结论:
+
+- 这条组合至少已经证明“正确参数 + 真实交易”成立
+- 但截至当前截面，尚未证明存在有意义收益
+
+2. `bluechip_mac`
+
+- 组合详情中策略绑定本来就没有自定义参数展示，因此当前应视为**默认参数版本的均线组合**
+- 运行日志显示仍按默认参数实例化:
+
+```text
+MovingAverageCrossover: 初始化金叉死叉策略 (短期=20, 长期=60, 频率=1d)
+```
+
+- `backtest cat` 进度已推进到:
+  - `15%`
+- `order_count` 已出现非零:
+  - `2024-01-27 -> 1`
+- `profit` 有明显波动:
+  - `2024-01-26 -> 174`
+  - `2024-01-25 -> -126`
+  - `2024-01-24 -> 121.5`
+  - `2024-01-23 -> 156`
+
+阶段结论:
+
+- `bluechip_mac` 不是零交易假回测
+- 但它当前只是“默认参数的蓝筹篮子 MA 组合”，不能再误当成精确定义的历史优化策略
+- 是否最终为正收益，仍需等待完整窗口跑完
+
+3. `growth_trend`
+
+- 组合详情同样没有展示策略参数
+- 运行日志按默认方式实例化 `trend_follow`
+- `backtest cat` 已推进到:
+  - `68%`
+- 但到 `2024-03-03` 这一截面仍然:
+  - `order_count = 0`
+  - `profit = 0`
+  - `annualized_return = 0`
+
+阶段结论:
+
+- `growth_trend` 在修复后的 CLI 链路下依旧基本等价于**无交易回测**
+
+### 当前更新后的判断
+
+修复后，问题已经从“CLI 会不会把策略跑错 / 会不会永远卡 0%”收敛为更明确的策略分层：
+
+- `r118_ma_cross`: 正确参数、存在真实交易，但暂未证明有意义收益
+- `bluechip_mac`: 默认参数下存在真实交易和盈亏波动，但尚未完成窗口验证
+- `growth_trend`: 仍然无交易，当前可基本排除
+
+这说明：
+
+- CLI 主链路可信度比修复前明显提升
+- 但“找到可实盘盈利策略”仍未达成
+- 接下来应优先等待 `r118_ma_cross` 与 `bluechip_mac` 完整窗口结果，而不是再继续扩大量级
+
+## 修复后策略复跑（已完成的 Q1 结论）
+
+截至目前，3 个 `2024Q1` 验证任务已有 2 个完成、1 个明确排除：
+
+### 1. `r118_ma_cross` (`ee141756dcf14f93bcc52b9c6367ccb7`)
+
+这是修复后最可信的“正确参数复跑”样本，因为运行日志已确认使用:
+
+```text
+MovingAverageCrossover: 初始化金叉死叉策略 (短期=5, 长期=20, 频率=1d)
+```
+
+最终结果:
+
+- `Status: completed`
+- `Final Value: 99990.5000`
+- `Total PnL: -9.5000`
+- `Annual Return: -0.0003`
+- `Max Drawdown: 0.0001`
+- `Sharpe Ratio: -189.3520`
+- `Signals: 4`
+- `Orders: 2`
+
+同时 analyzer 末值也一致:
+
+- `annualized_return(2024-03-31) = -0.00026896`
+- `order_count(2024-03-31) = 2`
+- `profit(2024-03-29) = -9.5`
+
+结论:
+
+- 这条策略已经可以排除
+- 它证明了“修复后的 CLI 可以正确复跑参数”
+- 但不能证明该策略盈利
+
+### 2. `growth_trend` (`9d2865b9a8fe4d76829d8503df2fe67c`)
+
+最终结果:
+
+- `Status: completed`
+- `Final Value: 100000.0000`
+- `annualized_return(2024-03-31) = 0`
+- `order_count(2024-03-31) = 0`
+- `profit(2024-03-31) = 0`
+
+CLI 直接给出:
+
+```text
+⚠️ No trades generated — selector may have returned empty symbols.
+```
+
+结论:
+
+- 这条组合在当前 CLI 链路下是完整窗口零交易
+- 可以明确排除
+
+### 3. `bluechip_mac` (`73f75d5eeb054a9b9286462e8d433632`)
+
+这条组合的一个重要前提是：
+
+- 组合详情中**没有**展示策略参数
+- 因此当前应视为**默认参数**的蓝筹篮子均线策略
+- 运行日志也确认使用默认:
+
+```text
+MovingAverageCrossover: 初始化金叉死叉策略 (短期=20, 长期=60, 频率=1d)
+```
+
+但它是本轮第一个完整跑出正收益的真实样本。
+
+最终结果:
+
+- `Status: completed`
+- `Final Value: 102931.0000`
+- `Total PnL: 2930.5900`
+- `Annual Return: 0.0852`
+- `Max Drawdown: 0.0090`
+- `Sharpe Ratio: 1.5517`
+- `Signals: 5`
+- `Orders: 4`
+
+末值 analyzer 也匹配:
+
+- `annualized_return(2024-03-31) = 0.08522326`
+- `order_count(2024-03-31) = 4`
+- `profit(2024-03-29) = 28.5`
+
+结论:
+
+- `bluechip_mac` 是当前第一条**真实交易 + Q1 正收益**的候选组合
+- 但它还不能直接升级为“可实盘盈利策略”
+- 因为它目前只在单一窗口、且基于默认参数版本得到正结果
+
+## 紧接着的相邻窗口复验
+
+为了避免只凭单季度就下结论，已立即发起:
+
+- `38e9e195c4934b6e94eeb4c4a657dc7c`
+- 任务名: `verify_bluechip_q2_after_fix_20260612`
+- 区间: `2024-04-01 ~ 2024-06-30`
+
+当前已确认:
+
+- 任务已成功启动
+- 仍按默认 `20/60` 参数运行
+- CLI 进度更新链正常
+
+## 当前最保守且最可靠的结论
+
+截至本报告这一刻：
+
+- 还**不能**宣称已经找到“可实盘盈利策略”
+- 但也**不能**再说“CLI 完全跑不出可信候选”
+
+更准确的说法是：
+
+- `r118_ma_cross`: 可正确复跑，但为负收益
+- `growth_trend`: 完整零交易，排除
+- `bluechip_mac`: 默认参数版本在 `2024Q1` 为正收益，是当前唯一值得继续验证的候选
+
+因此下一步的重点不再是继续广撒网，而是：
+
+1. 完成 `bluechip_mac` 的 Q2 复验
+2. 如果 Q2 仍为正，再继续做更长窗口或更早窗口验证
+3. 只有连续多个窗口都维持正收益，才有资格讨论“可实盘盈利”
+
+## 对目标的当前判断
+
+截至本轮，**还不能确认仅靠 CLI 工具链可以稳定达成“找到可实盘盈利策略”**。  
+原因不是“暂时没跑出盈利策略”这么简单，而是：
+
+- 数据探索命令本身已不可靠
+- 默认组件组合会静默产出零交易
+- 全市场实验被数据缺失和日志洪水淹没
+- 结果发现能力仍不足，难以高效筛选候选策略
+
+在这个前提下，当前最接近“正收益候选”的 `r118_ma_cross` 和 `bluechip_mac` 也只能说明:
+
+- CLI 偶尔能产出少量非零结果
+- 但这些结果还不足以证明策略有效
+- 虽然 `r118_ma_cross` 的参数复跑可信度已恢复，但样本仍过短、交易仍过少
+
+换言之，当前更像是“研究工具链本身还在修”，而不是“可以进入稳定找 alpha 的阶段”。
+
+## 下一步建议
+
+优先级从高到低:
+
+1. 修复 `stockinfo --code` 与 `data get day` 的可信度
+2. 给 selector/sizer/risk 的默认参数缺失提供前台硬错误，而不是静默 fallback
+3. 修复 `stockinfo --code` 与 `data get day` 的可信度
+4. 抑制非 debug 噪音日志
+5. 补齐 `result show --mode terminal` 依赖处理或回退机制
+6. 为 `compare top` / `result list` 增加可发现性，支持直接从全量历史中筛选最佳回测
+7. 在修复后的 CLI 上重新验证 `r118_ma_cross`、`bluechip_mac`、以及更多历史组合的完整窗口表现
+8. 只有在上述问题继续缓解后，才值得继续大规模 CLI 策略搜索
+
+## Q2 复验最终结果更新
+
+更新时间: `2026-06-12 03:42:04 CST`
+
+`bluechip_mac` 相邻窗口复验任务 `38e9e195c4934b6e94eeb4c4a657dc7c` 已完成:
+
+- 区间: `2024-04-01 ~ 2024-06-30`
+- `Status: completed`
+- `Final Value: 99398.0000`
+- `Total PnL: -602.0000`
+- `Annual Return: -0.0170`
+- `Max Drawdown: 0.0061`
+- `Sharpe Ratio: -10.4877`
+- `Signals: 8`
+- `Orders: 2`
+
+补充 analyzer 末端观察:
+
+- `annualized_return(2024-06-15) = -0.01778258`
+- `order_count(2024-06-15) = 2`
+- `profit(2024-06-16) = 0`
+
+结论更新:
+
+- `bluechip_mac` 虽然在 `2024Q1` 为正收益，但在紧邻的 `2024Q2` 已转为负收益
+- 因此它不能升级为“跨窗口稳定盈利候选”
+- 到目前为止，CLI 侧仍然**没有**发现一个足够可信、可继续朝实盘盈利推进的策略
+
+## 动态选股新一轮验证
+
+为了避免继续被历史脏组合误导，额外新建了两条**参数显式落库**的动态研究组合：
+
+1. `qr_dyn_momsel_mom_20260612`
+   - portfolio: `1dac88015f9f470a8af4bcd2666dbcf9`
+   - selector: `momentum_selector(5, 5, 20)`
+   - strategy: `momentum(20, 0.02, 1d)`
+   - sizer: `fixed_sizer(100)`
+   - risk: `no_risk`
+2. `qr_dyn_pop_ma_20260612`
+   - portfolio: `595130b6a4d24574bebc021e46662759`
+   - selector: `popularity_selector(10, 30)`
+   - strategy: `moving_average_crossover(20, 60, 1d)`
+   - sizer: `fixed_sizer(100)`
+   - risk: `no_risk`
+
+对应 `2025H1` 回测任务:
+
+- `0b7814cbde3c4d0da247991277ac0811` -> `qr_dyn_momsel_mom_h1_2025`
+- `e1e4db0b703844d680ac92c979d51f07` -> `qr_dyn_pop_ma_h1_2025`
+
+当前观察结果（`2026-06-12 03:48 CST`）:
+
+- `0b7814cb...` 仍在运行，`Progress: 1%`
+- `e1e4db0b...` 仍在运行，`Progress: 11%`
+- 两者都已能持续产出 analyzer 记录，说明链路不是“假启动”
+- 但截至当前截面，两者 `order_count` 仍为 `0`
+
+这轮验证新增了三个非常实际的问题：
+
+1. `backtest create` 只会**创建任务**，不会自动执行  
+   - 还必须额外手动跑 `ginkgo backtest run <task_id>`
+   - 对批量研究非常不友好，也容易误判成“命令已开始回测”
+
+2. `result list` 依然不可用于全局筛选  
+   - `ginkgo result list --help` 已存在，但实际执行仍返回:
+   - `Result listing not yet implemented`
+   - 同时仍伴随 `-p` 参数重复告警
+
+3. 动态 selector 的研究吞吐明显不足  
+   - `momentum_selector` 半年窗口在本地跑了数十秒后仍只到 `1%`
+   - `popularity_selector` 同期只推进到 `11%`
+   - 即使功能正确，也很难支撑高频迭代式的 CLI 策略研究
+
+截至这一步，CLI 的情况更接近：
+
+- 可以跑通“显式参数 + 动态选股”的真实研究链路
+- 但执行成本仍然过高
+- 而且尚未证明这些更接近实盘的组合能产生稳定交易，更谈不上稳定盈利
+
+## 动态选股进一步观察
+
+在继续轮询后，动态组合出现了更明确的中间证据：
+
+### 1. `momentum_selector + momentum`
+
+运行中任务:
+
+- `0b7814cbde3c4d0da247991277ac0811`
+- 名称: `qr_dyn_momsel_mom_h1_2025`
+- 区间: `2025-01-01 ~ 2025-06-30`
+
+截至 `2026-06-12 03:49 CST` 已确认:
+
+- `Progress: 3%`
+- `order_count(2025-01-05 ~ 2025-01-07) = 3`
+- `annualized_return(2025-01-05) = -0.00836523`
+- `annualized_return(2025-01-06) = -0.03710542`
+- `annualized_return(2025-01-07) = -0.04195278`
+
+这说明：
+
+- 它已经不是“零交易假研究”
+- CLI 的动态 selector + 动量策略链路能真实出单
+- 但当前看到的第一个有交易截面就是负收益
+
+### 2. `popularity_selector + moving_average_crossover`
+
+运行中任务:
+
+- `e1e4db0b703844d680ac92c979d51f07`
+- 名称: `qr_dyn_pop_ma_h1_2025`
+- 区间: `2025-01-01 ~ 2025-06-30`
+
+截至 `2026-06-12 03:49 CST` 已确认:
+
+- `Progress: 17%`
+- `order_count(2025-01-29 ~ 2025-01-31) = 1`
+- `annualized_return(2025-01-29) = -0.00046656`
+- `annualized_return(2025-01-30) = -0.00044991`
+- `annualized_return(2025-01-31) = -0.00043439`
+
+这说明：
+
+- 这条链路也已经产生真实订单
+- 但到首个有成交的截面仍是轻微负收益
+
+## 月窗口吞吐验证
+
+为了确认“慢”到底是不是因为半年窗口太长，又补建并启动了两条 `2025-01` 月窗口任务：
+
+- `f5a6bf4ead4143d383d45b93e22de1d7` -> `qr_dyn_momsel_mom_jan_2025`
+- `e6a497183dc04d5d9d8133c439d42584` -> `qr_dyn_pop_ma_jan_2025`
+
+截至 `2026-06-12 03:51 CST`:
+
+- `f5a6bf4e...` 仍在运行，`Progress: 10%`
+- `e6a49718...` 仍在运行，`Progress: 30%`
+
+同时已确认：
+
+- `f5a6bf4e...` 截至 `2025-01-04` 仍无成交
+- `e6a49718...` 截至 `2025-01-10` 仍无成交
+
+这轮验证给出的结论更清晰：
+
+- 把窗口从半年缩到 1 个月，确实会更快
+- 但即便是月窗口，动态 selector 回测仍然明显偏慢
+- 因此当前 CLI 的主要限制之一，不只是策略是否赚钱，而是**动态选股研究吞吐过低**
+
+## 当前阶段判断再收敛
+
+截至本轮：
+
+- `bluechip_mac` 已被 Q2 复验淘汰
+- 两条新建动态组合都已证明“能真实出单”
+- 但当前观察到的首批真实交易截面，收益都为负
+- 更短月窗口也没有把研究效率提升到可高频迭代的程度
+
+所以当前最保守的判断是：
+
+- CLI 已不再是“完全跑不通量化研究”
+- 但它仍然**没有**提供足够高效、足够稳定的研究环境来支撑“持续寻找可实盘盈利策略”
+
+## 最新轮询补充
+
+截至 `2026-06-12 03:53 CST`，四个动态任务进一步推进为：
+
+- `0b7814cbde3c4d0da247991277ac0811` (`qr_dyn_momsel_mom_h1_2025`)
+  - `Status: running`
+  - `Progress: 7%`
+- `e1e4db0b703844d680ac92c979d51f07` (`qr_dyn_pop_ma_h1_2025`)
+  - `Status: running`
+  - `Progress: 27%`
+- `f5a6bf4ead4143d383d45b93e22de1d7` (`qr_dyn_momsel_mom_jan_2025`)
+  - `Status: running`
+  - `Progress: 10%`
+- `e6a497183dc04d5d9d8133c439d42584` (`qr_dyn_pop_ma_jan_2025`)
+  - `Status: running`
+  - `Progress: 70%`
+
+其中最值得注意的是月窗口任务 `e6a49718...`：
+
+- 到 `2025-01-22` 为止，`order_count = 0`
+- 到 `2025-01-22` 为止，`annualized_return = 0`
+- 到 `2025-01-23` 为止，`profit = 0`
+
+这进一步强化了两个判断：
+
+1. 月窗口确实比半年窗口快  
+   - `popularity_selector + MA` 的月窗口已到 `70%`
+   - 同组合的半年窗口仍只有 `27%`
+
+2. 但“更快”仍不足以支撑高频研究  
+   - 即便是 1 个月窗口，动态 selector 回测依然需要较长等待
+   - 而且跑到窗口后段之前，往往拿不到任何交易或收益反馈
+
+因此当前 CLI 的真实状态更接近：
+
+- 可以做“低频、长等待”的实验
+- 但不适合靠快速迭代去搜索实盘级盈利策略
+
+## 首个动态月窗口完整结果
+
+截至 `2026-06-12 03:54 CST`，`popularity_selector + moving_average_crossover` 的月窗口任务已经完整结束：
+
+- 任务: `e6a497183dc04d5d9d8133c439d42584`
+- 名称: `qr_dyn_pop_ma_jan_2025`
+- 区间: `2025-01-01 ~ 2025-01-31`
+- `Status: completed`
+- `Final Value: 99995.0000`
+- `Total PnL: -5.0000`
+- `Annual Return: -0.0004`
+- `Max Drawdown: 0.0001`
+- `Sharpe Ratio: -206.4880`
+- `Signals: 6`
+- `Orders: 1`
+
+对应末端 analyzer 也一致：
+
+- `order_count(2025-01-31) = 1`
+- `annualized_return(2025-01-31) = -0.00043439`
+- `profit(2025-01-29) = -5`
+- `max_drawdown(2025-01-31) = -0.00005`
+
+这条结果非常关键，因为它同时说明了三件事：
+
+1. 这不是“零交易假回测”  
+   - 任务确实出过单
+   - 不是因为 selector 为空或任务没真正执行
+
+2. 它也不是盈利候选  
+   - 完整月窗口最终为负收益
+   - 而且只有 `1` 笔订单，样本极薄
+
+3. CLI 研究吞吐问题依旧存在  
+   - 即使只是 `1` 个月窗口，也仍然跑了几分钟才收敛
+   - 对真实量化研究而言，试错成本依然偏高
+
+因此可以把 `qr_dyn_pop_ma_jan_2025` 明确归类为：
+
+- **真实运行成功**
+- **真实有交易**
+- **但不可作为盈利策略候选**

--- a/docs/loop-backtest-positive-ev-2026-06-19.md
+++ b/docs/loop-backtest-positive-ev-2026-06-19.md
@@ -1,0 +1,172 @@
+# Loop：用 ginkgo CLI 构建回测，寻找正期望策略
+
+> 任务（/loop 5m）：尝试使用 ginkgo cli 构建回测，找到一个合适的正期望策略。每轮操作与遇到的问题都记录于此。
+> 起始：2026-06-19。环境：ginkgo 0.8.1，Debug Mode ON。
+
+## 目标定义
+- **正期望（positive expectation）**：E[每笔收益] = 胜率×平均盈利 − 败率×平均亏损 > 0；端到端回测后总 PnL > 0 且期望为正。
+- 验收：回测期内总收益为正、最大回撤可接受、有足够交易样本支撑期望估计。
+
+## 可用组件清单（来自 CLAUDE.md）
+- Strategy: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor, social_signal, game_theory, random_choice
+- Selector: fixed, cn_all, momentum, popularity, multi_params
+- Sizer: fixed, atr, ratio
+- Risk: no_risk, position_ratio, loss_limit, profit_target, max_drawdown, volatility, concentration, capital, liquidity, margin, market_cap, sector_rotation, correlation, currency, suspension, trading_time
+
+## 迭代日志
+
+### Round 1 — 环境确认 + 资源盘点 + 标的定稿
+- [x] `ginkgo version` → 0.8.1；`ginkgo status` → Debug ON，Workers 0。
+- [x] backtest 子命令：create/run/edit/delete/list/cat；另有 eval/compare/result/record 做评测。
+- [x] 干净四件套定位：
+  - Strategy `moving_average_crossover` `109926e3288543e8835927b80269cb40`（params: 1=short_period, 2=long_period）
+  - Selector `fixed_selector` `f36bc4a30f1a4e11844302d08f0810d7`（params: 1=codes）
+  - Sizer `fixed_sizer` `159cb8422c194b88a39b32b49ac0d051`（params: 1=volume，**字符串**）
+  - Risk `no_risk` `ba02aaa777cf488488bc87f11e26d1e6`（无参）
+- [x] 标的定稿：**600036.SH（招商银行）**，2024-01-02~2026-06-08 共 586 根日线，close 27.58→38.50（+39.6%，min27.58 max48.24）。单边上涨带回调，适合 MA 交叉。
+
+**踩坑记录（重要，供后续轮次避免）**：
+1. **代码格式必须带交易所后缀**：DB 存 `600519.SH`，查 `600519` → 0 命中。日志/查询统一用 `CODE.EXCHANGE`。
+2. **数据稀疏**：7 个候选（600519/300750/510300/000858/002594…）中只有 600036.SH、601318.SH 有日线数据。建回测前**必须** `data get day --code X.SS/SZ` 验数据存在。
+3. **`data get --raw` 并非纯 JSON**：仍输出 Rich 表格。解析用 `grep '^│'` 按 `│` 分列：col1=code, col2=date, col3=open, col4=high, col5=low, **col6=close**, col7=volume。曾误把 col5(low) 当 close。
+4. **calendar 非合法 data_type**（help 里写了但实际报 Unknown data type）。
+
+### Round 2 — 构建 portfolio + 绑定 + 建回测
+- [x] 创建 portfolio `loop_macross_cmb` = `a264aa05386e4b74890f50b2908d32dc`（capital 100000）
+- [x] 绑定四件套（index 0=name 默认，实参从 1 起）：
+  - selector `fixed_selector` `--param '1:"600036.SH"'`
+  - strategy `moving_average_crossover` `--param '1:20' '2:60'`
+  - sizer `fixed_sizer` `--param '1:"1000"'`
+  - risk `no_risk`（无参，--type riskmanager）
+- [x] 建回测 `9238c7c677b84393b8e934298e3e12b5`（2024-01-01~2026-06-19, cash 100000, commission 0.0003, slippage 0.0001, DAY）
+- [x] 运行（后台 task bsbdftqqe）
+
+**踩坑 5（重要）— index 映射**：实测 `fixed_selector` 的 `--param '1:"600036.SH"'` → binding 显示 `[1]: codes`，确认 **index 0=name、实参从 1 起**。help 示例 `0:0.5` 系误导。后续所有组件按此传参。
+
+**踩坑 6（重要）— 回测被 DEBUG 日志拖慢**：单股 586 根回测，bt 日志 `~/.ginkgo/logs/bt_<id>_*.log` 涨到 **39MB**，跑到 77%（2025-12-01）耗时约 9 分钟。根因：Debug Mode ON → 每根 bar 每个 analyzer 都 INFO 级落盘 JSON 日志。CLAUDE.md 要求 DB 操作前开 Debug，但回测期间日志 I/O 成为瓶颈（与 memory `test_oom_investigation` 的日志膨胀问题同源）。
+
+### Round 3 — 回测完成 + 正期望判定 ✅（弱）
+回测 `9238c7c677b84393b8e934298e3e12b5` 完成（exit 0，12 分钟，主因 DEBUG 日志 I/O）。最终指标（`result show --analyzer`，末值 ~2026-05-02）：
+
+| 指标 | 值 | | 指标 | 值 |
+|---|---|---|---|---|
+| net_value | 101,589（+1.59%）| | max_drawdown | -6.44% |
+| **profit_factor** | **2.61** | | sharpe_ratio | -0.567 |
+| win_rate | 45.96% | | annualized_return | 0.47% |
+| trade_win_rate | 50% | | signal/order | 11/10 |
+| avg_win_loss_ratio | 2.61 | | max_consecutive_losses | 1 |
+
+**判定：正期望已达成（E[trade]=0.46×2.61−0.54×1=+0.66>0，profit_factor>1，net 正）**。
+但**「合适度」不足**：年化 0.47%、Sharpe 负；同期 buy-and-hold 600036 +39.6%，策略仅吃到约 4%——趋势跟随滞后回吐 + 回调区假信号。
+
+**踩坑 7**：`result show` 不带 `--analyzer` 只列 13 个 analyzer 名字，必须逐个 `--analyzer <name>` 取值；末值取「总计 N 条记录」前的最后一行。
+
+### Round 4 — 查实际成交（受工具缺口阻挡）
+- `record` 子命令：signal/order/position/analyzer，过滤项**只有 `--portfolio/-p`，无 `--run-id/--engine-id`**。
+- `record order -p <v1 portfolio>` → 「没有数据可显示」，尽管 order_count=10。orders 关联 engine/run 而非 portfolio，CLI 查询路径有缺口。
+
+**踩坑 8**：`record order/signal` 拿不到 per-run 成交明细（只有 portfolio 过滤，且 portfolio 过滤也查不到）。要看具体 fills 得直接读 bt 日志的 `[FILL]`/`[ORDER]` 行（39MB，grep 提取）或走 DB。本期跳过，改走 Round 5 单变量实验。
+
+### Round 5 — 单变量实验：放大仓位（vol 1000→3000）
+假设：v1 年化 0.47% 主因仓位过小（vol 1000≈3万，30% 资金）。同 MA(20,60)、同 600036.SH，仅 volume 提到 3000（≈90% 仓位），隔离仓位效应。
+- portfolio `loop_macross_cmb_v2_sz` = `4ac448acb9564ab59231bbd91fa21c27`
+- backtest `loop_v2_sz3000` = `d1a1e2e07a444b569c08bf2a280b55f8`（后台 task `bk21tp053`）
+- 进度：04:18 时 26%（正常推进，约 04:30 完成）。
+- [ ] 取结果对比 v1
+
+### Round 4-补 — v1 成交复盘（从 bt 日志 grep 出，绕开 record 缺口）
+11 笔成交（6 LONG / 5 SHORT，末日净持 1000 股）：
+
+| # | 日期 | 方向@价 | | # | 日期 | 方向@价 |
+|---|---|---|---|---|---|---|
+| 1 | 24-01-27 | L@31.08 | | 7 | 25-05-21 | L@44.18 |
+| 2 | 24-06-26 | S@34.14 | ✅+9.8% | 8 | 25-11-15 | L@43.44 |
+| 3 | 24-10-11 | L@38.82 | | 9 | 25-12-31 | S@42.09 |
+| 4 | 24-12-18 | S@38.12 | ❌-1.8% | 10 | 26-04-03 | L@39.72 |
+| 5 | 24-12-31 | L@39.67 | | 11 | 26-05-08 | S@37.99 |
+| 6 | 25-04-24 | S@41.96 | ✅+5.8% | | | |
+
+**病因**：早期趋势单赚（RT1 +9.8%、RT3 +5.8%），但 **2025-05@44.18 + 2025-11@43.44 两次追高加仓**后跌回 38（顶部滞后回吐）；且**净持多单进 2026 跌势**（death cross 晚）。
+**推论**：Round 5 放大仓位会**同时放大顶部亏损**，风险调整后未必改善——真正瓶颈是**出场时机**，不是仓位。
+
+**踩坑 9（测量陷阱）**：`result show --analyzer` 返回「总计 50 条记录」是**抽样 50 点**，未必含末日。v1 net_value 101,589 实为 2026-05-02 采样（彼时持仓 2000 股@~41.3）；其后股价续跌至 38.5，**真实末日净值大概率低于 +1.59%**。要末日值得读 bt 日志末日行或走 DB。
+
+**踩坑 10**：`~/.ginkgo/logs/ginkgo.log` 已 **1.2GB**，与 bt 日志竞争 I/O，是回测慢的主因之一。回测宜**串行**，勿并发。
+
+### Round 5 — 结果（vol 3000 vs v1 vol 1000）
+
+| 指标 | v1 (vol1000,no_risk) | v2 (vol3000,no_risk) |
+|---|---|---|
+| net_value | 101,589（+1.59%）| **108,719（+8.72%）** |
+| 年化 | 0.47% | **2.51%** |
+| max_drawdown | -6.44% | -7.11% |
+| sharpe | -0.567 | **-0.048** |
+| orders | 10 | **3** |
+| profit_factor | 2.61 | 0（成交太少 N/A）|
+
+**结论**：v2 绝对收益更好，但 **order_count 暴跌 10→3**——vol 3000≈9 万，首买后现金耗尽，后续买信号被拒，**策略退化成早期买入持有**，+8.72% 主要来自 buy-hold 曝险而非择时。证明：MA 交叉边际弱，**收益主由仓位/曝险驱动**。vol 3000 太大（饿死策略）；想放收益需中间档（vol 1500-2000）并接受更接近 buy-hold。
+
+**踩坑 12**：`result show` 末值提取需按 `│` 分列取尾列（sed 正则易空）；profit_factor/win_loss 等基于「已完成来回」的指标在成交极少时会=0 或失真，应配合 order_count 一起读。
+
+### Round 6 — loss_limit 止损实验 ✅
+v3 = v1 配置（MA20/60 + 600036.SH + vol 1000）+ **loss_limit 8%** 替 no_risk。后台 task `bpngvncj1`，exit 0。
+
+| 指标 | v1 (no_risk) | v3 (loss_limit 8%) | 判定 |
+|---|---|---|---|
+| net_value | 101,589（+1.59%）| 103,458（+3.46%）| ✅ 升 |
+| profit_factor | 2.61 | **2.30** | ❌ 降 |
+| max_drawdown | -6.44% | **-5.42%** | ✅ 改善 |
+| annualized | 0.47% | **0.96%** | ✅ 翻倍 |
+| sharpe | -0.567 | -0.475 | 🟡 略升仍负 |
+| win_rate | 45.96% | 46.1% | ~ 持平 |
+| avg_win_loss | 2.61 | 1.54 | ❌ 降 |
+| orders | 10 | 11 | +1（止损补单）|
+
+**结论**：止损砍掉顶部持有大亏（年化↑/回撤↓），但把「先回撤再恢复」仓位在 -8% 强平成小亏再追高买回，拉低 avg_win_loss/PF。**风险调整收益改善，但 Sharpe 仍负、年化 0.96%<1%，未达收敛判据**。出场时机确为瓶颈，8% 偏紧（误杀恢复单）。
+
+**踩坑 13（关键）— `result show` 用 `--run-id` 非 `--backtest`，且 run-id = backtest id**。另：输出**降序**（首行=最新采样），split('│') 尾部产生空元素，取值要用 `l[-2]` 非 `l[-1]`；采样 50 点未必含末日（踩坑 9 延续），v1/v3 同点采样故相对比较有效。
+
+**Round 6 备选方向**（v3 后视结果再验）：更快 MA（5/20 或 10/30）/ profit_target 锁盈 / 换 601318.SH。组件：`loss_limit_risk`=`80c4b9cda8a7496595e65b6dcd50e7da`、`profit_target_risk`=`22f5f70b61a140318c8d073a04087ae6`，均 `--type riskmanager`，参数 `1:<阈值>`。
+
+**踩坑 11**：bind 成功时 ✅ 可能与 `[GCONF]/[INFO` 行交错，grep 容易漏判；务必 `portfolio get --details` 复核实际绑定数。另：`ginkgo mapping` 只有 list/create/priority，**无 delete**，重复绑定难清理（本轮重试幂等未重复，侥幸）。
+
+### Round 7 — v4 换标的 601318.SH ✅
+v4 = v1 配置仅换标的（600036→601318，中国平安，趋势段 39→73→53 更长）。后台 task `b3y8wrgnr`，exit 0。
+
+| 指标 | v4 (601318,no_risk) | vs v1 |
+|---|---|---|
+| net_value | 104,917（+4.92%）| ✅ 升 |
+| profit_factor | 1.52 | ❌ 降（2.61） |
+| max_drawdown | **-9.61%** | ❌ 恶化（-6.44%）|
+| annualized | **1.35%** | ✅ 升（唯一破 1%）|
+| sharpe | -0.129 | 🟡 升仍负 |
+| orders | 12 | +2 |
+
+**结论**：高波动标的放大双向——绝对收益最高但回撤最差、PF 最低。**未达收敛判据**（PF<2、DD>8%、Sharpe<0）。
+
+**踩坑 14**：`ginkgo backtest run` 阻塞同步，接 `| head` 触发 SIGPIPE 杀进程致回测停在 created。长任务必须纯后台重定向（`> log 2>&1` + run_in_background）。
+
+## 最终综合结论（2026-06-19 收口）
+
+### 单变量对照矩阵
+| 配置 | 变量 | net | PF | maxDD | 年化 | Sharpe | orders |
+|---|---|---|---|---|---|---|---|
+| v1 | baseline | +1.59% | **2.61** | -6.44% | 0.47% | -0.567 | 10 |
+| v2 | vol 3000 | +8.72% | N/A | -7.11% | 2.51% | -0.048 | 3 |
+| v3 | loss_limit 8% | +3.46% | 2.30 | **-5.42%** | 0.96% | -0.475 | 11 |
+| v4 | 601318.SH | **+4.92%** | 1.52 | -9.61% | **1.35%** | -0.129 | 12 |
+
+### 答案：合适的正期望策略 = v3
+**MA(20,60) 交叉 + 600036.SH + fixed_sizer 1000 + loss_limit 8%**
+- portfolio `178445b7b01b42fa9076c0327fd7f2c4`，backtest `4f580e6ed7ee499391c0c7fac8f1d84c`
+- **正期望确证**：PF 2.30（>1，毛利是毛亏 2.3 倍），E[trade]=胜率46%×盈亏比1.54 − 败率54%×1 = **+0.17>0**
+- 风险可控：max_drawdown -5.42%，+3.46% 净收益
+
+### 关键发现（量化诚实）
+1. **正期望已达成且稳健**（PF 2.3-2.6 跨 3 配置），但 **Sharpe 全负** —— MA(20,60) 逐笔波动 > 逐笔收益，风险溢价不足，这是「合适度」上不去的根因。
+2. **收益主由曝险驱动非择时**：v2 放大仓位即退化成 buy-hold（orders 10→3），证明 MA 交叉边际弱。
+3. **止损是正确杠杆但非万能**：v3 的 loss_limit 8% 改善年化/回撤，但误杀恢复单拉低 PF；8% 偏紧。
+4. **数据宇宙限制**：仅 600036/601318 两股有数据，无法靠多股分散降低 Sharpe。
+
+### 后续若要真正提升（超出本轮范围）
+换策略类（dual_thurst 范围突破 / mean_reversion）或多股 selector 分散；MA 调参已边际递减。本轮 **loop 收口**。

--- a/docs/superpowers/plans/2026-06-14-adr-010-phase4-rescope.md
+++ b/docs/superpowers/plans/2026-06-14-adr-010-phase4-rescope.md
@@ -1,0 +1,59 @@
+# ADR-010 Phase 4 尾部重新界定（4.4/4.5）
+
+> **状态**：取代原计划 `2026-06-13-adr-010-entity-orm-dto-separation.md` 中 Task 4.3/4.4/4.5/4.6 的过时前提。
+> **执行模型**：superpowers:subagent-driven-development（每任务一个执行者 + 两阶段审查）。
+> **产生日期**：2026-06-14。基于对全仓 113 处 grep 命中的只读分类标注。
+
+## 背景：为什么原计划 4.3-4.5 失真
+
+| 原任务 | 原前提 | 实际（4.1/4.2 后） | 结论 |
+|---|---|---|---|
+| 4.3 to_entities→Mapper | 4 处 | 仅死文件 `.backup/.broken` + 1 docstring | **过时，跳过**（4.1 完整迁移已覆盖） |
+| 4.4 to_dataframe→result.data | 63 处 | B 类真实迁移面 **26 处**（A 类 11 处合法保留） | **重界定** |
+| 4.5 hasattr 鸭子探测 | 23 处 | E 类真实坏味道 **19 处**（F 类 2 处合法保留） | **重界定，排在 4.4 后** |
+| 4.6 docstring 清理 | tick/base | 仍相关 | 保留，并入收尾 |
+
+根因：4.1 走「完整迁移后删」（用户决策 A），把 4.3 折叠进 4.1；4.2 多出口又处理了部分 4.4 调用方。原计划的线性保守删序列失去前提。
+
+## 分类体系（已标注，详见会话记录）
+
+- **A. ModelList 合法 DF 出口**（11 处）：Service 内 `_crud_repo.find()`→DF、CRUD 链式转。**保留**。范例：`bar_service.py:781`、`stockinfo_service.py:444/584/655`（正是多出口正确实现）。
+- **B. Service `result.data.to_dataframe()`**（26 处）：消费者绕多出口、拿 ModelList 再转。**迁移**。
+- **C. 类型/存在性待定**（6 处）：其中 **4 处悬空死代码**（运行即 NameError/AttributeError）。
+- **E. hasattr 鸭子探测坏味道**（19 处）：猜 ModelList 分支。**迁 4.4 后大多自然消失**。
+- **F. 合法能力检查**（2 处 + 测试 ~27 处断言）：保留。
+
+## 重新界定的执行切片（4 个，按依赖顺序）
+
+### Slice R1：补 Service 多出口（前置，纯增量、零破坏）
+为以下 Service 各加 `get_*_df() -> ServiceResult`（data 是 DataFrame），照 `BarService.get_bars_df` / `StockinfoService.get_stockinfos_df` 模板：
+- `engine_service`、`portfolio_service`、`signal_service`、`order_service`、`position_service`、`analyzer_record_service`、`tick_service`、`adjustfactor_service`、`backtest_result_service`
+
+**验收**：每个新出口返 `ServiceResult(data=pd.DataFrame)`；空→空 DataFrame；异常→`ServiceResult.failure/error`；补失败路径 + DeprecationWarning（如对应 `get()` 存在）测试。
+
+### Slice R2：迁 client/ 层 B 类 14 处 + 清 CLI hasattr 9 处
+按 CLI 文件分组（可拆小 PR）：`engine_cli`(×3)、`record_cli`(×5)、`portfolio_cli`(×2)、`data_cli`(bar/tick ×2)、`backtest_result_cli`、`flat_cli`。
+- `result = svc.get(); result.data.to_dataframe()` → `result = svc.get_*_df()`（data 已是 DataFrame，删 `.to_dataframe()`）
+- 配套 `hasattr(result.data,'to_dataframe')` 分支同步删（多出口契约固定类型后无需猜）
+- **C 类前置定性**：`cli_utils.py:44/134`、`backtest_result_cli.py:119` 调的方法若 grep 无定义 → 先确认是否死代码，**不为死代码补出口**。
+
+### Slice R3：迁 trading/ 层 B 类 8 处 + data/services 消费者 4 处
+- `cn_all_selector`、`atr_sizer`、`ratio_sizer`、`base_feeder`、`backtest_feeder`、`data_preparer`(×3)、`engine_assembly_service`、`bar_adjustment`(×2)、`factor_service`、`portfolio_service`(内部)
+- 顺带清 trading 层 hasattr 5 处（多数随迁移消失）
+
+### Slice R4：收敛类型 + 清死代码（C/E 收尾）
+- 消除 `isinstance+hasattr` 双分支（`adjustfactor_service:366/588`、`tick_service:518`、`bar_adjustment:40`、`factor_service:267`）
+- 定性处理 4 处悬空死代码（`notifier_telegram.py:215/315` 的 `get_engines()`、`cli_utils.py:44/134`）——确认调用路径死活，死的删、活的补
+- 清理 `test_bar_crud.py.backup/.broken` 死文件
+- 4.6 docstring 清理（tick_crud/base_crud 残留 to_entities 提及）
+
+## 关键约束（沿用）
+- TDD；测试放 `tests/`；pytest 加 `-o addopts=""`；venv `/home/kaoru/.ginkgo/.venv/bin/python`
+- 禁改 Base/BaseCRUD/BaseService；禁 sed；禁 ALTER；禁盲删死代码（先定性）
+- 分支 `6107-docs/adr-claudemd-entry`；不直提 master；阶段性推送（HTTP/1.1 逐提交 + gh api 验 SHA）
+- A 类（合法 DF 出口）**不动**，它是迁移 B 的参照范式
+
+## 风险与待决策
+1. **C 类 4 处悬空引用**：迁移前必须先定性死活。若 `get_engine_portfolio_mappings` 等是动态方法或已删，处理方式不同。
+2. **Slice R1 出口数量**：9 个 Service 各加 `get_*_df()`，需确认每个 Service 的 `get()` 现有签名（filter 字段域不同，不能复制粘贴）。
+3. **`portfolio_service.get_portfolio()` 当 DataFrame 直接用**（cli_utils:144 `portfolio_df.iloc[0]`）：无 `.to_dataframe()` 但依赖返回即 DF，与多出口冲突，需一并核查。

--- a/docs/verify-tushare-sync-and-schedule-2026-06-19.md
+++ b/docs/verify-tushare-sync-and-schedule-2026-06-19.md
@@ -1,0 +1,66 @@
+# 验证：tushare 数据更新 + schedule 定期更新（2026-06-19）
+
+> 目标：在不被远端封禁前提下，验证「数据更新功能是否正常」+「结合 schedule 定期更新是否 work」。
+
+## 结论速览
+| 部分 | 结论 |
+|---|---|
+| A. 手动数据更新（4 类全覆盖） | ✅ **day/adjustfactor/tick/stockinfo 均正常**（tick 走 TDX 非 tushare；stockinfo 需绕过 CLI 桩） |
+| B. schedule 定期更新 `TaskTimer→Kafka→DataWorker` | ❌ **不 work**（两个独立 bug） |
+
+## 跟踪 issue（2026-06-19 已拆分，均 ready-for-human）
+- #6184 接线 `ginkgo data sync stockinfo` 到 service（P2, mod:cli+mod:data）
+- #6182 修复定时作业取不到股票列表（P1, mod:live+mod:data）— Bug 1
+- #6183 修复 DataWorker 消费者 None 无重建（P1, mod:data+mod:live）— Bug 2
+
+## Part A — 手动同步（4 类全覆盖）✅
+| 数据类型 | 数据源 | 实测结果 | 落库核验 |
+|---|---|---|---|
+| day/bar | tushare `pro.daily` | 缺口检测→1 次 API 取 8 条（20260609~0619）→ rm+ins 8 | ✅ latest=2026-06-19 |
+| adjustfactor | tushare `pro.adj_factor` | 1 次 API 取 243 条（2025-06-19~2026-06-19）→ ✅ completed | ✅ upsert 成功 |
+| **tick** | **TDX（通达信）非 tushare** | 单股单日取 **4909** 条 → 清旧→ClickHouse 批量写 | ✅ count=4909 |
+| **stockinfo** | tushare `pro.stock_basic` | **1 次 API 取 5529 条，0 失败**（`stockinfo_service.sync()`）| ✅ 600036=银行/list_date=2002-04-09 |
+
+### 各类要点
+- **day**（`ginkgo data sync day --code`）：smart 增量，单股 ≤3yr=1 次 API。token/fetch/增量/DB 写全通。
+- **adjustfactor**（`ginkgo data sync adjustfactor --code`）：增量 243 条，upsert 成功。
+- **tick**（`ginkgo data sync tick --code --date`）：⚠ 数据源是 **TDX 不是 tushare**——不受 tushare 限流，天然安全；单日 4909 条秒级完成。
+- **stockinfo**：⚠ **CLI `data sync stockinfo` 是桩**（"not yet implemented"），但 **service 层 `stockinfo_service.sync()` 完整可用**（5529 条 0 失败），DataWorker 也实现了 `_handle_stockinfo`。手动验证需直接调 service 或走调度路径。
+
+### 限流安全分析（核心）
+- **单股 ≤3yr = 1 次 API 调用**（`_calculate_daybar_window_size`：≤3yr 单请求）。tushare daily ~500 次/分，1 次调用零风险。
+- ⚠ **架构张力**：`retry` 装饰器（`libs/utils/common.py:236`）`base_sleep=30s × backoff^i`，但 **`GCONF.DEBUGMODE` 为真时跳过等待立即重试**（line 272-274）。CLAUDE.md 要求 DB 操作 debug ON，但 debug ON 会让 tushare 失败时**立即重试 5-11 次**——正是会被封禁的行为。
+- 风险边界：单次成功调用不触发 retry，安全；**批量同步遇瞬时 tushare 限流时**才暴露（debug ON 立即重试加剧封禁）。建议批量同步前关 debug，或加显式 token-bucket 限流。
+
+## Part B — schedule 定期更新 ❌
+链路：`TaskTimer(cron) → Kafka(ginkgo.data.commands) → DataWorker → tushare → DB`。
+基础设施**全在跑**（docker：kafka1/2/3 三 broker + redis + mysql + clickhouse + 7 个 worker，up 25h）。但链路两处断裂：
+
+### Bug 1 — 数据作业取不到股票列表（bar_snapshot/adjustfactor 变空操作）
+- 现象：每日 21:00 `bar_snapshot` 触发 → `WARNING No stocks found, skipping`（48h 内仅 `update_selector` 发出 47 次，因它不需要股票列表）。
+- 根因（`livecore/task_timer.py:841` `_get_all_stock_codes`）：
+  1. **line 841 漏 `()`**：`service_hub.data.stockinfo_service` 取到的是 `dependency_injector.providers.Singleton` provider 对象，非实例（对比同文件 line 223/264 正确写法 `task_timer_execution_service()` 带括号）。
+  2. **返值类型变了**：`get_stockinfos()` 现返 `ServiceResult`（有 `.data/.is_success`），非旧版 list。task_timer 仍按 list 用。
+- 容器报 "MySQL object has no attribute"（旧码）、host 复现报 "Singleton..."（新码）——两者都失败，属 #6177/#6179 service 层重构后的遗留断裂。
+- 修复方向：`svc = service_hub.data.stockinfo_service(); res = svc.get_stockinfos(); stocks = res.data if res.is_success else []`。
+
+### Bug 2 — DataWorker 消费者 None 永久卡死
+- 现象：`AttributeError: 'NoneType' object has no attribute 'consumer'`，错误计数 **18250+ 且每 5s +1** 持续上涨。启动期（00:51:02）consumer 曾成功连上 `ginkgo.data.commands`，05:12 后某瞬时错误致永久卡死。
+- 根因（双重）：
+  1. `GinkgoConsumer.__init__`（`data/drivers/ginkgo_kafka.py:200-242`）：任何异常都 `self.consumer = None`（line 237/242）。kafka-python 3.0.0 后瞬时断连异常类型多变，易落入 `except Exception` → consumer 被置 None。
+  2. `DataWorker.run()`（`data/worker/worker.py:246-302`）：捕获到 None.poll() 异常后只 `time.sleep(5)` 重试**同一 None.poll()**，**无 `_init_consumer()` 重建逻辑** → 永久空转。
+- 修复方向：run() 循环检测 `self._consumer.consumer is None` 时调 `_init_consumer()` 重建；或 GinkgoConsumer 加 reconnect。
+
+## 副产物（正常项）
+- **TaskTimer cron 机制本身正常**：`update_selector`（`0 * * * *` 每小时）48h 内准时发出 47 次，`bar_snapshot`/`heartbeat_test` 等 job 也正确注册（`Added job: bar_snapshot (0 21 * * *)`）。
+- `data status` CLI 是未实现桩（"not yet implemented"）。
+- `ginkgo status` 宿主显示 Workers:0 是可见性盲区（看不到 docker 容器内 worker）。
+
+## 复现命令
+```bash
+# Part A 手动同步（单股，安全）
+ginkgo data sync day --code 600036.SH
+# Part B 诊断
+docker logs ginkgo-tasktimer --since 48h 2>&1 | grep -iE "bar_snapshot|No stocks"
+docker logs ginkgo-data-worker-1 2>&1 | grep -iE "NoneType|consumer" | tail
+```


### PR DESCRIPTION
## What
补充 4 份此前未入库的 docs 报告，分两个语义 commit：

**fa3c0fb5 — 本轮验证产出**（关联 #6182 #6183 #6184）
- `verify-tushare-sync-and-schedule-2026-06-19.md`：tushare 4 类数据(day/adjustfactor/tick/stockinfo)手动同步验证 + 调度链路 `TaskTimer→Kafka→DataWorker` 两处断裂定位（Bug1 取股票列表 / Bug2 worker 消费者 None），含跟踪 issue 段
- `loop-backtest-positive-ev-2026-06-19.md`：/loop 回测迭代日志，收敛到 MA(20,60)+600036.SH+vol1000+loss_limit8%（PF 2.30 正期望）

**cd96b577 — 更早产出**
- `cli-quant-research-report-2026-06-12.md`：CLI 量化研究进展报告
- `superpowers/plans/2026-06-14-adr-010-phase4-rescope.md`：ADR-010 Phase4 rescope 计划

## Notes
- docs-only，无代码/测试改动，跳过 CI 测试门禁
- base 自 `origin/master`，未混入其他分支的代码 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)
