### PR TITLE
fix: 日志告警漏报与通知内容注入修复 (#5511, #5556)

### DIFF
--- a/src/ginkgo/services/logging/alert_service.py
+++ b/src/ginkgo/services/logging/alert_service.py
@@ -3,6 +3,7 @@
 # Role: 日志告警服务，监控日志错误模式并发送多渠道告警通知
 
 import hashlib
+import html
 import json
 import smtplib
 import time
@@ -364,11 +365,11 @@ class AlertService(BaseService):
                 "msgtype": "markdown",
                 "markdown": {
                     "title": content["title"],
-                    "text": f"## {content['title']}\n\n"
-                            f"**消息**: {content['message']}\n\n"
-                            f"**错误模式**: `{content['pattern']}`\n\n"
-                            f"**规则ID**: {content['rule_id']}\n\n"
-                            f"**时间**: {content['timestamp']}"
+                    "text": f"## {html.escape(content['title'])}\n\n"
+                            f"**消息**: {html.escape(content['message'])}\n\n"
+                            f"**错误模式**: `{html.escape(content['pattern'])}`\n\n"
+                            f"**规则ID**: {html.escape(content['rule_id'])}\n\n"
+                            f"**时间**: {html.escape(content['timestamp'])}"
                 }
             }
 
@@ -412,11 +413,11 @@ class AlertService(BaseService):
             message = {
                 "msgtype": "markdown",
                 "markdown": {
-                    "content": f"## {content['title']}\n"
-                               f"> 消息: {content['message']}\n"
-                               f"> 错误模式: <font color=\"warning\">{content['pattern']}</font>\n"
-                               f"> 规则ID: {content['rule_id']}\n"
-                               f"> 时间: {content['timestamp']}"
+                    "content": f"## {html.escape(content['title'])}\n"
+                               f"> 消息: {html.escape(content['message'])}\n"
+                               f"> 错误模式: <font color=\"warning\">{html.escape(content['pattern'])}</font>\n"
+                               f"> 规则ID: {html.escape(content['rule_id'])}\n"
+                               f"> 时间: {html.escape(content['timestamp'])}"
                 }
             }
 
@@ -466,11 +467,11 @@ class AlertService(BaseService):
             html_body = f"""
             <html>
               <body>
-                <h2>{content['title']}</h2>
-                <p><strong>消息:</strong> {content['message']}</p>
-                <p><strong>错误模式:</strong> <code>{content['pattern']}</code></p>
-                <p><strong>规则ID:</strong> {content['rule_id']}</p>
-                <p><strong>时间:</strong> {content['timestamp']}</p>
+                <h2>{html.escape(content['title'])}</h2>
+                <p><strong>消息:</strong> {html.escape(content['message'])}</p>
+                <p><strong>错误模式:</strong> <code>{html.escape(content['pattern'])}</code></p>
+                <p><strong>规则ID:</strong> {html.escape(content['rule_id'])}</p>
+                <p><strong>时间:</strong> {html.escape(content['timestamp'])}</p>
               </body>
             </html>
             """

--- a/tests/unit/services/test_alert_service_escaping.py
+++ b/tests/unit/services/test_alert_service_escaping.py
@@ -1,0 +1,121 @@
+"""TDD for AlertService notification escaping -- #5556
+
+根因：三个通知渠道（钉钉/企业微信 markdown、邮件 HTML）用 f-string 直接插值
+content['pattern'/'message'/...]，pattern 来自规则匹配的日志关键词，若日志
+含恶意 HTML/JS 则注入。html.escape 在插值点转义。
+
+每个渠道一个 RED：注入恶意 pattern/message → 断言发出的 payload 中已被转义。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    from ginkgo.services.logging.alert_service import AlertService
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="alert_service not importable")
+class TestAlertServiceEscaping:
+    """#5556: 通知内容必须 HTML 转义，防注入"""
+
+    def _make_svc(self):
+        redis = MagicMock()
+        redis.get.return_value = None  # 未抑制，允许发送
+        with patch("ginkgo.services.logging.alert_service.GCONF"):
+            svc = AlertService(redis_client=redis, db_engine=MagicMock())
+        return svc
+
+    def _mock_post(self):
+        """捕获 requests.post 的 json 参数"""
+        captured = {}
+
+        def fake_post(url, json=None, **kw):
+            captured["json"] = json
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.json.return_value = {"errcode": 0}
+            return resp
+
+        return captured, fake_post
+
+    def test_dingtalk_escapes_html_in_pattern(self):
+        """钉钉 markdown：pattern 含 <script> 必须被转义为 &lt;script&gt;。"""
+        svc = self._make_svc()
+        svc._dingtalk_webhook = "http://hook.example.com/dingtalk"
+        captured, fake_post = self._mock_post()
+
+        with patch("ginkgo.services.logging.alert_service.requests.post",
+                   side_effect=fake_post):
+            svc.send_alert(
+                message="normal message",
+                rule_id="r1",
+                pattern="<script>alert(1)</script>",
+                channels=["dingtalk"],
+            )
+
+        text = captured["json"]["markdown"]["text"]
+        assert "<script>" not in text
+        assert "&lt;script&gt;" in text
+
+    def test_wechat_escapes_html_in_pattern(self):
+        """企业微信 markdown：pattern 含 <script> 必须被转义。"""
+        svc = self._make_svc()
+        svc._wechat_webhook = "http://hook.example.com/wechat"
+        captured, fake_post = self._mock_post()
+
+        with patch("ginkgo.services.logging.alert_service.requests.post",
+                   side_effect=fake_post):
+            svc.send_alert(
+                message="normal message",
+                rule_id="r1",
+                pattern="<script>alert(1)</script>",
+                channels=["wechat"],
+            )
+
+        text = captured["json"]["markdown"]["content"]
+        assert "<script>" not in text
+        assert "&lt;script&gt;" in text
+
+    def test_email_escapes_html_in_pattern(self):
+        """邮件 HTML body：pattern 含 <script> 必须被转义。"""
+        svc = self._make_svc()
+        svc._email_smtp_host = "smtp.example.com"
+        svc._email_to = ["a@b.com"]
+        svc._email_from = "f@b.com"
+        svc._email_username = "u"
+        svc._email_password = "p"
+        captured = {}
+
+        class FakeSMTP:
+            def __init__(self, host, port):
+                pass
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def starttls(self):
+                pass
+
+            def login(self, u, p):
+                pass
+
+            def send_message(self, msg):
+                captured["msg"] = msg
+
+        with patch("ginkgo.services.logging.alert_service.smtplib.SMTP", FakeSMTP):
+            svc.send_alert(
+                message="normal message",
+                rule_id="r1",
+                pattern="<script>alert(1)</script>",
+                channels=["email"],
+            )
+
+        html_body = captured["msg"].get_payload()[0].get_payload(decode=True).decode("utf-8")
+        assert "<script>" not in html_body
+        assert "&lt;script&gt;" in html_body


### PR DESCRIPTION
## Summary

修复 `alert_service.py` 相关两个日志告警缺陷（聚类：同文件 alert_service.py）。

### #5511 LogService.search_logs 支持 level/时间窗口过滤
- **根因**：`AlertService._count_error_pattern` 调用 `search_logs(level=, time_start=, time_end=)`，但旧签名只接受 `keyword/log_type/limit/offset`，触发 `TypeError`，被外层 `except Exception` 吞成 `return 0`——错误日志即使超阈值也**永不触发告警（漏报）**，而非 issue 描述的误报。
- **修复**：`search_logs` 新增可选 `level/time_start/time_end` 参数 + WHERE 过滤，复用同文件 `query_backtest_logs` 的 conditions 模式。默认 `None` 向后兼容（logging_cli、既有 smoke 调用不受影响）。

### #5556 通知渠道内容 HTML 转义防注入
- **根因**：钉钉/企业微信 markdown、邮件 HTML body 用 f-string 直接插值 `content['pattern'/...]`，pattern 来自规则匹配的日志关键词，若日志含恶意 HTML/JS 则注入通知内容。
- **修复**：三渠道所有动态值 `html.escape`。

## Test plan
- `test_log_service_filters.py`：参数契约 + level/timestamp 过滤生效（3）
- `test_alert_service_counting.py`：端到端——超阈值触发、低于阈值不触发（2）
- `test_alert_service_escaping.py`：三渠道 `<script>` 注入断言转义（3）
- 全量 `tests/unit/services/`：162 passed 无回归

Closes #5511
Closes #5556
