### PR TITLE
fix: 批量修复 JWT/auth 安全簇 (#6175 #6070 #5470)

### DIFF
--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -181,12 +181,10 @@ async def logout(req: Request):
 
 async def verify_token_endpoint(req: Request):
     """#5899: 手动验证 token（端点在 PUBLIC_PATHS，中间件不处理）"""
-    # 从 header 或 query param 提取 token
+    # #5470: 仅从 Authorization: Bearer 头提取 token，不回退 query param
+    # （query param token 会泄漏到日志/历史/Referer，与中间件 _extract_token 保持一致）
     authorization = req.headers.get("Authorization", "")
-    if authorization.startswith("Bearer "):
-        token = authorization[7:]
-    else:
-        token = req.query_params.get("token")
+    token = authorization[7:] if authorization.startswith("Bearer ") else None
 
     if not token:
         return ok(data={"valid": False, "user_uuid": None, "username": None, "is_admin": False})

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -40,18 +40,27 @@ def hash_password(password: str) -> str:
     return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
 
 
-def _require_admin(req: Request) -> None:
-    """#5467+review: 管理员授权须 DB 校验 is_admin，不信任 JWT（与 #5899 /auth/verify 一致），DB 异常 fail-closed"""
-    user_uuid = getattr(req.state, "user_uuid", None)
-    is_admin = False
+def _resolve_is_admin(user_uuid) -> bool:
+    """#6175/#5899: 从 DB 查询 is_admin（fail-closed），不信任 JWT 内嵌值。
+
+    单一权威 admin 权限源：_require_admin 与 reset_user_password 共用。
+    DB 异常或无 user_uuid 时返回 False（fail-closed），防止降权/撤销 admin 的
+    旧 JWT（≤ACCESS_TOKEN_EXPIRE_MINUTES）冒充 admin。
+    """
+    if not user_uuid:
+        return False
     try:
         credential = get_user_service().get_credential(user_uuid)
         if credential is not None:
-            is_admin = credential.is_admin
+            return bool(credential.is_admin)
     except Exception as e:
-        logger.warning(f"#5467: DB query failed for is_admin, user={user_uuid}: {e}")
-        is_admin = False
-    if not is_admin:
+        logger.warning(f"#6175: DB query failed for is_admin, user={user_uuid}: {e}")
+    return False
+
+
+def _require_admin(req: Request) -> None:
+    """#5467+review: 管理员授权须 DB 校验 is_admin，不信任 JWT（与 #5899 /auth/verify 一致），DB 异常 fail-closed"""
+    if not _resolve_is_admin(getattr(req.state, "user_uuid", None)):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Administrator privileges required",
@@ -291,9 +300,9 @@ async def reset_user_password(uuid: str, data: dict, req: Request):
     - 普通用户只能重置自己的密码
     - 响应不返回明文密码
     """
-    # 权限校验（#5770, #5679）
+    # 权限校验（#5770, #5679, #6175: admin 须 DB 校验，不信任 JWT 内嵌 is_admin）
     caller_uuid = getattr(req.state, "user_uuid", None)
-    is_admin = getattr(req.state, "is_admin", False)
+    is_admin = _resolve_is_admin(caller_uuid)
 
     if not is_admin and caller_uuid != uuid:
         raise HTTPException(

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -252,6 +252,22 @@ async def update_user(req: Request, uuid: str, data: UserUpdate):
     try:
         user_service = get_user_service()
 
+        # #6070: 读取变更前权限状态，用于判断是否需撤销旧 token（仅 status/roles 触发）
+        # 当前值读取失败→None，比较时按"已变更"处理（保守撤销，fail-safe）
+        cur_is_active = None
+        cur_is_admin = None
+        try:
+            if data.status is not None:
+                cur_user = user_service.get_user(uuid)
+                if cur_user.success and isinstance(cur_user.data, dict):
+                    cur_is_active = cur_user.data.get("is_active")
+            if data.roles is not None:
+                cur_cred = user_service.get_credential(uuid)
+                if cur_cred is not None:
+                    cur_is_admin = bool(cur_cred.is_admin)
+        except Exception as e:
+            logger.warning(f"#6070: failed reading current privilege state for {uuid}: {e}")
+
         # 构建更新参数
         updates = {}
         if data.display_name is not None:
@@ -276,6 +292,17 @@ async def update_user(req: Request, uuid: str, data: UserUpdate):
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail="Failed to update user"
                 )
+
+        # #6070: 仅当 status 或 roles 实际发生变更时撤销旧 token
+        # （与 delete_user/reset_user_password/change_password 一致；改 display_name/email 不触发）
+        revoke = False
+        if "is_active" in updates and updates["is_active"] != cur_is_active:
+            revoke = True
+        if "is_admin" in updates and updates["is_admin"] != cur_is_admin:
+            revoke = True
+        if revoke:
+            from middleware.auth import token_blacklist
+            token_blacklist.revoke_user(uuid)
 
         logger.info(f"User updated: {uuid}")
 

--- a/api/middleware/auth.py
+++ b/api/middleware/auth.py
@@ -133,12 +133,16 @@ class JWTAuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
     def _extract_token(self, request: Request) -> Optional[str]:
-        """先查 header，没有再查 query param"""
+        """仅从 Authorization: Bearer 头提取 token
+
+        #5470: 不再回退到 URL query param——query param 的 token 会泄漏到
+        访问日志、浏览器历史、Referer 头与代理日志，构成凭据泄漏面。
+        WebSocket 路径无法设置 header，由 handler 自行调用 verify_token（见文件头注释）。
+        """
         authorization = request.headers.get("Authorization")
         if authorization and authorization.startswith("Bearer "):
             return authorization[7:]
-
-        return request.query_params.get("token")
+        return None
 
 
 def verify_token(token: str) -> dict:

--- a/tests/api/test_auth_security_batch.py
+++ b/tests/api/test_auth_security_batch.py
@@ -87,8 +87,11 @@ class TestResetPasswordNoDefault:
         from api.settings import reset_user_password
         from fastapi import HTTPException
 
-        with pytest.raises(HTTPException) as exc_info:
-            asyncio.run(reset_user_password("user-target", {}, self._admin_req()))
+        with patch("api.settings.get_user_service") as mock_svc:
+            # #6175: admin 来自 DB（fail-closed），不再信任 req.state.is_admin
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(reset_user_password("user-target", {}, self._admin_req()))
         assert exc_info.value.status_code == 400
 
     def test_reset_does_not_call_service_with_default(self):
@@ -97,6 +100,8 @@ class TestResetPasswordNoDefault:
         from fastapi import HTTPException
 
         with patch("api.settings.get_user_service") as mock_svc:
+            # #6175: 显式 DB-admin，避免依赖 MagicMock 的隐式 truthy（is_admin）
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
             mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
             with pytest.raises(HTTPException):
                 asyncio.run(reset_user_password("user-target", {}, self._admin_req()))

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -162,19 +162,37 @@ class TestResetPasswordAuthorization:
         assert exc_info.value.status_code == 403
 
     def test_admin_can_reset_others_password(self):
-        """管理员应能重置他人密码"""
+        """DB 确认的 admin 应能重置他人密码（#6175: admin 来自 DB 非 JWT）"""
         from api.settings import reset_user_password
 
         req = MagicMock()
         req.state.user_uuid = "user-admin"
-        req.state.is_admin = True
+        req.state.is_admin = False  # JWT 不再被信任，故意设 False 验证走 DB
 
         with patch("api.settings.get_user_service") as mock_svc:
+            # DB 真相：是 admin
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
             mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
             result = asyncio.run(
                 reset_user_password("user-target-uuid", {"new_password": "NewPass123!"}, req)
             )
         # 不应抛异常
+        assert result is not None
+
+    def test_non_admin_can_reset_own_password(self):
+        """普通用户可重置自己的密码（self-reset 路径，#6175 须保留）"""
+        from api.settings import reset_user_password
+
+        req = MagicMock()
+        req.state.user_uuid = "user-self"
+        req.state.is_admin = False
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=False)
+            mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
+            result = asyncio.run(
+                reset_user_password("user-self", {"new_password": "NewPass123!"}, req)
+            )
         assert result is not None
 
     def test_reset_password_response_no_plaintext(self):
@@ -186,6 +204,7 @@ class TestResetPasswordAuthorization:
         req.state.is_admin = True
 
         with patch("api.settings.get_user_service") as mock_svc:
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
             mock_svc.return_value.reset_password.return_value = MagicMock(success=True)
             result = asyncio.run(
                 reset_user_password("user-target-uuid", {"new_password": "Secret123!"}, req)
@@ -252,3 +271,31 @@ class TestTokenBlacklistOnDeleteUser:
         # 确认被拒绝
         with pytest.raises(JWTError, match="revoked"):
             verify_token(token)
+
+
+# ============================================================
+# #6175: reset_user_password 须 DB 校验 is_admin（不信任 JWT）
+# 与 _require_admin / #5899 同款 fail-closed
+# ============================================================
+
+class TestResetPasswordDbAdminCheck:
+    """#6175: reset_user_password admin 校验须查 DB，被降权 admin 的旧 JWT 不得放行"""
+
+    def test_demoted_admin_jwt_blocked_by_db(self):
+        """DB 已降权（is_admin=False）但 JWT 仍带 is_admin=True 的用户，
+        不能重置他人密码——账户接管风险须阻断"""
+        from api.settings import reset_user_password
+        from fastapi import HTTPException
+
+        req = MagicMock()
+        req.state.user_uuid = "demoted-admin"
+        req.state.is_admin = True  # JWT 仍带 admin（旧 token 未过期）
+
+        with patch("api.settings.get_user_service") as mock_svc:
+            # DB 真相：该用户已被降为普通用户
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=False)
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    reset_user_password("victim-uuid", {"new_password": "hacked123"}, req)
+                )
+        assert exc_info.value.status_code == 403

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -299,3 +299,85 @@ class TestResetPasswordDbAdminCheck:
                     reset_user_password("victim-uuid", {"new_password": "hacked123"}, req)
                 )
         assert exc_info.value.status_code == 403
+
+
+# ============================================================
+# #6070: update_user 在 status/roles 实际变更时撤销旧 token
+# ============================================================
+
+class TestTokenBlacklistOnUpdateUser:
+    """#6070: update_user 禁用/降权后须 revoke_user，仅改档案不触发"""
+
+    def _admin_req(self):
+        req = MagicMock()
+        req.state.user_uuid = "admin-1"  # caller；_require_admin 走 DB
+        return req
+
+    def test_disable_user_revokes_tokens(self):
+        """禁用用户（status active→disabled）应撤销其所有旧 token"""
+        from api.settings import update_user, UserUpdate
+
+        req = self._admin_req()
+        data = UserUpdate(status="disabled")
+
+        with patch("api.settings.get_user_service") as mock_svc, \
+             patch("middleware.auth.token_blacklist") as mock_bl:
+            # caller DB-admin；目标当前 active
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
+            mock_svc.return_value.get_user.return_value = MagicMock(
+                success=True, data={"is_active": True})
+            mock_svc.return_value.update_user.return_value = MagicMock(success=True)
+
+            asyncio.run(update_user(req, "user-target", data))
+
+            mock_bl.revoke_user.assert_called_once_with("user-target")
+
+    def test_demote_user_revokes_tokens(self):
+        """降权（移除 admin 角色）应撤销其所有旧 token"""
+        from api.settings import update_user, UserUpdate
+
+        req = self._admin_req()
+        data = UserUpdate(roles=[])  # 移除 admin
+
+        with patch("api.settings.get_user_service") as mock_svc, \
+             patch("middleware.auth.token_blacklist") as mock_bl:
+            # caller admin；目标当前是 admin
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
+            mock_svc.return_value.update_user.return_value = MagicMock(success=True)
+
+            asyncio.run(update_user(req, "user-target", data))
+
+            mock_bl.revoke_user.assert_called_once_with("user-target")
+
+    def test_display_name_only_does_not_revoke(self):
+        """仅改 display_name（非权限字段）不应撤销 token"""
+        from api.settings import update_user, UserUpdate
+
+        req = self._admin_req()
+        data = UserUpdate(display_name="New Name")
+
+        with patch("api.settings.get_user_service") as mock_svc, \
+             patch("middleware.auth.token_blacklist") as mock_bl:
+            mock_svc.return_value.update_user.return_value = MagicMock(success=True)
+
+            asyncio.run(update_user(req, "user-target", data))
+
+            mock_bl.revoke_user.assert_not_called()
+
+    def test_status_unchanged_does_not_revoke(self):
+        """status 设为与当前相同值（无实际变更）不应撤销 token"""
+        from api.settings import update_user, UserUpdate
+
+        req = self._admin_req()
+        data = UserUpdate(status="active")  # 当前已是 active → 无变更
+
+        with patch("api.settings.get_user_service") as mock_svc, \
+             patch("middleware.auth.token_blacklist") as mock_bl:
+            mock_svc.return_value.get_credential.return_value = MagicMock(is_admin=True)
+            mock_svc.return_value.get_user.return_value = MagicMock(
+                success=True, data={"is_active": True})
+            mock_svc.return_value.update_user.return_value = MagicMock(success=True)
+
+            asyncio.run(update_user(req, "user-target", data))
+
+            mock_bl.revoke_user.assert_not_called()

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -381,3 +381,33 @@ class TestTokenBlacklistOnUpdateUser:
             asyncio.run(update_user(req, "user-target", data))
 
             mock_bl.revoke_user.assert_not_called()
+
+
+# ============================================================
+# #5470: 不再接受 URL query param 传递 JWT（防泄漏到日志/历史/Referer）
+# ============================================================
+
+class TestTokenQueryParamRejected:
+    """#5470: token 仅经 Authorization: Bearer 头接受，query param 不再提取"""
+
+    def _mw(self):
+        from middleware.auth import JWTAuthMiddleware
+        return JWTAuthMiddleware(MagicMock())
+
+    def test_query_param_token_rejected(self):
+        """仅 query param 提供 token 时 _extract_token 应返回 None（当前会泄漏）"""
+        mw = self._mw()
+        req = MagicMock()
+        req.headers = {}  # 无 Authorization
+        req.query_params = {"token": "eyJ.leaked.token"}
+
+        assert mw._extract_token(req) is None
+
+    def test_bearer_header_still_accepted(self):
+        """回归守卫：移除 query param 回退后，Authorization: Bearer 头仍须有效"""
+        mw = self._mw()
+        req = MagicMock()
+        req.headers = {"Authorization": "Bearer eyZ.valid.token"}
+        req.query_params = {}
+
+        assert mw._extract_token(req) == "eyZ.valid.token"


### PR DESCRIPTION
## Summary

批量修复 JWT/auth 安全簇（3 个 issue），统一收紧 token 生命周期与授权校验。

### #6175 (P0) — `reset_user_password` admin 校验改 DB fail-closed
**根因**：reset 端点信任 JWT 内嵌的 `req.state.is_admin`，被降权 admin 的旧 token 仍可重置他人密码（账户接管风险）。
**修复**：新增 `_resolve_is_admin(user_uuid)`，从 DB `get_credential().is_admin` 为唯一权威源，DB 异常 fail-closed（与 `_require_admin` / `/auth/verify` #5899 同款）。保留 self-reset（非 admin 可改自己密码）。

### #6070 (P1) — `update_user` 禁用/降权后撤销旧 token
**根因**：管理员禁用用户或移除 admin 角色后，旧 token 仍有效，被改用户可继续访问。
**修复**：update 前读当前 `is_active`/`is_admin`，仅当**实际发生变更**时调用 `token_blacklist.revoke_user(uuid)`。仅改 display_name 或 status 设为同值不触发。

### #5470 (P1) — ⚠️ 破坏性：拒绝 URL query param 传递 JWT
**根因**：HTTP 中间件 `_extract_token` 与 `/auth/verify` 回退到 `?token=` query param，token 泄漏到访问日志/浏览器历史/Referer 头/代理日志。
**修复**：仅接受 `Authorization: Bearer` 头。**WebSocket handler 不受影响**（浏览器无法在 WS 握手设 header，query param 是标准 WS 鉴权方式，由 handler 自行调 `verify_token`）。
**破坏性影响**：任何在 **REST** 端点用 `?token=xxx` 传 JWT 的客户端将收到 401，须改用 Authorization 头。

## Test plan

- `tests/api/test_jwt_security.py`：新增 `TestResetPasswordDbAdminCheck`(#6175)、`TestTokenBlacklistOnUpdateUser` 4 例(#6070)、`TestTokenQueryParamRejected` 2 例(#5470)
- `tests/api/test_auth_security_batch.py`：`TestResetPasswordNoDefault` 改用 DB-admin（#6175 联动）
- 冒烟：`tests/api/test_jwt_security.py + test_auth_verify.py + test_auth_security_batch.py` = 42 passed
- 基线对比：`tests/api/` 全量 9 failed / 11 errors **与 origin/master 完全一致**（均为 saga/validation/api_versioning 预存环境失败，与 auth 无关）

Closes #6175
Closes #6070
Closes #5470

🤖 Generated with [Claude Code](https://claude.com/claude-code)
