### PR TITLE
fix: correct kafka health tip, mark unimplemented data types in help

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -22,7 +22,7 @@ console = Console(emoji=True, legacy_windows=False)
 
 @app.command()
 def get(
-    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/calendar/day/tick/adjustfactor/sources)"),
+    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick) [planned: calendar/adjustfactor/sources]"),
     code: Optional[str] = typer.Option(None, "--code", "-c", help="Stock code (required for bars/ticks)"),
     start: Optional[str] = typer.Option(None, "--start", "-s", help="Start date (YYYYMMDD)"),
     end: Optional[str] = typer.Option(None, "--end", "-e", help="End date (YYYYMMDD)"),

--- a/src/ginkgo/client/kafka_cli.py
+++ b/src/ginkgo/client/kafka_cli.py
@@ -563,7 +563,7 @@ def _run_health_check():
         # 提供建议
         console.print("\n[bold blue]:bulb: Health Check Tips:[/]")
         console.print("• Run 'ginkgo kafka status' for detailed Kafka queue information")
-        console.print("• Run 'ginkgo worker status' for detailed worker information")
+        console.print("• Run 'ginkgo worker data status' or 'ginkgo worker backtest status' for detailed worker information")
         console.print("• Check logs if any components show errors")
         
     except Exception as e:


### PR DESCRIPTION
Two help text fixes:

- kafka health: refer to correct worker commands instead of nonexistent 'ginkgo worker status'
- data get: mark adjustfactor and sources as [planned] in help text

Fixes #4891
Fixes #4900