### PR TITLE
fix: 批量修复 API 空响应/500 (#5599 #5610 #5624 #5625 #5601)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -335,8 +335,10 @@ async def get_bars(
             return paginated(items=[], total=0, page=page, page_size=page_size)
 
         # 处理返回的数据
+        # bar_service.get() 返回裸 list[MBar]（无 to_entities）；
+        # ModelList 容器走 to_entities()，裸 list 本身即 entities 列表
         bars_data = result.data
-        bars_list = bars_data.to_entities() if hasattr(bars_data, 'to_entities') else []
+        bars_list = bars_data.to_entities() if hasattr(bars_data, 'to_entities') else bars_data
 
         bar_summaries = []
         for bar in bars_list:
@@ -355,7 +357,9 @@ async def get_bars(
 
         return paginated(
             items=bar_summaries,
-            total=bars_data.count() if hasattr(bars_data, 'count') else len(bar_summaries),
+            # 裸 list 的 .count() 需要参数（#5599/#5610 500 根因）；
+            # 直接用 len(bar_summaries)，total 与返回 items 数一致
+            total=len(bar_summaries),
             page=page,
             page_size=page_size
         )

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -730,27 +730,34 @@ async def list_user_groups():
     try:
         group_service = get_user_group_service()
 
-        result = group_service.list_groups(is_del=False)
+        # user 版本 UserGroupService.list_groups(is_active, limit)，
+        # 返回 ServiceResult.data = {"groups": [...], "count": N}
+        result = group_service.list_groups()
         if not result.success:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to list user groups"
             )
 
-        raw_groups = result.data
-
-        # 批量获取成员数（避免 N+1）
-        member_counts = group_service.count_all_members()
+        groups_payload = result.data or {}
+        raw_groups = groups_payload.get("groups", []) if isinstance(groups_payload, dict) else (groups_payload or [])
 
         group_list = []
         for group_data in raw_groups:
             group_uuid = group_data["uuid"]
+            # 逐组算成员数（user 版本无 count_all_members 批量方法）
+            try:
+                members_result = group_service.get_group_members(group_uuid)
+                members_data = members_result.data or {}
+                user_count = members_data.get("count", 0) if isinstance(members_data, dict) else len(members_data)
+            except Exception:
+                user_count = 0
 
             group_list.append({
                 "uuid": group_uuid,
                 "name": group_data["name"],
-                "description": group_data.get("description", ""),
-                "user_count": member_counts.get(group_uuid, 0),
+                "description": group_data.get("description", "") or "",
+                "user_count": user_count,
                 "permissions": []
             })
 
@@ -773,9 +780,10 @@ async def create_user_group(data: UserGroupCreate):
         group_service = get_user_group_service()
 
         # 检查组名是否已存在
-        existing_result = group_service.list_groups(is_del=False)
+        existing_result = group_service.list_groups()
         if existing_result.success:
-            existing_groups = existing_result.data
+            existing_payload = existing_result.data or {}
+            existing_groups = existing_payload.get("groups", []) if isinstance(existing_payload, dict) else (existing_payload or [])
             for g in existing_groups:
                 if g["name"] == data.name:
                     raise HTTPException(

--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -293,14 +293,16 @@ class Container(containers.DeclarativeContainer):
 
     # Notification management services
     # NotificationRecipientService manages global notification recipients (MySQL)
+    # 声明式 DI：dependency_injector 调用时解析各 provider。
+    # 不能用 lambda 引用同类作用域的 user_group_service/user_service —— Python
+    # 类体非闭包作用域，名字查找失败抛 NameError（#5624 500 根因）。
     notification_recipient_service = providers.Singleton(
-        lambda: NotificationRecipientService(
-            recipient_crud=get_crud("notification_recipient"),
-            user_contact_crud=get_crud("user_contact"),
-            user_group_mapping_crud=get_crud("user_group_mapping"),
-            user_group_service=user_group_service(),
-            user_service=user_service(),
-        )
+        NotificationRecipientService,
+        recipient_crud=notification_recipient_crud,
+        user_contact_crud=user_contact_crud,
+        user_group_mapping_crud=user_group_mapping_crud,
+        user_group_service=user_group_service,
+        user_service=user_service,
     )
 
     # Encryption service for API credentials

--- a/tests/api/test_data_bars_500_fix.py
+++ b/tests/api/test_data_bars_500_fix.py
@@ -1,0 +1,100 @@
+# Issue: #5599 / #5610 — GET /api/v1/data/bars 返回 500 (list.count() 无参 + 数据丢失)
+# Upstream: api.api.data.get_bars
+# Downstream: BarService.get() — result.data 在真实环境为裸 list[MBar]（无 to_entities）
+# Role: 验证 get_bars 在 result.data 为裸 list 时既不抛 TypeError，也不丢数据
+
+"""
+data/bars 500 修复测试
+
+真实场景：bar_service.get().data 返回裸 list[MBar]（无 to_entities 方法）。
+
+根因（双 bug）：
+1. data.py:339 `else []` — 裸 list 无 to_entities → bars_list=[] 数据全部丢失
+2. data.py:358 `bars_data.count()` — list 有 count 方法但需参数，hasattr 判断恒 True
+   对裸 list 无参调用抛 TypeError → except 捕获 → HTTPException(500)
+
+修复：339 行裸 list 本身即 entities（`else bars_data`）；358 行 total 取 len(bar_summaries)。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(data=None, success=True):
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.data = data
+    return result
+
+
+def make_bar(uuid="b1", code="000001.SZ"):
+    """模拟真实 MBar（有 uuid/code/timestamp/open 等，无 to_entities）"""
+    bar = MagicMock()
+    bar.uuid = uuid
+    bar.code = code
+    bar.timestamp = datetime(2025, 1, 1)
+    bar.open = 1.0
+    bar.high = 2.0
+    bar.low = 0.5
+    bar.close = 1.5
+    bar.volume = 100.0
+    bar.amount = 200.0
+    # 真实 MBar 无 to_entities（关键：触发裸 list 分支）
+    del bar.to_entities
+    return bar
+
+
+class TestGetBarsBareListFix:
+    """#5599 #5610: get_bars 处理裸 list[MBar] 不崩溃、不丢数据"""
+
+    def test_bare_list_does_not_raise_500(self):
+        """TDD Red: result.data 为裸 list[MBar]（非空、无 to_entities）时不抛 500"""
+        mock_service = MagicMock()
+        # 真实环境 bar_service.get().data 是裸 list（非空，无 to_entities）
+        mock_service.get.return_value = make_mock_result(data=[make_bar()])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            # 修复前：line 339 bars_list=[] → line 358 [bar].count() TypeError → 500
+            result = run_async(get_bars())
+
+        assert result.get("code") == 0
+
+    def test_bare_list_does_not_lose_data(self):
+        """TDD Red: 裸 list 的 bars 必须完整出现在返回 items 中（修复 line 339 丢数据）"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(
+            data=[make_bar("b1", "000001.SZ"), make_bar("b2", "000002.SZ")]
+        )
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            result = run_async(get_bars())
+
+        # 修复前：line 339 bars_list=[] → items=[]（数据丢失）
+        assert result.get("code") == 0
+        assert len(result["data"]) == 2
+        assert result["data"][0]["code"] == "000001.SZ"
+
+    def test_total_matches_items_for_bare_list(self):
+        """TDD Red: total 应等于 len(bar_summaries)，不调用 list.count()"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(
+            data=[make_bar("b1"), make_bar("b2")]
+        )
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            result = run_async(get_bars())
+
+        assert result.get("code") == 0
+        assert result["meta"]["total"] == 2

--- a/tests/api/test_user_groups_endpoint.py
+++ b/tests/api/test_user_groups_endpoint.py
@@ -1,0 +1,79 @@
+# Issue: #5625 — GET /api/v1/user-groups 空响应/500；#5601 — POST 创建空响应
+# Upstream: api.api.settings.list_user_groups / create_user_group
+# Downstream: ginkgo.user.services.user_group_service.UserGroupService（user 版本）
+# Role: 验证 user-groups 端点适配 user 版本 UserGroupService 的方法签名与返回结构
+
+"""
+user-groups 端点适配测试
+
+根因（端点按 data 版本 UserGroupService 写，但容器注入的是 user 版本）：
+1. list_groups(is_del=False) → user 版本签名 list_groups(is_active, limit)，无 is_del 参数 → TypeError
+2. result.data 当 list 迭代 → user 版本返回 {groups, count} dict，迭代 dict keys → str 索引 TypeError
+3. count_all_members() → user 版本无此方法 → AttributeError
+
+适配 user 版本：list_groups() 取 data["groups"]，user_count 逐组 get_group_members() 取 count。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_group(uuid="g1", name="admins", description="d", is_active=True):
+    return {"uuid": uuid, "name": name, "description": description, "is_active": is_active}
+
+
+class TestUserGroupsEndpoint:
+    """#5625 #5601: user-groups 端点适配 user 版本 UserGroupService"""
+
+    def test_list_returns_groups(self):
+        """TDD Red: GET /user-groups 返回实际组列表（不抛 TypeError / 不空）"""
+        mock_svc = MagicMock()
+        mock_svc.list_groups.return_value = ServiceResult.success(
+            data={"groups": [make_group("g1", "admins")], "count": 1}
+        )
+        mock_svc.get_group_members.return_value = ServiceResult.success(
+            data={"members": [{}, {}], "count": 2}
+        )
+
+        from api.settings import list_user_groups
+
+        with patch("api.settings.get_user_group_service", return_value=mock_svc):
+            result = run_async(list_user_groups())
+
+        # 修复前：list_groups(is_del=False) TypeError → HTTPException 500
+        assert result.get("code") == 0
+        assert len(result["data"]) == 1
+        assert result["data"][0]["name"] == "admins"
+        assert result["data"][0]["user_count"] == 2
+
+    def test_create_returns_created_group(self):
+        """TDD Red: POST /user-groups 返回创建的组（不抛 TypeError / 不空）"""
+        mock_svc = MagicMock()
+        mock_svc.list_groups.return_value = ServiceResult.success(
+            data={"groups": [], "count": 0}  # 无重名
+        )
+        mock_svc.create_group.return_value = ServiceResult.success(
+            data={"uuid": "g-new", "name": "test-group"}
+        )
+
+        from api.settings import create_user_group
+
+        # UserGroupCreate schema 字段：用 MagicMock 满足属性访问
+        payload = MagicMock()
+        payload.name = "test-group"
+        payload.description = "desc"
+        payload.permissions = []
+
+        with patch("api.settings.get_user_group_service", return_value=mock_svc):
+            result = run_async(create_user_group(payload))
+
+        # 修复前：list_groups(is_del=False) TypeError → HTTPException 500
+        assert result.get("code") == 0
+        assert result["data"]["uuid"] == "g-new"

--- a/tests/unit/data/test_containers_recipient_di.py
+++ b/tests/unit/data/test_containers_recipient_di.py
@@ -1,0 +1,44 @@
+# Issue: #5624 — GET/POST notification recipients 500 (容器 lambda NameError)
+# Upstream: ginkgo.data.containers.Container.notification_recipient_service
+# Downstream: api.api.settings.get_notification_recipient_service → API 端点
+# Role: 验证容器能解析 NotificationRecipientService，不抛 NameError
+
+"""
+notification_recipient_service 容器解析测试
+
+根因：containers.py 原用 lambda 封装 NotificationRecipientService 实例化，
+lambda 内引用同类作用域的 user_group_service / user_service —— 但 Python
+类体不是闭包作用域，名字查找走模块全局找不到 → NameError。
+（lambda lazy 执行，容器 import 不报错，首次取服务才崩 → 端点 500）
+
+修复：改用声明式 DI（providers.Singleton(Service, dep=provider)），
+由 dependency_injector 在调用时解析 provider，与其他 service 一致。
+"""
+
+import pytest
+
+
+class TestNotificationRecipientContainerDI:
+    """#5624: notification_recipient_service 容器解析不抛 NameError"""
+
+    def test_container_resolves_recipient_service(self):
+        """TDD Red: 容器应能解析 NotificationRecipientService，不抛 NameError"""
+        from ginkgo.data.containers import container
+        from ginkgo.notifier.services.notification_recipient_service import (
+            NotificationRecipientService,
+        )
+
+        # 修复前：lambda 引用类作用域名 → NameError
+        svc = container.notification_recipient_service()
+
+        assert isinstance(svc, NotificationRecipientService)
+
+    def test_recipient_service_has_injected_dependencies(self):
+        """TDD Red: 声明式 DI 应注入 user_group_service / user_service"""
+        from ginkgo.data.containers import container
+
+        svc = container.notification_recipient_service()
+
+        # NotificationRecipientService.__init__ 注入这些依赖
+        assert svc.user_group_service is not None
+        assert svc.user_service is not None


### PR DESCRIPTION
## Summary

批量修复 5 个 API 空响应/500 issue，归并为三个独立根因（端点与 service 版本/返回结构不匹配）。

### 根因 A — data/bars 裸 list（#5599 #5610）
`bar_service.get().data` 真实返回裸 `list[MBar]`（无 `to_entities`），原代码两处 bug：
- `else []` → 裸 list 无 `to_entities`，`bars_list=[]` 数据全部丢失
- `bars_data.count()` → `list.count()` 需参数，`hasattr` 判断恒 True，无参调用抛 `TypeError` → 500

修复：裸 list 本身即 entities（`else bars_data`）；`total` 取 `len(bar_summaries)`。

### 根因 B — recipients 容器 lambda NameError（#5624）
容器用 lambda 封装 `NotificationRecipientService` 实例化，lambda 内引用同类作用域的 `user_group_service`/`user_service`——Python 类体非闭包作用域，名字查找走模块全局失败抛 `NameError`。lambda lazy 执行，容器 import 不报错，API 端点首次取 recipient 服务才崩 → 500。

修复：改声明式 DI（`providers.Singleton(Service, dep=provider)`），由 dependency_injector 调用时解析，与容器内其他 service 写法一致。

### 根因 C — user-groups 端点版本错配（#5625 #5601）
端点按 data 版本 UserGroupService 写，但容器注入的是 user 版本，三处不匹配：
- `list_groups(is_del=False)` → user 版本签名 `list_groups(is_active, limit)` 无 `is_del` → `TypeError`
- `result.data` 当 list 迭代 → user 版本返回 `{groups, count}` dict，迭代 keys → str 索引 `TypeError`
- `count_all_members()` → user 版本无此方法 → `AttributeError`

适配：`list_groups()` 取 `data['groups']`；`user_count` 逐组 `get_group_members()` 取 count。

## Test plan
- [x] `tests/api/test_data_bars_500_fix.py`（3）— 裸 list 不崩 + 不丢数据 + total 正确
- [x] `tests/unit/data/test_containers_recipient_di.py`（2）— 容器解析不抛 + 依赖注入
- [x] `tests/api/test_user_groups_endpoint.py`（2）— GET 返回组列表 + POST 返回创建组
- [x] 同模块 `tests/api/test_data_pagination.py` 单独跑无回归

逐文件单独跑全绿（`tests/api/` 混跑有已知跨测试状态污染，非本次引入）。

Closes #5599
Closes #5610
Closes #5624
Closes #5625
Closes #5601
