### PR TITLE
fix: data get help 对齐实现（adjustfactor/sources 移出 [planned]）

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -22,7 +22,7 @@ console = Console(emoji=True, legacy_windows=False)
 
 @app.command()
 def get(
-    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick) \\[planned: calendar/adjustfactor/sources]"),
+    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick/adjustfactor/sources) \\[planned: calendar]"),
     code: Optional[str] = typer.Option(None, "--code", "-c", help="Stock code (required for bars/ticks)"),
     start: Optional[str] = typer.Option(None, "--start", "-s", help="Start date (YYYYMMDD)"),
     end: Optional[str] = typer.Option(None, "--end", "-e", help="End date (YYYYMMDD)"),

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -72,23 +72,22 @@ class TestDataCLIHelp:
         assert "--raw" in result.output
 
     def test_get_help_marks_unimplemented_as_planned(self, cli_runner):
-        """data get help 必须把未实现的 data_type 标为 [planned]（#4900/#5242）。
+        """data get help 区分"可用"与 [planned] 未实现的 data_type（#4900/#5242）。
 
-        calendar/adjustfactor/sources 当前不可用（calendar 报 Unknown data type，
-        adjustfactor/sources 报 not yet implemented），不能与可用的
-        stockinfo/day/tick 无差别并列。
+        adjustfactor/sources 已实现（PR #6234：接 service / 列数据源），列入可用；
+        calendar 仍不可用（报 Unknown data type，#5242 not_planned），标 [planned]。
+        help 必须与实际一致，否则误导用户——#6230 旧的 [planned: calendar/adjustfactor/sources]
+        在 #6234 实现两者后已过时。
         """
         result = cli_runner.invoke(data_cli.app, ["get", "--help"])
         assert result.exit_code == 0
         out = result.output
-        # 可用类型应列出
-        assert "stockinfo" in out
-        assert "day" in out
-        assert "tick" in out
-        # 未实现类型必须带 [planned] 标注
-        assert "[planned" in out
-        # 防回归：不再出现无标注的全列表
-        assert "(stockinfo/calendar/day/tick/adjustfactor/sources)" not in out
+        # 可用类型应列出（adjustfactor/sources 已实现，移入可用括号内）
+        assert "(stockinfo/day/tick/adjustfactor/sources)" in out
+        # calendar 仍未实现，必须带 [planned] 标注，且 planned 里只剩 calendar
+        assert "[planned: calendar]" in out
+        # 旧的 planned 多项列表不应再出现（calendar 后不再跟 adjustfactor）
+        assert "calendar/adjustfactor" not in out
 
     def test_sync_help_shows_options(self, cli_runner):
         """data sync --help 显示 sync 命令的参数"""


### PR DESCRIPTION
## Summary

修复 #6234 合并引入的 help 与实现不一致。

`#6234`（真正实现 adjustfactor/sources）与 `#6230`（help 把它们标 `[planned]`）方案冲突。
两个 PR 都 squash 合并到 master 后，help 仍把 **已实现** 的 adjustfactor/sources 标为
`[planned]`，而命令实际可用——help 反向误导用户。

### 改动
- `data get` 的 help：adjustfactor/sources 从 `[planned]` 移入可用括号；
  `[planned]` 只留确实未实现的 `calendar`（#5242 not_planned，仍报 Unknown data type）。
- 测试断言精确化：校验可用括号含全部 5 类型 + `[planned: calendar]` 精确匹配，
  防"已实现类型被误标 planned"回归——这正是 #6230 旧测试的盲区（它只防
  "退回无标注全列表"，漏了"已实现却被标 planned"这个方向，故未拦住本 PR 修的 bug）。

## Test plan

- [x] `test_get_help_marks_unimplemented_as_planned` 精确断言（可用括号含 5 类型 + `[planned: calendar]`）
- [x] 真实 CLI 冒烟 `data get --help` 渲染确认：`(stockinfo/day/tick/adjustfactor/sources)` + `[planned: calendar]`
- [x] `tests/unit/client/test_data_cli.py` + `test_data_cli_adjustfactor.py` 48 passed 无回归

Follow-up to #6234 / #6230. #4900 已由 #6234 关闭，本 PR 不重复关闭。
