### PR TITLE
fix: Data sync 单数 code 归一化 + 明确 codes 格式提示 (#5784)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -3,7 +3,7 @@
 """
 
 from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 import time as _time
@@ -84,11 +84,23 @@ class DataStats(BaseModel):
 
 
 class DataUpdateRequest(BaseModel):
-    """数据更新请求"""
+    """数据更新请求
+
+    #5784: 同时接受单数 code (str) 与复数 codes (list)。
+    单数 code 归一化为 codes=[code]，三种 sync 分支统一消费 codes。
+    """
     type: str  # stockinfo, bars, ticks, adjustfactor
+    code: Optional[str] = None
     codes: Optional[List[str]] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _normalize_code_to_codes(self) -> "DataUpdateRequest":
+        """单数 code 归一化进 codes（仅当 codes 未提供时填充，不覆盖显式传入的 codes）"""
+        if self.code and not self.codes:
+            self.codes = [self.code]
+        return self
 
 
 class DataSource(BaseModel):
@@ -577,7 +589,7 @@ async def sync_data(request: DataUpdateRequest):
         elif request.type == "bars":
             codes = request.codes or []
             if not codes:
-                raise HTTPException(status_code=400, detail="Codes are required for bars update")
+                raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for bars update")
 
             bar_service = get_bar_service()
             for code in codes:
@@ -599,7 +611,7 @@ async def sync_data(request: DataUpdateRequest):
         elif request.type == "ticks":
             codes = request.codes or []
             if not codes:
-                raise HTTPException(status_code=400, detail="Codes are required for ticks update")
+                raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for ticks update")
 
             tick_service = get_tick_service()
             start_dt = datetime.fromisoformat(request.start_date) if request.start_date else None
@@ -626,7 +638,7 @@ async def sync_data(request: DataUpdateRequest):
             sync_type = "adjustfactor"
             codes = request.codes or []
             if not codes:
-                raise HTTPException(status_code=400, detail="Codes are required for adjust factors update")
+                raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for adjust factors update")
 
             adjustfactor_service = get_adjustfactor_service()
             # 批量同步复权因子，整体记录

--- a/tests/api/test_data_sync_codes_field.py
+++ b/tests/api/test_data_sync_codes_field.py
@@ -1,0 +1,108 @@
+# Upstream: api.api.data.sync_data (POST /api/v1/data/sync)
+# Downstream: BarService.sync_smart, DataSyncRecordService
+# Role: 验证 DataUpdateRequest 单数 code 字段归一化 + 明确错误提示 (#5784)
+"""
+sync_data 单数 code 字段归一化测试
+
+#5784: 客户端发 {"type":"bars","code":"000001.SZ"}（单数字符串）报
+'Codes are required'，因为 DataUpdateRequest 只认复数 codes(list)。
+pydantic 默认 ignore extra，单数 code 被静默丢弃 → codes=None。
+本测试锁定：单数 code 应归一化为 codes=[code] 并路由成功。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi import HTTPException
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_ok_result():
+    """构造一个 is_success 的 ServiceResult 替身"""
+    r = MagicMock()
+    r.is_success.return_value = True
+    r.success = True
+    r.message = "ok"
+    r.data = None
+    r.metadata = {}
+    return r
+
+
+def make_sync_record_mock():
+    """构造 DataSyncRecordService + record_start 返回值的替身"""
+    svc = MagicMock()
+    rec = MagicMock()
+    rec.is_success.return_value = True
+    rec.data = {"uuid": "rec-uuid-1"}
+    svc.record_start.return_value = rec
+    return svc
+
+
+class TestSyncDataCodeField:
+    """#5784: 单数 code 字段归一化"""
+
+    @pytest.mark.unit
+    def test_singular_code_normalized_to_codes_list(self):
+        """单数 code (string) 应被接受并归一化为 codes=[code]，路由到 bars 分支
+
+        RED: 当前 DataUpdateRequest 无 code 字段，pydantic ignore extra →
+        codes=None → HTTPException(400, 'Codes are required for bars update')。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_smart.return_value = make_ok_result()
+
+        request = DataUpdateRequest(type="bars", code="000001.SZ")
+
+        with patch("api.data.get_bar_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            try:
+                run_async(sync_data(request))
+            except HTTPException as e:
+                pytest.fail(f"单数 code 应归一化后路由成功，却抛 HTTPException: {e.detail}")
+
+        mock_svc.sync_smart.assert_called_once_with("000001.SZ")
+
+    @pytest.mark.unit
+    def test_missing_codes_error_message_names_field_and_format(self):
+        """codes 与 code 都缺时，错误提示应明确字段名与格式
+
+        RED: 当前提示 'Codes are required for bars update' 不含格式说明(list)。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        request = DataUpdateRequest(type="bars")  # 既无 code 也无 codes
+
+        with patch("api.data.get_bar_service"), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            with pytest.raises(HTTPException) as exc:
+                run_async(sync_data(request))
+
+        assert exc.value.status_code == 400
+        detail = str(exc.value.detail).lower()
+        assert "codes" in detail          # 明确字段名
+        assert "list" in detail           # 明确格式
+
+    @pytest.mark.unit
+    def test_singular_code_works_across_ticks_branch(self):
+        """单数 code 归一化在 ticks 分支同样生效（validator 在 model 层，全分支受益）"""
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_smart.return_value = make_ok_result()
+
+        request = DataUpdateRequest(type="ticks", code="000001.SZ")
+
+        with patch("api.data.get_tick_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            try:
+                run_async(sync_data(request))
+            except HTTPException as e:
+                pytest.fail(f"ticks 分支单数 code 应路由成功，却抛 HTTPException: {e.detail}")
+
+        mock_svc.sync_smart.assert_called_once_with("000001.SZ", start_date=None, end_date=None)

--- a/tests/unit/data/services/test_bar_service_mock.py
+++ b/tests/unit/data/services/test_bar_service_mock.py
@@ -273,3 +273,71 @@ class TestBarServiceSyncRange:
 
         assert result.success is True
         assert "No new data available" in result.message
+
+    @pytest.mark.unit
+    def test_sync_range_normal_path_records_processed_gt_zero(self, service, mock_deps):
+        """#5584: 正常同步路径 records_processed 应 = raw_data 行数 > 0（证伪"恒 0"）
+
+        正常路径(bar_service.py:206-210): 数据源有数据 → 转实体 → 过滤后仍有新数据 →
+        落库，records_processed = len(raw_data)。旧代码此处恒 0，现应正确统计。
+        """
+        mock_deps["stockinfo_service"].exists.return_value = True
+        df = pd.DataFrame({
+            "open": [10.0, 11.0, 12.0],
+            "high": [11.0, 12.0, 13.0],
+            "low": [9.0, 10.0, 11.0],
+            "close": [10.5, 11.5, 12.5],
+        })
+        mock_deps["data_source"].fetch_cn_stock_daybar.return_value = df
+        entities = [MagicMock(timestamp=datetime(2024, 1, 1 + i)) for i in range(3)]
+        mock_deps["crud_repo"].find.return_value = []  # 无已存在记录 → 全部视为新数据
+        mock_deps["crud_repo"].add_batch.return_value = entities
+
+        with patch("ginkgo.data.services.bar_service.datetime_normalize", side_effect=lambda x: x), \
+                patch("ginkgo.data.services.bar_service.mappers") as mock_mappers:
+            mock_mappers.dataframe_to_bar_entities.return_value = entities
+            result = service.sync_range(
+                code="000001.SZ",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 1, 3),
+            )
+
+        assert result.success is True
+        assert result.data.records_processed == 3  # 证伪 #5584 "恒 0"
+
+    @pytest.mark.unit
+    def test_sync_range_idempotent_path_records_processed_gt_zero(self, service, mock_deps):
+        """#5584: 幂等路径(数据已全部存在) records_processed 仍应 = len(raw_data) > 0
+
+        幂等路径(bar_service.py:161-175): _filter_existing_data 返空(全部已存在)，
+        但 records_processed 仍 = len(raw_data)、records_skipped 同步、is_idempotent=True。
+        旧代码此处恒 0，现应正确统计。
+        """
+        mock_deps["stockinfo_service"].exists.return_value = True
+        df = pd.DataFrame({
+            "open": [10.0, 11.0, 12.0],
+            "high": [11.0, 12.0, 13.0],
+            "low": [9.0, 10.0, 11.0],
+            "close": [10.5, 11.5, 12.5],
+        })
+        mock_deps["data_source"].fetch_cn_stock_daybar.return_value = df
+
+        # 3 个实体 + 3 条已存在记录，timestamp 完全一致 → new_models=[] 走幂等分支
+        ts = [datetime(2024, 1, 1 + i) for i in range(3)]
+        entities = [MagicMock(timestamp=ts[i]) for i in range(3)]
+        existing = [MagicMock(timestamp=ts[i]) for i in range(3)]
+        mock_deps["crud_repo"].find.return_value = existing  # 全部已存在
+
+        with patch("ginkgo.data.services.bar_service.datetime_normalize", side_effect=lambda x: x), \
+                patch("ginkgo.data.services.bar_service.mappers") as mock_mappers:
+            mock_mappers.dataframe_to_bar_entities.return_value = entities
+            result = service.sync_range(
+                code="000001.SZ",
+                start_date=datetime(2024, 1, 1),
+                end_date=datetime(2024, 1, 3),
+            )
+
+        assert result.success is True
+        assert result.data.records_processed == 3  # 幂等路径也非 0
+        assert result.data.records_skipped == 3
+        assert result.data.is_idempotent is True


### PR DESCRIPTION
## Summary

修复 #5784: Data sync API 字段命名混淆（code vs codes）。

**根因**: `DataUpdateRequest` 只有 `codes: Optional[List[str]]`，pydantic 默认 `ignore extra`，客户端传单数 `code`(string) 被静默丢弃 → `codes=None` → 报 `"Codes are required"`。

**改动**:
- `DataUpdateRequest` 加 `code: Optional[str]`，`model_validator(mode='after')` 归一化为 `codes=[code]`（仅当 codes 未提供时填充，不覆盖显式传入的 codes）
- bars/ticks/adjustfactor 三处 400 提示统一改为 `codes (list of stock codes) is required for X update`

**附带**: #5584（bars 同步 processed 恒 0）经验证为 **stale issue**，新增单测证伪（正常/幂等路径均返回 `len(raw_data) > 0`），已评论关闭。

## Test plan

- `tests/api/test_data_sync_codes_field.py`（3 tracer bullet：单数归一化 / 提示明确含 list / ticks 跨分支）
- `tests/unit/data/services/test_bar_service_mock.py`（#5584 验证：正常+幂等 records_processed>0）
- 回归 `tests/api/test_data_sync_adjustfactor.py`（validator 不破坏 adjustfactor 路径）

⚠️ 冒烟须**按目录分组跑**：`tests/api/` 与 `tests/unit/` 混跑因既有 sys.path 污染（`core` 包在 `api/core/`，而 `test_bar_service_mock.py` 把项目根 insert 到 sys.path[0]）报 `ModuleNotFoundError: core.logging`，与本次改动无关（import 区未动）。

Closes #5784
