### PR TITLE
fix: data get adjustfactor 接 service + sources 列出数据源 (#4900)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -333,28 +333,83 @@ def get(
                 console.print(":x: Stock code required for adjustfactor data")
                 raise typer.Exit(1)
 
-            # 设置默认时间范围（如果未提供）
+            # 默认时间范围（对齐 day 分支：end 缺省补 now，start 缺省补 now-365d）
+            from datetime import datetime, timedelta
+            if not end:
+                end = datetime.now().strftime("%Y%m%d")
             if not start:
-                from datetime import datetime, timedelta
-                end_date = datetime.now()
-                start_date = end_date - timedelta(days=365)  # 默认获取最近1年的数据
-                start = start_date.strftime("%Y%m%d")
-                end = end_date.strftime("%Y%m%d")
+                start = (datetime.now() - timedelta(days=365)).strftime("%Y%m%d")
 
-            console.print(f":information: Getting adjustfactor data for {code} from {start} to {end}")
-            console.print(":information: Adjustfactor data retrieval not yet implemented")
-            console.print(f"  • Code: {code}")
-            console.print(f"  • Start: {start}")
-            console.print(f"  • End: {end}")
-            console.print(f"  • Page Size: {page_size or 'Default (all)'}")
+            # "YYYYMMDD" → datetime（DB timestamp__gte/lte 过滤需 datetime 类型，
+            # 不可像 day 分支透传 str——adjustfactor_service.get_adjustfactors_df 签名为 datetime）
+            start_dt = datetime.strptime(start, "%Y%m%d")
+            end_dt = datetime.strptime(end, "%Y%m%d")
 
-            # TODO: 实现adjustfactor数据获取
-            # from ginkgo.data.containers import container
-            # adjustfactor_service = container.adjustfactor_service()
-            # result = adjustfactor_service.get(code=code, start_date=start, end_date=end)
+            from ginkgo.data.containers import container
+            adjustfactor_service = container.adjustfactor_service()
+            result = adjustfactor_service.get_adjustfactors_df(
+                code=code, start_date=start_dt, end_date=end_dt
+            )
+
+            if not result.success:
+                console.print(f":x: Failed to get adjustfactor data: {result.message}")
+                raise typer.Exit(1)
+
+            import pandas as pd
+            df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
+
+            if df.empty:
+                console.print(f":information: No adjustfactor data found for {code} ({start}-{end})")
+                return
+
+            # Raw JSON 输出（对齐 stockinfo 分支）
+            if raw:
+                import json
+                console.print(json.dumps(df.to_dict('records'), indent=2, ensure_ascii=False, default=str))
+                return
+
+            display_cols = ["code", "timestamp", "adjust_type", "adj_factor"]
+            show_cols = [c for c in display_cols if c in df.columns]
+            df_display = df[show_cols].copy()
+            if "timestamp" in df_display.columns:
+                df_display["timestamp"] = df_display["timestamp"].astype(str).str[:10]
+
+            limit = page_size or 50
+            if len(df_display) > limit:
+                console.print(f":information: Showing {limit} of {len(df_display)} records")
+                df_display = df_display.tail(limit)
+
+            table = Table(title=f"Adjustfactor Data: {code} ({start}-{end})", show_lines=False)
+            for col in show_cols:
+                table.add_column(col, style="cyan")
+            for _, row in df_display.iterrows():
+                table.add_row(*[str(v) for v in row])
+            console.print(table)
+            console.print(f":information: {len(df)} records")
 
         elif data_type == "sources":
-            console.print(":information: Data sources functionality not yet implemented")
+            from ginkgo.data.sources import GinkgoTushare, GinkgoTDX
+            from ginkgo.libs import GCONF
+
+            # 容器已注入的数据源（containers.py: ginkgo_tushare_source / ginkgo_tdx_source）。
+            # 仅展示元信息，不实例化——避免触发 connect() 的网络/token 副作用。
+            configured_sources = [
+                ("tushare", GinkgoTushare, getattr(GCONF, "TUSHARETOKEN", None)),
+                ("tdx", GinkgoTDX, None),  # TDX 无 token 依赖
+            ]
+
+            table = Table(title=":plug: Configured Data Sources", show_lines=False)
+            table.add_column("name", style="cyan")
+            table.add_column("type", style="green")
+            table.add_column("configured", style="yellow")
+
+            for name, cls, token in configured_sources:
+                # token 为 None 表示该数据源不依赖 token（如 TDX），视为已配置
+                is_configured = "yes" if token is None or token else "no"
+                table.add_row(name, cls.__name__, is_configured)
+
+            console.print(table)
+            console.print(f":information: {len(configured_sources)} data source(s) configured")
 
         else:
             console.print(f":x: Unknown data type: {data_type}")

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -368,7 +368,10 @@ def get(
                 console.print(json.dumps(df.to_dict('records'), indent=2, ensure_ascii=False, default=str))
                 return
 
-            display_cols = ["code", "timestamp", "adjust_type", "adj_factor"]
+            # 列名对齐 MAdjustfactor（foreadjustfactor/backadjustfactor/adjustfactor），
+            # 对齐 day/tick 分支用 model 真实列名的写法——虚构列名会被 show_cols 过滤掉，
+            # 导致表格只显示 code/timestamp、因子值全丢。
+            display_cols = ["code", "timestamp", "foreadjustfactor", "backadjustfactor", "adjustfactor"]
             show_cols = [c for c in display_cols if c in df.columns]
             df_display = df[show_cols].copy()
             if "timestamp" in df_display.columns:

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -234,11 +234,13 @@ class TestGetOtherTypes:
         assert result.exit_code == 1
         assert "Unknown" in result.output or "unknown" in result.output
 
-    def test_get_sources_shows_not_implemented(self, cli_runner):
-        """sources 数据类型显示尚未实现"""
+    def test_get_sources_lists_configured_sources(self, cli_runner):
+        """sources 数据类型列出已配置的数据源（不再显示 not yet implemented 桩）"""
         result = cli_runner.invoke(data_cli.app, ["get", "sources"])
         assert result.exit_code == 0
-        assert "not yet implemented" in result.output
+        assert "not yet implemented" not in result.output
+        # 容器注入了 tushare/tdx（containers.py），应被列出
+        assert "tushare" in result.output.lower()
 
 
 # ============================================================================

--- a/tests/unit/client/test_data_cli_adjustfactor.py
+++ b/tests/unit/client/test_data_cli_adjustfactor.py
@@ -76,14 +76,17 @@ class TestGetAdjustfactor:
         RED: 桩输出 "not yet implemented"，从不调 service.get_adjustfactors_df。
         """
         mock_svc = MagicMock()
+        # mock 必须用 model 真实列名（foreadjustfactor/backadjustfactor/adjustfactor），
+        # 不是虚构的 adjust_type/adj_factor——否则与实现错配一致，测试绿却掩盖 bug。
         mock_svc.get_adjustfactors_df.return_value = ServiceResult(
             success=True,
             message="ok",
             data=pd.DataFrame([{
                 "code": "000001.SZ",
                 "timestamp": datetime(2025, 11, 1),
-                "adjust_type": "fore",
-                "adj_factor": 1.0,
+                "foreadjustfactor": 1.0,
+                "backadjustfactor": 0.95,
+                "adjustfactor": 0.98,
             }]),
         )
 
@@ -104,6 +107,8 @@ class TestGetAdjustfactor:
         # start/end 从 "YYYYMMDD" 转 datetime（DB timestamp__gte/lte 需 datetime）
         assert kwargs["start_date"] == datetime(2025, 11, 1)
         assert kwargs["end_date"] == datetime(2025, 11, 7)
+        # 表格路径必须显示因子列（防 show_cols 列名错配致因子列丢失，review #6234）
+        assert "foreadjustfactor" in result.output
 
     @pytest.mark.unit
     def test_get_adjustfactor_service_failure_exits_nonzero(self):

--- a/tests/unit/client/test_data_cli_adjustfactor.py
+++ b/tests/unit/client/test_data_cli_adjustfactor.py
@@ -14,10 +14,14 @@ if _path not in sys.path:
     sys.path.insert(0, _path)
 
 import pytest
+from datetime import datetime
 from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
+import pandas as pd
+
 from ginkgo.client.data_cli import app
+from ginkgo.data.services.base_service import ServiceResult
 
 runner = CliRunner()
 
@@ -55,3 +59,82 @@ class TestSyncAdjustfactorWiring:
         assert mock_svc.sync.call_args.args[0] == "000001.SZ"
         # sync 成功后衔接 calculate（与 timer/worker/API handler 对齐）
         mock_svc.calculate.assert_called_once_with("000001.SZ")
+
+
+class TestGetAdjustfactor:
+    """CLI get adjustfactor 直调 service.get_adjustfactors_df（修复 not yet implemented 桩）
+
+    旧桩 (data_cli get adjustfactor) 只打印 "not yet implemented"，从不查库。
+    收敛后：经 container 调 adjustfactor_service.get_adjustfactors_df，与 sync/update 同源；
+    start/end 从 "YYYYMMDD" 转 datetime（DB timestamp 过滤需 datetime 类型）。
+    """
+
+    @pytest.mark.unit
+    def test_get_adjustfactor_success_calls_service_with_datetime(self):
+        """get adjustfactor --code X --start ... --end ... 接 get_adjustfactors_df(datetime)
+
+        RED: 桩输出 "not yet implemented"，从不调 service.get_adjustfactors_df。
+        """
+        mock_svc = MagicMock()
+        mock_svc.get_adjustfactors_df.return_value = ServiceResult(
+            success=True,
+            message="ok",
+            data=pd.DataFrame([{
+                "code": "000001.SZ",
+                "timestamp": datetime(2025, 11, 1),
+                "adjust_type": "fore",
+                "adj_factor": 1.0,
+            }]),
+        )
+
+        with patch("ginkgo.data.containers.container.adjustfactor_service", return_value=mock_svc):
+            result = runner.invoke(
+                app,
+                ["get", "adjustfactor", "--code", "000001.SZ", "--start", "20251101", "--end", "20251107"],
+            )
+
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        # 不再是桩
+        assert "not yet implemented" not in result.output
+        # 真实查库：经 service.get_adjustfactors_df
+        mock_svc.get_adjustfactors_df.assert_called_once()
+        kwargs = mock_svc.get_adjustfactors_df.call_args.kwargs
+        assert kwargs["code"] == "000001.SZ"
+        # start/end 从 "YYYYMMDD" 转 datetime（DB timestamp__gte/lte 需 datetime）
+        assert kwargs["start_date"] == datetime(2025, 11, 1)
+        assert kwargs["end_date"] == datetime(2025, 11, 7)
+
+    @pytest.mark.unit
+    def test_get_adjustfactor_service_failure_exits_nonzero(self):
+        """service 返回失败 → exit 1 + 失败信息（不静默成功）"""
+        mock_svc = MagicMock()
+        mock_svc.get_adjustfactors_df.return_value = ServiceResult(
+            success=False, message="DB down", data=pd.DataFrame(),
+        )
+
+        with patch("ginkgo.data.containers.container.adjustfactor_service", return_value=mock_svc):
+            result = runner.invoke(
+                app,
+                ["get", "adjustfactor", "--code", "000001.SZ", "--start", "20251101", "--end", "20251107"],
+            )
+
+        assert result.exit_code == 1
+        assert "Failed" in result.output or "failed" in result.output.lower()
+
+    @pytest.mark.unit
+    def test_get_adjustfactor_empty_result_shows_friendly(self):
+        """空结果 → 友好提示，exit 0（不崩溃、不误报失败）"""
+        mock_svc = MagicMock()
+        mock_svc.get_adjustfactors_df.return_value = ServiceResult(
+            success=True, message="ok", data=pd.DataFrame(),
+        )
+
+        with patch("ginkgo.data.containers.container.adjustfactor_service", return_value=mock_svc):
+            result = runner.invoke(
+                app,
+                ["get", "adjustfactor", "--code", "000001.SZ", "--start", "20251101", "--end", "20251107"],
+            )
+
+        assert result.exit_code == 0, f"exit={result.exit_code} out={result.output}\nexc={result.exception}"
+        assert "No adjustfactor data found" in result.output


### PR DESCRIPTION
## Summary

修复 #4900：`ginkgo data get` 帮助列出 6 种数据类型，但 `adjustfactor` 和 `sources` 返回 "not yet implemented" 桩——列在 help 里却不可用。

### adjustfactor（半成品漏接，非功能缺失）
- `AdjustfactorService.get_adjustfactors_df()` 服务已存在、容器已注入、桩里连调用代码都注释写好了，只是没接线
- 替换桩：经 `container.adjustfactor_service().get_adjustfactors_df(code, start_date, end_date)` 真实查库
- `--start/--end` 从 `"YYYYMMDD"` 转 `datetime`（DB `timestamp__gte/lte` 过滤需 datetime 类型，非字符串）
- 支持 `--raw` JSON 与表格展示，与 stockinfo get 分支对齐

### sources（需新设计）
- 无 sources service，但容器注入了数据源实例（tushare/tdx）
- 替换桩：列出已配置数据源（名称 + 类型 + 配置状态）
- 仅读类元信息，**不实例化**（避免 `connect()` 触发真实 tushare 网络/token 副作用）

## Test plan

- [x] `test_get_adjustfactor_success_calls_service_with_datetime` — get 接 service + datetime 转换
- [x] `test_get_adjustfactor_service_failure_exits_nonzero` — service 失败 exit 1
- [x] `test_get_adjustfactor_empty_result_shows_friendly` — 空结果友好提示
- [x] `test_get_sources_lists_configured_sources` — sources 列出数据源，不再显示桩
- [x] 真实 CLI 冒烟：`data get sources` exit 0，表格渲染 tushare/tdx，configured 状态正确
- [x] `tests/unit/client/test_data_cli.py` 43 passed（无回归）

Closes #4900
