### PR TITLE
fix(#6223): notify()/notify_with_fields() is_success 改方法调用，修发送失败误报成功

### DIFF
--- a/src/ginkgo/notifier/core/notification_service.py
+++ b/src/ginkgo/notifier/core/notification_service.py
@@ -344,11 +344,11 @@ class NotificationDeliveryService:
 
                 results.append({
                     "user_uuid": user_uuid,
-                    "success": result.is_success,
+                    "success": result.is_success(),
                     "data": result.data
                 })
 
-                if result.is_success:
+                if result.is_success():
                     success_count += 1
 
             GLOG.INFO(f"Batch notification sent: {success_count}/{len(user_uuids)} users")
@@ -485,7 +485,7 @@ class NotificationDeliveryService:
         try:
             result = self.user_service.fuzzy_search(user_input, limit=1)
 
-            if not result.is_success:
+            if not result.is_success():
                 GLOG.ERROR(f"User search failed: {result.message}")
                 return None
 
@@ -513,7 +513,7 @@ class NotificationDeliveryService:
         try:
             result = self.user_group_service.fuzzy_search(group_input, limit=1)
 
-            if not result.is_success:
+            if not result.is_success():
                 GLOG.ERROR(f"Group search failed: {result.message}")
                 return []
 
@@ -798,11 +798,11 @@ class NotificationDeliveryService:
 
                 results.append({
                     "user_uuid": user_uuid,
-                    "success": result.is_success,
+                    "success": result.is_success(),
                     "message_id": result.data.get("message_id") if result.data else None
                 })
 
-                if result.is_success:
+                if result.is_success():
                     success_count += 1
 
             GLOG.INFO(f"Group notification sent: {success_count}/{len(user_uuids)} users in group '{group.name}'")
@@ -880,11 +880,11 @@ class NotificationDeliveryService:
 
                 results.append({
                     "user_uuid": user_uuid,
-                    "success": result.is_success,
+                    "success": result.is_success(),
                     "message_id": result.data.get("message_id") if result.data else None
                 })
 
-                if result.is_success:
+                if result.is_success():
                     success_count += 1
 
             GLOG.INFO(f"Group template notification sent: {success_count}/{len(user_uuids)} users in group '{group.name}'")

--- a/src/ginkgo/notifier/core/notify.py
+++ b/src/ginkgo/notifier/core/notify.py
@@ -153,7 +153,7 @@ def notify(
                     fields=fields if fields else None,
                     footer={"text": f"{module} • {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"}
                 )
-                if result.is_success:
+                if result.is_success():
                     success_count += 1
 
             GLOG.INFO(f"Notification queued for {success_count}/{len(user_uuids)} users: {clean_content}")
@@ -170,7 +170,7 @@ def notify(
                 )
 
                 # 如果发送成功，发送带格式的 Discord 消息
-                if result.is_success:
+                if result.is_success():
                     success_count += 1
 
             # 额外发送格式化的 Discord webhook 消息
@@ -301,7 +301,7 @@ def notify_with_fields(
                             fields=fields,
                             footer={"text": f"{module} • {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"}
                         )
-                        if result.is_success:
+                        if result.is_success():
                             success_count += 1
                         break  # 每个用户只发送一次
 

--- a/src/ginkgo/notifier/workers/notification_worker.py
+++ b/src/ginkgo/notifier/workers/notification_worker.py
@@ -644,7 +644,7 @@ class NotificationWorker:
                         fields=fields,
                         footer={"text": f"{module} • {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"}
                     )
-                    if result.is_success:
+                    if result.is_success():
                         success_count += 1
                     break  # 每个用户只发送一次
 

--- a/tests/unit/notifiers/test_notification_service_is_success_regression.py
+++ b/tests/unit/notifiers/test_notification_service_is_success_regression.py
@@ -1,0 +1,60 @@
+"""
+回归 #6223（扩充）：notification_service.py / notification_worker.py 同款
+result.is_success 属性恒真 bug（#6224 自审发现的系统性 9 处）。
+
+三个 pattern：
+- A: if result.is_success:        （send_to_users / send_to_group / send_template_to_group / worker）
+- B: if not result.is_success:    （_resolve_user_uuid / _resolve_group_uuids）
+- C: "success": result.is_success  （结果 dict 存绑定方法，下游恒真）
+
+每个测试用真实 ServiceResult + 显式失败，逼出 bug（勿靠 MagicMock auto-truthy）。
+"""
+from unittest.mock import MagicMock
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.notifier.core.notification_service import NotificationDeliveryService
+
+
+def _bare_service():
+    """绕过重型 __init__，构造仅带所需属性的服务实例。"""
+    return NotificationDeliveryService.__new__(NotificationDeliveryService)
+
+
+class TestSendToUsersFailurePath:
+    """Pattern A + C：send_to_users 批量发送，self.send 失败时不能计成功，
+    结果 dict 的 "success" 必须是真实 bool 而非绑定方法。"""
+
+    def test_send_failure_yields_zero_count_and_false_bool(self):
+        svc = _bare_service()
+        svc.send = MagicMock(return_value=ServiceResult.error("send failed"))
+
+        result = svc.send_to_users(["user-1"], "content", "webhook")
+
+        assert result.is_success()
+        data = result.data
+        # Pattern A: 失败不能计成功
+        assert data["success_count"] == 0, "send 失败时不能因 is_success 是方法而恒真计成功"
+        # Pattern C: dict 里 "success" 必须是 False（bool），不是绑定方法
+        assert data["results"][0]["success"] is False, (
+            '"success" 必须存真实 bool False，不能存绑定方法对象（下游恒 truthy）'
+        )
+
+
+class TestResolveUserUuidFailurePath:
+    """Pattern B：fuzzy_search 失败（且 data 泄漏用户）时必须返回 None。
+
+    buggy `not result.is_success` = `not <绑定方法>` = not True = False → 跳过校验，
+    继续读 result.data["users"] 返回泄漏的 uuid。固定后 `not result.is_success()`=True → 返回 None。
+    """
+
+    def test_failed_search_with_leaked_data_returns_none(self):
+        svc = _bare_service()
+        svc.user_service = MagicMock()
+        # 失败结果，但 data 里塞了用户（模拟泄漏/脏数据）
+        svc.user_service.fuzzy_search.return_value = ServiceResult.error(
+            "search failed", data={"users": [{"uuid": "LEAKED-UUID"}]}
+        )
+
+        uuid = svc._resolve_user_uuid("ghost-user")
+
+        assert uuid is None, "fuzzy_search 失败时不能因 not is_success(方法) 跳过校验返回泄漏 uuid"

--- a/tests/unit/notifiers/test_notification_worker_is_success_regression.py
+++ b/tests/unit/notifiers/test_notification_worker_is_success_regression.py
@@ -1,0 +1,56 @@
+"""
+回归 #6223（扩充）：notification_worker.py L647 同款
+result.is_success 属性恒真 bug（Pattern A）。
+
+_process_custom_fields_message：send_discord_webhook 失败时必须返回 False。
+buggy `if result.is_success:`（方法对象恒真）→ 计成功 → 返回 True（假成功）。
+用真实 ServiceResult.error（非 MagicMock auto-truthy）逼出 bug。
+"""
+from unittest.mock import MagicMock
+from types import SimpleNamespace
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.notifier.workers.notification_worker import NotificationWorker
+
+
+def _bare_worker():
+    """绕过重型 __init__，构造仅带 notification_service 的 worker。"""
+    w = NotificationWorker.__new__(NotificationWorker)
+    w.notification_service = MagicMock()
+    return w
+
+
+class TestProcessCustomFieldsFailurePath:
+    """Pattern A：Discord webhook 发送失败时不能假成功。"""
+
+    def test_send_discord_webhook_failure_returns_false(self):
+        w = _bare_worker()
+        ns = w.notification_service
+
+        # 组存在、有成员、成员有活跃 WEBHOOK 联系方式
+        ns.user_group_service.get_group_by_name.return_value = SimpleNamespace(
+            success=True, data=MagicMock(uuid="grp-1")
+        )
+        ns.user_group_service.get_group_member_uuids.return_value = SimpleNamespace(
+            success=True, data=["member-1"]
+        )
+        contact = MagicMock()
+        contact.get_contact_type_enum.return_value = SimpleNamespace(name="WEBHOOK")
+        contact.is_active = True
+        contact.address = "http://hook.example"
+        ns.user_service.get_active_contacts.return_value = SimpleNamespace(
+            success=True, data=[contact]
+        )
+        # 发送失败（真实 ServiceResult，is_success() 返回 False）
+        ns.send_discord_webhook.return_value = ServiceResult.error("webhook failed")
+
+        message = {
+            "content": "hello",
+            "fields": [{"name": "x", "value": "y", "inline": True}],
+            "group_name": "System",
+            "module": "System",
+        }
+
+        result = w._process_custom_fields_message(message)
+
+        assert result is False, "send_discord_webhook 失败时不能因 is_success 是方法而恒真报成功"

--- a/tests/unit/notifiers/test_notify_is_success_regression.py
+++ b/tests/unit/notifiers/test_notify_is_success_regression.py
@@ -1,0 +1,94 @@
+"""
+回归 #6223：notify() / notify_with_fields() 的 result.is_success 属性恒真 bug。
+
+ServiceResult.is_success 是方法（base_service.py:135，无 @property）。
+buggy 代码 `if result.is_success:` 取回绑定方法对象（恒 truthy）→ 发送失败也计成功，
+notify/notify_with_fields 返回 True 但实际无人收到。
+
+每个测试用 mock.is_success.return_value=False 强制失败路径，断言返回 False，
+才能逼出 bug（MagicMock 的 is_success 属性默认 auto-truthy 会掩盖）。
+"""
+from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+
+from ginkgo.notifier.core.notify import notify, notify_with_fields
+
+
+class TestNotifySyncFailurePath:
+    """notify() 同步路径：send_to_user 失败时必须返回 False。"""
+
+    def test_sync_send_to_user_failure_returns_false(self):
+        fail_result = MagicMock()
+        fail_result.is_success.return_value = False  # 方法返回失败
+
+        fake_service = MagicMock()
+        fake_service.send_to_user.return_value = fail_result
+        # 同步路径后半段会查 contacts 发 discord webhook，置空避免迭代 MagicMock 报错
+        fake_service.user_service.get_active_contacts.return_value = SimpleNamespace(
+            success=True, data=[]
+        )
+
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1"],
+        ):
+            result = notify("boom", async_mode=False)
+
+        assert result is False, "send_to_user 失败时不能因 is_success 是方法而恒真报成功"
+
+
+class TestNotifyAsyncFailurePath:
+    """notify() 异步路径：send_async 失败时必须返回 False。"""
+
+    def test_async_send_async_failure_returns_false(self):
+        fail_result = MagicMock()
+        fail_result.is_success.return_value = False
+
+        fake_service = MagicMock()
+        fake_service.send_async.return_value = fail_result
+
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1"],
+        ):
+            result = notify("boom", async_mode=True)
+
+        assert result is False, "send_async 失败时不能因 is_success 是方法而恒真报成功"
+
+
+class TestNotifyWithFieldsSyncFailurePath:
+    """notify_with_fields() 同步路径：send_discord_webhook 失败时必须返回 False。"""
+
+    def test_sync_discord_webhook_failure_returns_false(self):
+        fail_result = MagicMock()
+        fail_result.is_success.return_value = False
+
+        fake_service = MagicMock()
+        fake_service.send_discord_webhook.return_value = fail_result
+
+        contact = MagicMock()
+        contact.get_contact_type_enum.return_value = SimpleNamespace(name="WEBHOOK")
+        contact.is_active = True
+        contact.address = "http://hook.example"
+        fake_service.user_service.get_active_contacts.return_value = SimpleNamespace(
+            success=True, data=[contact]
+        )
+
+        with patch(
+            "ginkgo.notifier.core.notify._get_notification_service",
+            return_value=fake_service,
+        ), patch(
+            "ginkgo.notifier.core.notify._get_recipient_user_uuids",
+            return_value=["user-1"],
+        ):
+            result = notify_with_fields(
+                "content", [{"name": "x", "value": "y", "inline": True}], async_mode=False
+            )
+
+        assert result is False, "send_discord_webhook 失败时不能因 is_success 是方法而恒真报成功"


### PR DESCRIPTION
## Summary
修复通知链路同款 `result.is_success`（属性恒真）误用为 `is_success()`（方法）的 bug，跨 3 文件 12 处。

### 根因
`ServiceResult.is_success` 是 `def` 方法（`base_service.py:135`，无 `@property`）。属性访问取回**绑定方法对象** → 恒 truthy。

### 改动
| 文件 | 处 | 方法 | 表现 |
|---|---|---|---|
| `notify.py` | 3 | notify / notify_with_fields | 失败计成功（commit 6ed9b0f3） |
| `notification_service.py` | 8 | send_to_users / send_to_group / send_template_to_group | 失败计成功 + 结果 dict 存绑定方法（下游恒 truthy） |
| `notification_service.py` | 2 | _resolve_user_uuid / _resolve_group_uuids | fuzzy_search 失败时 `not<方法>=False` 跳校验，返回**泄漏数据** |
| `notification_worker.py` | 1 | _process_custom_fields_message | webhook 失败假成功（日志打印 sent 但实际失败） |

### 回归（6 个，真实 ServiceResult 非 MagicMock——避免 auto-truthy 掩盖）
- notify: 同步/异步 send 失败→False（3）
- service: send_to_users 失败 `success_count==0` + dict bool；_resolve_user_uuid 失败+泄漏 data→None（2）
- worker: webhook 失败→False（1）

**实盘半手动链路影响**：日志打印 sent 但实际失败，用户误以为通知已送达。

## Test plan
- [x] `pytest tests/unit/notifiers/` → 11 passed, 70 skipped
- [x] import 冒烟通过
- [x] notifier 全域 `result.is_success[^()]` 清零（grep 验证）

Closes #6223
