### PR TITLE
fix(#5174,#5987): scheduler status 读 Redis 回显 + schedule:plan 用 hgetall

### DIFF
--- a/src/ginkgo/client/scheduler_cli.py
+++ b/src/ginkgo/client/scheduler_cli.py
@@ -19,7 +19,6 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich.json import JSON
-import json
 from datetime import datetime
 from ginkgo.interfaces.kafka_topics import KafkaTopics
 
@@ -160,59 +159,52 @@ def status():
     """
     :bar_chart: Show Scheduler status.
 
-    Display Scheduler information from Redis state.
+    Read Scheduler state from Redis heartbeat synchronously and display it.
+    This is a query — it does NOT send a Kafka command (#5174 / #5987).
     """
     console.print(":information: Scheduler status check")
 
     try:
-        from ginkgo.data.crud import RedisCRUD
+        from ginkgo import services
 
-        redis_crud = RedisCRUD()
-        redis_client = redis_crud.redis
+        redis_svc = services.data.redis_service()
+        result = redis_svc.get_scheduler_status()
 
-        # Get scheduler info from Redis
-        # Check for heartbeat keys to find active nodes
-        from ginkgo.data.redis_schema import RedisKeyPattern
-        heartbeat_keys = redis_client.keys(RedisKeyPattern.EXECUTION_NODE_HEARTBEAT_ALL)
+        if not result.is_success():
+            console.print(f"[red]:x: Error getting Scheduler status: {result.error}[/red]")
+            raise typer.Exit(1)
 
-        if not heartbeat_keys:
-            console.print("[yellow]:warning: No ExecutionNodes found (no heartbeats)[/yellow]")
+        schedulers = result.data or []
+        if not schedulers:
+            console.print(
+                "[yellow]:warning: 调度器未启动（未发现运行中的 Scheduler 心跳）[/yellow]"
+            )
             return
 
-        # Create table
-        table = Table(title=":calendar: Scheduler Status", show_header=True, header_style="bold magenta")
-        table.add_column("Metric", style="cyan", width=30)
-        table.add_column("Value", style="green")
+        table = Table(
+            title=":calendar: Scheduler Status",
+            show_header=True,
+            header_style="bold magenta",
+        )
+        table.add_column("Node ID", style="cyan", no_wrap=False)
+        table.add_column("Status", style="green")
+        table.add_column("Running Tasks", justify="right", style="yellow")
+        table.add_column("Pending Tasks", justify="right", style="yellow")
+        table.add_column("Last Heartbeat", style="dim")
 
-        # Count healthy nodes
-        healthy_count = len(heartbeat_keys)
-        table.add_row("Healthy ExecutionNodes", str(healthy_count))
-
-        # Get current schedule plan
-        plan_data = redis_client.hgetall("schedule:plan")
-        if plan_data:
-            table.add_row("Scheduled Portfolios", str(len(plan_data)))
-        else:
-            table.add_row("Scheduled Portfolios", "0")
-
-        # Get node metrics
-        metric_keys = redis_client.keys("node:metrics:*")
-        total_portfolios = 0
-        total_queue_size = 0
-
-        for key in metric_keys:
-            metrics = redis_client.hgetall(key)
-            if metrics:
-                total_portfolios += int(metrics.get(b'portfolio_count', 0))
-                total_queue_size += int(metrics.get(b'queue_size', 0))
-
-        if metric_keys:
-            table.add_row("Total Portfolios Running", str(total_portfolios))
-            table.add_row("Average Queue Size", str(total_queue_size // len(metric_keys)))
+        for s in schedulers:
+            table.add_row(
+                str(s.get("node_id", "-")),
+                str(s.get("status", "-")),
+                str(s.get("running_tasks", 0)),
+                str(s.get("pending_tasks", 0)),
+                str(s.get("last_heartbeat", "-")),
+            )
 
         console.print(table)
         console.print()
-
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"[red]:x: Error getting Scheduler status: {e}[/red]")
         raise typer.Exit(1)
@@ -494,10 +486,14 @@ def recalculate(
             if ttl > 0:
                 healthy_nodes.append(node_id)
 
-        # Get current plan
+        # Get current plan (#5987-b): schedule:plan 是 Redis HASH（publisher.hset 写入），
+        # 必须用 hgetall 读；误用 get() 会触发 WRONGTYPE。
         plan_key = "schedule:plan"
-        current_plan_json = redis_client.get(plan_key)
-        current_plan = json.loads(current_plan_json) if current_plan_json else {}
+        plan_data = redis_client.hgetall(plan_key)
+        current_plan = {
+            k.decode("utf-8"): v.decode("utf-8")
+            for k, v in plan_data.items()
+        } if plan_data else {}
 
         # Show current state
         console.print(f"\n:clipboard: [bold]Current State:[/bold]")
@@ -587,10 +583,14 @@ def schedule(
             console.print("[red]:x: No healthy nodes available[/red]")
             raise typer.Exit(1)
 
-        # Get current plan
+        # Get current plan (#5987-b): schedule:plan 是 Redis HASH（publisher.hset 写入），
+        # 必须用 hgetall 读；误用 get() 会触发 WRONGTYPE。
         plan_key = "schedule:plan"
-        current_plan_json = redis_client.get(plan_key)
-        current_plan = json.loads(current_plan_json) if current_plan_json else {}
+        plan_data = redis_client.hgetall(plan_key)
+        current_plan = {
+            k.decode("utf-8"): v.decode("utf-8")
+            for k, v in plan_data.items()
+        } if plan_data else {}
 
         # Get all live portfolios from database
         console.print(f"\n:database: Fetching live portfolios from database...")
@@ -728,42 +728,3 @@ def resume():
         raise typer.Exit(1)
 
 
-@app.command()
-def status():
-    """
-    :information: Query Scheduler status.
-
-    Shows the current status of the Scheduler including:
-    - Running state
-    - Paused state
-    - Schedule interval
-    - Node ID
-
-    Examples:
-      ginkgo scheduler status
-    """
-    try:
-        from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
-        from ginkgo.interfaces.dtos import SchedulerCommandDTO
-
-        console.print("\n:information: Querying Scheduler status...")
-
-        # Send status command to Kafka
-        producer = GinkgoProducer()
-        command_dto = SchedulerCommandDTO(
-            command=SchedulerCommandDTO.Commands.STATUS,
-            source="cli"
-        )
-
-        success = producer.send("scheduler.commands", command_dto.model_dump())
-
-        if success:
-            console.print(":white_check_mark: [green]Status command sent successfully[/green]")
-            console.print(":information: Check Scheduler logs for detailed status information")
-        else:
-            console.print("[red]:x: Failed to send status command[/red]")
-            raise typer.Exit(1)
-
-    except Exception as e:
-        console.print(f"[red]:x: Error querying scheduler status: {e}[/red]")
-        raise typer.Exit(1)

--- a/tests/unit/client/test_scheduler_cli.py
+++ b/tests/unit/client/test_scheduler_cli.py
@@ -1,0 +1,164 @@
+"""
+Scheduler CLI 单元测试
+
+测试 ginkgo.client.scheduler_cli 的查询类命令（status / schedule / recalculate）。
+
+覆盖 issue：
+- #5174: status 只发 Kafka 不回显 → 改为读 RedisService.get_scheduler_status() 同步显示
+- #5987: status 发 Kafka datetime 序列化失败（随 #5174 改读 Redis 一并消解）；
+         schedule/recalculate 对 hash key schedule:plan 误用 get() → WRONGTYPE
+
+Mock 策略：
+  - status 修复后用 services.data.redis_service().get_scheduler_status() -> patch "ginkgo.services"
+  - 隔离真实 Kafka IO -> patch "ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer"
+  - get_scheduler_status 返回 ServiceResult（真实数据流）
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import patch, MagicMock
+
+from ginkgo.client import scheduler_cli
+from ginkgo.data.services.base_service import ServiceResult
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_services():
+    """Mock ginkgo.services，预设 redis_service.get_scheduler_status 默认无 scheduler。"""
+    m = MagicMock()
+    m.data.redis_service.return_value.get_scheduler_status.return_value = ServiceResult.success(
+        data=[], message="Found 0 schedulers"
+    )
+    return m
+
+
+# ===========================================================================
+# status 命令（#5174 + #5987-a）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSchedulerStatus:
+    """status 子命令应同步读 Redis 展示，不发 Kafka。"""
+
+    def test_no_scheduler_shows_not_running_and_no_kafka(self, cli_runner, mock_services):
+        """#5174 tracer: 无 Scheduler 心跳时，显示未启动提示，且绝不发 Kafka 命令。"""
+        with patch("ginkgo.services", mock_services), \
+             patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as mock_producer:
+            result = cli_runner.invoke(scheduler_cli.app, ["status"])
+
+        assert result.exit_code == 0
+        # 查询不该走命令通道
+        assert "sent successfully" not in result.output.lower()
+        mock_producer.return_value.send.assert_not_called()
+        # 应同步读取 Scheduler 状态
+        mock_services.data.redis_service.return_value.get_scheduler_status.assert_called_once()
+
+    def test_with_scheduler_shows_status_table(self, cli_runner, mock_services):
+        """#5174: 有 Scheduler 心跳时，显示 node_id / status / 任务数 / 心跳。"""
+        mock_services.data.redis_service.return_value.get_scheduler_status.return_value = ServiceResult.success(
+            data=[{
+                "node_id": "sched-1",
+                "status": "running",
+                "running_tasks": 3,
+                "pending_tasks": 1,
+                "last_heartbeat": "2026-06-20T10:00:00",
+            }],
+            message="Found 1 schedulers",
+        )
+        with patch("ginkgo.services", mock_services):
+            result = cli_runner.invoke(scheduler_cli.app, ["status"])
+
+        assert result.exit_code == 0
+        assert "sched-1" in result.output
+        assert "running" in result.output.lower()
+
+    def test_service_error_reports_and_exits(self, cli_runner, mock_services):
+        """get_scheduler_status 失败时显示错误并 exit 1（而非吞掉）。"""
+        mock_services.data.redis_service.return_value.get_scheduler_status.return_value = ServiceResult.error(
+            error="Redis unavailable"
+        )
+        with patch("ginkgo.services", mock_services):
+            result = cli_runner.invoke(scheduler_cli.app, ["status"])
+
+        assert result.exit_code == 1
+        assert "Error" in result.output
+
+
+# ===========================================================================
+# schedule / recalculate 命令（#5987-b）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSchedulePlanRead:
+    """#5987-b: schedule:plan 是 Redis HASH（publisher.hset / plan_manager.hgetall / plan 命令均用 hash）。
+    schedule / recalculate 读端误用 get()（string 语义）会触发 WRONGTYPE。
+    修复后必须用 hgetall() 读 hash。
+    """
+
+    def _mock_hash_plan_redis(self):
+        """构造 RedisCRUD().redis 的 mock：1 个 healthy node + schedule:plan hash 视图。"""
+        mock_redis = MagicMock()
+        mock_redis.keys.return_value = [b"heartbeat:node:node1"]
+        mock_redis.ttl.return_value = 30
+        # schedule:plan 的 hash 真实形态（bytes 字段）
+        mock_redis.hgetall.return_value = {b"port-uuid-1": b"node1"}
+        # 误用 get() 时让 plan 视为「不存在」，隔离 WRONGTYPE 根因断言
+        mock_redis.get.return_value = None
+        return mock_redis
+
+    def test_recalculate_reads_plan_via_hgetall(self, cli_runner):
+        """recalculate 用 hgetall 读 schedule:plan，绝不用 get。
+
+        注：recalculate 的 except Exception 会吞掉 typer.Exit(0)（dry-run 正常退出），
+        属独立缺陷，不在此断 exit_code；本测试只锁 #5987-b 根因（读 hash 用对方法）。
+        """
+        # RedisCRUD 在 scheduler_cli 函数体内 from ginkgo.data.crud import，patch 源头
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._mock_hash_plan_redis()
+            cli_runner.invoke(scheduler_cli.app, ["recalculate", "--dry-run"])
+
+        mock_redis = MockCRUD.return_value.redis
+        mock_redis.hgetall.assert_any_call("schedule:plan")
+        get_calls = [
+            c for c in mock_redis.get.call_args_list
+            if c.args and c.args[0] == "schedule:plan"
+        ]
+        assert get_calls == [], "schedule:plan 是 hash，用 get() 会触发 WRONGTYPE"
+
+    def test_schedule_reads_plan_via_hgetall(self, cli_runner):
+        """schedule 用 hgetall 读 schedule:plan，绝不用 get。
+
+        schedule 的 except Exception 同样会吞 typer.Exit，本测试只锁 #5987-b 根因。
+        portfolio_service 返回空 → unassigned=0 → 命令在读取 plan 之后正常退出。
+        """
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD, \
+             patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer"), \
+             patch("ginkgo.services") as MockSvc:
+            MockCRUD.return_value.redis = self._mock_hash_plan_redis()
+            MockSvc.data.portfolio_service.return_value.get.return_value = ServiceResult.success(
+                data=[], message="Found 0 live portfolios"
+            )
+            cli_runner.invoke(scheduler_cli.app, ["schedule", "--force"])
+
+        mock_redis = MockCRUD.return_value.redis
+        mock_redis.hgetall.assert_any_call("schedule:plan")
+        get_calls = [
+            c for c in mock_redis.get.call_args_list
+            if c.args and c.args[0] == "schedule:plan"
+        ]
+        assert get_calls == [], "schedule:plan 是 hash，用 get() 会触发 WRONGTYPE"


### PR DESCRIPTION
## Summary

合并修复两个 scheduler CLI 问题（根因同区域，合并减少回归面）。

### #5174 — `scheduler status` 只发 Kafka 不回显
- **表象**：`ginkgo scheduler status` 仅打印「Status command sent successfully」，不展示调度器状态。
- **根因**：`scheduler_cli.py` 中存在**两个同名 `def status`**，后定义的 Kafka 版覆盖了先定义的 Redis 版（Python 模块级 name shadowing；click 层 `add_command` 按名覆盖）。运行时只走 Kafka 版。
- **修复**：合并为单一 `status`，改读 `services.data.redis_service().get_scheduler_status()` 同步展示 Scheduler 心跳（node_id / status / running_tasks / pending_tasks / last_heartbeat）。查询不再走 Kafka 命令通道。

### #5987 — schedule:plan 类型契约
- **#5987-a**（status 发 Kafka 时 datetime 序列化失败）：随 #5174 的「status 不再发 Kafka」**自动消解**。
- **#5987-b**（`scheduler schedule` 报 WRONGTYPE）：写端 `publisher.hset` / `plan_manager.hgetall` / `plan` 命令均按 **hash** 读写 `schedule:plan`，但 `schedule` / `recalculate` 读端误用 `get()`（string 语义），契约不一致触发 `WRONGTYPE`。改为 `hgetall` + decode dict。

## 根因合并
| 根因 | 位置 | 影响 |
|---|---|---|
| A. 两个同名 status（Kafka 覆盖 Redis） | scheduler_cli.py | #5174 全部 + #5987-a |
| B. get() 读 hash key schedule:plan | schedule / recalculate | #5987-b |

## Test plan
- [x] `tests/unit/client/test_scheduler_cli.py` 5 cases 全绿
  - `TestSchedulerStatus`：无 scheduler（显示未启动 + 不发 Kafka）/ 有 scheduler（表格）/ service error（exit 1）
  - `TestSchedulePlanRead`：schedule / recalculate 用 `hgetall("schedule:plan")` 读，绝不用 `get`
- [x] `test_model_dump_double_encoding.py` 7/7（验证 scheduler_cli import 链健康）
- [x] ruff 无新 F401（仅删自己引入的 `import json`）
- [ ] 手动：启动 scheduler 后 `ginkgo scheduler status` 显示心跳表

## Notes（非本次范围，留 follow-up）
1. **recalculate / schedule 的 `except Exception` 吞掉 `typer.Exit(0)`**：`typer.Exit` 继承自 `RuntimeError`（Exception 子类），导致 dry-run / 取消确认等正常退出被当异常吞并改写为 exit 1。独立缺陷，本次未修。
2. **master 既有 4 个 F401**（`Optional` / `rich.json.JSON` / `datetime` / 函数内 `RedisCRUD`）为先前 refactor 残留，本次未扩大清理。

Closes #5174
Closes #5987
