### PR TITLE
chore: add issue state-label cleanup workflow

### DIFF
--- a/.github/workflows/issue-state-label-cleanup.yml
+++ b/.github/workflows/issue-state-label-cleanup.yml
@@ -1,0 +1,40 @@
+name: cleanup-issue-state-labels
+
+# issue 关闭时自动移除残留的 state-label，防止"已关闭但带 in-review/ready-for-*/in-progress"的僵尸。
+# 解决 /triage 状态机缺口：关闭动作没有 owner —— /triage 不管 in-review/in-progress，
+# /pick-issue 到 in-review 就退出，/review 误以为"合并后无需额外操作"。
+# 见 docs/agents/triage-labels.md 状态机：ready-for-* → in-progress → in-review → 关闭。
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const STATE = ['ready-for-agent', 'ready-for-human', 'in-progress', 'in-review'];
+            const issue = context.payload.issue;
+            const toRemove = (issue.labels || []).map(l => l.name).filter(n => STATE.includes(n));
+            if (toRemove.length === 0) {
+              core.info(`issue #${issue.number}: 无 state-label，跳过`);
+              return;
+            }
+            core.info(`issue #${issue.number}: 移除 ${toRemove.join(', ')}`);
+            for (const name of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name,
+                });
+              } catch (e) {
+                core.warning(`移除 ${name} 失败: ${e.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary
新增 GitHub Actions：issue 关闭时自动移除 `ready-for-*/in-progress/in-review` state-label，堵 /triage 状态机的关闭缺口。

## 背景
发现 370 个「CLOSED 但残留 state-label」的僵尸 issue。根因：状态机缺关闭钩子 —— `/triage` 不管 `in-review`/`in-progress`，`/pick-issue` 到 `in-review` 就退出，`/review` 误以为「合并后无需额外操作」。GitHub 自动关闭 issue 时无人移除 state-label。

先期已手动清理 370 个僵尸（376 次 label 移除，0 失败，其它标签如 bug/P1/mod:xxx 保留）。

## Test plan
- [ ] 合并后关闭一个带 `in-review` 的 issue，确认 Actions 移除该 label
