### PR TITLE
fix(config): config reset 崩溃修复 - 补 set_quiet setter (#5936)

### DIFF
--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -834,6 +834,17 @@ class GinkgoConfig(object):
             os.environ[key] = quiet
         return quiet.upper() == "TRUE"
 
+    def set_quiet(self, value: bool) -> None:
+        """#5936: persist quiet + sync env so the QUIET getter observes it.
+
+        Symmetric with set_cpu_ratio: config reset / `config set quiet` rely on
+        this — QUIET reads env first, so the env sync must happen here.
+        """
+        key = "GINKGO_QUIET"
+        if isinstance(value, bool):
+            self._write_config("quiet", value)
+            os.environ[key] = str(value)
+
     @property
     def PYTHONPATH(self) -> str:
         """Python路径（环境标识，有默认值）"""

--- a/tests/unit/client/test_config_cli.py
+++ b/tests/unit/client/test_config_cli.py
@@ -303,6 +303,31 @@ class TestConfigReset:
         assert result.exit_code == 0
         assert "Failed" in result.output
 
+    def test_reset_real_gconf_does_not_crash(self, cli_runner, tmp_path):
+        """#5936: reset on the REAL GinkgoConfig singleton must not crash.
+
+        The mock-based tests above masked the crash because MagicMock accepts
+        any set_quiet call. This exercises the true path (no patch on GCONF),
+        isolating ~/.ginkgo via GINKGO_DIR so nothing real is written.
+        """
+        import yaml
+        os.environ["GINKGO_DIR"] = str(tmp_path)
+        os.environ.pop("GINKGO_QUIET", None)
+        (tmp_path / "config.yml").write_text(
+            "debug: true\nquiet: true\ncpu_ratio: 0.5\n"
+        )
+        try:
+            # No patch on ginkgo.libs.GCONF — real singleton in play
+            result = cli_runner.invoke(config_cli.app, ["reset"])
+            assert result.exit_code == 0
+            assert "Failed" not in result.output
+            # reset persisted quiet=False via the new set_quiet setter
+            data = yaml.safe_load((tmp_path / "config.yml").read_text())
+            assert data["quiet"] is False
+        finally:
+            os.environ.pop("GINKGO_DIR", None)
+            os.environ.pop("GINKGO_QUIET", None)
+
 
 # ============================================================================
 # 6. workers 命令

--- a/tests/unit/libs/test_ginkgo_config.py
+++ b/tests/unit/libs/test_ginkgo_config.py
@@ -233,3 +233,40 @@ class TestPasswordEncryption:
         cfg = GinkgoConfig()
         result = cfg._decode_password("plain_text_pwd")
         assert result == "plain_text_pwd"
+
+
+# ---------------------------------------------------------------------------
+# Root Cause G: Missing set_quiet setter (#5936)
+# ---------------------------------------------------------------------------
+
+
+class TestQuietSetter:
+    """#5936: config reset / `config set quiet` crash because GinkgoConfig has
+    no set_quiet (QUIET is a read-only property). The setter must exist, persist
+    to config.yml, and sync env so the QUIET getter observes the new value."""
+
+    def test_set_quiet_persists_to_config_and_env(self, tmp_path):
+        """set_quiet(True) writes `quiet` to config.yml and syncs GINKGO_QUIET."""
+        import yaml
+        from ginkgo.libs.core.config import GinkgoConfig
+
+        os.environ["GINKGO_DIR"] = str(tmp_path)
+        os.environ.pop("GINKGO_QUIET", None)
+        config_file = tmp_path / "config.yml"
+        config_file.write_text("debug: false\nquiet: false\n")
+        try:
+            cfg = GinkgoConfig()
+            cfg._has_local_config = True  # skip generate_config_file copy logic
+
+            # Must not raise AttributeError (the #5936 crash)
+            cfg.set_quiet(True)
+
+            # Persisted to config.yml
+            data = yaml.safe_load(config_file.read_text())
+            assert data["quiet"] is True
+            # Env synced so the read-only QUIET getter observes it immediately
+            assert os.environ["GINKGO_QUIET"] == str(True)
+            assert cfg.QUIET is True
+        finally:
+            os.environ.pop("GINKGO_DIR", None)
+            os.environ.pop("GINKGO_QUIET", None)


### PR DESCRIPTION
## Summary

`ginkgo config reset` 崩溃 `'GinkgoConfig' object has no attribute 'set_quiet'`。

**根因**：`GinkgoConfig.QUIET` 是只读 property，类无 `set_quiet` 方法；但 `config_cli.reset()`(行235) 与 `config_cli.set('quiet',...)`(行174) 都调用 `GCONF.set_quiet()`。同源波及 `config set quiet on/off`。

**为何既有测试没拦住**：`tests/unit/client/test_config_cli.py` 全程 mock GCONF（`MagicMock`），`set_quiet` 在 mock 上自动成立，掩盖了真实缺失 —— 见 `feedback_magicmock_method_attr_mask`。

**修复**：在 `config.py` 补 `set_quiet(value)`，对称现有 `set_cpu_ratio` —— 写 `config.yml` 的 `quiet` 键并同步 env `GINKGO_QUIET`（`QUIET` getter 先读 env，必须同步才能立即生效）。CLI 层不动（其调用是正确期望）。

## Test plan

- [x] `tests/unit/libs/test_ginkgo_config.py::TestQuietSetter` —— 真实 GinkgoConfig 上 `set_quiet(True)` 写 config + 同步 env（先 RED 复现 AttributeError，加 setter 后 GREEN）
- [x] `tests/unit/client/test_config_cli.py::test_reset_real_gconf_does_not_crash` —— 端到端 `config reset`（**真实 GCONF 不 patch**，隔离 `GINKGO_DIR`）exit_code=0 且 `quiet` 落盘为 False
- [x] 两文件全量 57 passed 无回归

Closes #5936