### PR TITLE
fix(#5399): backtest worker commit 时序 + task_uuid 去重

### DIFF
--- a/src/ginkgo/workers/backtest_worker/node.py
+++ b/src/ginkgo/workers/backtest_worker/node.py
@@ -203,13 +203,8 @@ class BacktestWorker:
                             # GinkgoConsumer 已反序列化，message.value 直接是 dict
                             assignment = message.value
 
-                            # 立即提交 offset，防止 worker 重启后重复消费
-                            # 任务状态由数据库跟踪，失败的任务会被标记为 failed
-                            try:
-                                self.task_consumer.commit()
-                            except Exception as e:
-                                GLOG.ERROR(f"Failed to commit offset after receiving task: {e}")
-
+                            # #5399②: 不在派发前提前提交 offset——派发失败会导致任务静默丢失
+                            # commit 移到 _handle_task_assignment 正常完成决策后（at-least-once）
                             self._handle_task_assignment(assignment)
 
                 except Exception as e:
@@ -220,38 +215,62 @@ class BacktestWorker:
         self.task_consumer_thread.start()
 
     def _handle_task_assignment(self, assignment: dict):
-        """处理任务分配"""
+        """处理任务分配
+
+        #5399②: Kafka offset 在派发决策成功「之后」提交（at-least-once）。
+        派发/处理异常时不提交，留给重启后 DB 状态去重 + Kafka 重投。
+        """
         task_uuid = assignment.get("task_uuid")
         command = assignment.get("command", "start")
 
-        if command == "start":
-            self._start_task(assignment)
-        elif command == "cancel":
-            self._cancel_task(task_uuid)
+        try:
+            if command == "start":
+                self._start_task(assignment)
+            elif command == "cancel":
+                self._cancel_task(task_uuid)
+        except Exception as e:
+            GLOG.ERROR(f"Error handling assignment {task_uuid}: {e}")
+            raise
+
+        # 派发决策完成（派发/skip/discard 均视为消息已正确消费）后提交 offset
+        self._commit_assignment_offset(task_uuid)
+
+    def _commit_assignment_offset(self, task_uuid: str):
+        """提交当前 Kafka offset（派发决策后调用，保证 at-least-once）"""
+        task_short = task_uuid[:8] if task_uuid else "unknown"
+        if self.task_consumer and self.task_consumer.is_connected:
+            try:
+                self.task_consumer.commit()
+                GLOG.DEBUG(f"[{task_short}] Kafka offset committed after dispatch")
+            except Exception as e:
+                GLOG.ERROR(f"[{task_short}] Failed to commit offset after dispatch: {e}")
 
     def _start_task(self, assignment: dict):
         """启动新任务（阻塞等待空闲槽位）"""
-        task_uuid = assignment.get("task_uuid", "unknown")[:8]
+        # #5399③: 去重查找用完整 task_uuid（与 self.tasks 存储 key 一致），
+        # 日志显示单独截断，避免 [:8] 截断导致 :238 查找与 :354 存储 key 不匹配
+        task_uuid = assignment.get("task_uuid", "unknown")
+        task_short = task_uuid[:8] if task_uuid else "unknown"
 
         # 检查任务是否已经在 Worker 中运行
         with self.task_lock:
             if task_uuid in self.tasks:
-                GLOG.WARN(f"[{task_uuid}] Task already running in this worker, skipping...")
+                GLOG.WARN(f"[{task_short}] Task already running in this worker, skipping...")
                 return
 
         # 检查任务状态
         existing_status = self.progress_tracker.get_task_status(assignment.get("task_uuid"))
-        GLOG.DEBUG(f"[{task_uuid}] Current task status: {existing_status}")
+        GLOG.DEBUG(f"[{task_short}] Current task status: {existing_status}")
 
         # 如果任务已完成/失败/取消，跳过
         if existing_status and existing_status in ["completed", "failed", "cancelled"]:
-            GLOG.INFO(f"[{task_uuid}] Task already {existing_status}, skipping...")
+            GLOG.INFO(f"[{task_short}] Task already {existing_status}, skipping...")
             return
 
         # 如果任务状态是 pending 或 running，但不在 Worker 中运行，可能是僵尸任务
         # 重置任务状态为 created，允许重新处理
         if existing_status and existing_status in ["pending", "running"]:
-            GLOG.WARN(f"[{task_uuid}] Task is {existing_status} but not running, resetting to created...")
+            GLOG.WARN(f"[{task_short}] Task is {existing_status} but not running, resetting to created...")
             try:
                 # 尝试重置状态为 created
                 result = self.progress_tracker.task_service.update_status(
@@ -259,21 +278,21 @@ class BacktestWorker:
                     status="created"
                 )
                 if result.is_success():
-                    GLOG.INFO(f"[{task_uuid}] Reset task status to created")
+                    GLOG.INFO(f"[{task_short}] Reset task status to created")
                 else:
-                    GLOG.ERROR(f"[{task_uuid}] Failed to reset status: {result.error}")
+                    GLOG.ERROR(f"[{task_short}] Failed to reset status: {result.error}")
             except Exception as e:
-                GLOG.ERROR(f"[{task_uuid}] Error resetting status: {e}")
+                GLOG.ERROR(f"[{task_short}] Error resetting status: {e}")
 
         # 阻塞等待空闲槽位
         while not self._can_accept_task():
-            GLOG.INFO(f"[{task_uuid}] Worker at full capacity, waiting for slot...")
+            GLOG.INFO(f"[{task_short}] Worker at full capacity, waiting for slot...")
             # 清除标志，等待任务完成时被设置
             self._slot_available.clear()
             # 等待最多 60 秒，每隔 1 秒检查一次是否应该停止
             for _ in range(60):
                 if self.should_stop:
-                    GLOG.WARN(f"[{task_uuid}] Worker stopping, discarding task")
+                    GLOG.WARN(f"[{task_short}] Worker stopping, discarding task")
                     return
                 if self._slot_available.wait(timeout=1):
                     break
@@ -283,13 +302,13 @@ class BacktestWorker:
 
             # 被唤醒后再次检查容量
             if self._can_accept_task():
-                GLOG.INFO(f"[{task_uuid}] Slot available, proceeding with task")
+                GLOG.INFO(f"[{task_short}] Slot available, proceeding with task")
                 break
 
         # 验证必要的任务参数
         portfolio_uuid = assignment.get("portfolio_uuid")
         if not portfolio_uuid:
-            GLOG.ERROR(f"[{task_uuid}] ERROR: portfolio_uuid is required but missing, discarding task")
+            GLOG.ERROR(f"[{task_short}] ERROR: portfolio_uuid is required but missing, discarding task")
             # 上报任务失败到数据库
             self.progress_tracker.report_failed_by_uuid(
                 task_uuid=assignment.get("task_uuid", ""),
@@ -302,7 +321,7 @@ class BacktestWorker:
         start_date = config_dict.get("start_date")
         end_date = config_dict.get("end_date")
         if not start_date or not end_date:
-            GLOG.ERROR(f"[{task_uuid}] ERROR: start_date and end_date are required, discarding task")
+            GLOG.ERROR(f"[{task_short}] ERROR: start_date and end_date are required, discarding task")
             self.progress_tracker.report_failed_by_uuid(
                 task_uuid=assignment.get("task_uuid", ""),
                 error=f"Missing dates: start_date={start_date}, end_date={end_date}"

--- a/tests/unit/workers/test_backtest_worker_node.py
+++ b/tests/unit/workers/test_backtest_worker_node.py
@@ -1,0 +1,108 @@
+"""
+BacktestWorker node 测试
+
+覆盖 #5399 子问题 ②③：
+- ③ task_uuid 用完整值查 self.tasks 去重（node.py:234 [:8] 截断 bug）
+- ② Kafka offset 在任务派发决策后提交（at-least-once 语义）
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+project_root = Path(__file__).parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+
+def _make_assignment(task_uuid: str = "abcdef1234567890abcdef1234567890") -> dict:
+    """构造合法的 Kafka 任务分配 payload（含 _start_task 所需全部必填字段）"""
+    return {
+        "task_uuid": task_uuid,  # 完整 32 hex，验证 [:8] 截断不误判
+        "portfolio_uuid": "portfolio-uuid-full",
+        "name": "dedup-test",
+        "command": "start",
+        "config": {
+            "start_date": "2025-01-01",
+            "end_date": "2025-06-01",
+            "initial_cash": 100000.0,
+        },
+    }
+
+
+@pytest.mark.unit
+class TestStartTaskDedupByFullUuid:
+    """③ #5399: _start_task 必须用完整 task_uuid 查 self.tasks 去重
+
+    bug: node.py:234 `task_uuid = ...[:8]` 截断后用于 :238 查找，
+    而 :354 存储用完整 `task.task_uuid`，两者 key 永不匹配 →
+    同一任务的重复 start 不被去重，processor 被重复创建并覆盖。
+    """
+
+    def test_duplicate_start_task_uuid_deduped(self):
+        """同一完整 task_uuid 连续两次 _start_task，第二次应被去重（processor 仅创建一次）"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+
+        worker = BacktestWorker("test-dedup")
+        # __init__ 不连外部，progress_tracker 为 None；注入 mock 跳过 DB 状态检查
+        worker.progress_tracker = MagicMock()
+        worker.progress_tracker.get_task_status.return_value = None  # DB 无既有记录
+
+        assignment = _make_assignment()
+
+        with patch("ginkgo.workers.backtest_worker.node.BacktestProcessor") as MockProc:
+            MockProc.return_value = MagicMock()
+            worker._start_task(assignment)
+            worker._start_task(assignment)  # 重复派发同一任务
+
+        # 修复后：第二次被 self.tasks 完整 UUID 检测拦截，processor 只创建一次
+        assert MockProc.call_count == 1, (
+            f"重复 task_uuid 应被去重，但 BacktestProcessor 被创建 {MockProc.call_count} 次"
+        )
+
+
+@pytest.mark.unit
+class TestHandleAssignmentCommitTiming:
+    """② #5399: Kafka offset 必须在任务派发决策完成「之后」提交
+
+    bug: node.py consume_tasks:209 在 _handle_task_assignment(:213)「之前」
+    无条件 commit，违反 at-least-once——若派发/处理抛异常，消息已 commit，
+    worker 重启后不会重投，任务静默丢失。
+    修复：commit 移到 _handle_task_assignment 正常完成决策后；异常不 commit。
+    """
+
+    def test_commits_offset_after_successful_dispatch(self):
+        """派发决策完成后提交 Kafka offset（commit 在 _start_task 之后调用）"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+
+        worker = BacktestWorker("test-commit")
+        worker.task_consumer = MagicMock()
+        worker.progress_tracker = MagicMock()
+        worker.progress_tracker.get_task_status.return_value = None
+
+        with patch("ginkgo.workers.backtest_worker.node.BacktestProcessor"):
+            worker._handle_task_assignment(_make_assignment())
+
+        # commit 必须在派发决策完成「之后」调用（at-least-once）
+        worker.task_consumer.commit.assert_called_once()
+
+    def test_no_commit_offset_on_dispatch_exception(self):
+        """② 派发/处理异常时不提交 offset，留给重启后 Kafka 重投 + DB 去重"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+
+        worker = BacktestWorker("test-commit-err")
+        worker.task_consumer = MagicMock()
+        worker.progress_tracker = MagicMock()
+        worker.progress_tracker.get_task_status.return_value = None
+
+        # _start_task 内创建 BacktestProcessor 抛异常（模拟派发失败）
+        with patch(
+            "ginkgo.workers.backtest_worker.node.BacktestProcessor",
+            side_effect=RuntimeError("dispatch boom"),
+        ):
+            with pytest.raises(RuntimeError):
+                worker._handle_task_assignment(_make_assignment())
+
+        # 异常分支绝不提交 offset（at-least-once：重启后重投）
+        worker.task_consumer.commit.assert_not_called()


### PR DESCRIPTION
## Summary

修复 #5399 子问题 ②③（仅 `node.py`）：

**② Kafka commit 时序（at-least-once）**
`consume_tasks` 原在 `_handle_task_assignment` **之前**无条件 `commit()`，违反 at-least-once：派发/处理抛异常时消息已 commit，worker 重启后 Kafka 不重投，任务静默丢失。
- 移除 `consume_tasks` 提前 commit
- commit 移到 `_handle_task_assignment` 派发决策成功之后（新增 `_commit_assignment_offset`）
- 异常分支不 commit，留重启后 DB 状态去重（pending/running 僵尸重置）+ Kafka 重投

**③ task_uuid 去重 key 不匹配**
`_start_task` 用 `task_uuid[:8]` 截断查 `self.tasks`，而存储用完整 `task.task_uuid`（32 hex），两者 key 永不匹配 → 同一任务重复 start 不被去重，processor 被重复创建并覆盖。
- 局部变量 `task_uuid` 保持完整（与存储 key 一致）
- 日志显示用独立 `task_short`（[:8]）

> #5399 标题打包 4 个子问题，逐字核对后仅 ②③ 为真实 bug：
> - ① GLOG.clear_context：非 bug（contextvars 线程隔离，processor 线程各自独立）
> - ④ 起止日期缺失：已由 #5382/#6044/#6055 修复

## Test plan

新增 `tests/unit/workers/test_backtest_worker_node.py`（3 个 `@pytest.mark.unit`）：
- `test_duplicate_start_task_uuid_deduped`：同完整 task_uuid 两次 `_start_task`，processor 仅创建一次（③）
- `test_commits_offset_after_successful_dispatch`：派发决策成功后 commit（②a）
- `test_no_commit_offset_on_dispatch_exception`：派发异常不 commit，留重投（②b）

```
$ pytest tests/unit/workers/test_backtest_worker_node.py \
         tests/unit/workers/test_execution_node_load_portfolio.py -q
6 passed in 1.26s
```

Closes #5399
