### PR TITLE
fix(data,logging): DI 容器错注入 + search_logs 签名缺过滤

### DIFF
--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -160,8 +160,7 @@ class Container(containers.DeclarativeContainer):
     api_key_crud = providers.Singleton(get_crud, "api_key")
     deployment_crud = providers.Singleton(get_crud, "deployment")
 
-    # Backtest task CRUD
-    backtest_task_crud = providers.Singleton(get_crud, "backtest_task")
+    # NOTE: backtest_task_crud 已在上方主 CRUD 块(line 141)定义，勿重复（#5554）
 
     # Services (Dependencies are injected here)
     # StockinfoService must be defined before AdjustfactorService as it's a dependency
@@ -264,7 +263,7 @@ class Container(containers.DeclarativeContainer):
         BacktestTaskService,
         crud_repo=backtest_task_crud,
         analyzer_service=analyzer_service,
-        engine_service=providers.Singleton(get_crud, "engine"),
+        engine_service=engine_service,
         portfolio_service=portfolio_service,
         signal_crud=providers.Singleton(get_crud, "signal"),
         order_crud=providers.Singleton(get_crud, "order"),

--- a/src/ginkgo/services/logging/log_service.py
+++ b/src/ginkgo/services/logging/log_service.py
@@ -379,7 +379,10 @@ class LogService(BaseService):
                     )
                 ]
                 if level is not None and hasattr(model, "level"):
-                    conditions.append(model.level == level)
+                    # 落库 level 混大小写（Master 全大写 / Test 大小写并存，旧写入大写、新写入小写），
+                    # ClickHouse == 大小写敏感，须双向 lower() 归一，否则 alert_service 透传 "ERROR"
+                    # 时漏匹配告警恒空（#5553 review：从 TypeError 崩溃换成静默 0，仍未达成告警目标）
+                    conditions.append(func.lower(model.level) == level.lower())
                 if time_start is not None and hasattr(model, "timestamp"):
                     conditions.append(model.timestamp >= time_start)
                 if time_end is not None and hasattr(model, "timestamp"):

--- a/src/ginkgo/services/logging/log_service.py
+++ b/src/ginkgo/services/logging/log_service.py
@@ -340,16 +340,22 @@ class LogService(BaseService):
         keyword: str,
         log_type: str = "backtest",
         limit: int = 100,
-        offset: int = 0
+        offset: int = 0,
+        level: Optional[str] = None,
+        time_start: Optional[datetime] = None,
+        time_end: Optional[datetime] = None,
     ) -> List[Dict[str, Any]]:
         """
-        关键词全文搜索
+        关键词全文搜索（可选级别/时间窗过滤）
 
         Args:
             keyword: 搜索关键词
             log_type: 日志类型
             limit: 最大返回结果数
             offset: 偏移量
+            level: 日志级别过滤（如 "ERROR"），None 不过滤（#5553）
+            time_start: 起始时间（含），None 不过滤
+            time_end: 结束时间（含），None 不过滤
 
         Returns:
             List[Dict]: 匹配的日志条目列表
@@ -366,12 +372,20 @@ class LogService(BaseService):
                     return []
 
                 # ClickHouse 使用 LIKE 进行全文搜索
-                query = select(model).where(
+                conditions = [
                     or_(
                         model.message.like(f"%{keyword}%"),
                         model.logger_name.like(f"%{keyword}%")
                     )
-                )
+                ]
+                if level is not None and hasattr(model, "level"):
+                    conditions.append(model.level == level)
+                if time_start is not None and hasattr(model, "timestamp"):
+                    conditions.append(model.timestamp >= time_start)
+                if time_end is not None and hasattr(model, "timestamp"):
+                    conditions.append(model.timestamp <= time_end)
+
+                query = select(model).where(and_(*conditions))
 
                 query = query.order_by(model.timestamp.desc())
                 query = query.limit(limit).offset(offset)

--- a/tests/unit/data/test_data_container_wiring.py
+++ b/tests/unit/data/test_data_container_wiring.py
@@ -1,0 +1,46 @@
+"""TDD tests for DI container wiring bugs #5504 / #5554.
+
+#5504: BacktestTaskService 的 engine_service 注入了 CRUD(get_crud,"engine")
+       而非 EngineService provider → 调用业务方法 AttributeError。
+#5554: backtest_task_crud provider 重复定义（141/164），后者静默覆盖前者。
+"""
+import re
+from pathlib import Path
+
+from ginkgo.data import containers as containers_module
+from ginkgo.data.containers import container
+
+
+class TestBacktestTaskServiceWiring:
+    """#5504: engine_service 必须注入 EngineService，而非 CRUD。"""
+
+    def test_engine_service_injected_is_engine_service_provider(self):
+        """backtest_task_service 的 engine_service 应来自 engine_service provider。"""
+        bts_provider = container.backtest_task_service
+        injected = bts_provider.kwargs.get("engine_service")
+        # 修复后：注入的是 container.engine_service provider（EngineService）
+        # 修复前：是 providers.Singleton(get_crud, "engine")（CRUD）
+        assert injected is container.engine_service, (
+            "engine_service 应注入 container.engine_service provider，"
+            "而非 get_crud(\"engine\") CRUD（#5504）"
+        )
+
+    def test_engine_service_provider_is_engine_service_class(self):
+        """engine_service provider 应装配 EngineService 类。"""
+        from ginkgo.data.services.engine_service import EngineService
+        es_provider = container.engine_service
+        # dependency_injector Singleton 的 .cls 暴露被装配的类
+        assert getattr(es_provider, "cls", None) is EngineService
+
+
+class TestNoDuplicateBacktestTaskCrud:
+    """#5554: backtest_task_crud 不得重复定义。"""
+
+    def test_backtest_task_crud_defined_once(self):
+        """源文件中 backtest_task_crud provider 定义应仅出现一次。"""
+        src = Path(containers_module.__file__).read_text(encoding="utf-8")
+        # 匹配顶层的 `backtest_task_crud = providers.Singleton(...)` 赋值
+        matches = re.findall(r"^\s+backtest_task_crud\s*=\s*providers\.", src, re.MULTILINE)
+        assert len(matches) == 1, (
+            f"backtest_task_crud 应只定义一次，实际 {len(matches)} 次（#5554 重复 provider）"
+        )

--- a/tests/unit/services/test_log_search_and_alert_count.py
+++ b/tests/unit/services/test_log_search_and_alert_count.py
@@ -49,6 +49,44 @@ class TestSearchLogsAcceptsLevelAndTimeFilters:
         )
         assert isinstance(result, list)
 
+    def test_search_logs_level_filter_is_case_insensitive(self):
+        """level 过滤须大小写不敏感（#5553 review）。
+
+        落库 level 混大小写：Master CH 全大写(INFO/WARNING/ERROR)，
+        Test CH 大小写并存(info 28.5M / INFO 3.7M / error 14K / ERROR 6.5K)。
+        alert_service 透传 level="ERROR"(大写)，ClickHouse == 大小写敏感，
+        故 model.level == level 会漏匹配告警恒空。须 func.lower() 双向归一。
+        """
+        from ginkgo.services.logging.log_service import LogService
+
+        captured = []
+
+        session = MagicMock()
+        engine = MagicMock()
+        engine.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        engine.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        def capture(query):
+            captured.append(query)
+            result = MagicMock()
+            result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute.side_effect = capture
+
+        svc = LogService(engine=engine)
+        svc.search_logs(keyword="x", level="ERROR", limit=10)
+
+        assert len(captured) == 1, "search_logs 应执行一次查询"
+        compiled = str(
+            captured[0].compile(compile_kwargs={"literal_binds": True})
+        ).lower()
+        # 修复前: "level = 'ERROR'"（无 lower，大小写敏感漏匹配）
+        # 修复后: "lower(level) = 'error'"（双向归一，混大小写均命中）
+        assert "lower" in compiled, (
+            "level 过滤须大小写不敏感(func.lower)，落库混大小写否则漏匹配告警恒空(#5553 review)"
+        )
+
 
 class TestCountErrorPatternReturnsInt:
     """#5553: _count_error_pattern 不应 TypeError，应返回 int。"""

--- a/tests/unit/services/test_log_search_and_alert_count.py
+++ b/tests/unit/services/test_log_search_and_alert_count.py
@@ -1,0 +1,73 @@
+"""TDD tests for #5553: alert_service._count_error_pattern -> search_logs
+签名不匹配 TypeError 杀死整个告警管线。
+
+根因: search_logs(keyword, log_type, limit, offset) 不接受 level/time_start/time_end,
+而 _count_error_pattern 传了这些 kwargs -> TypeError。
+修复: search_logs 增加可选 level/time_start/time_end 过滤（向后兼容）。
+"""
+import inspect
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestSearchLogsAcceptsLevelAndTimeFilters:
+    """#5553: search_logs 必须接受 level/time_start/time_end。"""
+
+    def test_search_logs_signature_has_optional_filters(self):
+        from ginkgo.services.logging.log_service import LogService
+        sig = inspect.signature(LogService.search_logs)
+        params = sig.parameters
+        assert "level" in params, "search_logs 应支持 level 过滤（#5553）"
+        assert "time_start" in params, "search_logs 应支持 time_start 过滤（#5553）"
+        assert "time_end" in params, "search_logs 应支持 time_end 过滤（#5553）"
+        # 向后兼容：新增参数须有默认值
+        assert params["level"].default is None
+        assert params["time_start"].default is None
+        assert params["time_end"].default is None
+
+    def test_search_logs_call_with_filters_does_not_raise(self):
+        """带 level/time 过滤调用不应 TypeError（mock engine 返回空）。"""
+        from ginkgo.services.logging.log_service import LogService
+
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = []
+        engine = MagicMock()
+        engine.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        engine.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        svc = LogService(engine=engine)
+        # 修复前: TypeError（unexpected keyword 'level'）
+        # 修复后: 返回 []（空结果）
+        result = svc.search_logs(
+            keyword="timeout",
+            level="ERROR",
+            time_start=datetime.now() - timedelta(minutes=5),
+            time_end=datetime.now(),
+            limit=100,
+        )
+        assert isinstance(result, list)
+
+
+class TestCountErrorPatternReturnsInt:
+    """#5553: _count_error_pattern 不应 TypeError，应返回 int。"""
+
+    def _make_svc(self):
+        session = MagicMock()
+        session.execute.return_value.scalars.return_value.all.return_value = []
+        db_engine = MagicMock()
+        db_engine.get_session.return_value.__enter__ = MagicMock(return_value=session)
+        db_engine.get_session.return_value.__exit__ = MagicMock(return_value=False)
+        with patch("ginkgo.services.logging.alert_service.GCONF"):
+            from ginkgo.services.logging.alert_service import AlertService
+            svc = AlertService(redis_client=MagicMock(), db_engine=db_engine)
+        return svc
+
+    def test_count_error_pattern_returns_int(self):
+        svc = self._make_svc()
+        # 修复前: TypeError（search_logs 不接受 level/time_start/time_end）
+        # 修复后: 返回 int（0，因为 mock 返回空）
+        result = svc._count_error_pattern(pattern="ERROR.*timeout", window_minutes=5, level="ERROR")
+        assert isinstance(result, int)
+        assert result == 0


### PR DESCRIPTION
## 修复 3 个 P0 接线/签名 bug

| Issue | 文件 | 问题 | 修复 |
|---|---|---|---|
| #5504 | data/containers.py:267 | BacktestTaskService.engine_service 误注入 get_crud("engine") CRUD | 改用已有 engine_service provider(EngineService) |
| #5554 | data/containers.py:164 | backtest_task_crud 重复定义,后者静默覆盖 | 删重复,留主块定义 |
| #5553 | log_service.py:338 | search_logs 不接受 level/time,alert 计数 TypeError 被 try/except 吞为静默0 | 增加可选 level/time_start/time_end 过滤 |

## TDD
- 容器 provider 内省免 DB 验 DI 接线(engine_service 注入源 + 无重复 provider)
- search_logs 签名/调用测试 + _count_error_pattern 返回 int

## 验证
- 6 新测试全 GREEN
- 回归 63 过(容器/服务/log/alert 桶)
- test_backtest_to_live_transition 失败为 master 预存在(stash 对比确认),非本次回归

issue 引用但不含 auto-close 关键词,关闭由维护者 triage 决定。