### PR TITLE
fix: 线程管理自杀脚枪 + 移除 run_live 死桩 (#5516 #6118 #5573)

### DIFF
--- a/src/ginkgo/libs/core/threading.py
+++ b/src/ginkgo/libs/core/threading.py
@@ -1,6 +1,6 @@
 # Upstream: 全局所有模块 (通过GTM单例管理线程/Worker)、CLI命令(ginkgo worker)
 # Downstream: GCONF(配置), GLOG(日志), GinkgoLogger, retry(装饰器), psutil, rich, redis_service/kafka_service(延迟加载)
-# Role: GinkgoThreadManager线程/进程管理器，支持Kafka数据Worker管理、WatchDog守护、MainControl主控和LiveEngine生命周期管理
+# Role: GinkgoThreadManager线程/进程管理器，支持Kafka数据Worker管理、WatchDog守护、MainControl主控（run_live/stop_live 远控总线已退役，实盘启动改走 livecore/main.py）
 
 
 
@@ -603,55 +603,20 @@ if __name__ == "__main__":
             return status
         return "NOT EXIST"
 
-    def process_main_control_command(self, value: str) -> None:
-        # TODO: live engine lifecycle management
+    def process_main_control_command(self, value: Dict) -> None:
         control_logger.INFO(f"Deal with main control. {value}")
-        if value["type"] == "run_live":
-            id = value["id"]
-            control_logger.INFO(f"Run live engine for {id}.")
-            self.run_live_daemon(id)
-        elif value["type"] == "stop_live":
-            id = value["id"]
-            console.print(f"Stop live engine {id}.")
-            # TODO: implement live engine stop via process signal
+        cmd_type = value.get("type") if isinstance(value, dict) else None
+        if cmd_type in ("run_live", "stop_live"):
+            # #6118/#5573: Kafka 驱动的 live engine 远控总线已被 livecore/main.py
+            # （config + enable_live_engine + get_live_engine 单例）取代，此处不再启动。
+            # 此前 run_live/run_live_daemon 引用不存在的 trading.engines.live_engine 模块
+            # 并把 id 插值进生成脚本（注入风险）；现统一记退役日志。
+            control_logger.WARN(
+                f"Live engine launch via main-control ({cmd_type}) is retired; "
+                "use livecore/main.py (enable_live_engine) to start a live engine."
+            )
         else:
-            control_logger.WARN(f"Can not process {type}.")
-
-    def run_live(self, id: str, *args, **kwargs):
-        # TODO
-        console.print(f"Try run live engine {id}")
-        from ginkgo.trading.engines.live_engine import LiveEngine
-
-        e = LiveEngine(id)
-        e.start()
-
-    def run_live_daemon(self, id: str, *args, **kwargs):
-        # TODO: live engine daemon management
-        content = f"""
-from ginkgo.trading.engines.live_engine import LiveEngine
-
-
-if __name__ == "__main__":
-    e = LiveEngine("{id}")
-    e.start()
-"""
-        with tempfile.NamedTemporaryFile("w", delete=False, prefix="ginkgo_live_", suffix=".py") as file:
-            file.write(content)
-            file_name = file.name
-        try:
-            work_dir = GCONF.WORKING_PATH
-            log_dir = GCONF.LOGGING_PATH
-            with open(file_name, "w") as file:
-                file.write(content)
-            command = ["nohup", f"{GCONF.PYTHONPATH}", "-u", f"{file_name}", ">/dev/null", "2>&1", "&"]
-            subprocess.run(command)
-            console.print(f":sun_with_face: Live {id} is [steel_blue1]RUNNING[/steel_blue1] now.")
-            time.sleep(1)
-        except Exception as e:
-            GLOG.ERROR(f"Error running live engine: {e}")
-        finally:
-            if os.path.exists(file_name):
-                os.remove(file_name)
+            control_logger.WARN(f"Can not process {cmd_type}.")
 
     def handle_sigint(self, signum, frame):
         # 自定义 Ctrl+C 行为

--- a/src/ginkgo/libs/core/threading.py
+++ b/src/ginkgo/libs/core/threading.py
@@ -65,6 +65,10 @@ class GinkgoThreadManager:
         # 通知回调（由业务层注入，如 beep 提示音）
         self._on_task_complete = on_task_complete
         self._on_task_error = on_task_error
+
+        # #5516: in-memory 线程句柄注册表。Redis 缓存存线程 ident（非宿主 pid），
+        # 但 ident 跨进程无法查存活，故本地保留 Thread 句柄供 get_thread_status/kill_thread 使用。
+        self._threads: Dict[str, threading.Thread] = {}
     
     @property
     def redis_service(self):
@@ -525,54 +529,43 @@ if __name__ == "__main__":
         return r
 
     def add_thread(self, name: str, target: threading.Thread) -> None:
-        # TODO
-        # TODO
         key = self.get_thread_cache_name(name)
         # 检查线程是否已存在
         if self.redis_service.exists(key):
             console.print(f"{name} exists. Please change the name and try it again.")
             return
-        pid = os.getpid()
         t = threading.Thread(target=target, name=name)
-        self.redis_service.set_thread_cache(key, str(pid))
-        self.redis_service.add_to_thread_list(self.thread_pool_name, key)
         t.start()
+        # #5516: 缓存线程 ident（非宿主 pid）并保留 in-memory 句柄。
+        # 此前存 os.getpid() 会让 kill_thread SIGKILL 宿主进程（自杀），
+        # 且同进程多线程 pid 相同无法区分。
+        self._threads[name] = t
+        self.redis_service.set_thread_cache(key, str(t.ident))
+        self.redis_service.add_to_thread_list(self.thread_pool_name, key)
 
     def get_thread_status(self, name: str) -> bool:
-        # TODO
+        # #5516: 优先用 in-memory Thread 句柄判断真实存活（is_alive），
+        # 而非用 psutil 查宿主进程（对 in-process 线程恒为 True，无法反映线程实际状态）。
         key = self.get_thread_cache_name(name)
-        value = self.redis_service.get_thread_from_cache(key)
-        if not value:
-            return False
-        try:
-            pid = int(value)
-            proc = psutil.Process(pid)
-            return proc.is_running()
-        except psutil.NoSuchProcess:
+        t = self._threads.get(name)
+        if t is not None:
+            return t.is_alive()
+        # 无句柄（跨进程 GTM 实例 / 历史残留）：清理缓存并视为不存活
+        if self.redis_service.exists(key):
             self.redis_service.delete_cache(key)
-            console.print(f"No such process, remove {key} from REDIS.")
-            return False
-        except (ValueError, TypeError):
-            return False
+            self.redis_service.remove_from_thread_list(self.thread_pool_name, key)
+        return False
 
     def kill_thread(self, name: str) -> None:
-        # TODO
+        # #5516: Python 无法从外部安全强杀 threading.Thread（无 thread.kill()）。
+        # 此前缓存 os.getpid() 后 os.kill(host_pid, SIGKILL) 会杀掉整个宿主进程
+        # （自杀脚枪）。现仅清理注册（缓存 + 线程列表 + in-memory 句柄），
+        # 目标线程需自行协作式停止。
         key = self.get_thread_cache_name(name)
-        if self.redis_service.exists(key):
-            value = self.redis_service.get_thread_from_cache(key)
-            if value:
-                try:
-                    pid = int(value)
-                    proc = psutil.Process(pid)
-                    if proc.is_running():
-                        os.kill(pid, signal.SIGKILL)
-                    self.redis_service.delete_cache(key)
-                    self.redis_service.remove_from_thread_list(self.thread_pool_name, key)
-                    console.print(f"Kill thread:{key} pid: {pid}")
-                except Exception as e:
-                    self.redis_service.delete_cache(key)
-                    self.redis_service.remove_from_thread_list(self.thread_pool_name, key)
-                    console.print(f"Remove {name} from REDIS.")
+        self._threads.pop(name, None)
+        self.redis_service.delete_cache(key)
+        self.redis_service.remove_from_thread_list(self.thread_pool_name, key)
+        console.print(f"Unregistered thread:{key} (in-process threads cannot be hard-killed; cooperative stop required).")
 
     def restart_thread(self, name: str, target) -> None:
         self.kill_thread(name)

--- a/tests/unit/libs/core/test_threading_live_control_retired.py
+++ b/tests/unit/libs/core/test_threading_live_control_retired.py
@@ -1,0 +1,90 @@
+"""
+Tests for the retired Kafka live-engine launch path (#6118 / #5573).
+
+#6118/#5573: run_live / run_live_daemon referenced a never-existing module
+       (ginkgo.trading.engines.live_engine) — a perpetually-broken import that
+       failed before #5573's f-string interpolation of an untrusted id could
+       even execute. The Kafka live-launch design was superseded by
+       livecore/main.py (config + enable_live_engine + get_live_engine).
+
+Disposition: delete run_live / run_live_daemon; the run_live / stop_live
+main-control command branches are retired (log a warning pointing at
+livecore/main.py) instead of spawning a subprocess or importing the
+non-existent engine.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_redis():
+    """Create a mock RedisService."""
+    return MagicMock()
+
+
+@pytest.fixture
+def gtm(mock_redis):
+    """Create a GTM instance with injected mock Redis."""
+    from ginkgo.libs.core.threading import GinkgoThreadManager
+    return GinkgoThreadManager(redis_service=mock_redis)
+
+
+# ===========================================================================
+# #6118 / #5573 — run_live / stop_live main-control commands are retired
+# ===========================================================================
+
+class TestRunLiveCommandRetired:
+    """The Kafka live-launch design was superseded by livecore/main.py.
+    run_live/stop_live commands must NOT spawn a subprocess or reference the
+    never-existing ginkgo.trading.engines.live_engine module."""
+
+    def test_run_live_command_does_not_spawn_subprocess(self, gtm, mock_redis):
+        with patch("ginkgo.libs.core.threading.subprocess.run") as mock_run, \
+             patch("ginkgo.libs.core.threading.subprocess.Popen") as mock_popen:
+            gtm.process_main_control_command({"type": "run_live", "id": "anything"})
+        mock_run.assert_not_called()
+        mock_popen.assert_not_called()
+
+    def test_stop_live_command_does_not_spawn_subprocess(self, gtm, mock_redis):
+        with patch("ginkgo.libs.core.threading.subprocess.run") as mock_run, \
+             patch("ginkgo.libs.core.threading.subprocess.Popen") as mock_popen:
+            gtm.process_main_control_command({"type": "stop_live", "id": "anything"})
+        mock_run.assert_not_called()
+        mock_popen.assert_not_called()
+
+
+# ===========================================================================
+# #6118 / #5573 — dead stubs fully removed (refactor guard)
+# ===========================================================================
+
+class TestDeadLiveEngineStubsRemoved:
+    """The broken run_live/run_live_daemon stubs and the never-existing
+    trading.engines.live_engine import must be fully removed from the module."""
+
+    def test_no_dead_live_engine_import_in_source(self):
+        import inspect
+        import ginkgo.libs.core.threading as mod
+
+        src = inspect.getsource(mod)
+        # The never-existing import must not be EXECUTED and LiveEngine must not be
+        # instantiated anywhere in code. (Comments may legitimately reference the
+        # retired path to explain history, so only check non-comment lines.)
+        code_lines = [
+            ln for ln in src.splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        code = "\n".join(code_lines)
+        assert "from ginkgo.trading.engines.live_engine" not in code, (
+            "dead import statement still present in code"
+        )
+        assert "LiveEngine(" not in code, "LiveEngine still instantiated in code"
+
+    def test_run_live_daemon_removed(self, gtm):
+        assert not hasattr(gtm, "run_live_daemon"), "run_live_daemon stub still present"
+        assert not hasattr(gtm, "run_live"), "run_live stub still present"

--- a/tests/unit/libs/core/test_threading_scan_and_gdata.py
+++ b/tests/unit/libs/core/test_threading_scan_and_gdata.py
@@ -132,7 +132,8 @@ class TestGetThreadPids:
 # ===========================================================================
 
 class TestGdataRemoval:
-    """process_main_control_command and run_live_daemon must not reference GDATA."""
+    """process_main_control_command must not reference GDATA (run_live_daemon stub
+    was removed in #6118; only the run_live/stop_live command paths remain)."""
 
     def test_run_live_command_no_nameerror(self, gtm, mock_redis):
         """
@@ -159,17 +160,6 @@ class TestGdataRemoval:
 
         try:
             gtm.process_main_control_command(cmd)
-        except NameError as e:
-            pytest.fail(f"NameError raised (GDATA still referenced?): {e}")
-        except Exception:
-            pass
-
-    def test_run_live_daemon_no_nameerror(self, gtm, mock_redis):
-        """
-        run_live_daemon should not raise NameError for GDATA.
-        """
-        try:
-            gtm.run_live_daemon("test-id")
         except NameError as e:
             pytest.fail(f"NameError raised (GDATA still referenced?): {e}")
         except Exception:

--- a/tests/unit/libs/core/test_threading_thread_safety.py
+++ b/tests/unit/libs/core/test_threading_thread_safety.py
@@ -1,0 +1,128 @@
+"""
+Tests for GinkgoThreadManager thread-safety fixes (#5516).
+
+#5516: add_thread previously cached os.getpid() (the host process pid), so
+       kill_thread did os.kill(host_pid, SIGKILL) — killing the entire process
+       (suicide footgun). get_thread_status checked psutil.Process(host_pid)
+       which is always True for an in-process thread (not actual liveness).
+
+The fixes:
+  - add_thread caches the thread ident AND keeps the live Thread handle.
+  - get_thread_status uses Thread.is_alive() on the cached handle.
+  - kill_thread drops os.kill entirely (in-process threads can't be hard-killed).
+"""
+
+import os
+import time
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_redis():
+    """Mock RedisService. Configured per-test (exists/get_thread_from_cache)."""
+    return MagicMock()
+
+
+@pytest.fixture
+def gtm(mock_redis):
+    """GTM with injected mock Redis (no real infra)."""
+    from ginkgo.libs.core.threading import GinkgoThreadManager
+    return GinkgoThreadManager(redis_service=mock_redis)
+
+
+# ===========================================================================
+# #5516 — kill_thread must not signal the host process (tracer bullet)
+# ===========================================================================
+
+class TestKillThreadSafety:
+    """kill_thread must never os.kill the host process pid."""
+
+    def test_kill_thread_does_not_signal_host_pid(self, gtm, mock_redis):
+        """
+        Previously add_thread cached os.getpid() and kill_thread did
+        os.kill(host_pid, SIGKILL) -> killed the entire process (suicide).
+        kill_thread must not signal the host pid at all.
+        """
+        host_pid = os.getpid()
+        # Simulate the buggy cache state: cached value == host pid
+        # (what add_thread used to store before the fix).
+        mock_redis.exists.return_value = True
+        mock_redis.get_thread_from_cache.return_value = str(host_pid)
+
+        with patch("ginkgo.libs.core.threading.os.kill") as mock_kill:
+            gtm.kill_thread("worker-a")
+
+        # in-process threads must NEVER be os.kill'd (especially not the host pid)
+        mock_kill.assert_not_called()
+
+
+# ===========================================================================
+# #5516 — add_thread must cache the thread ident, not the host pid
+# ===========================================================================
+
+class TestAddThreadCachesIdent:
+    """add_thread must register the actual thread (ident + handle), not os.getpid()."""
+
+    def test_add_thread_caches_thread_ident_not_host_pid(self, gtm, mock_redis):
+        """
+        Previously add_thread cached str(os.getpid()) (identical for every thread
+        in the process -> impossible to distinguish workers). Must cache the
+        started thread's ident instead.
+        """
+        host_pid = os.getpid()
+        mock_redis.exists.return_value = False
+
+        started = threading.Event()
+
+        def target():
+            started.set()
+            time.sleep(5)
+
+        gtm.add_thread("worker-b", target)
+        assert started.wait(2), "target thread did not start"
+
+        mock_redis.set_thread_cache.assert_called_once()
+        cached_value = mock_redis.set_thread_cache.call_args.args[1]
+        assert cached_value != str(host_pid), "cached host pid, not thread ident"
+        assert int(cached_value) > 0  # ident must be a positive integer string
+
+
+# ===========================================================================
+# #5516 — get_thread_status must reflect actual thread liveness
+# ===========================================================================
+
+class TestGetThreadStatusLiveness:
+    """get_thread_status must report the thread's real liveness (is_alive),
+    not the host process (always True for an in-process thread)."""
+
+    def test_live_thread_reports_alive(self, gtm, mock_redis):
+        mock_redis.exists.return_value = False
+        keep_alive = threading.Event()
+
+        def target():
+            keep_alive.wait(5)
+
+        gtm.add_thread("worker-c", target)
+        # while the thread is actually running, status must be True
+        assert gtm.get_thread_status("worker-c") is True
+        keep_alive.set()  # release the thread
+
+    def test_finished_thread_reports_not_alive(self, gtm, mock_redis):
+        mock_redis.exists.return_value = False
+        done = threading.Event()
+
+        def target():
+            done.set()
+
+        gtm.add_thread("worker-d", target)
+        assert done.wait(2)
+        time.sleep(0.1)  # let the thread exit
+        # once the thread has finished, status must be False
+        assert gtm.get_thread_status("worker-d") is False


### PR DESCRIPTION
## Summary

批量修复 threading/core 簇（3 个 issue）：线程管理自杀脚枪 (#5516) 与 run_live 死桩移除 (#6118 / #5573)。三者同处 `libs/core/threading.py`，#6118 的破损 import 正好掩蔽了 #5573 的注入点，故一并处理。

### #5516 — `kill_thread` 自杀脚枪（最小安全）
**根因**：`add_thread` 缓存的是 `os.getpid()`（宿主进程 pid，同进程所有线程相同），导致 `kill_thread` 执行 `os.kill(host_pid, SIGKILL)` —— 直接杀掉整个宿主进程（例如 notifier 重启 telebot 时会把 notifier 进程本身干掉）。`get_thread_status` 用 `psutil.Process(host_pid).is_running()` 判断，对 in-process 线程恒为 True，无法反映线程真实存活。
**修复**：
- `add_thread`：改存 `str(thread.ident)` 并在 `self._threads` 保留活 `Thread` 句柄（ident 单独无法跨进程查存活，故需句柄）。
- `get_thread_status`：用 `Thread.is_alive()` 判断真实存活；无句柄（跨进程/历史残留）时清缓存并视为不存活。
- `kill_thread`：完全移除 `os.kill`（Python 无法从外部安全强杀 `threading.Thread`，只能协作式 `threading.Event` 停止），仅清理注册（缓存 + 线程列表 + in-memory 句柄）。

**语义变化（需知晓）**：存活判断从"宿主进程是否存活"（跨进程可见但对 in-process 线程恒 True）改为"该线程在当前进程是否存活"（真实 per-thread，同进程更准确）。Ginkgo 的 GTM 托管线程（数据 worker / watchdog / telebot）均在进程内运行，此粒度正确。

### #6118 / #5573 — 删除 run_live / run_live_daemon 死桩
**根因**：`run_live` / `run_live_daemon` 引用了 `ginkgo.trading.engines.live_engine` —— 一个从未存在过的模块（`git log --all` 无此路径）。该 import 永久破损，在 #5573 的 f-string 注入（把不可信 command id 插进生成的脚本）执行之前就已 ImportError，所以 #6118 的破损 import 实际掩蔽了 #5573 的注入点。Kafka 驱动的实盘启动设计已被 `livecore/main.py`（config + `enable_live_engine` + `get_live_engine()`）取代。
**处置（删除死桩）**：
- 彻底删除 `run_live` / `run_live_daemon`。
- `process_main_control_command`：`run_live` / `stop_live` 分支改为记录退役告警并指向 `livecore/main.py`，不再 import 不存在的引擎、不再 spawn 子进程。顺手修了 `{type}` 内建遮蔽的 f-string 隐患（→ `cmd_type`）。

**后续（不在本 PR 范围）**：`data_preparer.py:365` 有相同的 `trading.engines.live_engine` 破损 import，留作单独 issue。

## Test plan

- `tests/unit/libs/core/test_threading_thread_safety.py`（新增，#5516）：`TestKillThreadSafety` / `TestAddThreadCachesIdent` / `TestGetThreadStatusLiveness`
- `tests/unit/libs/core/test_threading_live_control_retired.py`（新增，#6118/#5573）：`TestRunLiveCommandRetired` / `TestDeadLiveEngineStubsRemoved`
- `tests/unit/libs/core/test_threading_scan_and_gdata.py`：移除已删方法的 `test_run_live_daemon_no_nameerror`，更新 docstring
- 冒烟：`tests/unit/libs/core/` 14 passed；`tests/unit/notifier/` 153 passed（notifier 是 add_thread/kill_thread 唯一生产调用方）；线程相关 5 文件合计 42 passed
- 覆盖率门禁：`threading.py` 由 3 个测试文件覆盖；`py_compile` + PYTHONPATH 锁定导入冒烟通过

Closes #6118
Closes #5573
Closes #5516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
