### PR TITLE
fix: 批量修复回测结果上报/展示 (方案C, 6 issues)

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -16,7 +16,7 @@ import asyncio
 from core.logging import logger
 from core.redis_client import get_backtest_progress
 from core.response import ok, paginated
-from core.exceptions import NotFoundError, ValidationError, BusinessError
+from core.exceptions import APIError, NotFoundError, ValidationError, BusinessError
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
 from ginkgo.interfaces.kafka_topics import KafkaTopics
 from ginkgo.data.containers import container
@@ -721,9 +721,29 @@ async def get_backtest_analyzer_data(
     uuid: str,
     analyzer_name: str
 ):
-    """获取回测分析器时序数据和统计信息"""
+    """获取回测分析器时序数据和统计信息。
+
+    #5847: 指标名为准。权威白名单取自该回测实际产出的指标名
+    (list_analyzer_groups 的 group.name); 未知名(含类名如 SharpeAnalyzer)
+    → 404 且 message 列出可用指标名, 不再静默返回空。
+    """
     try:
         task_service = get_backtest_task_service()
+
+        # #5847: 以该回测实际产出的指标名为权威白名单, 拒绝类名/未知名。
+        groups_result = task_service.list_analyzer_groups(uuid)
+        if not groups_result.is_success():
+            raise NotFoundError("BacktestTask", uuid)
+        available = [g.name for g in (groups_result.data or [])]
+        if analyzer_name not in available:
+            names = ", ".join(available) if available else "(无)"
+            raise APIError(
+                f"Analyzer '{analyzer_name}' not found. "
+                f"Available analyzers: {names}",
+                code=404,
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
         result = task_service.get_analyzer_data(uuid, analyzer_name)
 
         if not result.is_success():
@@ -734,6 +754,8 @@ async def get_backtest_analyzer_data(
                   message="Analyzer data retrieved successfully")
 
     except NotFoundError:
+        raise
+    except APIError:
         raise
     except Exception as e:
         logger.error(f"Error getting analyzer data for {uuid}: {str(e)}")

--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -623,6 +623,34 @@ async def get_backtest_orders(uuid: str):
         raise BusinessError(f"Error getting orders: {str(e)}")
 
 
+@router.get("/{uuid}/order-records")
+async def get_backtest_order_records(uuid: str):
+    """获取回测订单记录流水(完整状态流转, 不去重)。
+
+    与 /orders 区分: /orders 按 order_id 去重返回订单(最终态);
+    /order-records 返回同一 order_id 的全部状态变更记录(NEW/SUBMITTED/FILLED 等)。
+    """
+    try:
+        task_service = get_backtest_task_service()
+        result = task_service.list_order_records(uuid)
+
+        if not result.is_success():
+            return paginated(items=[], total=0,
+                             message=result.error or "Failed to retrieve order records")
+
+        items = result.data
+        total = result.metadata.get("total", 0)
+        return paginated(items=[o.dict() for o in items], total=total,
+                         page=1, page_size=max(total, 1),
+                         message="Order records retrieved successfully")
+
+    except NotFoundError:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting order records for {uuid}: {str(e)}")
+        raise BusinessError(f"Error getting order records: {str(e)}")
+
+
 @router.get("/{uuid}/positions")
 async def get_backtest_positions(uuid: str):
     """获取回测持仓记录"""

--- a/src/ginkgo/client/engine_cli_helpers.py
+++ b/src/ginkgo/client/engine_cli_helpers.py
@@ -67,7 +67,7 @@ def resolve_engine_id(engine_identifier: str) -> Optional[str]:
             console.print(f":information: Fuzzy search found {len(fuzzy_result.data)} engines matching '{engine_identifier}':")
 
             # 显示模糊搜索结果
-            table = Table(title="Fuzzy Search Results")
+            table = RichTable(title="Fuzzy Search Results")
             table.add_column("Name", style="cyan")
             table.add_column("UUID", style="magenta")
             table.add_column("Status", style="green")

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -627,34 +627,69 @@ def list(
 
 @result_app.command()
 def get(
-    result_id: str = typer.Argument(..., help=":mag: Result ID"),
-    details: bool = typer.Option(False, "--details", "-d", help=":information_source: Show detailed result information"),
-    trades: bool = typer.Option(False, "--trades", "-t", help=":repeat: Show trade history"),
+    task_id: str = typer.Argument(..., help=":mag: 回测任务ID (uuid 或 task_id)"),
+    details: bool = typer.Option(False, "--details", "-d", help=":information_source: 显示完整回测记录详情"),
+    trades: bool = typer.Option(False, "--trades", "-t", help=":repeat: 显示成交订单(按 order_id 去重后的最终态)"),
 ):
     """
-    :mag: Get backtest result details.
+    :mag: 获取回测结果详情。参数为 task_id。
+
+    Examples:
+        ginkgo result get <task_id>
+        ginkgo result get <task_id> --details
+        ginkgo result get <task_id> --trades
     """
-    console.print(f":mag: Getting result details: {result_id}")
+    from ginkgo.data.containers import container
+
+    console.print(f":mag: 获取回测结果: {task_id}")
 
     try:
-        # TODO: Implement actual result retrieval
-        console.print(":information: Result details not yet implemented")
+        task_service = container.backtest_task_service()
 
-        # 模拟数据
-        console.print(f":white_check_mark: Found result: {result_id}")
+        # #5957: 参数即 task_id(取消 result_id 概念), 走真实 service 取回测记录
+        result = task_service.get_by_id(task_id)
+        if not result.is_success() or result.data is None:
+            console.print(f":x: [red]未找到回测任务: {task_id}[/red]")
+            raise typer.Exit(1)
+
+        record = result.data
+        name = getattr(record, "name", None) or task_id
+        console.print(f":white_check_mark: 回测: {name}")
 
         if details:
-            console.print("\n:gear: Detailed Results:")
-            console.print("  • Total Return: 15.2%")
-            console.print("  • Annualized Return: 18.7%")
-            console.print("  • Sharpe Ratio: 1.45")
-            console.print("  • Max Drawdown: -8.3%")
+            console.print("\n:gear: 回测详情:")
+            for field in ("uuid", "task_id", "status", "start", "end", "portfolio_id"):
+                val = getattr(record, field, None)
+                if val is not None:
+                    console.print(f"  • {field}: {val}")
 
+        # #5842: --trades 走 list_orders(已按 order_id 去重取最终态)
         if trades:
-            console.print("\n:repeat: Trade History:")
-            console.print("  • 2025-01-01: BUY 000001.SZ @ 10.50 (100 shares)")
-            console.print("  • 2025-01-05: SELL 000001.SZ @ 11.20 (100 shares)")
+            orders_result = task_service.list_orders(task_id)
+            if not orders_result.is_success():
+                console.print(f":x: [red]获取订单失败: {orders_result.error}[/red]")
+            else:
+                orders = orders_result.data
+                total = orders_result.metadata.get("total", 0)
+                console.print(f"\n:repeat: 成交订单 (共 {total}):")
+                table = Table(show_header=True, header_style="bold cyan")
+                table.add_column("时间", style="dim")
+                table.add_column("代码", style="cyan")
+                table.add_column("方向")
+                table.add_column("成交量", justify="right")
+                table.add_column("成交价", justify="right")
+                for o in orders:
+                    table.add_row(
+                        str(getattr(o, "timestamp", "") or ""),
+                        str(getattr(o, "code", "") or ""),
+                        str(getattr(o, "direction", "") or ""),
+                        str(getattr(o, "transaction_volume", 0) or 0),
+                        str(getattr(o, "transaction_price", 0) or 0),
+                    )
+                console.print(table)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: Error: {e}")
 
@@ -811,40 +846,6 @@ def show(
         console.print(f":x: [red]不支持的显示模式: {mode}[/red]")
         console.print("[yellow]支持的模式: table, terminal[/yellow]")
         raise typer.Exit(1)
-
-
-@result_app.command()
-def get(
-    result_id: str = typer.Argument(..., help=":mag: Result ID"),
-    details: bool = typer.Option(False, "--details", "-d", help=":information_source: Show detailed result information"),
-    trades: bool = typer.Option(False, "--trades", "-t", help=":repeat: Show trade history"),
-):
-    """
-    :mag: Get backtest result details.
-    """
-    console.print(f":mag: Getting result details: {result_id}")
-
-    try:
-        # TODO: Implement actual result retrieval
-        console.print(":information: Result details not yet implemented")
-
-        # 模拟数据
-        console.print(f":white_check_mark: Found result: {result_id}")
-
-        if details:
-            console.print("\n:gear: Detailed Results:")
-            console.print("  • Total Return: 15.2%")
-            console.print("  • Annualized Return: 18.7%")
-            console.print("  • Sharpe Ratio: 1.45")
-            console.print("  • Max Drawdown: -8.3%")
-
-        if trades:
-            console.print("\n:repeat: Trade History:")
-            console.print("  • 2025-01-01: BUY 000001.SZ @ 10.50 (100 shares)")
-            console.print("  • 2025-01-05: SELL 000001.SZ @ 11.20 (100 shares)")
-
-    except Exception as e:
-        console.print(f":x: Error: {e}")
 
 
 @result_app.command(name="segment-stability")

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -1190,7 +1190,9 @@ class BacktestTaskService(BaseService):
                     message="No net value data",
                 )
 
-            records = result.data
+            # #5848: get_by_task_id 硬编码 desc_order=True（aggregator 依赖它取最新累计值），
+            # 净值曲线需要正序（最早在前），组装前反转，不动共享 CRUD。
+            records = list(reversed(result.data))
             strategy = []
             for r in records:
                 ts = r.business_timestamp.isoformat() if r.business_timestamp else (

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -1080,6 +1080,54 @@ class BacktestTaskService(BaseService):
             GLOG.ERROR(f"list_orders failed: {e}")
             return ServiceResult.error(f"Failed to list orders: {e}")
 
+    def list_order_records(self, uuid: str) -> "ServiceResult":
+        """获取回测订单记录流水(完整状态流转, 不去重), 返回 list[BacktestOrderItem]。
+
+        与 list_orders 区分: list_orders 返回去重后的订单(每个 order_id 最终态一条),
+        本方法返回同一 order_id 的全部状态变更记录(NEW/SUBMITTED/FILLED/CANCELED 等)。
+        """
+        from ginkgo.data.services.backtest_task_schemas import BacktestOrderItem
+
+        try:
+            task_id, portfolio_id, err = self._resolve_task_id(uuid)
+            if err:
+                return err
+
+            from ginkgo.data.containers import container
+            result_service = container.result_service()
+            result = result_service.get_order_records(task_id=task_id)
+            if not result.is_success():
+                return ServiceResult.success(data=[], message=result.error)
+
+            records = result.data.get("data", [])
+            total = result.data.get("total", 0)
+
+            items = []
+            for o in records:
+                items.append(BacktestOrderItem(
+                    uuid=getattr(o, "uuid", ""),
+                    portfolio_id=getattr(o, "portfolio_id", ""),
+                    engine_id=getattr(o, "engine_id", ""),
+                    task_id=getattr(o, "task_id", ""),
+                    code=getattr(o, "code", ""),
+                    direction=str(getattr(o, "direction", "")) if getattr(o, "direction", None) is not None else None,
+                    order_type=str(getattr(o, "order_type", "")) if getattr(o, "order_type", None) is not None else None,
+                    status=str(getattr(o, "status", "")) if getattr(o, "status", None) is not None else None,
+                    volume=int(getattr(o, "volume", 0) or 0),
+                    limit_price=str(getattr(o, "limit_price", 0)),
+                    transaction_price=str(getattr(o, "transaction_price", 0)),
+                    transaction_volume=int(getattr(o, "transaction_volume", 0) or 0),
+                    fee=str(getattr(o, "fee", 0)),
+                    timestamp=self._format_dt(getattr(o, "timestamp", None)),
+                ))
+
+            sr = ServiceResult.success(data=items, message="Order records retrieved")
+            sr.set_metadata("total", total)
+            return sr
+        except Exception as e:
+            GLOG.ERROR(f"list_order_records failed: {e}")
+            return ServiceResult.error(f"Failed to list order records: {e}")
+
     def list_positions(self, uuid: str) -> "ServiceResult":
         """获取回测持仓列表，返回 list[BacktestPositionItem]"""
         from ginkgo.data.services.backtest_task_schemas import BacktestPositionItem

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -1183,7 +1183,11 @@ class BacktestTaskService(BaseService):
 
             from ginkgo.data.containers import container
             analyzer_service = container.analyzer_service()
-            result = analyzer_service.find_by_portfolio(portfolio_id=portfolio_id, task_id=task_id)
+            # #5403: task_id 是主查询键(ADR-012); portfolio_id 仅在非空时作为可选过滤。
+            # 原走 find_by_portfolio 无条件按 portfolio_id 过滤, 当 portfolio_id 为空时
+            # filter {"portfolio_id": ""} 匹配不到记录, 导致 analyzers 端点返回空数组。
+            result = analyzer_service.get_by_task_id(
+                task_id=task_id, portfolio_id=portfolio_id or None)
             if not getattr(result, "success", False):
                 return ServiceResult.error(getattr(result, "error", "查询分析器失败"))
             records = result.data

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -1186,8 +1186,11 @@ class BacktestTaskService(BaseService):
             # #5403: task_id 是主查询键(ADR-012); portfolio_id 仅在非空时作为可选过滤。
             # 原走 find_by_portfolio 无条件按 portfolio_id 过滤, 当 portfolio_id 为空时
             # filter {"portfolio_id": ""} 匹配不到记录, 导致 analyzers 端点返回空数组。
+            # review #6205: find_by_portfolio 原无上限, 而 get_by_task_id 默认 limit=1000,
+            # 长周期回测(>1000 条)会被截断, 使分组 change(首尾差)/count 失真。
+            # 显式传大 limit(对齐 result_service 的 page_size=10000)消除回归。
             result = analyzer_service.get_by_task_id(
-                task_id=task_id, portfolio_id=portfolio_id or None)
+                task_id=task_id, portfolio_id=portfolio_id or None, limit=10000)
             if not getattr(result, "success", False):
                 return ServiceResult.error(getattr(result, "error", "查询分析器失败"))
             records = result.data

--- a/src/ginkgo/data/services/result_service.py
+++ b/src/ginkgo/data/services/result_service.py
@@ -428,40 +428,93 @@ class ResultService(BaseService):
         portfolio_id: Optional[str] = None
     ) -> ServiceResult:
         """
-        获取回测订单记录
+        获取回测订单（去重后，每个 order_id 取时间最新的最终态）。
+
+        与 get_order_records 区分: 本方法返回的是"订单"语义——同一 order_id 的
+        多条状态流转(NEW→SUBMITTED→FILLED)只保留最终态一条; 失败单
+        (CANCELED/REJECTED)也保留其终态。完整状态流水见 get_order_records。
 
         Args:
             task_id: 运行会话ID
             portfolio_id: 投资组合ID（可选）
 
         Returns:
-            ServiceResult[List]: 订单记录列表
+            ServiceResult[Dict]: {"data": 去重后订单列表, "total": 唯一订单数}
         """
         try:
             if not task_id:
                 return ServiceResult.error("task_id 不能为空")
 
-            from ginkgo.data.crud.order_record_crud import OrderRecordCRUD
-            order_record_crud = OrderRecordCRUD()
+            records = self._find_order_records(task_id, portfolio_id)
 
-            filters = {"task_id": task_id}
-            if portfolio_id:
-                filters["portfolio_id"] = portfolio_id
+            # find 已按 timestamp desc 返回, 首次出现的即该 order_id 的最新最终态
+            seen: set = set()
+            unique = []
+            for r in records:
+                oid = getattr(r, "order_id", "")
+                if oid in seen:
+                    continue
+                seen.add(oid)
+                unique.append(r)
 
-            result = order_record_crud.find(
-                filters=filters,
-                order_by="timestamp",
-                desc_order=True
-            )
+            GLOG.INFO(f"获取 task_id={task_id} 的订单成功: {len(unique)} 个唯一订单 (流水 {len(records)} 条)")
+            return ServiceResult.success({"data": unique, "total": len(unique)})
 
-            total = order_record_crud.count(filters)
+        except Exception as e:
+            GLOG.ERROR(f"获取订单失败: {e}")
+            return ServiceResult.error(f"获取订单失败: {e}")
 
-            GLOG.INFO(f"获取 task_id={task_id} 的订单记录成功: {len(result)} 条")
-            return ServiceResult.success({"data": result, "total": total})
+    def get_order_records(
+        self,
+        task_id: str,
+        portfolio_id: Optional[str] = None
+    ) -> ServiceResult:
+        """
+        获取回测订单记录（完整状态流水，不去重）。
+
+        与 get_orders 区分: 本方法返回的是"订单记录"语义——同一 order_id 的
+        每一次状态变更(NEW/SUBMITTED/PARTIAL_FILLED/FILLED/CANCELED/REJECTED)
+        各保留一行, 用于还原订单的完整生命周期。去重后的订单见 get_orders。
+
+        Args:
+            task_id: 运行会话ID
+            portfolio_id: 投资组合ID（可选）
+
+        Returns:
+            ServiceResult[Dict]: {"data": 全部订单记录流水, "total": 流水总数}
+        """
+        try:
+            if not task_id:
+                return ServiceResult.error("task_id 不能为空")
+
+            records = self._find_order_records(task_id, portfolio_id)
+            total = len(records)
+
+            GLOG.INFO(f"获取 task_id={task_id} 的订单记录流水成功: {total} 条")
+            return ServiceResult.success({"data": records, "total": total})
 
         except Exception as e:
             GLOG.ERROR(f"获取订单记录失败: {e}")
             return ServiceResult.error(f"获取订单记录失败: {e}")
+
+    def _find_order_records(
+        self,
+        task_id: str,
+        portfolio_id: Optional[str] = None
+    ) -> list:
+        """查询订单记录流水(按 timestamp desc), 供 get_orders/get_order_records 共用。"""
+        from ginkgo.data.crud.order_record_crud import OrderRecordCRUD
+        order_record_crud = OrderRecordCRUD()
+
+        filters = {"task_id": task_id}
+        if portfolio_id:
+            filters["portfolio_id"] = portfolio_id
+
+        return order_record_crud.find(
+            filters=filters,
+            order_by="timestamp",
+            desc_order=True
+        )
 
     def get_positions(
         self,

--- a/tests/api/test_backtest_analyzer_name_authority.py
+++ b/tests/api/test_backtest_analyzer_name_authority.py
@@ -1,0 +1,71 @@
+"""#5847: 分析器命名以指标名为准, 不接受类名。
+
+GET /{uuid}/analyzer/{name} 对类名(如 SharpeAnalyzer)原静默返回空 data。
+根因: get_analyzer_data 对无记录名返回 success(空 detail), 路由再包成
+ok(data=[])——调用方无从区分"该指标本次无数据"与"名字写错了"。
+
+决策(#5847): 指标名为准, 未知名(含类名)→404, message 列出可用指标名。
+权威白名单取自该回测实际产出的指标名(list_analyzer_groups 的 group.name)。
+"""
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _groups_result(names):
+    """模拟 list_analyzer_groups 的 ServiceResult, groups 带 .name。"""
+    return ServiceResult(success=True, data=[SimpleNamespace(name=n) for n in names])
+
+
+class TestAnalyzerNameAuthority:
+    """#5847: 类名/未知名 → 404 且 message 列出可用指标名。"""
+
+    @pytest.mark.unit
+    def test_class_name_rejected_with_404_listing_available(self):
+        from api.backtest import get_backtest_analyzer_data
+        from core.exceptions import APIError
+
+        task_service = MagicMock()
+        task_service.list_analyzer_groups.return_value = _groups_result(
+            ["sharpe_ratio", "max_drawdown"])
+
+        with patch("api.backtest.get_backtest_task_service", return_value=task_service):
+            with pytest.raises(APIError) as exc:
+                asyncio.run(get_backtest_analyzer_data("uuid-1", "SharpeAnalyzer"))
+
+        # 未知名 → 404
+        assert exc.value.code == 404, "类名应被拒为 404, 不再静默返回空"
+        assert exc.value.status_code == 404
+        # message 列出可用指标名, 且点名被拒的名字
+        assert "sharpe_ratio" in exc.value.message
+        assert "SharpeAnalyzer" in exc.value.message
+        # 白名单未命中即拒, 不应再下钻取数据
+        task_service.get_analyzer_data.assert_not_called()
+
+    @pytest.mark.unit
+    def test_metric_name_returns_data(self):
+        """#5847: 合法指标名穿过白名单, 正常返回时序数据(守卫不误伤)。"""
+        from api.backtest import get_backtest_analyzer_data
+
+        point = MagicMock()
+        point.dict.return_value = {"time": "2025-01-01", "value": 1.5}
+        detail = MagicMock()
+        detail.data = [point]
+        detail.stats = {"mean": 1.5}
+
+        task_service = MagicMock()
+        task_service.list_analyzer_groups.return_value = _groups_result(["sharpe_ratio"])
+        task_service.get_analyzer_data.return_value = ServiceResult(
+            success=True, data=detail)
+
+        with patch("api.backtest.get_backtest_task_service", return_value=task_service):
+            resp = asyncio.run(get_backtest_analyzer_data("uuid-1", "sharpe_ratio"))
+
+        task_service.get_analyzer_data.assert_called_once_with("uuid-1", "sharpe_ratio")
+        # ok() 把 {"data":..., "stats":...} 包进 resp["data"]
+        assert resp["data"]["data"] == [{"time": "2025-01-01", "value": 1.5}]
+        assert resp["data"]["stats"] == {"mean": 1.5}

--- a/tests/api/test_backtest_order_records_endpoint.py
+++ b/tests/api/test_backtest_order_records_endpoint.py
@@ -1,0 +1,48 @@
+"""#5842: 新增 GET /{uuid}/order-records 端点，暴露完整订单状态流水。
+
+/orders 已去重返回订单(最终态); /order-records 返回同一 order_id 的全部
+状态变更记录。本测试覆盖 API 路由: 直调路由函数, mock task_service,
+断言 /order-records 调用 list_order_records(非 list_orders)并原样透传完整流水。
+"""
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _item_dict(order_id, status):
+    return {"order_id": order_id, "status": status}
+
+
+def _mock_item(order_id, status):
+    m = MagicMock()
+    m.dict.return_value = _item_dict(order_id, status)
+    return m
+
+
+class TestOrderRecordsEndpoint:
+    """#5842: /{uuid}/order-records 端点返回完整流水。"""
+
+    @pytest.mark.unit
+    def test_order_records_returns_full_flow(self):
+        from api.backtest import get_backtest_order_records
+
+        full = [_mock_item("ord-A", 4), _mock_item("ord-A", 2), _mock_item("ord-A", 1)]
+        sr = ServiceResult(success=True, data=full)
+        sr.set_metadata("total", 3)
+
+        task_service = MagicMock()
+        task_service.list_order_records.return_value = sr
+
+        with patch("api.backtest.get_backtest_task_service", return_value=task_service):
+            resp = asyncio.run(get_backtest_order_records("any-uuid"))
+
+        # 路由调用了 list_order_records, 透传完整 3 条流水
+        task_service.list_order_records.assert_called_once_with("any-uuid")
+        task_service.list_orders.assert_not_called()
+        assert resp["data"] == [
+            _item_dict("ord-A", 4), _item_dict("ord-A", 2), _item_dict("ord-A", 1),
+        ]
+        assert resp["meta"]["total"] == 3, "total 应反映完整流水数(3)"

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -679,3 +679,34 @@ class TestUnbindPortfolio:
             )
         assert result.exit_code == 1
         assert "Failed" in result.output or "not found" in result.output
+
+
+# ===========================================================================
+# #5375: resolve_engine_id 的 fuzzy 搜索分支
+# ===========================================================================
+
+class TestResolveEngineIdFuzzy:
+    """#5375: 模糊搜索命中时 resolve_engine_id 必须返回 UUID，不能崩溃。
+
+    根因: engine_cli_helpers.py 仅导入 ``Table as RichTable``，而 fuzzy 分支
+    用了裸名 ``Table`` 触发 NameError，被外层 except 吞掉伪装成"解析失败"。
+    现有 cat 测试均 patch 掉 resolve_engine_id，该路径从未被覆盖。
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_fuzzy_match_returns_uuid_without_crash(self):
+        from ginkgo.client.engine_cli_helpers import resolve_engine_id
+
+        engine = _make_engine_model(name="low_usage_engine")
+        svc = _mock_engine_service()
+        # UUID 精确查找与 name 精确查找均空 -> 落入 fuzzy 分支
+        svc.get.return_value = ServiceResult.success(data=[])
+        svc.fuzzy_search.return_value = ServiceResult.success(data=[engine])
+        container = _mock_container(engine_service=svc)
+
+        with patch("ginkgo.data.containers.container", container):
+            resolved = resolve_engine_id("low_usage_en")
+
+        # fuzzy 命中第一条的 UUID 应被返回，而非因 NameError 返回 None
+        assert resolved == engine.uuid

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -232,20 +232,8 @@ class TestResultCommands:
         assert result.exit_code == 0
         assert "not yet implemented" in result.output
 
-    def test_result_get_with_details_and_trades(self, cli_runner):
-        result = cli_runner.invoke(flat_cli.result_app, [
-            "get", "result-001", "--details", "--trades"
-        ])
-        assert result.exit_code == 0
-        assert "result-001" in result.output
-        assert "Sharpe Ratio" in result.output
-        assert "Trade History" in result.output
-
-    def test_result_get_without_options(self, cli_runner):
-        result = cli_runner.invoke(flat_cli.result_app, ["get", "result-002"])
-        assert result.exit_code == 0
-        assert "result-002" in result.output
-        assert "Sharpe Ratio" not in result.output
+    # #5957: 旧 test_result_get_* 断言已删除的假数据("Sharpe Ratio"/"Trade History")，
+    # 新契约(真实 service + task_id 参数)由 TestResultGetRealData 覆盖，故移除。
 
     def test_result_show_no_task_id_lists_runs(self, cli_runner):
         """result show without --run-id should list available runs."""
@@ -304,3 +292,65 @@ class TestExceptionHandling:
             result = cli_runner.invoke(flat_cli.component_app, ["list"])
         assert result.exit_code == 0
         assert "Error" in result.output
+
+
+# ============================================================================
+# #5957: result get 接入真实数据(task_id 为参数), 删除重复 def get 与假数据
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestResultGetRealData:
+    """#5957: result get <task_id> 走真实 service, 不打印硬编码假数据。"""
+
+    def _task_svc(self, orders=None, record=None):
+        from ginkgo.data.services.base_service import ServiceResult
+
+        svc = MagicMock()
+        sr_orders = ServiceResult(success=True, data=orders or [])
+        sr_orders.set_metadata("total", len(orders or []))
+        svc.list_orders.return_value = sr_orders
+        svc.get_by_id.return_value = ServiceResult(success=True, data=record)
+        return svc
+
+    def test_trades_shows_real_orders_not_fake_data(self, cli_runner):
+        from ginkgo.data.services.backtest_task_schemas import BacktestOrderItem
+
+        order = BacktestOrderItem(
+            code="600000.SH", direction="1", status="4",
+            volume=100, transaction_price="12.34",
+            transaction_volume=100, timestamp="2025-06-03 09:30",
+        )
+        record = MagicMock(name="bt-record")
+        record.name = "my-bt"
+        task_svc = self._task_svc(orders=[order], record=record)
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = task_svc
+            result = cli_runner.invoke(
+                flat_cli.result_app, ["get", "task-123", "--trades"])
+
+        assert result.exit_code == 0, result.output
+        # 参数透传为 task_id
+        task_svc.list_orders.assert_called_once_with("task-123")
+        # 真实订单数据出现
+        assert "600000.SH" in result.output
+        # 假数据标记必须消失
+        assert "not yet implemented" not in result.output
+        assert "15.2%" not in result.output
+        assert "000001.SZ @ 10.50" not in result.output
+
+    def test_default_calls_get_by_id_no_fake_header(self, cli_runner):
+        record = MagicMock(name="bt-record")
+        record.name = "real-backtest"
+        task_svc = self._task_svc(record=record)
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = task_svc
+            result = cli_runner.invoke(flat_cli.result_app, ["get", "task-9"])
+
+        assert result.exit_code == 0, result.output
+        task_svc.get_by_id.assert_called_once_with("task-9")
+        assert "not yet implemented" not in result.output
+        assert "15.2%" not in result.output

--- a/tests/unit/services/test_backtest_task_service_analyzer_groups.py
+++ b/tests/unit/services/test_backtest_task_service_analyzer_groups.py
@@ -55,3 +55,28 @@ class TestListAnalyzerGroupsTaskIdPath:
         assert called_kwargs.get("task_id") == "task-1"
         # 不再调用强制 portfolio_id 的 find_by_portfolio
         analyzer_svc.find_by_portfolio.assert_not_called()
+
+    @pytest.mark.unit
+    def test_passes_large_limit_to_avoid_truncation(self):
+        """#5403 review: get_by_task_id 默认 limit=1000, 长周期回测(>1000 条)
+        会被截断, 使分组的 change(首尾差)/count 失真。原 find_by_portfolio 无上限,
+        故调用处须显式传大 limit(对齐 result_service 的 page_size=10000)。"""
+        svc = BacktestTaskService(MagicMock())
+
+        analyzer_svc = MagicMock()
+        analyzer_svc.get_by_task_id.return_value = ServiceResult(
+            success=True, data=[SimpleNamespace(name="Sharpe", value=1.0)])
+
+        container = MagicMock()
+        container.analyzer_service.return_value = analyzer_svc
+
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "", None)), \
+             patch("ginkgo.data.containers.container", container):
+            svc.list_analyzer_groups("any-uuid")
+
+        called_kwargs = analyzer_svc.get_by_task_id.call_args.kwargs
+        # 与 result_service 一致的大额安全值, 覆盖长周期回测
+        assert called_kwargs.get("limit") == 10000, (
+            "须显式传 limit=10000 避免 get_by_task_id 默认 1000 截断")
+

--- a/tests/unit/services/test_backtest_task_service_analyzer_groups.py
+++ b/tests/unit/services/test_backtest_task_service_analyzer_groups.py
@@ -1,0 +1,57 @@
+"""#5403: analyzers 端点返回空数组。
+
+根因: list_analyzer_groups 调 find_by_portfolio(portfolio_id, task_id),
+而 find_by_portfolio 无条件按 portfolio_id 过滤。_resolve_task_id 取得的
+portfolio_id 可能是 ""(空), 导致 filter {"portfolio_id": ""} 匹配不到任何
+analyzer 记录, 返回空。
+
+按 ADR-012(task_id 是主查询键), 改走 task_id 主键路径:
+list_analyzer_groups → analyzer_service.get_by_task_id(task_id, portfolio_id),
+portfolio_id 仅在非空时作为可选过滤。CRUD 的 get_by_task_id 已满足此语义。
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+class TestListAnalyzerGroupsTaskIdPath:
+    """#5403: list_analyzer_groups 按 task_id 主键查询, portfolio_id 空时仍返回记录。"""
+
+    @pytest.mark.unit
+    def test_uses_task_id_primary_query_when_portfolio_id_empty(self):
+        svc = BacktestTaskService(MagicMock())
+
+        records = [
+            SimpleNamespace(name="Sharpe", value=-4.85),
+            SimpleNamespace(name="MaxDrawdown", value=0.12),
+        ]
+        analyzer_svc = MagicMock()
+        analyzer_svc.get_by_task_id.return_value = ServiceResult(
+            success=True, data=records)
+
+        container = MagicMock()
+        container.analyzer_service.return_value = analyzer_svc
+
+        # 模拟 _resolve_task_id 返回 portfolio_id="" (复现 bug 场景)
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "", None)), \
+             patch("ginkgo.data.containers.container", container):
+            out = svc.list_analyzer_groups("any-uuid")
+
+        assert out.is_success()
+        groups = out.data
+        # 两个分析器名 → 两个分组, 不再为空
+        assert len(groups) == 2, f"expected 2 analyzer groups, got {len(groups)}"
+        names = {g.name for g in groups}
+        assert names == {"Sharpe", "MaxDrawdown"}
+
+        # 走 task_id 主键路径
+        analyzer_svc.get_by_task_id.assert_called_once()
+        called_kwargs = analyzer_svc.get_by_task_id.call_args.kwargs
+        assert called_kwargs.get("task_id") == "task-1"
+        # 不再调用强制 portfolio_id 的 find_by_portfolio
+        analyzer_svc.find_by_portfolio.assert_not_called()

--- a/tests/unit/services/test_backtest_task_service_netvalue.py
+++ b/tests/unit/services/test_backtest_task_service_netvalue.py
@@ -1,0 +1,54 @@
+"""#5848: get_netvalue 的 strategy 数组必须按时间正序（最早在前）。
+
+根因: analyzer_record_crud.get_by_task_id 硬编码 desc_order=True，
+get_netvalue 原序 append records，导致最新日期落在 strategy[0]，
+前端按序绘制净值曲线时显示反向走势图。
+
+修复在组装前 reverse records（不改共享 CRUD——backtest_result_aggregator
+依赖 desc 顺序取最新累计值）。
+"""
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _rec(day: int, val: float):
+    """模拟一条 analyzer record（含 business_timestamp + value）。"""
+    r = MagicMock()
+    ts = datetime.datetime(2025, 6, day)
+    r.business_timestamp = ts
+    r.timestamp = ts
+    r.value = val
+    return r
+
+
+class TestGetNetvalueOrdering:
+    """#5848: 净值 strategy 数组按时间正序排列。"""
+
+    @pytest.mark.unit
+    def test_strategy_oldest_first_newest_last(self):
+        svc = BacktestTaskService(MagicMock())
+        # 模拟 DB desc_order 返回：最新日期(6/30)在前，最早(6/2)在后
+        records_desc = [_rec(30, 1.30), _rec(20, 1.20), _rec(2, 1.00)]
+
+        result_svc = MagicMock()
+        result_svc.get_analyzer_values.return_value = ServiceResult(
+            success=True, data=records_desc
+        )
+        container = MagicMock()
+        container.result_service.return_value = result_svc
+
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            out = svc.get_netvalue("any-uuid")
+
+        assert out.is_success()
+        strategy = out.data.strategy
+        assert len(strategy) == 3
+        assert strategy[0].time.startswith("2025-06-02"), f"first={strategy[0].time}"
+        assert strategy[-1].time.startswith("2025-06-30"), f"last={strategy[-1].time}"

--- a/tests/unit/services/test_backtest_task_service_order_records.py
+++ b/tests/unit/services/test_backtest_task_service_order_records.py
@@ -1,0 +1,62 @@
+"""#5842: task_service 层 order/order_record 双语义分流。
+
+list_orders       → result_service.get_orders (去重, 订单语义)
+list_order_records → result_service.get_order_records (完整流水, 记录语义)
+
+本测试固定分流契约: 同一原始流水经两条入口返回不同数量,
+证明 /orders 端点拿到的是去重订单, /order-records 拿到的是完整记录。
+"""
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _rec(order_id: str, status: int, day: int):
+    return SimpleNamespace(
+        uuid=f"u-{order_id}-{status}", order_id=order_id,
+        portfolio_id="port-1", engine_id="eng-1", task_id="task-1",
+        code="000001.SZ", direction=1, order_type=1, status=status,
+        volume=100, limit_price=10.0, transaction_price=10.0,
+        transaction_volume=100, fee=5.0,
+        timestamp=datetime.datetime(2025, 6, day, 9, 30),
+    )
+
+
+class TestListOrdersDedupRouting:
+    """#5842: list_orders 与 list_order_records 分流到去重/完整两个源。"""
+
+    @pytest.mark.unit
+    def test_list_orders_deduped_and_list_order_records_full(self):
+        svc = BacktestTaskService(MagicMock())
+
+        full = [_rec("ord-A", 4, 3), _rec("ord-A", 2, 2), _rec("ord-A", 1, 1)]
+        deduped = [_rec("ord-A", 4, 3)]  # 仅最终态一条
+
+        result_svc = MagicMock()
+        result_svc.get_orders.return_value = ServiceResult(
+            success=True, data={"data": deduped, "total": 1})
+        result_svc.get_order_records.return_value = ServiceResult(
+            success=True, data={"data": full, "total": 3})
+
+        container = MagicMock()
+        container.result_service.return_value = result_svc
+
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            orders = svc.list_orders("any-uuid")
+            records = svc.list_order_records("any-uuid")
+
+        assert orders.is_success()
+        assert records.is_success()
+        # /orders 入口 → 去重订单(1 个唯一订单)
+        assert len(orders.data) == 1, "list_orders 应返回去重后订单"
+        assert orders.metadata.get("total") == 1
+        # /order-records 入口 → 完整流水(3 条状态变更)
+        assert len(records.data) == 3, "list_order_records 应返回完整流水"
+        assert records.metadata.get("total") == 3

--- a/tests/unit/services/test_result_service_orders_dedup.py
+++ b/tests/unit/services/test_result_service_orders_dedup.py
@@ -1,0 +1,97 @@
+"""#5842: order 与 order_record 在接口上区分开。
+
+根因: result_service.get_orders 直接把 order_record_crud.find 的全部
+状态流转记录(NEW→SUBMITTED→FILLED，每条变更一行)当作"订单"返回，
+导致 /orders 端点把同一 order_id 的多条流水当成多个订单(实测 624 条流水
+对 208 个唯一订单)。
+
+修复在 service 层做接口分离:
+- get_orders        按 order_id 去重，保留时间最新的最终态(=订单语义)
+- get_order_records 不去重，返回完整状态流水(=订单记录语义)
+
+CRUD 层不掺业务去重逻辑(符合 API→Service→CRUD→DB 分层边界)。
+"""
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.result_service import ResultService
+
+
+def _rec(order_id: str, status: int, day: int, code: str = "000001.SZ"):
+    """模拟一条 order_record(find 按 timestamp desc 返回，调用方负责乱序)。"""
+    ts = datetime.datetime(2025, 6, day, 9, 30)
+    return SimpleNamespace(
+        order_id=order_id, status=status, timestamp=ts, code=code,
+        direction=1, order_type=1, volume=100, limit_price=10.0,
+        transaction_price=0.0, transaction_volume=0, fee=0.0,
+    )
+
+
+class TestGetOrdersDedup:
+    """#5842: get_orders 每个 order_id 只保留最终态。"""
+
+    @pytest.mark.unit
+    def test_dedup_keeps_latest_terminal_state_per_order_id(self):
+        svc = ResultService(MagicMock())
+
+        # order_id=ord-A: NEW(d1)→SUBMITTED(d2)→FILLED(d3)，最终态 FILLED
+        # order_id=ord-B: NEW(d1)→CANCELED(d2)，最终态 CANCELED(失败单也保留)
+        # find 按 timestamp desc 交错返回:
+        raw = [
+            _rec("ord-A", 4, 3),   # FILLED @ d3  ← ord-A 最新
+            _rec("ord-A", 2, 2),   # SUBMITTED @ d2
+            _rec("ord-B", 5, 2),   # CANCELED @ d2  ← ord-B 最新
+            _rec("ord-A", 1, 1),   # NEW @ d1
+            _rec("ord-B", 1, 1),   # NEW @ d1
+        ]
+
+        crud = MagicMock()
+        crud.find.return_value = raw
+        crud.count.return_value = len(raw)
+
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD", return_value=crud):
+            out = svc.get_orders(task_id="task-1")
+
+        assert out.is_success()
+        data = out.data["data"]
+        total = out.data["total"]
+        # 去重后 2 个唯一订单，total 与 data 一致
+        assert len(data) == 2, f"expected 2 unique orders, got {len(data)}"
+        assert total == 2, f"total must match deduped count, got {total}"
+
+        by_oid = {r.order_id: r for r in data}
+        # ord-A 取最终态 FILLED(4)，不是 NEW(1)
+        assert by_oid["ord-A"].status == 4, "ord-A 应保留 FILLED 最终态"
+        # ord-B 失败单也保留，最终态 CANCELED(5)，不被丢失
+        assert by_oid["ord-B"].status == 5, "ord-B 失败单应保留 CANCELED 终态"
+
+
+class TestGetOrderRecordsFullFlow:
+    """#5842: get_order_records 返回完整状态流水，不去重。"""
+
+    @pytest.mark.unit
+    def test_returns_all_status_transitions(self):
+        svc = ResultService(MagicMock())
+
+        raw = [
+            _rec("ord-A", 4, 3),
+            _rec("ord-A", 2, 2),
+            _rec("ord-A", 1, 1),
+        ]
+        crud = MagicMock()
+        crud.find.return_value = raw
+
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD", return_value=crud):
+            out = svc.get_order_records(task_id="task-1")
+
+        assert out.is_success()
+        data = out.data["data"]
+        total = out.data["total"]
+        # 完整流水: 3 条状态变更全部保留
+        assert len(data) == 3, f"order-records 应保留全部流水, got {len(data)}"
+        assert total == 3
+        statuses = [r.status for r in data]
+        assert statuses == [4, 2, 1], "完整流水按 timestamp desc 保留所有状态"


### PR DESCRIPTION
## Summary

方案C「回测结果上报/展示」簇批量修复, 每个 issue 单独提交, TDD 验证。

- **#5375** `engine cat` fuzzy 搜索崩溃: RichTable 导入别名不一致, 修正导入。
- **#5848** netvalue strategy 数组倒序: 组装前 reverse records。
- **#5842** order 与 order_record 接口分离: `/orders` 按 order_id 去重取最终态(含失败单), 新增 `/order-records` 暴露完整状态流水。
- **#5957** `result get` 接入真实数据: 参数 `result_id`→`task_id`, 删除重复 `def get` 与硬编码假数据。
- **#5403** analyzers 端点返回空: `list_analyzer_groups` 按 ADR-012 改走 task_id 主键路径(portfolio_id 空时仍返回记录)。
- **#5847** 分析器命名以指标名为准: 类名/未知名→404 且 message 列出可用指标名, 不再静默返回空。

## Test plan

逐文件隔离运行(api 与 service 测试混跑触发既有 `core.logging` 污染, 须隔离):
- `tests/unit/client/test_engine_cli.py` — 41 passed (#5375)
- `tests/unit/services/test_result_service_orders_dedup.py` + `test_backtest_task_service_order_records.py` — 3 passed (#5842)
- `tests/api/test_backtest_order_records_endpoint.py` — passed (#5842 端点)
- `tests/unit/services/test_backtest_task_service_analyzer_groups.py` — passed (#5403)
- `tests/api/test_backtest_analyzer_name_authority.py` — 2 passed (#5847)
- `tests/unit/client/test_flat_cli.py::TestResultGetRealData` — passed (#5957)

既有失败(非本 PR 引入, 已对照 origin/master 验证): `TestComponentCreate`(Typer exit 2)。

Closes #5375
Closes #5848
Closes #5842
Closes #5957
Closes #5403
Closes #5847
