### PR TITLE
fix(#4891): kafka health 提示指向真实存在的 worker status 子命令

### DIFF
--- a/src/ginkgo/client/kafka_cli.py
+++ b/src/ginkgo/client/kafka_cli.py
@@ -563,7 +563,7 @@ def _run_health_check():
         # 提供建议
         console.print("\n[bold blue]:bulb: Health Check Tips:[/]")
         console.print("• Run 'ginkgo kafka status' for detailed Kafka queue information")
-        console.print("• Run 'ginkgo worker status' for detailed worker information")
+        console.print("• Run 'ginkgo worker data status' or 'ginkgo worker backtest status' for detailed worker information")
         console.print("• Check logs if any components show errors")
         
     except Exception as e:

--- a/tests/unit/client/test_kafka_cli.py
+++ b/tests/unit/client/test_kafka_cli.py
@@ -163,6 +163,35 @@ class TestHealth:
         assert result.exit_code == 0
         assert "HEALTHY" in result.output.upper() or "healthy" in result.output.lower()
 
+    def test_health_tip_references_real_worker_commands(self, cli_runner):
+        """kafka health 提示必须指向真实存在的 worker 子命令（防回归 #4891）。
+
+        旧提示 'ginkgo worker status' 无效——worker 顶层无 status 子命令，
+        status 是 data/backtest 各自的子命令（worker_cli.py:65 / :266）。
+        """
+        mock_kafka = MagicMock()
+        mock_kafka.health_check.return_value = {"status": "healthy", "kafka_connection": True}
+        mock_kafka.get_topic_status.return_value = {"exists": True}
+        mock_redis = MagicMock()
+        mock_redis.get_redis_info.return_value = {"connected": True, "version": "7.0"}
+        mock_gtm = MagicMock()
+        mock_gtm.get_worker_count.return_value = 0
+        mock_gtm.get_workers_status.return_value = {}
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.kafka_service.return_value = mock_kafka
+            mock_container.redis_service.return_value = mock_redis
+            with patch("ginkgo.libs.core.threading.GinkgoThreadManager", return_value=mock_gtm), \
+                 patch("ginkgo.libs.GLOG"):
+                result = cli_runner.invoke(kafka_cli.app, ["health"])
+
+        assert result.exit_code == 0, result.output
+        # 回归断言：旧的无效命令必须消失
+        assert "'ginkgo worker status'" not in result.output
+        # 正向断言：指向两个真实存在的 worker status 子命令
+        assert "ginkgo worker data status" in result.output
+        assert "ginkgo worker backtest status" in result.output
+
 
 @pytest.mark.unit
 @pytest.mark.cli


### PR DESCRIPTION
## Summary

`ginkgo kafka health` 底部 Health Check Tips 提示 `Run 'ginkgo worker status'`，但 `ginkgo worker` 顶层只有 `data`/`backtest` 子命令，没有 `status`，实际运行报 `No such command 'status'`。

修复：将该提示改为指向两个真实注册的 status 子命令：
- `ginkgo worker data status`  (worker_cli.py:65 `data_app.command("status")`)
- `ginkgo worker backtest status`  (worker_cli.py:266 `backtest_app.command("status")`)

## Test plan

- [x] 新增 `test_health_tip_references_real_worker_commands`：mock 健康检查依赖，断言提示不再含 `'ginkgo worker status'`，且引用的两个命令文本均出现（防回归）
- [x] 实跑确认 `ginkgo worker data status --help` / `ginkgo worker backtest status --help` 均存在
- [x] `tests/unit/client/test_kafka_cli.py` 17 passed、`test_worker_cli.py` 12 passed

Closes #4891
