### PR TITLE
fix: ATRSizer 近零 ATR 仓位底值保护 (#5490)

### DIFF
--- a/src/ginkgo/trading/sizers/atr_sizer.py
+++ b/src/ginkgo/trading/sizers/atr_sizer.py
@@ -26,12 +26,23 @@ class ATRSizer(BaseSizer):
     __abstract__ = False
 
     def __init__(
-        self, name: str = "ATRSizer", period: int = 14, risk: float = 0.01, risk_ratio: float = 2, *args, **kwargs
+        self,
+        name: str = "ATRSizer",
+        period: int = 14,
+        risk: float = 0.01,
+        risk_ratio: float = 2,
+        min_atr_percent: float = 0.005,
+        *args,
+        **kwargs,
     ):
         super().__init__(name, *args, **kwargs)
         self.period = period
         self.risk = risk
         self.risk_ratio = risk_ratio
+        # #5490: minimum ATR as a fraction of close. When ATR collapses near
+        # zero (halt / limit board / stale quotes) the raw max_money/atr would
+        # produce oversized positions; floor ATR before sizing.
+        self.min_atr_percent = min_atr_percent
 
     def set_risk(self, risk: float):
         self.risk = risk
@@ -85,9 +96,19 @@ class ATRSizer(BaseSizer):
 
             if atr == 0 or pd.isna(atr):
                 return None
+            # #5490: floor ATR to a minimum fraction of close so a collapsed ATR
+            # (halt / limit board / stale quotes) cannot inflate max_shares.
+            close = df.iloc[-1]["close"]
+            min_atr = close * self.min_atr_percent
+            if atr < min_atr:
+                GLOG.WARN(
+                    f"ATRSizer: ATR {atr} below floor {min_atr:.4f} "
+                    f"({self.min_atr_percent * 100:.2f}% of close {close}) for {code}; flooring"
+                )
+                atr = min_atr
             max_money = portfolio_info["cash"] * self.risk
             max_shares = int((max_money / atr) / 100) * 100
-            price = df.iloc[-1]["close"] * 1.1
+            price = close * 1.1
             o = self.create_order(
                 code=signal.code,
                 direction=signal.direction,

--- a/tests/unit/trading/sizers/test_atr_sizer.py
+++ b/tests/unit/trading/sizers/test_atr_sizer.py
@@ -1,0 +1,144 @@
+"""
+Unit tests for ATRSizer near-zero ATR protection (#5490).
+
+ATRSizer still uses container.bar_service() (not yet migrated to _data_feeder),
+so tests patch ginkgo.trading.sizers.atr_sizer.container.
+"""
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.entities import Signal
+from ginkgo.trading.sizers.atr_sizer import ATRSizer
+
+
+@pytest.fixture
+def sizer():
+    s = ATRSizer(name="TestATRSizer", period=14, risk=0.01, risk_ratio=2)
+    s.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
+    return s
+
+
+def _make_signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG):
+    s = Signal(code=code, direction=direction)
+    return s
+
+
+def _make_portfolio_info(cash=500000.0, positions=None):
+    # NOTE: cash as float — atr_sizer.py:88 does `cash * self.risk` with no
+    # Decimal coercion, so Decimal cash raises TypeError. That is a separate
+    # pre-existing issue, out of scope for #5490 (near-zero ATR floor).
+    return {"cash": cash, "positions": positions or {}}
+
+
+def _bar_df(n, high, low, close):
+    """Build a flat-price bar DataFrame (n rows) producing a known ATR."""
+    return pd.DataFrame({
+        "high": [high] * n,
+        "low": [low] * n,
+        "close": [close] * n,
+    })
+
+
+class TestATRSizerNearZeroFloor:
+    """#5490: ATR approaching zero must not produce oversized positions."""
+
+    def test_normal_atr_returns_expected_volume(self, sizer):
+        """Tracer: normal ATR (TR=1 → ATR=1 → atr=2) yields bounded volume.
+
+        max_money=5000, atr=2 → max_shares=int(5000/2/100)*100=2500.
+        Establishes mock path + baseline before adding floor logic.
+        """
+        df = _bar_df(15, high=11.0, low=10.0, close=10.0)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+
+            order = sizer.cal(info, signal)
+
+        assert order is not None
+        assert order.volume == 2500
+
+    def test_near_zero_atr_floored_to_prevent_oversized_position(self, sizer):
+        """#5490: tiny non-zero ATR (near-stagnant bar) must not explode volume.
+
+        high=10.001/low=10.0/close=10.0 → TR=0.001 → ATR=0.001 → atr=0.002.
+        Without a floor: int(5000/0.002/100)*100 = 2,500,000 shares (oversized).
+        Floor (close * min_atr_percent=0.005 → 0.05, since 0.002<0.05):
+        int(5000/0.05/100)*100 = 100,000 shares (bounded, 25x smaller).
+        """
+        df = _bar_df(15, high=10.001, low=10.0, close=10.0)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+
+            order = sizer.cal(info, signal)
+
+        assert order is not None
+        # 2,500,000 (unfloored) would mean ~25M CNY position on 500k cash.
+        assert order.volume == 100000
+
+    def test_zero_atr_returns_none_not_floored(self, sizer):
+        """Regression: flat bar (TR=0 → ATR=0) must return None, not floor up.
+
+        The floor sits AFTER the atr==0 guard, so a true zero still declines
+        the signal. Without this ordering, floor would turn a dead market into
+        a max-size order.
+        """
+        df = _bar_df(15, high=10.0, low=10.0, close=10.0)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+
+            order = sizer.cal(info, signal)
+
+        assert order is None
+
+    def test_min_atr_percent_configurable(self):
+        """min_atr_percent raises the floor → smaller max_shares on near-zero ATR.
+
+        Same tiny-ATR bar as the floor test, but min_atr_percent=0.01 →
+        min_atr=0.1 (vs 0.05 default) → int(5000/0.1/100)*100 = 50,000.
+        """
+        s = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2, min_atr_percent=0.01)
+        s.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        df = _bar_df(15, high=10.001, low=10.0, close=10.0)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+
+            order = s.cal(info, signal)
+
+        assert order is not None
+        assert order.volume == 50000


### PR DESCRIPTION
## Summary
#5490: ATR 崩塌（停牌/一字板/陈旧报价）时 ATR 接近 0，`max_money/atr` 爆炸产生超大仓位。

- 新增 `min_atr_percent`（默认 0.5%）：ATR < `close*min_atr_percent` 时抬升到 floor 再算仓位
- 真零 ATR 仍返回 None（floor 位于 `atr==0` 守卫之后，死市场拒绝下单）
- 参数可配，可按品种波动特征调整 floor

## Test plan
- [x] tests/unit/trading/sizers/test_atr_sizer.py（4 用例）
  - 正常 ATR→volume=2500（baseline）
  - 近零 ATR→floor 后 volume=100000（原 2,500,000，25x 缩减）
  - 真零 ATR→None（守卫回归）
  - min_atr_percent=0.01→volume=50000（可配置）
- [x] sizers 目录 10 passed

Closes #5490
