### PR TITLE
fix: FixedSelector 空 codes 装配期告警防静默零信号 (#5363)

### DIFF
--- a/src/ginkgo/trading/selectors/fixed_selector.py
+++ b/src/ginkgo/trading/selectors/fixed_selector.py
@@ -25,6 +25,14 @@ class FixedSelector(BaseSelector):
     def __init__(self, name: str = "FixedSelector", codes: Union[str, List[str]] = "", *args, **kwargs) -> None:
         super().__init__(name, *args, **kwargs)
         self._interested = ensure_list(codes)
+        # #5363: codes 为空(默认 "")→ ensure_list 返 []→ pick() 恒空→ 回测静默零信号/零交易。
+        # 在装配期(__init__)一次性告警，而非 pick()(每 bar 调用会刷屏)，fail-fast 让用户绑定组件时即知漏配 codes。
+        if len(self._interested) == 0:
+            GLOG.WARNING(
+                f"FixedSelector({name}) codes 为空，pick() 将始终返回空列表，"
+                f"回测会零信号/零交易。请在 portfolio bind-component 时设置 codes "
+                f"(如 --param '0:\"000001.SZ\"')。(#5363)"
+            )
 
     def pick(self, time: any = None, *args, **kwargs) -> list[str]:
         r = self._interested

--- a/tests/unit/trading/selectors/test_fixed_selector.py
+++ b/tests/unit/trading/selectors/test_fixed_selector.py
@@ -1,0 +1,48 @@
+"""TDD tests for #5363: FixedSelector 默认 codes="" → ensure_list("")=[] → pick() 返空，
+回测静默零信号/零交易，无任何告警。
+
+根因: fixed_selector.py __init__ `codes: Union[str,List[str]] = ""`，
+`self._interested = ensure_list(codes)` 当 codes="" 得 []，pick() 直接返回 self._interested。
+修复: __init__ 检测 _interested 为空时发 GLOG.WARNING（装配期一次性，非 pick 每 bar 刷屏）。
+"""
+from unittest.mock import patch
+
+import pytest
+
+from ginkgo.trading.selectors.fixed_selector import FixedSelector
+
+
+class TestFixedSelectorEmptyCodesWarns:
+    """#5363: 空 codes 不应静默——须在装配期(__init__)发明确告警。"""
+
+    def test_init_empty_codes_emits_warning(self):
+        """codes="" 时 __init__ 应发 WARNING，提示 pick 将恒空致零信号。"""
+        with patch("ginkgo.trading.selectors.fixed_selector.GLOG") as mock_glog:
+            FixedSelector(codes="")
+        # 修复前: 无 WARNING 调用（静默）
+        # 修复后: WARNING 被调用，消息含 codes/空 等关键词
+        mock_glog.WARNING.assert_called_once()
+        msg = mock_glog.WARNING.call_args[0][0]
+        assert "codes" in msg.lower() or "空" in msg, (
+            "空 codes 的告警消息应点明根因（codes 为空）#5363"
+        )
+
+    def test_init_default_codes_emits_warning(self):
+        """不传 codes（走默认 ""）同样应告警——这是 issue 复现路径。"""
+        with patch("ginkgo.trading.selectors.fixed_selector.GLOG") as mock_glog:
+            FixedSelector()
+        mock_glog.WARNING.assert_called_once()
+
+    def test_init_with_codes_does_not_warn(self):
+        """有 codes 时不应告警（避免误报，且不影响正常回测）。"""
+        with patch("ginkgo.trading.selectors.fixed_selector.GLOG") as mock_glog:
+            sel = FixedSelector(codes="000001.SZ")
+        mock_glog.WARNING.assert_not_called()
+        # 有 codes 正常出信号（验收: 有 codes 回测正常产生信号）
+        assert sel.pick() == ["000001.SZ"]
+
+    def test_pick_empty_codes_returns_empty(self):
+        """行为不变: 空 codes 时 pick() 仍返回 []（告警不改变返回值）。"""
+        with patch("ginkgo.trading.selectors.fixed_selector.GLOG"):
+            sel = FixedSelector(codes="")
+        assert sel.pick() == []


### PR DESCRIPTION
## 背景
#5363 FixedSelector 默认 `codes=""` → `ensure_list([])` → `pick()` 恒空 → 回测**静默零信号零交易**，无任何告警。用户无法完成最基本的回测流程且无提示。

## 根因（已验证）
`fixed_selector.py` `__init__` `codes` 默认 `""`，`self._interested = ensure_list(codes)` 得 `[]`，`pick()` 直接返回 `self._interested`。实测 `ensure_list("") == []`、`ensure_list("000001.SZ") == ['000001.SZ']`。

## 修复
`__init__` 检测 `_interested` 为空发 `GLOG.WARNING`。**选 `__init__` 而非 `pick()`**：
- `pick()` 每 bar 调用会刷屏
- `__init__` 装配期一次性 fail-fast，用户 `bind-component` 时即知漏配 codes

## 方案取舍（issue 给 A/B/C）
选 **A 精炼版（装配期告警）**：
- **B**（backtest create 检测空）不可行：selector 在 `create` 时未装配，`run` 时才实例化，create 期无从检测
- **C**（bind-component 强制 codes）散落 CLI 校验，不如源码层一处拦截

满足全部验收：空 codes 有明确提示 ✓、不再静默 ✓、有 codes 正常产生信号 ✓。

## 测试（TDD）
新增 `tests/unit/trading/selectors/test_fixed_selector.py`，4 例：
- 空 codes 发 WARNING ✓
- 默认（不传 codes）发 WARNING ✓（issue 复现路径）
- 有 codes 不告警 + pick 返回正确 ✓
- 空 codes pick 仍返 `[]`（行为不变）✓

回归 selector/bases 桶 23 passed。`test_default_analyzers.py` 5 失败为**预存**（断言 `len(config)==10` 实际 21，与本 PR 无关，不在 diff 内）。

Closes #5363
