### PR TITLE
fix(#4900 #5242): data get help 标注未实现类型为 [planned]

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -22,7 +22,7 @@ console = Console(emoji=True, legacy_windows=False)
 
 @app.command()
 def get(
-    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/calendar/day/tick/adjustfactor/sources)"),
+    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick) \\[planned: calendar/adjustfactor/sources]"),
     code: Optional[str] = typer.Option(None, "--code", "-c", help="Stock code (required for bars/ticks)"),
     start: Optional[str] = typer.Option(None, "--start", "-s", help="Start date (YYYYMMDD)"),
     end: Optional[str] = typer.Option(None, "--end", "-e", help="End date (YYYYMMDD)"),

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -71,6 +71,25 @@ class TestDataCLIHelp:
         assert "--filter" in result.output
         assert "--raw" in result.output
 
+    def test_get_help_marks_unimplemented_as_planned(self, cli_runner):
+        """data get help 必须把未实现的 data_type 标为 [planned]（#4900/#5242）。
+
+        calendar/adjustfactor/sources 当前不可用（calendar 报 Unknown data type，
+        adjustfactor/sources 报 not yet implemented），不能与可用的
+        stockinfo/day/tick 无差别并列。
+        """
+        result = cli_runner.invoke(data_cli.app, ["get", "--help"])
+        assert result.exit_code == 0
+        out = result.output
+        # 可用类型应列出
+        assert "stockinfo" in out
+        assert "day" in out
+        assert "tick" in out
+        # 未实现类型必须带 [planned] 标注
+        assert "[planned" in out
+        # 防回归：不再出现无标注的全列表
+        assert "(stockinfo/calendar/day/tick/adjustfactor/sources)" not in out
+
     def test_sync_help_shows_options(self, cli_runner):
         """data sync --help 显示 sync 命令的参数"""
         result = cli_runner.invoke(data_cli.app, ["sync", "--help"])


### PR DESCRIPTION
## Summary

`ginkgo data get --help` 把 `calendar/adjustfactor/sources` 列为支持的 data_type，但实际：

| data_type | 实际行为 | 代码位置 |
|---|---|---|
| `calendar` | `Unknown data type`（get 函数无分支） | 落 `data_cli.py:360` else |
| `adjustfactor` | `not yet implemented` | `data_cli.py:345` |
| `sources` | `not yet implemented` | `data_cli.py:357` |

修复：将 help 改为 `(stockinfo/day/tick) \[planned: calendar/adjustfactor/sources]`，把可用的 3 类与未实现的 3 类明确区分。（`sync` 命令的 help 不动——其 `adjustfactor` 已实现。）

### 关键：rich markup 转义

`data_cli` 的 app 用 `rich_markup_mode="rich"`，`[planned: ...]` 会被 rich 当作样式标签**整个吞掉**，help 里标注凭空消失（实测：不转义时输出只剩 `(stockinfo/day/tick)`）。必须转义开括号为 `\[` 才能显示字面 `[planned]`。此问题由新增的防回归测试捕获。

## Test plan

- [x] 新增 `test_get_help_marks_unimplemented_as_planned`：断言 help 含 `[planned]` 标注、不再无差别列出全列表（同时锁住 rich 转义）
- [x] 实跑确认输出为 `Data type to get (stockinfo/day/tick) [planned: calendar/adjustfactor/sources]`
- [x] `tests/unit/client/test_data_cli.py` + `test_data_cli_adjustfactor.py` 共 45 passed

Closes #4900
Closes #5242
