### PR TITLE
fix: config containers status 查询真实 Docker 状态 (#5518)

### DIFF
--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -321,14 +321,29 @@ def containers(
             table.add_column("Memory", style="red", width=10)
             table.add_column("Image", style="dim", width=20)
 
-            # 这里应该调用Docker API获取容器状态
-            # 示例数据
-            table.add_row("ginkgo-worker-1", "Running", "45%", "256MB", "ginkgo/worker:latest")
-            table.add_row("ginkgo-worker-2", "Running", "38%", "192MB", "ginkgo/worker:latest")
-            table.add_row("ginkgo-worker-3", "Idle", "2%", "64MB", "ginkgo/worker:latest")
-
-            console.print(table)
-            console.print(f"\n:bar_chart: Summary: {3} containers running, {0} idle")
+            # 查询真实 Docker 容器状态(-a 包含 stopped/exited 全状态)
+            import subprocess
+            try:
+                result = subprocess.run(
+                    ["docker", "ps", "-a", "--format", "{{.Names}}\t{{.Status}}\t{{.Image}}"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                lines = [l for l in result.stdout.splitlines() if l.strip()]
+                running = 0
+                for line in lines:
+                    parts = line.split("\t")
+                    name = parts[0]
+                    status = parts[1] if len(parts) > 1 else "-"
+                    image = parts[2] if len(parts) > 2 else "-"
+                    table.add_row(name, status, "-", "-", image)
+                    if status.lower().startswith("up"):
+                        running += 1
+                console.print(table)
+                console.print(f"\n:bar_chart: Summary: {len(lines)} containers total, {running} running")
+            except subprocess.TimeoutExpired:
+                console.print("[yellow]:warning: Docker 状态查询超时,Docker 是否响应?[/yellow]")
+            except FileNotFoundError:
+                console.print("[yellow]:warning: 未安装 Docker 或不在 PATH 中,无法查询容器状态。[/yellow]")
 
         elif action == "start":
             target_count = count or 1

--- a/tests/unit/client/test_config_cli.py
+++ b/tests/unit/client/test_config_cli.py
@@ -403,6 +403,37 @@ class TestConfigContainers:
         assert result.exit_code == 0
         assert "Container" in result.output or "container" in result.output.lower()
 
+    def test_containers_status_queries_real_docker(self, cli_runner):
+        """status 应查询真实 Docker 状态,显示真实容器(非硬编码示例数据)"""
+        fake = MagicMock(
+            stdout="my-real-container\tUp 1 hour\tmyimg:v1\n",
+            stderr="", returncode=0,
+        )
+        with patch("subprocess.run", return_value=fake) as mock_run:
+            result = cli_runner.invoke(config_cli.app, ["containers", "status"])
+        assert result.exit_code == 0
+        assert mock_run.called, "应调用 subprocess.run 查询 Docker"
+        # 真实容器名须出现(硬编码代码不会打印 my-real-container)
+        assert "my-real-container" in result.output
+        # docker ps -a 才能看到 stopped/exited 全状态(验收第 2 条)
+        cmd = mock_run.call_args[0][0]
+        assert "ps" in cmd and "-a" in cmd
+
+    def test_containers_status_docker_not_installed(self, cli_runner):
+        """Docker 未安装时优雅降级,不崩溃(验收第 3 条)"""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = cli_runner.invoke(config_cli.app, ["containers", "status"])
+        assert result.exit_code == 0
+        assert "docker" in result.output.lower() or "未安装" in result.output
+
+    def test_containers_status_docker_timeout(self, cli_runner):
+        """Docker 查询超时时优雅降级"""
+        import subprocess
+        with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd=["docker"], timeout=10)):
+            result = cli_runner.invoke(config_cli.app, ["containers", "status"])
+        assert result.exit_code == 0
+        assert "超时" in result.output or "timeout" in result.output.lower()
+
     def test_containers_start(self, cli_runner):
         """containers start 启动容器"""
         result = cli_runner.invoke(config_cli.app, ["containers", "start"])


### PR DESCRIPTION
## Summary

将 `ginkgo config containers status` 的硬编码示例数据(ginkgo-worker-1/2/3 Running/Idle)替换为真实 `docker ps -a` 查询。

- **真实状态**:用 `docker ps -a` 查询全状态容器(含 stopped/exited,满足验收第 2 条),透传 docker 返回的 Status 文案(Up / Restarting / Exited …)
- **优雅降级**:Docker 未安装(`FileNotFoundError`)或查询超时(`TimeoutExpired`)时友好提示,不崩溃(验收第 3 条);异常处理收窄,不再用 bare `Exception`
- 关联:在已 close 的外部贡献者 PR #6197(review 留三点:漏 `-a` / 无测试 / except 过宽)实现基础上补齐三点

## Test plan

- [x] `pytest tests/unit/client/test_config_cli.py` — 44 passed
- [x] 新增 3 测试:真实查询(断言 `docker ps -a` 调用 + 真实容器名透传)、Docker 未安装、查询超时
- [x] 真实启动路径冒烟:`python -m ginkgo.client.config_cli containers status` 显示本机真实容器(ginkgo-livecore 等,多状态),与 `docker ps -a` 一致

Closes #5518
