### PR TITLE
fix(#5622,#5859): Portfolio 创建使用请求体 mode 而非硬编码 BACKTEST

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -399,16 +399,20 @@ async def create_portfolio(data: PortfolioCreate):
     """
     try:
         from services.saga_transaction import PortfolioSagaFactory
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
 
         # 准备组件数据
         sizer_data = None
         if data.sizer_uuid:
             sizer_data = {'component_uuid': data.sizer_uuid, 'config': data.sizer_config or {}}
 
+        # #5622 #5859: 使用请求体的 mode（映射为 core 枚举 int），而非硬编码 BACKTEST(0)
+        mode_int = PORTFOLIO_MODE_TYPES[data.mode.value].value
+
         # 创建 Saga 事务
         saga = PortfolioSagaFactory.create_portfolio_saga(
             name=data.name,
-            mode=0,  # BACKTEST 模式
+            mode=mode_int,
             selectors=data.selectors,
             sizer=sizer_data,
             strategies=data.strategies,

--- a/tests/api/test_portfolio_create_mode.py
+++ b/tests/api/test_portfolio_create_mode.py
@@ -1,0 +1,70 @@
+# #5622 #5859 — Portfolio 创建 mode 被忽略，硬编码为 BACKTEST
+"""
+验证 POST /api/v1/portfolios/ 创建组合时，请求体的 mode 字段
+（BACKTEST/PAPER/LIVE）被正确传递给 Saga，而非硬编码为 BACKTEST(0)。
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from models.portfolio import PortfolioCreate, PortfolioMode
+
+
+def _mock_saga(uuid: str = "portfolio-uuid"):
+    """构造一个执行成功的 mock saga。"""
+    saga = MagicMock()
+    saga.execute = AsyncMock(return_value=True)
+    step = MagicMock()
+    step.result = {"uuid": uuid}
+    saga.steps = [step]
+    saga.error = None
+    return saga
+
+
+class TestCreatePortfolioPassesMode:
+    """create_portfolio 应把请求的 mode 传给 Saga（不硬编码）"""
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio.get_portfolio", new_callable=AsyncMock)
+    @patch("services.saga_transaction.PortfolioSagaFactory")
+    async def test_paper_mode_passed_to_saga(self, mock_factory, mock_get_portfolio):
+        from api.portfolio import create_portfolio
+
+        mock_factory.create_portfolio_saga.return_value = _mock_saga()
+        mock_get_portfolio.return_value = {"uuid": "portfolio-uuid", "mode": "PAPER"}
+
+        data = PortfolioCreate(name="test_paper", initial_cash=100000, mode=PortfolioMode.PAPER)
+        await create_portfolio(data)
+
+        _, kwargs = mock_factory.create_portfolio_saga.call_args
+        assert kwargs["mode"] == 1, f"PAPER 应映射为 1，实际为 {kwargs['mode']}"
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio.get_portfolio", new_callable=AsyncMock)
+    @patch("services.saga_transaction.PortfolioSagaFactory")
+    async def test_live_mode_passed_to_saga(self, mock_factory, mock_get_portfolio):
+        from api.portfolio import create_portfolio
+
+        mock_factory.create_portfolio_saga.return_value = _mock_saga()
+        mock_get_portfolio.return_value = {"uuid": "portfolio-uuid", "mode": "LIVE"}
+
+        data = PortfolioCreate(name="test_live", initial_cash=100000, mode=PortfolioMode.LIVE)
+        await create_portfolio(data)
+
+        _, kwargs = mock_factory.create_portfolio_saga.call_args
+        assert kwargs["mode"] == 2, f"LIVE 应映射为 2，实际为 {kwargs['mode']}"
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio.get_portfolio", new_callable=AsyncMock)
+    @patch("services.saga_transaction.PortfolioSagaFactory")
+    async def test_default_mode_is_backtest(self, mock_factory, mock_get_portfolio):
+        """不传 mode 时默认 BACKTEST(0)"""
+        from api.portfolio import create_portfolio
+
+        mock_factory.create_portfolio_saga.return_value = _mock_saga()
+        mock_get_portfolio.return_value = {"uuid": "portfolio-uuid", "mode": "BACKTEST"}
+
+        data = PortfolioCreate(name="test_default", initial_cash=100000)
+        await create_portfolio(data)
+
+        _, kwargs = mock_factory.create_portfolio_saga.call_args
+        assert kwargs["mode"] == 0, f"默认应映射为 0(BACKTEST)，实际为 {kwargs['mode']}"


### PR DESCRIPTION
## Summary

修复 `POST /api/v1/portfolios/` 创建组合时忽略请求体 `mode` 字段的 bug。

**根因**：`create_portfolio` 端点调用 `PortfolioSagaFactory.create_portfolio_saga` 时硬编码 `mode=0`（BACKTEST），丢弃了 `PortfolioCreate.mode`。导致 PAPER/LIVE 组合创建后仍是 BACKTEST，无法 start/stop（#5622）。

**修复**：把 `data.mode`（API 枚举 BACKTEST/PAPER/LIVE）映射为 core 枚举 int（`PORTFOLIO_MODE_TYPES[data.mode.value].value`）后传入 Saga。两个枚举成员名一致，映射无歧义；默认仍 BACKTEST。

- 关闭 #5622（表象：组合默认 backtest 无法 start/stop）
- 关闭 #5859（根因：mode 硬编码）

## 改动
- `api/api/portfolio.py`：`create_portfolio` 用 `data.mode` 映射替换硬编码 `mode=0`
- `tests/api/test_portfolio_create_mode.py`：新增 3 个测试（PAPER→1 / LIVE→2 / 默认→0）

## Test plan
- [x] `pytest tests/api/test_portfolio_create_mode.py` — 3 passed
- [x] 模块导入冒烟 + 三种 mode 映射验证（BACKTEST=0/PAPER=1/LIVE=2）
- [x] 回归对照（stash）：`test_saga_transaction`/`test_saga_integration` 的 8 个失败为 base 上既有，与本改动无关
- [ ] 手动验证（review 时）：`POST /portfolios/ {"mode":"PAPER"}` → 组合 mode=PAPER，可 start/stop

Closes #5622
Closes #5859
