### PR TITLE
feat: Signal→消息通知链路（半手动实盘核心）(#6150)

### DIFF
--- a/api/api/signals.py
+++ b/api/api/signals.py
@@ -1,0 +1,102 @@
+"""
+Signal Execution Report API (#6150 半手动实盘核心).
+
+用户收到交易信号通知 → 手动执行 → 通过本端点回报实际成交价/量。
+端点职责仅限：翻译请求 → 调 signal_tracking_service.set_confirmed → 翻译响应
+（API→Service 单向，端点零业务逻辑）。actual_* 写入与时间偏差由 service 层完成。
+"""
+import sys
+from pathlib import Path
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Depends
+from pydantic import BaseModel, Field
+
+# 添加 Ginkgo 源码路径（与 api/api/trading.py 一致）
+ginkgo_path = Path(__file__).parent.parent.parent / "src"
+sys.path.insert(0, str(ginkgo_path))
+
+from core.response import ok
+from ginkgo.libs import GLOG
+
+router = APIRouter()
+
+
+class SignalExecutionReport(BaseModel):
+    """用户手动执行后的实际成交回报。"""
+
+    actual_price: float = Field(..., description="实际成交价")
+    actual_volume: int = Field(..., description="实际成交量")
+    execution_timestamp: Optional[datetime] = Field(
+        None, description="实际成交时间（业务时间），缺省由 service 用信号业务时间"
+    )
+
+
+def _get_signal_tracking_service():
+    """获取 SignalTrackingService 实例（DI 工厂，便于测试注入）。"""
+    from ginkgo.data.containers import container
+    return container.signal_tracking_service()
+
+
+def _compute_deviation(tracker) -> dict:
+    """计算预期 − 实际的偏差（#6150 "轻" 对账替代，不回写仓位）。
+
+    set_confirmed 已写入时间偏差(time_delay_seconds)；这里补价格/数量偏差，
+    供用户对照排查。预期值缺失时返回 None，不抛异常（信号可能未带预期价/量）。
+    """
+    expected_price = getattr(tracker, "expected_price", None)
+    actual_price = getattr(tracker, "actual_price", None)
+    expected_volume = getattr(tracker, "expected_volume", None)
+    actual_volume = getattr(tracker, "actual_volume", None)
+
+    price_deviation = None
+    if expected_price is not None and actual_price is not None:
+        price_deviation = float(expected_price) - float(actual_price)
+
+    volume_deviation = None
+    if expected_volume is not None and actual_volume is not None:
+        volume_deviation = int(expected_volume) - int(actual_volume)
+
+    return {
+        "price_deviation": price_deviation,
+        "volume_deviation": volume_deviation,
+    }
+
+
+@router.post("/{signal_id}/report")
+def report_signal_execution(
+    signal_id: str,
+    report: SignalExecutionReport,
+    service=Depends(_get_signal_tracking_service),
+):
+    """回报信号的实际执行结果，触发 actual_* 写入与时间偏差计算。"""
+    result = service.set_confirmed(
+        signal_id=signal_id,
+        actual_price=report.actual_price,
+        actual_volume=report.actual_volume,
+        execution_timestamp=report.execution_timestamp,
+    )
+
+    if not result.is_success():
+        # 未找到 tracker / 已确认过 → 404（首版不细分 409）
+        raise HTTPException(status_code=404, detail=result.error)
+
+    tracker = result.data
+    deviation = _compute_deviation(tracker)
+    code = getattr(tracker, "expected_code", None) or signal_id
+    # 偏差只记录不回写：半手动实盘由用户决定是否追单
+    if deviation["price_deviation"] is not None or deviation["volume_deviation"] is not None:
+        GLOG.INFO(
+            f"Signal {code} execution deviation: "
+            f"price={deviation['price_deviation']}, volume={deviation['volume_deviation']}"
+        )
+
+    return ok(
+        data={
+            "signal_id": signal_id,
+            "tracking_status": getattr(tracker, "tracking_status", None),
+            "deviation": deviation,
+        },
+        message="execution reported",
+    )

--- a/api/main.py
+++ b/api/main.py
@@ -113,6 +113,7 @@ async def health_check_api():
 
 # 路由注册 - 统一使用 /api/v1 前缀
 from api import auth, dashboard, portfolio, backtest, components, data, arena, node_graph, accounts, trading, validation, deployment
+from api import signals as signal_router
 from api import settings as settings_router
 from api import system as system_router
 from core.version import API_PREFIX
@@ -128,6 +129,7 @@ app.include_router(settings_router.router, prefix=f"{API_PREFIX}/settings", tags
 app.include_router(node_graph.router, prefix=f"{API_PREFIX}/node-graphs", tags=["node-graphs"])
 app.include_router(accounts.router, prefix=f"{API_PREFIX}/accounts", tags=["accounts"])
 app.include_router(trading.router, prefix=f"{API_PREFIX}/paper-trading", tags=["paper-trading"])
+app.include_router(signal_router.router, prefix=f"{API_PREFIX}/signals", tags=["signals"])
 app.include_router(validation.router, prefix=f"{API_PREFIX}/validation", tags=["validation"])
 app.include_router(deployment.router, prefix=f"{API_PREFIX}/deploy", tags=["deploy"])
 app.include_router(system_router.router, prefix=f"{API_PREFIX}/system", tags=["system"])

--- a/src/ginkgo/notifier/core/notify.py
+++ b/src/ginkgo/notifier/core/notify.py
@@ -371,12 +371,12 @@ def notify_trading_signal(signal, order, async_mode: bool = True) -> bool:
             for user_uuid in user_uuids:
                 result = service.send_async(
                     content=content,
-                    channels=["mail"],
+                    channels=["email"],
                     user_uuid=user_uuid,
                     priority=2,
                     title=title,
                 )
-                if getattr(result, "is_success", False):
+                if result.is_success():
                     success_count += 1
 
             GLOG.INFO(
@@ -391,10 +391,10 @@ def notify_trading_signal(signal, order, async_mode: bool = True) -> bool:
                 user_uuid=user_uuid,
                 content=content,
                 title=title,
-                channels=["mail"],
+                channels=["email"],
                 priority=2,
             )
-            if getattr(result, "is_success", False):
+            if result.is_success():
                 success_count += 1
 
         GLOG.INFO(f"Trading signal sent to {success_count}/{len(user_uuids)} users: {code}")

--- a/src/ginkgo/notifier/core/notify.py
+++ b/src/ginkgo/notifier/core/notify.py
@@ -315,3 +315,91 @@ def notify_with_fields(
     except Exception as e:
         GLOG.ERROR(f"[{module}] Failed to send notification with fields: {e}")
         return False
+
+
+def notify_trading_signal(signal, order, async_mode: bool = True) -> bool:
+    """
+    发送交易信号通知（#6150 半手动实盘核心链路）
+
+    实盘产生信号→订单时调用，让用户收到 code/direction/volume/reason，
+    手动执行后回报（POST /api/v1/signals/{id}/report）。
+
+    镜像 notify()：收件人从配置表（notification_recipient）解析，
+    支持同步直发与异步 Kafka→worker 两种模式。
+
+    Note:
+        通知发送实现由后续测试驱动（S1b 异步路径 / S2 渠道配置）。
+        当前为 seam 占位，确保 _process_signal 已接线。
+
+    Args:
+        signal: Signal 对象（含 code/direction/reason）
+        order: 产出的 Order 对象（含 volume/limit_price）
+        async_mode: 异步模式（通过 Kafka Worker），默认 True
+
+    Returns:
+        bool: 是否发送成功
+    """
+    try:
+        service = _get_notification_service()
+        if service is None:
+            GLOG.ERROR("NotificationDeliveryService not available for trading signal")
+            return False
+
+        user_uuids = _get_recipient_user_uuids()
+        if not user_uuids:
+            GLOG.WARN("No notification recipients found, trading signal not sent")
+            return False
+
+        # 从 signal/order 抽取交易字段
+        code = str(getattr(signal, "code", ""))
+        direction_raw = getattr(signal, "direction", "")
+        direction_key = getattr(direction_raw, "name", str(direction_raw))
+        direction_text = {"LONG": "做多", "SHORT": "做空", "VOID": "平仓"}.get(
+            direction_key, direction_key
+        )
+        volume = getattr(order, "volume", 0)
+        reason = getattr(signal, "reason", "") or ""
+
+        content = f"{direction_text}信号 {code} 数量 {volume}"
+        if reason and reason != "no reason":
+            content += f"\n原因: {reason}"
+        title = f"交易信号 {code}"
+
+        if async_mode:
+            # 异步路径：Kafka→worker 订阅→渠道发送（镜像 notify()）
+            success_count = 0
+            for user_uuid in user_uuids:
+                result = service.send_async(
+                    content=content,
+                    channels=["mail"],
+                    user_uuid=user_uuid,
+                    priority=2,
+                    title=title,
+                )
+                if getattr(result, "is_success", False):
+                    success_count += 1
+
+            GLOG.INFO(
+                f"Trading signal queued for {success_count}/{len(user_uuids)} users (async): {code}"
+            )
+            return success_count > 0
+
+        # 同步路径：逐个收件人直发
+        success_count = 0
+        for user_uuid in user_uuids:
+            result = service.send_to_user(
+                user_uuid=user_uuid,
+                content=content,
+                title=title,
+                channels=["mail"],
+                priority=2,
+            )
+            if getattr(result, "is_success", False):
+                success_count += 1
+
+        GLOG.INFO(f"Trading signal sent to {success_count}/{len(user_uuids)} users: {code}")
+        return success_count > 0
+
+    except Exception as e:
+        GLOG.ERROR(f"Failed to send trading signal notification: {e}")
+        return False

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -43,6 +43,7 @@ from ginkgo.libs.utils.display import base_repr
 
 from ginkgo.data.containers import container
 from ginkgo.interfaces.notification_interface import INotificationService, NotificationServiceFactory
+from ginkgo.notifier.core.notify import notify_trading_signal
 
 console = Console()
 
@@ -175,6 +176,12 @@ class PortfolioLive(PortfolioBase):
         order_event = EventOrderAck(order_adjusted, broker_order_id=f"BROKER_{order_adjusted.uuid[:8]}")
         GLOG.INFO(f"Order submitted for {signal.code}: {order_adjusted.direction} {order_adjusted.volume}")
         self._notification_service.beep()
+
+        # 5. 触发交易信号通知（#6150 半手动实盘核心）：用户收到 code/direction/volume/reason
+        try:
+            notify_trading_signal(signal, order_adjusted)
+        except Exception as e:
+            GLOG.ERROR(f"notify_trading_signal failed (non-fatal): {e}")
 
         # Note: Portfolio 只负责内存处理，订单持久化由 ExecutionNode.output_queue_listener 处理
 

--- a/tests/api/test_signal_report.py
+++ b/tests/api/test_signal_report.py
@@ -1,0 +1,80 @@
+"""
+Tests for POST /api/v1/signals/{signal_id}/report (#6150 回报录入).
+
+#6150 半手动实盘：用户收到信号通知→手动执行→回报实际成交价/量。
+端点职责：把回报转发给 signal_tracking_service.set_confirmed（API→Service 单向，
+端点零业务逻辑）。set_confirmed 的 actual_* 写入 + 时间偏差计算已在 service 层测试覆盖。
+"""
+import pytest
+from unittest.mock import MagicMock
+from types import SimpleNamespace
+
+
+class TestReportSignalExecution:
+    """回报端点：转发用户实际执行结果到 signal_tracking_service。"""
+
+    def test_delegates_to_set_confirmed_with_actual_values(self):
+        from api.signals import report_signal_execution, SignalExecutionReport
+
+        mock_service = MagicMock()
+        # set_confirmed 返回成功结果（actual_* 已写入由 service 层保证）
+        mock_service.set_confirmed.return_value = SimpleNamespace(
+            is_success=lambda: True,
+            data=SimpleNamespace(signal_id="sig-1"),
+        )
+        report = SignalExecutionReport(actual_price=10.5, actual_volume=1000)
+
+        report_signal_execution("sig-1", report, service=mock_service)
+
+        mock_service.set_confirmed.assert_called_once_with(
+            signal_id="sig-1",
+            actual_price=10.5,
+            actual_volume=1000,
+            execution_timestamp=None,
+        )
+
+    def test_not_found_raises_404(self):
+        """service 找不到 tracker 时，端点必须返回 404，而非 200 假成功。"""
+        from fastapi import HTTPException
+        from api.signals import report_signal_execution, SignalExecutionReport
+
+        mock_service = MagicMock()
+        mock_service.set_confirmed.return_value = SimpleNamespace(
+            is_success=lambda: False,
+            error="Signal tracking record not found: sig-x",
+        )
+        report = SignalExecutionReport(actual_price=10.5, actual_volume=1000)
+
+        with pytest.raises(HTTPException) as exc:
+            report_signal_execution("sig-x", report, service=mock_service)
+        assert exc.value.status_code == 404
+
+
+class TestComputeDeviation:
+    """#6150 "轻"：偏差 = 预期 − 实际，只算+记录，不回写仓位。
+
+    set_confirmed 已算时间偏差(time_delay_seconds)；这里补价格/数量偏差，
+    作为半手动实盘的"对账替代"——用户对照预期手动执行，端点算出差异供排查。
+    """
+
+    def test_returns_expected_minus_actual(self):
+        from api.signals import _compute_deviation
+
+        tracker = SimpleNamespace(
+            expected_price=10.5,
+            actual_price=10.3,
+            expected_volume=1000,
+            actual_volume=980,
+        )
+        dev = _compute_deviation(tracker)
+        assert dev["price_deviation"] == pytest.approx(0.2)
+        assert dev["volume_deviation"] == 20
+
+    def test_missing_fields_yield_none(self):
+        """预期值缺失时不能崩，返回 None（信号可能未带预期价/量）。"""
+        from api.signals import _compute_deviation
+
+        tracker = SimpleNamespace(actual_price=10.3, actual_volume=980)
+        dev = _compute_deviation(tracker)
+        assert dev["price_deviation"] is None
+        assert dev["volume_deviation"] is None

--- a/tests/unit/notifiers/test_notify_trading_signal.py
+++ b/tests/unit/notifiers/test_notify_trading_signal.py
@@ -93,3 +93,60 @@ class TestNotifyTradingSignalAsync:
         assert call.kwargs["user_uuid"] == "user-1"
         assert "000001.SZ" in call.kwargs["content"]
         assert "1000" in call.kwargs["content"]
+
+
+class TestSendFailureHandling:
+    """回归（PR#6215 review Issue 1+2）：send 失败时不能报成功。
+
+    ServiceResult.is_success 是方法非属性；渠道必须用已注册的 email（非 mail）。
+    两者叠加曾导致生产全程静默失败却返回 True。
+    """
+
+    def test_sync_send_failure_returns_false(self):
+        """send 返回失败(is_success()==False)时，notify 必须返回 False。
+
+        回归锚点：buggy `getattr(result, "is_success", False)` 取回绑定方法
+        （恒 truthy）会把失败计为成功→返回 True。本测试用 is_success() 返回
+        False 的 mock 逼出该 bug。
+        """
+        signal = Signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=100)
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=100)
+
+        fake_service = MagicMock()
+        fail_result = MagicMock()
+        fail_result.is_success.return_value = False  # 方法返回失败
+        fake_service.send_to_user.return_value = fail_result
+
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1"],
+        ):
+            result = notify_trading_signal(signal, order, async_mode=False)
+
+        assert result is False, "send 失败时不能因 is_success 是方法而恒真报成功"
+
+    def test_uses_registered_email_channel_not_unregistered_mail(self):
+        """渠道必须用已注册的 email，而非不存在的 mail（否则 send 必 Channel not found）。"""
+        signal = Signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
+
+        fake_service = MagicMock()
+        ok_result = MagicMock()
+        ok_result.is_success.return_value = True
+        fake_service.send_async.return_value = ok_result
+
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1"],
+        ):
+            notify_trading_signal(signal, order, async_mode=True)
+
+        channels = fake_service.send_async.call_args.kwargs["channels"]
+        assert "email" in channels, "必须用已注册的 email 渠道"
+        assert "mail" not in channels, "mail 未注册，会导致 Channel not found"

--- a/tests/unit/notifiers/test_notify_trading_signal.py
+++ b/tests/unit/notifiers/test_notify_trading_signal.py
@@ -1,0 +1,95 @@
+"""
+Tests for notify_trading_signal (#6150 信号→消息通知链路).
+
+验证交易信号通知的发送行为：收件人解析、内容字段、同步/异步路径。
+镜像 notify() 的结构，但不依赖真实 Kafka/DB（注入 fake service + 收件人）。
+"""
+from unittest.mock import patch, MagicMock
+
+from ginkgo.entities import Signal, Order
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.notifier.core.notify import notify_trading_signal
+
+
+class TestNotifyTradingSignalSync:
+    """同步模式：解析收件人，逐个发送携带信号字段的通知。"""
+
+    def test_sync_sends_to_each_recipient_with_code_and_volume(self):
+        signal = Signal(
+            code="000001.SZ",
+            direction=DIRECTION_TYPES.LONG,
+            volume=1000,
+            reason="golden cross",
+        )
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
+
+        fake_service = MagicMock()
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1", "user-2"],
+        ):
+            result = notify_trading_signal(signal, order, async_mode=False)
+
+        assert result is True
+        # 每个收件人都收到一条通知
+        assert fake_service.send_to_user.call_count == 2
+        recipients = [c.kwargs["user_uuid"] for c in fake_service.send_to_user.call_args_list]
+        assert set(recipients) == {"user-1", "user-2"}
+        # 内容携带信号关键事实：代码 + 数量（对实现格式不敏感）
+        for call in fake_service.send_to_user.call_args_list:
+            content = call.kwargs["content"]
+            assert "000001.SZ" in content, "通知内容必须含股票代码"
+            assert "1000" in content, "通知内容必须含数量"
+
+    def test_sync_no_recipients_returns_false(self):
+        """无收件人时优雅降级，不抛异常。"""
+        signal = Signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG)
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=100)
+
+        fake_service = MagicMock()
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=[],
+        ):
+            result = notify_trading_signal(signal, order, async_mode=False)
+
+        assert result is False
+        fake_service.send_to_user.assert_not_called()
+
+
+class TestNotifyTradingSignalAsync:
+    """异步模式：走 Kafka（send_async）→ worker 订阅，镜像 notify() 的异步路径。"""
+
+    def test_async_routes_via_send_async_not_send_to_user(self):
+        signal = Signal(
+            code="000001.SZ",
+            direction=DIRECTION_TYPES.LONG,
+            volume=1000,
+            reason="golden cross",
+        )
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
+
+        fake_service = MagicMock()
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1"],
+        ):
+            result = notify_trading_signal(signal, order, async_mode=True)
+
+        assert result is True
+        # 异步路径走 send_async（Kafka→worker），不走同步 send_to_user
+        fake_service.send_async.assert_called_once()
+        fake_service.send_to_user.assert_not_called()
+        call = fake_service.send_async.call_args
+        assert call.kwargs["user_uuid"] == "user-1"
+        assert "000001.SZ" in call.kwargs["content"]
+        assert "1000" in call.kwargs["content"]

--- a/tests/unit/trading/portfolios/test_portfolio_live.py
+++ b/tests/unit/trading/portfolios/test_portfolio_live.py
@@ -157,3 +157,52 @@ class TestNoPositionWriter:
         )
         # Should not raise
         p._sync_status_to_redis(PORTFOLIO_RUNSTATE_TYPES.RUNNING)
+
+
+class TestSignalTriggersNotification:
+    """#6150: 信号→消息通知链路（半手动实盘核心）。
+
+    处理一个产出订单的信号时，必须触发交易信号通知，让用户收到
+    code/direction/volume/reason 并手动执行后回报。
+    """
+
+    def _wire_minimal(self, portfolio, order):
+        """让 is_all_set() 通过，并让 sizer 产出给定订单。
+
+        直接赋 _sizer 绕开 bind_sizer 的 isinstance 守卫——sizer 类型校验
+        是 bind_sizer 的职责，不是 _process_signal 的（测行为不测胶水）。
+        """
+        sizer = MagicMock()
+        sizer.cal.return_value = order
+        portfolio._sizer = sizer
+        portfolio._selectors = [MagicMock()]  # is_all_set 要求 selectors 非空
+        portfolio.add_strategy(MagicMock())  # is_all_set 要求 strategies 非空
+        # risk_managers 为空：is_all_set 仅 WARN，放行
+
+    def test_long_signal_fires_trading_signal_notification(self, portfolio):
+        """一个产出订单的 LONG 信号，必须触发 notify_trading_signal。"""
+        from ginkgo.entities import Order, Signal
+        from ginkgo.enums import DIRECTION_TYPES
+
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
+        self._wire_minimal(portfolio, order)
+
+        signal = Signal(
+            code="000001.SZ",
+            direction=DIRECTION_TYPES.LONG,
+            volume=1000,
+            reason="golden cross",
+        )
+
+        with patch(
+            "ginkgo.trading.portfolios.portfolio_live.notify_trading_signal",
+            create=True,
+        ) as mock_notify:
+            portfolio._process_signal(signal)
+
+        mock_notify.assert_called_once()
+        args, kwargs = mock_notify.call_args
+        passed = list(args) + list(kwargs.values())
+        # 信号对象与产出的订单必须传给通知器（深模块接口：传对象，内部抽取字段）
+        assert signal in passed, "信号对象必须传给 notify_trading_signal"
+        assert order in passed, "产出的订单必须传给 notify_trading_signal"


### PR DESCRIPTION
## Summary
#6150 半手动实盘核心链路：Ginkgo 产出 Signal 时自动发通知（code/direction/volume/reason），用户手动执行后回报实际成交，Ginkgo 记录并对账（偏差只算+记录，不回写仓位）。

- **notify_trading_signal**（notifier/core/notify.py）：镜像 `notify()`，收件人从 `notification_recipient` 配置表解析，支持同步直发（send_to_user）与异步 Kafka→worker（send_async）双模。
- **portfolio_live._process_signal**：信号产出订单后触发通知，非致命（异常仅记日志）。
- **POST /api/v1/signals/{signal_id}/report**（api/api/signals.py）：回报端点，转发 `signal_tracking_service.set_confirmed`，偏差 `_compute_deviation`（expected−actual）记日志不回写。文件命名 `signals.py` 避开 stdlib `signal` 模块遮蔽。

## Test plan
- `tests/unit/notifiers/test_notify_trading_signal.py`（3）：同步收件人/内容、无收件人降级、异步走 Kafka
- `tests/unit/trading/portfolios/test_portfolio_live.py::TestSignalTriggersNotification`（1）：LONG 信号触发 notify_trading_signal
- `tests/api/test_signal_report.py`（4）：端点转发 set_confirmed、404、偏差计算
- 冒烟：app 构建（cwd=api/）+ `/signals/{id}/report` 路由注册成功（捕获 stdlib 冲突）
- 注：api 与 unit 测试因既有 `core` 命名空间冲突需分目录隔离跑（既有 paper_trading 测试同此约束）

Closes #6150
