### PR TITLE
fix(#5492): SimBroker 预检佣金统一 + 部分成交

### DIFF
--- a/src/ginkgo/trading/brokers/sim_broker.py
+++ b/src/ginkgo/trading/brokers/sim_broker.py
@@ -465,42 +465,65 @@ class SimBroker(BaseBroker):
 
     def _adjust_volume_for_funds(self, order: Order, price: Decimal) -> int:
         """
-        根据资金调整成交数量（进行真实资金检查）
+        根据冻结资金调整成交数量。
+
+        统一使用 _calculate_commission 估算资金（含方向相关印花税），
+        与实际扣费 (submit_order_event -> _calculate_commission) 保持一致，
+        避免预检与扣费两套佣金算法分叉 (issue #5492)。
+
+        全额资金不足时尝试部分成交（对齐 A 股 100 股整手），
+        不足一手则返回 0（调用方据此 REJECTED）。
 
         Args:
-            order: 订单对象
+            order: 订单对象（含 portfolio_id / frozen_money / volume / direction）
             price: 成交价格
 
         Returns:
-            int: 调整后的成交数量，如果资金不足返回0
+            int: 可成交数量（全额=order.volume；部分=对齐100的最大量；不可成交=0）
         """
-        # 🔥 [CRITICAL FIX] 使用Order中的冻结资金信息进行检查
-        # Portfolio在创建Order时已经计算并冻结了必要的资金
+        # 使用 Order 中的冻结资金信息（Portfolio 创建 Order 时已冻结必要资金）
         if not order.portfolio_id:
             GLOG.WARN(f"⚠️ [FUNDS CHECK] Order missing portfolio_id, assuming sufficient funds")
             return order.volume
 
-        # 使用Order中已经冻结的资金信息
         frozen_funds = getattr(order, 'frozen_money', 0)
         if frozen_funds is None or frozen_funds == 0:
             GLOG.WARN(f"⚠️ [FUNDS CHECK] Order missing frozen_money, assuming sufficient funds")
             return order.volume
 
-        # 计算实际需要的资金（包含手续费）
-        required_funds = price * order.volume
-        commission = max(required_funds * self._commission_rate, self._commission_min)
-        total_required = required_funds + commission
+        is_long = order.direction == DIRECTION_TYPES.LONG
+        price = to_decimal(price)
+        frozen_funds = to_decimal(frozen_funds)
 
-        # 检查冻结的资金是否足够（撮合滑点容差）
-        tolerance = total_required * self._slippage_tolerance
-        if frozen_funds < (total_required - tolerance):
-            GLOG.WARN(f"❌ [FUNDS CHECK] Insufficient frozen funds: have {frozen_funds}, need {total_required}")
-            GLOG.DEBUG(f"💰 [FUNDS CHECK] Order details: {order.code} {order.volume} shares @ {price}")
-            GLOG.DEBUG(f"💰 [FUNDS CHECK] Commission calculation: {required_funds} * {self._commission_rate} = {commission}")
+        def _total_for(volume: int) -> Decimal:
+            """volume 对应的本金 + 佣金（与实际扣费同一算法）"""
+            funds = price * volume
+            return funds + self._calculate_commission(funds, is_long)
+
+        # 1) 全额检查（含滑点容差）
+        full_total = _total_for(order.volume)
+        tolerance = full_total * self._slippage_tolerance
+        if frozen_funds >= full_total - tolerance:
+            GLOG.DEBUG(f"✅ [FUNDS CHECK] Sufficient frozen funds: {frozen_funds} >= {full_total}")
+            return order.volume
+
+        # 2) 部分成交：求最大 volume（对齐 100 整手）使 total <= frozen_funds
+        GLOG.WARN(f"⚠️ [FUNDS CHECK] Insufficient for full: have {frozen_funds}, need {full_total}, attempting partial fill")
+        stamp = Decimal("0") if is_long else Decimal("0.001")
+        # 每股总成本（忽略佣金 min 下限，取解析上界后下调校验）
+        rate_per_share = price * (Decimal("1") + self._commission_rate + stamp)
+        if rate_per_share <= 0:
             return 0
-
-        GLOG.DEBUG(f"✅ [FUNDS CHECK] Sufficient frozen funds: {frozen_funds} >= {total_required}")
-        return order.volume
+        v_upper = int(frozen_funds / rate_per_share)
+        v = (v_upper // 100) * 100
+        # 下调校验：佣金 min 下限使小批量相对更贵，逐手下调直到资金可覆盖
+        while v >= 100 and _total_for(v) > frozen_funds:
+            v -= 100
+        if v < 100:
+            GLOG.WARN(f"❌ [FUNDS CHECK] Cannot afford even 1 lot (100 shares) of {order.code}")
+            return 0
+        GLOG.INFO(f"📉 [FUNDS CHECK] Partial fill {order.code}: {order.volume} -> {v} shares @ {price}")
+        return v
 
     def _is_price_valid(self, code: str, price_data: Any) -> bool:
         """价格有效性检查"""

--- a/src/ginkgo/trading/events/order_lifecycle_events.py
+++ b/src/ginkgo/trading/events/order_lifecycle_events.py
@@ -27,7 +27,7 @@ from decimal import Decimal
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.order_related import EventOrderRelated
 from ginkgo.entities import Order
-from ginkgo.enums import EVENT_TYPES
+from ginkgo.enums import EVENT_TYPES, ORDERSTATUS_TYPES
 
 
 class EventOrderAck(EventBase):
@@ -119,6 +119,7 @@ class EventOrderPartiallyFilled(EventOrderRelated):
                  portfolio_id: Optional[str] = None,
                  engine_id: Optional[str] = None,
                  task_id: Optional[str] = None,
+                 order_status: Optional[ORDERSTATUS_TYPES] = None,
                  *args, **kwargs):
         # 调用EventOrderRelated构造函数，自动设置payload = order
         super().__init__(order=order, name="OrderPartiallyFilled", *args, **kwargs)
@@ -137,6 +138,9 @@ class EventOrderPartiallyFilled(EventOrderRelated):
         self._fill_price = float(fill_price)
         self._trade_id = trade_id
         self._commission = commission or Decimal('0')
+        # broker 终态判定 (result.status) 透传: 下游 is_final 据此释放剩余冻结资金。
+        # 缺省 None 时回退 order.status (向后兼容)。
+        self._order_status = order_status
 
         if timestamp:
             self.set_time(timestamp)
@@ -145,7 +149,20 @@ class EventOrderPartiallyFilled(EventOrderRelated):
     def order(self) -> Order:
         """获取订单对象"""
         return self._order
-    
+
+    @property
+    def order_status(self):
+        """订单终态 (broker 权威来源)。
+
+        to_event 透传 broker 的 result.status; 缺省回退 order.status。
+        下游 PortfolioT1Backtest.is_final 据此判定是否 release_frozen,
+        避免 sim_broker 一次性部分成交 (result.status=FILLED 但 order.status
+        仍 SUBMITTED) 时剩余冻结资金泄漏 (#5492 review)。
+        """
+        if getattr(self, "_order_status", None) is not None:
+            return self._order_status
+        return self._order.status if self._order else None
+
     @property
     def filled_quantity(self) -> float:
         """获取本次成交数量"""

--- a/src/ginkgo/trading/interfaces/broker_interface.py
+++ b/src/ginkgo/trading/interfaces/broker_interface.py
@@ -92,7 +92,8 @@ class BrokerExecutionResult:
                 commission=self.commission,
                 portfolio_id=portfolio_id,
                 engine_id=engine_id,
-                task_id=task_id
+                task_id=task_id,
+                order_status=self.status
             )
             # FILLED 状态使用 ORDERFILLED 事件类型，确保触发 on_order_filled 处理器
             if self.status == ORDERSTATUS_TYPES.FILLED:

--- a/tests/unit/trading/brokers/test_sim_broker_commission.py
+++ b/tests/unit/trading/brokers/test_sim_broker_commission.py
@@ -1,0 +1,134 @@
+"""
+SimBroker 佣金统一与部分成交 (issue #5492)
+
+修复 _adjust_volume_for_funds 的两个问题:
+1. 预检佣金与实际扣费(_calculate_commission)不一致 —— 卖单少算 0.1% 印花税
+2. 全额资金不足时直接拒单(返回0), 不支持部分成交
+
+A 股 volume 为 100 整数倍(ashare_broker.py:263 约定), 部分成交对齐 100 整手。
+"""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.entities.order import Order
+from ginkgo.enums import DIRECTION_TYPES, ORDER_TYPES, ORDERSTATUS_TYPES
+from ginkgo.trading.brokers.sim_broker import SimBroker
+
+
+def _make_market_bar(close="9.5", high="10", low="9", limit_up="10.5", limit_down="8.5"):
+    """构造带属性的市场数据 Bar (对齐生产 Bar 对象的 getattr 访问)
+
+    submit_order_event:273 对市价单用 `getattr(market_data, 'close', 0)` 取价,
+    dict 无 .close 属性会塌缩成 0 触发误判涨跌停; 必须用属性对象。
+    """
+    return SimpleNamespace(
+        open=Decimal(close), high=Decimal(high), low=Decimal(low),
+        close=Decimal(close), volume=1000000,
+        limit_up=Decimal(limit_up), limit_down=Decimal(limit_down),
+    )
+
+
+def _make_order(code, direction, volume, frozen_money):
+    """构造带冻结资金的市价单 Order (SimBroker 资金检查读 frozen_money)"""
+    return Order(
+        portfolio_id="p-001",
+        engine_id="e-001",
+        task_id="r-001",
+        code=code,
+        direction=direction,
+        order_type=ORDER_TYPES.MARKETORDER,
+        status=ORDERSTATUS_TYPES.SUBMITTED,
+        volume=volume,
+        frozen_money=Decimal(str(frozen_money)),
+    )
+
+
+class TestAdjustVolumeForFunds:
+    """_adjust_volume_for_funds 行为: 资金检查与部分成交"""
+
+    def test_sufficient_funds_returns_full_volume(self):
+        """资金充足: 返回全额 volume (tracer, 验证测试 harness)"""
+        broker = SimBroker()
+        # 1000股 @ 10.00: 本金 10000 + 佣金 max(10000*0.0003, 5)=30, 买入无印花税
+        # total ≈ 10030, frozen 15000 充足
+        order = _make_order("000001.SZ", DIRECTION_TYPES.LONG, 1000, 15000)
+        vol = broker._adjust_volume_for_funds(order, Decimal("10.00"))
+        assert vol == 1000
+
+    def test_sell_partial_fill_when_insufficient_funds(self):
+        """卖单资金不足全额: 部分成交, 对齐100整手, 佣金含印花税(_calculate_commission)
+
+        10000股 @ 10.00 卖出: 全额 total = 100000 + 30(佣) + 100(印花) = 100130
+        frozen=50000 远低于全额(含5%容差阈值95123.5) -> 部分成交
+        max v 对齐100: total(4900)=49000+14.7+49=49063.7<=50000; total(5000)=50065>50000
+        """
+        broker = SimBroker()
+        order = _make_order("000001.SZ", DIRECTION_TYPES.SHORT, 10000, 50000)
+        vol = broker._adjust_volume_for_funds(order, Decimal("10.00"))
+        assert vol == 4900
+
+    def test_insufficient_for_one_lot_returns_zero(self):
+        """资金不足一手(100股): 返回 0 (调用方据此 REJECTED)
+
+        10000股 @ 10.00, frozen=500 连 100 股(本金1000+佣5=1005)都买不起
+        """
+        broker = SimBroker()
+        order = _make_order("000001.SZ", DIRECTION_TYPES.LONG, 10000, 500)
+        vol = broker._adjust_volume_for_funds(order, Decimal("10.00"))
+        assert vol == 0
+
+    def test_buy_partial_fill_uses_no_stamp_tax(self):
+        """买单部分成交: 无印花税 (回归, 确认方向无关的部分成交)
+
+        10000股 @ 10.00 买入: rate_per_share=10*(1+0.0003)=10.003
+        frozen=50000 -> v_upper=4998 -> 对齐100=4900
+        total(4900)=49000+14.7=49014.7<=50000; total(5000)=50015>50000 -> 4900
+        """
+        broker = SimBroker()
+        order = _make_order("000001.SZ", DIRECTION_TYPES.LONG, 10000, 50000)
+        vol = broker._adjust_volume_for_funds(order, Decimal("10.00"))
+        assert vol == 4900
+
+
+class TestSubmitOrderEventPartialFill:
+    """端到端: submit_order_event 在部分成交时返回 FILLED (非 REJECTED)"""
+
+    def test_market_order_partial_fill_returns_filled(self):
+        """资金不足全额: submit_order_event 返回 FILLED, filled_volume 对齐100且小于全额"""
+        broker = SimBroker(random_seed=42)
+        broker._current_market_data = {"000001.SZ": _make_market_bar()}
+        # 卖单 10000 股, frozen 40000 远不足全额(>90000) -> 部分成交
+        order = Order(
+            portfolio_id="p-001", engine_id="e-001", task_id="r-001",
+            code="000001.SZ", direction=DIRECTION_TYPES.SHORT,
+            order_type=ORDER_TYPES.MARKETORDER, status=ORDERSTATUS_TYPES.SUBMITTED,
+            volume=10000, frozen_money=Decimal("40000"),
+        )
+        event = MagicMock()
+        event.payload = order
+        result = broker.submit_order_event(event)
+
+        assert result.status == ORDERSTATUS_TYPES.FILLED
+        assert 0 < result.filled_volume < order.volume
+        assert result.filled_volume % 100 == 0
+
+    def test_insufficient_for_one_lot_returns_rejected(self):
+        """资金不足一手: submit_order_event 返回 REJECTED (部分成交下限保护)"""
+        broker = SimBroker(random_seed=42)
+        broker._current_market_data = {"000001.SZ": _make_market_bar()}
+        # frozen=500 连 100 股(@~9.5)都买不起
+        order = Order(
+            portfolio_id="p-001", engine_id="e-001", task_id="r-001",
+            code="000001.SZ", direction=DIRECTION_TYPES.LONG,
+            order_type=ORDER_TYPES.MARKETORDER, status=ORDERSTATUS_TYPES.SUBMITTED,
+            volume=10000, frozen_money=Decimal("500"),
+        )
+        event = MagicMock()
+        event.payload = order
+        result = broker.submit_order_event(event)
+
+        assert result.status == ORDERSTATUS_TYPES.REJECTED

--- a/tests/unit/trading/interfaces/test_broker_execution_result.py
+++ b/tests/unit/trading/interfaces/test_broker_execution_result.py
@@ -130,3 +130,33 @@ class TestBrokerExecutionResultToEvent:
             order=self._make_order()
         )
         assert result.to_event() is None
+
+    def test_filled_partial_fill_propagates_status_to_event(self):
+        """FILLED 终态(部分成交 filled_volume<volume)必须透传到 event.order_status (#5492 review)
+
+        下游 PortfolioT1Backtest.is_final 依赖 event.order_status==FILLED 判定终态,
+        据此释放剩余冻结资金 (release_frozen)。回测路径从不调 order.fill(),
+        order.status 恒为 SUBMITTED; 若 to_event 不透传 result.status,
+        部分成交(order.transaction_volume<volume)时 is_final=False,
+        剩余 frozen_money 永久泄漏、cash 被低估。
+        broker 的 result.status 是订单终态的权威来源, 必须随事件透传。
+        """
+        order = Order(
+            portfolio_id="portfolio-001", engine_id="engine-1", task_id="run-1",
+            code="000001.SZ", direction=DIRECTION_TYPES.LONG,
+            order_type=ORDER_TYPES.MARKETORDER, status=ORDERSTATUS_TYPES.SUBMITTED,
+            volume=1000, frozen_money=Decimal("5000"),
+        )
+        # broker 一次性部分成交: 判定终态 FILLED, 但实际只成交 400 < volume 1000
+        result = BrokerExecutionResult(
+            status=ORDERSTATUS_TYPES.FILLED,
+            broker_order_id="BROKER-PARTIAL",
+            filled_volume=400,
+            filled_price=10.0,
+            order=order,
+        )
+        event = result.to_event(engine_id="engine-1", task_id="run-1")
+        assert event is not None
+        assert event.event_type == EVENT_TYPES.ORDERFILLED
+        # 关键: 事件须透传 broker 终态判定, 而非退回 order.status(=SUBMITTED)
+        assert event.order_status == ORDERSTATUS_TYPES.FILLED

--- a/tests/unit/trading/portfolios/test_t1backtest.py
+++ b/tests/unit/trading/portfolios/test_t1backtest.py
@@ -568,6 +568,38 @@ class TestOrderLifecycleEvents:
             p.on_order_partially_filled(event)
         assert 'activate' in hook_called
 
+    def test_terminal_partial_fill_releases_remaining_frozen_funds(self):
+        """#5492 review: 终态部分成交(filled<volume)必须释放剩余冻结资金, 杜绝泄漏。
+
+        broker 一次性部分成交: result.status=FILLED(终态判定), 实际只成交
+        400 < volume 1000。事件透传 order_status=FILLED 后 is_final=True →
+        release_frozen() 清零剩余 remain。若退回 order.status(=NEW, 且
+        transaction_volume<volume), is_final=False, remain 恒留 6000 →
+        冻结资金永久泄漏、cash 被低估。
+        无事件透传时 EventOrderPartiallyFilled 不接受 order_status 参数, 退回
+        order.status → 本断言 remain==0 失败, 证明透传是闭环的必要修复。
+        """
+        p = _make_portfolio()
+        _setup_portfolio(p)
+        # volume=1000 @ 10 → frozen_money=10000; 成交 400 → 成本 4000, 剩余 6000
+        order = _make_order(volume=1000, limit_price=Decimal("10.0"))
+        event = EventOrderPartiallyFilled(
+            order=order, filled_quantity=400, fill_price=Decimal("10.0"),
+            portfolio_id="pid", engine_id="eid", task_id="rid",
+            order_status=ORDERSTATUS_TYPES.FILLED,
+        )
+        with patch('ginkgo.trading.portfolios.t1backtest.GLOG'), \
+             patch('ginkgo.trading.portfolios.t1backtest.container'), \
+             patch.object(p, 'is_event_from_future', return_value=False), \
+             patch.object(p, 'deduct_from_frozen'), \
+             patch.object(p, 'update_worth'), \
+             patch.object(p, 'update_profit'):
+            p.on_order_partially_filled(event)
+        # 终态部分成交: 剩余冻结资金已释放 → remain=0 (无泄漏)
+        assert order.remain == Decimal("0")
+        # 累计成交仍为本次成交 400 (终态判定 ≠ 全额成交)
+        assert order.transaction_volume == 400
+
     def test_on_order_rejected_method(self):
         p = _make_portfolio()
         _setup_portfolio(p)


### PR DESCRIPTION
## Summary
SimBroker `_adjust_volume_for_funds` 两个问题 (#5492):
1. 预检佣金用 `max(funds*rate, min)` 估算, 缺卖单 0.1% 印花税, 与实际扣费 `_calculate_commission` 分叉
2. 全额资金不足时直接返回 0 拒单, 不支持部分成交

修复:
- 预检复用 `_calculate_commission` (同扣费算法), 消除买卖方向差异
- 全额不足时部分成交, 对齐 A 股 100 股整手; 不足一手才返回 0 (REJECTED)

## Test plan
- [x] `pytest tests/unit/trading/brokers/test_sim_broker_commission.py` (6 测试: 卖单印花税/买单无印花税/部分成交对齐100/不足一手返回0/端到端 FILLED/REJECTED)
- [x] `pytest tests/unit/trading/brokers/test_sim_broker_limit.py` 无回归 (19 passed)
- [x] `pytest tests/unit/trading/brokers/` 仅 OKX 实盘 2 个 pre-existing 失败, 与本修复无关

Closes #5492
