### PR TITLE
fix(#6200): deploy 透传 initial_capital 到目标组合

### DIFF
--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -97,6 +97,8 @@ class DeploymentService(BaseService):
                 name=name,
                 portfolio_name=getattr(portfolio_obj, "name", None) or portfolio_id,
                 deployment_id=deployment_id,
+                # #6200: 目标组合继承源组合 initial_capital(原漏传致重置为 service 默认 1000000)
+                initial_capital=float(getattr(portfolio_obj, "initial_capital", 0) or 0),
             )
         except Exception as e:
             GLOG.ERROR(f"部署流程异常: {e}")
@@ -118,6 +120,7 @@ class DeploymentService(BaseService):
         name: Optional[str],
         portfolio_name: str,
         deployment_id: str,
+        initial_capital: float = 0,
     ) -> ServiceResult:
         """核心部署流程: 步骤 4-8。失败时由调用方标记 FAILED。"""
         # 4. 读取原 Portfolio 的组件映射
@@ -138,6 +141,7 @@ class DeploymentService(BaseService):
             name=name,
             mode=mode,
             description=f"部署自组合 {source_portfolio_id}",
+            initial_capital=initial_capital,
         )
         if not portfolio_result.success:
             raise RuntimeError(f"创建Portfolio失败: {portfolio_result.error}")

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -11,9 +11,8 @@ import pytest
 from unittest.mock import MagicMock
 from ginkgo.enums import PORTFOLIO_MODE_TYPES
 
-# Note: 只有第 4 个测试 (test_deploy_paper_creates_deployment_and_calls_core) 会触发
-# #3626 的 MUserCredential mapper 错误（MDeployment() 实例化时），前 3 个测试在
-# _make_svc() 构造前就短路返回，可以正常运行。
+# #3626 已修: MDeployment() 实例化不再触发 MUserCredential mapper 错误, 全部测试可跑。
+# deploy→_deploy_core 路径现可经公共接口测(见 test_deploy_propagates_source_initial_capital)。
 
 from ginkgo.trading.services.deployment_service import DeploymentService
 
@@ -68,7 +67,34 @@ class TestDeploymentServiceDeploy:
         assert not result.success
         assert "account_id" in result.error
 
-    @pytest.mark.skip(reason="blocked by #3626 MUserCredential mapper failure")
+    def test_deploy_propagates_source_initial_capital(self):
+        """#6200 部署时目标组合应继承源组合 initial_capital(非 service 默认 1000000)。
+
+        根因: _deploy_core 调 portfolio_service.add 时漏传 initial_capital。
+        通过公共 deploy() 接口验证: add 被调用时须带 initial_capital == 源组合 capital。
+        """
+        svc = _make_svc()
+        # 源组合: capital=500000 (≠ service 默认 1000000, 才能区分"继承" vs "默认")
+        source_portfolio = MagicMock()
+        source_portfolio.name = "Src"
+        source_portfolio.initial_capital = 500000
+        svc._portfolio_service.get.return_value = MagicMock(success=True, data=[source_portfolio])
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        # _deploy_core 依赖: 空映射、deployment_crud(MDeployment 已可实例化, #3626 已修)、add 返回 uuid
+        svc._mapping_service.get_portfolio_mappings.return_value = MagicMock(success=True, data=[])
+        svc._portfolio_service.add.return_value = MagicMock(success=True, data={"uuid": "new_pid"})
+        svc._deployment_crud.modify.return_value = None
+
+        result = svc.deploy(portfolio_id="src_pid", mode=PORTFOLIO_MODE_TYPES.PAPER, name="Deployed")
+
+        assert result.success, f"deploy 应成功: {result.error}"
+        # 行为断言: 创建目标组合时须透传源组合 capital
+        svc._portfolio_service.add.assert_called_once()
+        _, kwargs = svc._portfolio_service.add.call_args
+        assert kwargs.get("initial_capital") == 500000, (
+            f"部署未透传 initial_capital, add 收到 kwargs={kwargs}"
+        )
+
     def test_deploy_paper_creates_deployment_and_calls_core(self):
         """PAPER 模式应创建 deployment 记录并调用 _deploy_core"""
         svc = _make_svc()


### PR DESCRIPTION
## Summary

`DeploymentService._deploy_core` 调 `portfolio_service.add()` 时漏传 `initial_capital`,导致从源组合部署(paper/live)时,**目标组合的 initial_capital 被重置为 service 默认 1000000,而非继承源组合**。例如源组合 capital=500000,部署后目标组合变成 1000000。

### 根因
`deployment_service.py` `_deploy_core` 持有 `source_portfolio_id` 但不持有源组合对象;而源组合的 `initial_capital` 只在 `deploy()` 取到的 `portfolio_obj` 上,从未透传给 `_deploy_core`。

### 改动
- `deployment_service.deploy()`:从 `portfolio_obj` 取 `initial_capital` 透传进 `_deploy_core`
- `_deploy_core`:新增 `initial_capital` 形参,传给 `portfolio_service.add(initial_capital=...)`
- 默认值 `0` 保后向兼容(`_deploy_core` 仅 `deploy()` 单一调用方)

### 顺带清理
- **#3626 已修**:`MDeployment()` 实例化不再触发 MUserCredential mapper 错误。移除 `test_deploy_paper_creates_deployment_and_calls_core` 的过时 `@pytest.mark.skip` 并更新陈旧注释。此前该 skip 让 `_deploy_core` 内部逻辑长期处于测试盲区,正是 capital bug 未被早发现的原因之一。

## 范围缩窄说明(#6200 epic)
本轮原计划含 UUID 横线 bug,经运行时实测 drop:DB 存 `uuid4().hex`(无横线),`list`/`create`/`deploy` 输出全是无横线,仅手敲/外部粘贴横线才命中,自用工作流不产生 → YAGNI。

## Test plan
- [x] 新增 `test_deploy_propagates_source_initial_capital`:源组合 capital=500000 时,断言 `add` 被调用时带 `initial_capital==500000`(刻意 ≠ 默认 1000000 以区分"继承" vs "默认")
- [x] RED→GREEN:TDD 先确认测试失败(漏传 kwarg),再最小修复使其通过
- [x] `tests/unit/trading/services/` 全目录 138 passed,无回归
- [x] stash 对照:既有的 `test_deployment_integration.py` 失败(`deploy(backtest_task_id=...)` 签名漂移)在 base 即存在,非本次回归

Closes #5001

