### PR TITLE
fix(#5488): ProfitTargetRisk 移动止盈接线 + Decimal 边界精度

### DIFF
--- a/src/ginkgo/trading/risk_management/profit_target_risk.py
+++ b/src/ginkgo/trading/risk_management/profit_target_risk.py
@@ -125,6 +125,9 @@ class ProfitTargetRisk(BaseRiskManagement):
 
         # 检查移动止盈
         if self.trailing_stop and hasattr(event, 'close'):
+            # #5488: 每次价格更新先记录最高价，否则 trailing_highs 永远为空，
+            # check_trailing_stop 因 code not in trailing_highs 恒返回 False。
+            self.update_trailing_high(event.code, event.close)
             if self.check_trailing_stop(event.code, event.close):
                 signal = self.create_signal(
                     code=event.code,
@@ -191,10 +194,9 @@ class ProfitTargetRisk(BaseRiskManagement):
             code: 股票代码
             price: 当前价格
         """
-        if code not in self.trailing_highs:
+        if code not in self.trailing_highs or price > self.trailing_highs[code]:
             self.trailing_highs[code] = price
-        else:
-            self.trailing_highs[code] = max(self.trailing_highs[code], price)
+            GLOG.DEBUG(f"Trailing high updated: {code} -> {price}")
 
     def check_trailing_stop(self, code: str, current_price: Decimal) -> bool:
         """
@@ -213,4 +215,7 @@ class ProfitTargetRisk(BaseRiskManagement):
         high_price = self.trailing_highs[code]
         decline_ratio = (high_price - current_price) / high_price
 
-        return decline_ratio >= self.trailing_percentage
+        # #5488: trailing_percentage 是用户 float 参数（如 0.1），其浮点精确值
+        # 0.1000...055 会让精确的 Decimal decline_ratio 漏触发边界（精确 10% 回撤
+        # 被判为未达阈值）。经 str() 桥接为精确 Decimal 后比较（同 #6107 纪律）。
+        return decline_ratio >= Decimal(str(self.trailing_percentage))

--- a/tests/unit/backtest/risk_managements/test_profit_limit_risk.py
+++ b/tests/unit/backtest/risk_managements/test_profit_limit_risk.py
@@ -435,3 +435,89 @@ class TestProfitLimitRiskBreakEven:
 
         signals = risk.generate_signals(portfolio_info, event)
         assert len(signals) == 0  # No profit = no signal
+
+
+@pytest.mark.unit
+@pytest.mark.risk
+@pytest.mark.financial
+class TestProfitTargetRiskTrailingStop:
+    """移动止盈行为（#5488）：update_trailing_high 必须被 generate_signals 接线，
+    否则 trailing_highs 永远为空，check_trailing_stop 恒返回 False。"""
+
+    def test_trailing_stop_triggers_after_rise_then_decline(self):
+        """价格涨到高点后回撤达 trailing_percentage → 触发 SHORT 平仓信号。"""
+        risk = ProfitTargetRisk(
+            profit_target=1.0,  # 极高，屏蔽止盈分支，只验移动止盈
+            trailing_stop=True,
+            trailing_percentage=0.1,
+        )
+        risk._context = EngineContext(engine_id="test_engine_id")
+
+        position = _make_dict_position(profit_loss_ratio=0.0)
+        portfolio_info = _make_portfolio_info(positions={"000001.SZ": position})
+
+        # 涨到 12.0（建立 trailing high）
+        risk.generate_signals(portfolio_info, _make_price_event(close="12.0"))
+        # 跌到 10.5（回撤 (12-10.5)/12 = 12.5% > 10%）→ 应触发
+        signals = risk.generate_signals(portfolio_info, _make_price_event(close="10.5"))
+
+        assert len(signals) == 1
+        assert signals[0].direction == DIRECTION_TYPES.SHORT
+        assert "Trailing stop" in signals[0].reason
+
+    def test_trailing_stop_no_trigger_when_decline_below_percentage(self):
+        """回撤未达 trailing_percentage → 不触发。"""
+        risk = ProfitTargetRisk(
+            profit_target=1.0,
+            trailing_stop=True,
+            trailing_percentage=0.1,
+        )
+        risk._context = EngineContext(engine_id="test_engine_id")
+
+        position = _make_dict_position(profit_loss_ratio=0.0)
+        portfolio_info = _make_portfolio_info(positions={"000001.SZ": position})
+
+        # 涨到 12.0，跌到 11.0（回撤 8.3% < 10%）
+        risk.generate_signals(portfolio_info, _make_price_event(close="12.0"))
+        signals = risk.generate_signals(portfolio_info, _make_price_event(close="11.0"))
+
+        assert len(signals) == 0
+
+    def test_trailing_stop_disabled_never_triggers(self):
+        """trailing_stop=False 时即使价格涨跌也不触发。"""
+        risk = ProfitTargetRisk(
+            profit_target=1.0,
+            trailing_stop=False,
+            trailing_percentage=0.1,
+        )
+        risk._context = EngineContext(engine_id="test_engine_id")
+
+        position = _make_dict_position(profit_loss_ratio=0.0)
+        portfolio_info = _make_portfolio_info(positions={"000001.SZ": position})
+
+        risk.generate_signals(portfolio_info, _make_price_event(close="12.0"))
+        signals = risk.generate_signals(portfolio_info, _make_price_event(close="10.5"))
+
+        assert len(signals) == 0
+
+    def test_trailing_high_tracks_peak_across_updates(self):
+        """trailing high 跟踪持续上涨的峰值，回撤从峰值计算。"""
+        risk = ProfitTargetRisk(
+            profit_target=1.0,
+            trailing_stop=True,
+            trailing_percentage=0.1,
+        )
+        risk._context = EngineContext(engine_id="test_engine_id")
+
+        position = _make_dict_position(profit_loss_ratio=0.0)
+        portfolio_info = _make_portfolio_info(positions={"000001.SZ": position})
+
+        # 涨 12.0 → 涨 15.0（峰值）→ 跌 13.5（从 15 回撤 10%）
+        risk.generate_signals(portfolio_info, _make_price_event(close="12.0"))
+        risk.generate_signals(portfolio_info, _make_price_event(close="15.0"))
+        signals = risk.generate_signals(portfolio_info, _make_price_event(close="13.5"))
+
+        # 从峰值 15 回撤：(15-13.5)/15 = 10% >= 10% → 触发
+        # 若错误地从首个价 12 算：(12-13.5)/12 < 0 不触发——反证峰值跟踪
+        assert len(signals) == 1
+        assert "Trailing stop" in signals[0].reason


### PR DESCRIPTION
## Summary

修复 #5488 ProfitTargetRisk 移动止盈(trailing stop)从未触发。

**根因**：`update_trailing_high` 已定义但 `generate_signals` 从未调用，`trailing_highs` 永远为空 → `check_trailing_stop` 因 `code not in trailing_highs` 恒返回 False。在 `check_trailing_stop` 前补 `update_trailing_high` 接线。

**第二处 bug（TDD 过程发现）**：`decline_ratio`(Decimal) 与 `trailing_percentage`(float) 混合比较，`float(0.1)` 精确值 `0.1000...055` 使精确 10% 回撤漏触发边界。统一用 `Decimal(str())` 桥接比较（同 #6107 Decimal 混算纪律）。

## Changes
- `profit_target_risk.py`：`generate_signals` 补 `update_trailing_high` 接线；`check_trailing_stop` 改 Decimal 比较；`update_trailing_high` 创新高时 `GLOG.DEBUG`。

## Test plan
新增 `TestProfitTargetRiskTrailingStop` 4 例：涨后回撤达阈值触发 SHORT / 未达不触发 / disabled 不触发 / 峰值跟踪（从峰值算非首价）。

baseline 对比（stash 验证）：origin/master `17 failed/57 passed` → 本 PR `17 failed/61 passed`，**零新增回归**（+4 全绿）。

## 备注
17 个预先存在失败（profit_limit 8 + loss_limit 9）非本 PR 引入：根因是 `patch xxx_risk.Signal` 失效（`create_signal` 局部 import）+ #3957 `getattr(dict_position, ...)` 对 dict 返回 0。超出 #5488 范围。

Closes #5488
