### PR TITLE
fix: record 三命令过滤统一 + stockinfo --code 透传 (#4743 #5949 #5950)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -43,7 +43,7 @@ def get(
 
             stockinfo_service = container.stockinfo_service()
             # ADR-010：此处消费 DataFrame（后续 iloc/columns/过滤），走 DF 出口
-            result = stockinfo_service.get_stockinfos_df(market=market, exchange=exchange)
+            result = stockinfo_service.get_stockinfos_df(code=code, market=market, exchange=exchange)
             if result.success:
                 df = result.data
 

--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -20,80 +20,25 @@ console = Console()
 
 @app.command()
 def signal(
-    engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
+    engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
+    task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
     page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
 ):
     """
     :satellite_antenna: List trading signals.
+
+    All filters (-p/-e/-t) optional. Symmetric with ``record order/position``.
     """
     from ginkgo.data.containers import Container
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
-        # 第一层：如果没有传入 engine，显示所有可用的 engines
-        if engine is None:
-            engine_svc = Container.engine_service()
-            result = engine_svc.get_engines_df()
-            if not result.success:
-                console.print(f":x: [red]{result.error}[/red]")
-                return
-            # ADR-010 R2b: get_engines_df 出口已保证 data 为 DataFrame（类型即契约）
-            engines_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
-
-            console.print("Please specify an engine ID. Available engines:")
-            engines_columns_config = {
-                "uuid": {"display_name": "Engine ID", "style": "dim"},
-                "name": {"display_name": "Name", "style": "cyan"},
-                "desc": {"display_name": "Description", "style": "dim"},
-                "update_at": {"display_name": "Update At", "style": "dim"}
-            }
-
-            display_dataframe(
-                data=engines_df,
-                columns_config=engines_columns_config,
-                title=":wrench: [bold]Available Engines:[/bold]",
-                console=console
-            )
-            console.print("\n[dim]Use: ginkgo record signal --engine <engine_id>[/dim]")
-            return
-
-        # 第二层：如果有 engine 但没有 portfolio，显示该 engine 下绑定的所有 portfolios
-        if portfolio is None:
-            engine_svc = Container.engine_service()
-            mapping_result = engine_svc.get_portfolios(engine_id=engine)
-            if not mapping_result.success or not mapping_result.data.get("mappings"):
-                console.print(f":exclamation: [yellow]No portfolios found for engine {engine}.[/yellow]")
-                return
-
-            mappings = mapping_result.data["mappings"]
-            mappings_df = mappings.to_dataframe()
-
-            if mappings_df.shape[0] == 0:
-                console.print(f":exclamation: [yellow]No portfolios found for engine {engine}.[/yellow]")
-                return
-
-            console.print(f"Please specify a portfolio ID. Available portfolios for engine {engine}:")
-            portfolios_columns_config = {
-                "portfolio_id": {"display_name": "Portfolio ID", "style": "dim"},
-                "portfolio_name": {"display_name": "Name", "style": "cyan"},
-                "update_at": {"display_name": "Update At", "style": "dim"}
-            }
-
-            display_dataframe(
-                data=mappings_df,
-                columns_config=portfolios_columns_config,
-                title=f":briefcase: [bold]Portfolios for Engine {engine}:[/bold]",
-                console=console
-            )
-            console.print(f"\n[dim]Use: ginkgo record signal --engine {engine} --portfolio <portfolio_id>[/dim]")
-            return
-
-        # 第三层：有 engine 和 portfolio，显示具体的 signals
         signal_svc = Container.signal_service()
         result = signal_svc.get_signals_df(
-            engine_id=engine,
             portfolio_id=portfolio,
+            engine_id=engine,
+            task_id=task,
             page_size=page,
         )
         if not result.success:
@@ -104,20 +49,21 @@ def signal(
         signals_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
         if signals_df.shape[0] == 0:
-            console.print(f":exclamation: [yellow]No signals found for engine {engine} and portfolio {portfolio}.[/yellow]")
+            console.print(":exclamation: [yellow]No signals found.[/yellow]")
             return
 
         signal_columns_config = {
             "uuid": {"display_name": "Signal ID", "style": "dim"},
             "engine_id": {"display_name": "Engine ID", "style": "dim"},
             "portfolio_id": {"display_name": "Portfolio ID", "style": "dim"},
+            "task_id": {"display_name": "Task ID", "style": "dim"},
             "direction": {"display_name": "Direction", "style": "green"},
             "code": {"display_name": "Code", "style": "cyan"},
             "timestamp": {"display_name": "Timestamp", "style": "dim"},
             "reason": {"display_name": "Reason", "style": "yellow"}
         }
 
-        title = f":satellite_antenna: [bold]Signals for Engine {engine} / Portfolio {portfolio}:[/bold]"
+        title = ":satellite_antenna: [bold]Signals:[/bold]"
         display_dataframe(
             data=signals_df,
             columns_config=signal_columns_config,

--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -135,6 +135,8 @@ def signal(
 @app.command()
 def order(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
+    engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
+    task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
     page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
 ):
     """
@@ -147,6 +149,8 @@ def order(
         order_svc = Container.order_service()
         result = order_svc.get_orders_df(
             portfolio_id=portfolio,
+            engine_id=engine,
+            task_id=task,
             page_size=page,
         )
         if not result.success:
@@ -186,6 +190,8 @@ def order(
 @app.command()
 def position(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
+    engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
+    task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
     page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
 ):
     """
@@ -198,6 +204,8 @@ def position(
         position_svc = Container.position_service()
         result = position_svc.get_positions_df(
             portfolio_id=portfolio,
+            engine_id=engine,
+            task_id=task,
             page_size=page,
         )
         if not result.success:

--- a/src/ginkgo/data/services/order_service.py
+++ b/src/ginkgo/data/services/order_service.py
@@ -69,20 +69,31 @@ class OrderService(BaseService):
             GLOG.ERROR(f"查询订单失败: {e}")
             return ServiceResult.error(str(e))
 
-    def _build_order_filters(self, portfolio_id: Optional[str] = None) -> dict:
+    def _build_order_filters(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> dict:
         """从业务参数构造 Order CRUD filters。get_orders_df 独立使用（DRY）。
 
-        filter 域与现有 get_orders() 一致（portfolio_id），
+        filter 域与 Signal/Position 对称（portfolio_id/engine_id/task_id），
         固定排除 is_del=True。未抽改 get_orders()，保持纯增量。
         """
         filters = {"is_del": False}
         if portfolio_id:
             filters["portfolio_id"] = portfolio_id
+        if engine_id:
+            filters["engine_id"] = engine_id
+        if task_id:
+            filters["task_id"] = task_id
         return filters
 
     def get_orders_df(
         self,
         portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
@@ -92,7 +103,9 @@ class OrderService(BaseService):
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
         """
         try:
-            filters = self._build_order_filters(portfolio_id=portfolio_id)
+            filters = self._build_order_filters(
+                portfolio_id=portfolio_id, engine_id=engine_id, task_id=task_id,
+            )
             model_list = self._crud_repo.find(
                 filters=filters,
                 page_size=page_size if page_size > 0 else None,

--- a/src/ginkgo/data/services/position_service.py
+++ b/src/ginkgo/data/services/position_service.py
@@ -81,20 +81,31 @@ class PositionService(BaseService):
             GLOG.ERROR(f"查询持仓失败: {e}")
             return ServiceResult.error(str(e))
 
-    def _build_position_filters(self, portfolio_id: Optional[str] = None) -> dict:
+    def _build_position_filters(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> dict:
         """从业务参数构造 Position CRUD filters。get_positions_df 独立使用（DRY）。
 
-        filter 域与现有 get_all_positions() 一致（portfolio_id），
+        filter 域与 Signal/Order 对称（portfolio_id/engine_id/task_id），
         固定排除 is_del=True。未抽改 get_all_positions()，保持纯增量。
         """
         filters = {"is_del": False}
         if portfolio_id:
             filters["portfolio_id"] = portfolio_id
+        if engine_id:
+            filters["engine_id"] = engine_id
+        if task_id:
+            filters["task_id"] = task_id
         return filters
 
     def get_positions_df(
         self,
         portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
@@ -104,7 +115,9 @@ class PositionService(BaseService):
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
         """
         try:
-            filters = self._build_position_filters(portfolio_id=portfolio_id)
+            filters = self._build_position_filters(
+                portfolio_id=portfolio_id, engine_id=engine_id, task_id=task_id,
+            )
             model_list = self._crud_repo.find(
                 filters=filters,
                 page_size=page_size if page_size > 0 else None,

--- a/src/ginkgo/data/services/signal_service.py
+++ b/src/ginkgo/data/services/signal_service.py
@@ -58,10 +58,11 @@ class SignalService(BaseService):
         self,
         engine_id: Optional[str] = None,
         portfolio_id: Optional[str] = None,
+        task_id: Optional[str] = None,
     ) -> dict:
         """从业务参数构造 Signal CRUD filters。get_signals_df 独立使用（DRY）。
 
-        filter 域与现有 get_signals() 一致（engine_id / portfolio_id），
+        filter 域与 Order/Position 三维对称（engine_id/portfolio_id/task_id），
         固定排除 is_del=True。未抽改 get_signals()，保持纯增量。
         """
         filters = {"is_del": False}
@@ -69,12 +70,15 @@ class SignalService(BaseService):
             filters["engine_id"] = engine_id
         if portfolio_id:
             filters["portfolio_id"] = portfolio_id
+        if task_id:
+            filters["task_id"] = task_id
         return filters
 
     def get_signals_df(
         self,
         engine_id: Optional[str] = None,
         portfolio_id: Optional[str] = None,
+        task_id: Optional[str] = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
@@ -85,7 +89,7 @@ class SignalService(BaseService):
         """
         try:
             filters = self._build_signal_filters(
-                engine_id=engine_id, portfolio_id=portfolio_id,
+                engine_id=engine_id, portfolio_id=portfolio_id, task_id=task_id,
             )
             model_list = self._crud_repo.find(
                 filters=filters,

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -113,12 +113,9 @@ class TestGetStockinfo:
 
     @patch("ginkgo.data.containers.container")
     def test_get_stockinfo_with_filter(self, mock_container, cli_runner, mock_stockinfo_df):
-        """使用 --filter 模糊过滤"""
-        filtered_df = mock_stockinfo_df[mock_stockinfo_df["industry"] == "银行"]
+        """使用 --filter 模糊过滤（DF 出口，客户端模糊匹配）"""
         mock_service = MagicMock()
-        mock_data = MagicMock()
-        mock_data.to_dataframe.return_value = mock_stockinfo_df
-        mock_service.get.return_value = ServiceResult.success(data=mock_data)
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
         mock_container.stockinfo_service.return_value = mock_service
 
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--filter", "银行"])
@@ -138,12 +135,24 @@ class TestGetStockinfo:
         assert result.exit_code == 0
 
     @patch("ginkgo.data.containers.container")
-    def test_get_stockinfo_raw_mode(self, mock_container, cli_runner, mock_stockinfo_df):
-        """--raw 模式输出 JSON"""
+    def test_get_stockinfo_passes_code_to_service(self, mock_container, cli_runner, mock_stockinfo_df):
+        """--code 过滤透传到 service.get_stockinfos_df (#5950)"""
         mock_service = MagicMock()
-        mock_data = MagicMock()
-        mock_data.to_dataframe.return_value = mock_stockinfo_df
-        mock_service.get.return_value = ServiceResult.success(data=mock_data)
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--code", "000001.SZ"])
+        assert result.exit_code == 0
+        # 核心：code 必须透传到 DF 出口，而非只靠 --filter 客户端模糊匹配
+        mock_service.get_stockinfos_df.assert_called_once()
+        _, kwargs = mock_service.get_stockinfos_df.call_args
+        assert kwargs.get("code") == "000001.SZ"
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_raw_mode(self, mock_container, cli_runner, mock_stockinfo_df):
+        """--raw 模式输出 JSON（DF 出口）"""
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
         mock_container.stockinfo_service.return_value = mock_service
 
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--raw"])
@@ -153,9 +162,9 @@ class TestGetStockinfo:
 
     @patch("ginkgo.data.containers.container")
     def test_get_stockinfo_service_error(self, mock_container, cli_runner):
-        """服务返回错误时显示错误信息"""
+        """服务返回错误时显示错误信息（DF 出口 else 分支）"""
         mock_service = MagicMock()
-        mock_service.get.return_value = ServiceResult.error(error="Database connection failed")
+        mock_service.get_stockinfos_df.return_value = ServiceResult.error(error="Database connection failed")
         mock_container.stockinfo_service.return_value = mock_service
 
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo"])

--- a/tests/unit/client/test_record_cli.py
+++ b/tests/unit/client/test_record_cli.py
@@ -1,0 +1,119 @@
+"""
+record CLI 单元测试。
+
+覆盖 record signal/order/position 命令：
+- #4743: order/position 的 engine/task 过滤透传（与 signal 对称）
+- #5949: signal 的 portfolio/engine/task 可选过滤 + 拆分强制阶段
+
+Run: pytest tests/unit/client/test_record_cli.py -v -o "addopts="
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+from typer.testing import CliRunner
+
+from ginkgo.client import record_cli
+from ginkgo.data.services.base_service import ServiceResult
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_orders_df():
+    return pd.DataFrame({
+        "uuid": ["o1"],
+        "portfolio_id": ["p1"],
+        "engine_id": ["e1"],
+        "task_id": ["t1"],
+        "code": ["000001.SZ"],
+        "direction": ["LONG"],
+        "order_type": ["MARKET"],
+        "quantity": [100],
+        "limit_price": [10.5],
+        "timestamp": ["2026-01-01"],
+        "status": ["FILLED"],
+    })
+
+
+@pytest.fixture
+def mock_positions_df():
+    return pd.DataFrame({
+        "uuid": ["pos1"],
+        "portfolio_id": ["p1"],
+        "engine_id": ["e1"],
+        "task_id": ["t1"],
+        "code": ["000001.SZ"],
+        "quantity": [100],
+        "average_price": [10.5],
+        "market_value": [1050.0],
+        "timestamp": ["2026-01-01"],
+    })
+
+
+# ============================================================================
+# #4743: order / position 加 -e/-t 过滤（与 signal 对称）
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestRecordOrderFilters:
+    """record order 的 engine/task 过滤透传（#4743）"""
+
+    @patch("ginkgo.data.containers.Container")
+    def test_order_passes_engine_and_task(self, mock_container, cli_runner, mock_orders_df):
+        """-e/-t 透传到 service.get_orders_df"""
+        mock_service = MagicMock()
+        mock_service.get_orders_df.return_value = ServiceResult.success(data=mock_orders_df)
+        mock_container.order_service.return_value = mock_service
+
+        result = cli_runner.invoke(record_cli.app, [
+            "order", "--portfolio", "p1", "--engine", "e1", "--task", "t1",
+        ])
+        assert result.exit_code == 0
+        _, kwargs = mock_service.get_orders_df.call_args
+        assert kwargs.get("portfolio_id") == "p1"
+        assert kwargs.get("engine_id") == "e1"
+        assert kwargs.get("task_id") == "t1"
+
+    @patch("ginkgo.data.containers.Container")
+    def test_order_without_filters_still_works(self, mock_container, cli_runner, mock_orders_df):
+        """无过滤参数时正常返回全部（不传 None 进 service）"""
+        mock_service = MagicMock()
+        mock_service.get_orders_df.return_value = ServiceResult.success(data=mock_orders_df)
+        mock_container.order_service.return_value = mock_service
+
+        result = cli_runner.invoke(record_cli.app, ["order"])
+        assert result.exit_code == 0
+        mock_service.get_orders_df.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestRecordPositionFilters:
+    """record position 的 engine/task 过滤透传（#4743）"""
+
+    @patch("ginkgo.data.containers.Container")
+    def test_position_passes_engine_and_task(self, mock_container, cli_runner, mock_positions_df):
+        """-e/-t 透传到 service.get_positions_df"""
+        mock_service = MagicMock()
+        mock_service.get_positions_df.return_value = ServiceResult.success(data=mock_positions_df)
+        mock_container.position_service.return_value = mock_service
+
+        result = cli_runner.invoke(record_cli.app, [
+            "position", "--portfolio", "p1", "--engine", "e1", "--task", "t1",
+        ])
+        assert result.exit_code == 0
+        _, kwargs = mock_service.get_positions_df.call_args
+        assert kwargs.get("portfolio_id") == "p1"
+        assert kwargs.get("engine_id") == "e1"
+        assert kwargs.get("task_id") == "t1"

--- a/tests/unit/client/test_record_cli.py
+++ b/tests/unit/client/test_record_cli.py
@@ -117,3 +117,72 @@ class TestRecordPositionFilters:
         assert kwargs.get("portfolio_id") == "p1"
         assert kwargs.get("engine_id") == "e1"
         assert kwargs.get("task_id") == "t1"
+
+
+# ============================================================================
+# #5949: signal 可选过滤（-p/-e/-t）+ 拆分强制阶段
+# ============================================================================
+
+
+def _signals_df():
+    return pd.DataFrame({
+        "uuid": ["s1"],
+        "engine_id": ["e1"],
+        "portfolio_id": ["p1"],
+        "task_id": ["t1"],
+        "code": ["000001.SZ"],
+        "direction": ["LONG"],
+        "timestamp": ["2026-01-01"],
+        "reason": ["test"],
+    })
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestRecordSignalFilters:
+    """record signal 的可选过滤 + 拆分强制阶段（#5949）
+
+    原实现强制三阶段（无 engine→列 engines；有 engine 无 portfolio→列 portfolios；
+    都有→查 signals）。统一后 -p/-e/-t 全可选，与 order/position 一致。
+    """
+
+    @patch("ginkgo.data.containers.Container")
+    def test_signal_passes_all_filters(self, mock_container, cli_runner):
+        """-p/-e/-t 全透传到 service.get_signals_df"""
+        mock_service = MagicMock()
+        mock_service.get_signals_df.return_value = ServiceResult.success(data=_signals_df())
+        mock_container.signal_service.return_value = mock_service
+
+        result = cli_runner.invoke(record_cli.app, [
+            "signal", "--portfolio", "p1", "--engine", "e1", "--task", "t1",
+        ])
+        assert result.exit_code == 0
+        _, kwargs = mock_service.get_signals_df.call_args
+        assert kwargs.get("portfolio_id") == "p1"
+        assert kwargs.get("engine_id") == "e1"
+        assert kwargs.get("task_id") == "t1"
+
+    @patch("ginkgo.data.containers.Container")
+    def test_signal_portfolio_only_queries_directly(self, mock_container, cli_runner):
+        """单 -p 直接查该 portfolio 全部 signal，不再强制先选 engine"""
+        mock_service = MagicMock()
+        mock_service.get_signals_df.return_value = ServiceResult.success(data=_signals_df())
+        mock_container.signal_service.return_value = mock_service
+
+        result = cli_runner.invoke(record_cli.app, ["signal", "--portfolio", "p1"])
+        assert result.exit_code == 0
+        # 核心：直接走 signal 查询，不触发 engine 选择阶段
+        mock_container.signal_service.assert_called_once()
+        _, kwargs = mock_service.get_signals_df.call_args
+        assert kwargs.get("portfolio_id") == "p1"
+
+    @patch("ginkgo.data.containers.Container")
+    def test_signal_no_filters_returns_all(self, mock_container, cli_runner):
+        """无任何过滤参数时查全部 signal（不再强制选 engine）"""
+        mock_service = MagicMock()
+        mock_service.get_signals_df.return_value = ServiceResult.success(data=_signals_df())
+        mock_container.signal_service.return_value = mock_service
+
+        result = cli_runner.invoke(record_cli.app, ["signal"])
+        assert result.exit_code == 0
+        mock_service.get_signals_df.assert_called_once()

--- a/tests/unit/data/services/test_order_service.py
+++ b/tests/unit/data/services/test_order_service.py
@@ -8,6 +8,7 @@ Run: pytest tests/unit/data/services/test_order_service.py -v -o "addopts="
 
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from ginkgo.data.services.order_service import OrderService
@@ -157,3 +158,41 @@ class TestDeleteOrdersByPortfolio:
         result = order_svc.delete_orders_by_portfolio("")
 
         assert result.is_failure()
+
+
+class TestGetOrdersDfFilters:
+    """get_orders_df 的 engine_id/task_id 过滤透传（#4743）
+
+    OrderModel 与 Signal/Position 对称持有 engine_id + task_id，
+    但 order 的 filter builder 仅连了 portfolio_id。此处验证三维过滤透传。
+    """
+
+    def test_filters_by_engine_and_task(self, order_svc, mock_crud):
+        """engine_id + task_id 应透传到 crud.find 的 filters"""
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        order_svc.get_orders_df(
+            portfolio_id="p1", engine_id="e1", task_id="t1"
+        )
+
+        _, kwargs = mock_crud.find.call_args
+        filters = kwargs["filters"]
+        assert filters == {
+            "is_del": False,
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "t1",
+        }
+
+    def test_omits_unset_filters(self, order_svc, mock_crud):
+        """未传的过滤维度不应进入 filters（避免误加 None）"""
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        order_svc.get_orders_df(portfolio_id="p1")
+
+        _, kwargs = mock_crud.find.call_args
+        assert kwargs["filters"] == {"is_del": False, "portfolio_id": "p1"}

--- a/tests/unit/data/services/test_signal_service.py
+++ b/tests/unit/data/services/test_signal_service.py
@@ -1,0 +1,60 @@
+"""
+SignalService unit tests (#5949).
+
+覆盖 get_signals_df 的 task_id 过滤透传：signal 已有 engine_id/portfolio_id，
+补齐 task_id 后与 order/position 三维对称。
+
+Run: pytest tests/unit/data/services/test_signal_service.py -v -o "addopts="
+"""
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from ginkgo.data.services.signal_service import SignalService
+
+
+@pytest.fixture
+def mock_crud():
+    return MagicMock()
+
+
+@pytest.fixture
+def signal_svc(mock_crud):
+    return SignalService(crud_repo=mock_crud)
+
+
+@pytest.mark.unit
+class TestGetSignalsDfFilters:
+    """get_signals_df 的三维过滤透传（#5949）"""
+
+    def test_filters_by_engine_portfolio_task(self, signal_svc, mock_crud):
+        """engine_id + portfolio_id + task_id 透传到 crud.find 的 filters"""
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        signal_svc.get_signals_df(
+            engine_id="e1", portfolio_id="p1", task_id="t1"
+        )
+
+        _, kwargs = mock_crud.find.call_args
+        filters = kwargs["filters"]
+        assert filters == {
+            "is_del": False,
+            "engine_id": "e1",
+            "portfolio_id": "p1",
+            "task_id": "t1",
+        }
+
+    def test_task_id_optional(self, signal_svc, mock_crud):
+        """未传 task_id 时不应进入 filters（避免误加 None）"""
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        signal_svc.get_signals_df(engine_id="e1")
+
+        _, kwargs = mock_crud.find.call_args
+        assert "task_id" not in kwargs["filters"]

--- a/tests/unit/services/test_position_service.py
+++ b/tests/unit/services/test_position_service.py
@@ -5,6 +5,7 @@ Verifies that PositionService orchestrates position persistence
 through PositionCRUD, providing the `save_positions` interface
 that PortfolioLive depends on.
 """
+import pandas as pd
 import pytest
 from unittest.mock import MagicMock, call
 
@@ -102,3 +103,41 @@ class TestGetPositions:
         result = service.get_portfolio_value("p-001")
         assert result.is_success()
         assert result.data["total_market_value"] == 10000
+
+
+class TestGetPositionsDfFilters:
+    """get_positions_df 的 engine_id/task_id 过滤透传（#4743）
+
+    PositionModel 与 Signal/Order 对称持有 engine_id + task_id，
+    但 position 的 filter builder 仅连了 portfolio_id。此处验证三维过滤透传。
+    """
+
+    def test_filters_by_engine_and_task(self, service, mock_crud):
+        """engine_id + task_id 应透传到 crud.find 的 filters"""
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        service.get_positions_df(
+            portfolio_id="p1", engine_id="e1", task_id="t1"
+        )
+
+        _, kwargs = mock_crud.find.call_args
+        filters = kwargs["filters"]
+        assert filters == {
+            "is_del": False,
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "t1",
+        }
+
+    def test_omits_unset_filters(self, service, mock_crud):
+        """未传的过滤维度不应进入 filters（避免误加 None）"""
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        service.get_positions_df(portfolio_id="p1")
+
+        _, kwargs = mock_crud.find.call_args
+        assert kwargs["filters"] == {"is_del": False, "portfolio_id": "p1"}


### PR DESCRIPTION
## Summary

统一 `record signal/order/position` 三个命令的过滤行为，全部支持 `-p/-e/-t` 可选过滤；并修复 `data get stockinfo` 的 `--code` 透传断点。

### #5950 — stockinfo --code 透传断点
`data get stockinfo -c <code>` 的 code 未传到 service（CLI 层断点）。补 `code` 参数到 `get_stockinfos_df` 调用。顺带修了 3 个既有 mock 链错误的测试（mock 了 `service.get` 但实际走 `get_stockinfos_df`）。

### #4743 — order/position 缺 engine/task 过滤
`record order/position` 仅有 portfolio 过滤，与 signal 不一致。service 的 `get_orders_df`/`get_positions_df` 补 `engine_id`/`task_id` 维度，CLI 补 `-e/-t`。

### #5949 — signal 强制三阶段门
`record signal` 原实现是引导式状态机（无 engine→列引擎，无 portfolio→列组合），与 order/position 直接查询不对称。改为直接查询，`-p/-e/-t` 全可选；columns 补 `task_id` 列。

三个命令现在同构：过滤器全可选、透传到 service 的三维 filter builder（engine_id/portfolio_id/task_id），未传的维度不进 filter（避免误加 None）。

## Test plan
- [x] service 层：order/position/signal 的 filter 透传（25 passed）
- [x] client 层：record_cli 三命令过滤 + data_cli stockinfo 透传（49 passed）
- [x] 变更文件覆盖率：5/5 均有对应测试

Closes #5950
Closes #4743
Closes #5949
