### PR TITLE
fix: worker_cli 迭代 Dict[pid,dict] 改 .values() 修复 AttributeError (#5515)

### DIFF
--- a/src/ginkgo/client/worker_cli.py
+++ b/src/ginkgo/client/worker_cli.py
@@ -119,8 +119,10 @@ def data_status(
                 return
 
             # 汇总统计
+            # #5515: get_workers_status() 返回 Dict[pid, dict]（threading.py: res[pid]=data），
+            # 迭代 dict 默认拿到 key(pid 字符串)；须 .values() 迭代 status dict。
             total_workers = len(worker_list)
-            active_workers = len([w for w in worker_list if w.get("status") == "running"])
+            active_workers = len([w for w in worker_list.values() if w.get("status") == "running"])
 
             # 创建汇总表格
             table = Table(title=":gear: Data Worker Status Summary")
@@ -142,7 +144,7 @@ def data_status(
                 detailed_table.add_column("Memory", justify="right")
                 detailed_table.add_column("Tasks", justify="center")
 
-                for w in worker_list:
+                for w in worker_list.values():  # #5515: 迭代 Dict[pid,dict] 的 value
                     pid = w.get("pid", "N/A")
                     status = w.get("status", "unknown")
                     cpu = f"{w.get('cpu_percent', 0):.1f}%" if "cpu_percent" in w else "N/A"

--- a/tests/unit/client/test_worker_cli.py
+++ b/tests/unit/client/test_worker_cli.py
@@ -89,12 +89,18 @@ class TestDataWorkerStatus:
     """worker data status 命令"""
 
     def test_data_status_shows_summary(self, cli_runner):
-        """data status 显示 worker 汇总信息"""
+        """data status 显示 worker 汇总信息
+
+        #5515: GinkgoThreadManager.get_workers_status() returns Dict[pid, dict]
+        (threading.py: res[pid]=data), NOT list[dict]. Mocking the real shape
+        exposes the iteration bug — `for w in dict` yields keys (pid strings),
+        and w.get() raises AttributeError.
+        """
         mock_gtm = MagicMock()
-        mock_gtm.get_workers_status.return_value = [
-            {"pid": "1001", "status": "running", "cpu_percent": 1.5, "memory_mb": 128.0, "tasks": 3},
-            {"pid": "1002", "status": "idle", "cpu_percent": 0.0, "memory_mb": 64.0, "tasks": 0},
-        ]
+        mock_gtm.get_workers_status.return_value = {
+            "1001": {"pid": "1001", "status": "running", "cpu_percent": 1.5, "memory_mb": 128.0, "tasks": 3},
+            "1002": {"pid": "1002", "status": "idle", "cpu_percent": 0.0, "memory_mb": 64.0, "tasks": 0},
+        }
 
         with patch("ginkgo.libs.core.threading.GinkgoThreadManager", return_value=mock_gtm):
             result = cli_runner.invoke(worker_cli.app, ["data", "status"])
@@ -103,15 +109,36 @@ class TestDataWorkerStatus:
         assert "Total Workers" in result.output
 
     def test_data_status_raw_outputs_json(self, cli_runner):
-        """data status --raw 输出 JSON 格式"""
+        """data status --raw 输出 JSON 格式
+
+        #5515: 真实结构 Dict[pid, dict]；raw 分支 json.dumps 整个 dict，pid 作 key 仍在输出中。
+        """
         mock_gtm = MagicMock()
-        mock_gtm.get_workers_status.return_value = [
-            {"pid": "1001", "status": "running"},
-        ]
+        mock_gtm.get_workers_status.return_value = {
+            "1001": {"pid": "1001", "status": "running"},
+        }
 
         with patch("ginkgo.libs.core.threading.GinkgoThreadManager", return_value=mock_gtm):
             result = cli_runner.invoke(worker_cli.app, ["data", "status", "--raw"])
         assert result.exit_code == 0
+        assert "1001" in result.output
+        assert "running" in result.output
+
+    def test_data_status_detailed_dict(self, cli_runner):
+        """data status --detailed 迭代 Dict[pid, dict].values() 不崩溃 (#5515 detailed 分支)
+
+        复现：for w in worker_list 拿到 pid 字符串 → w.get() AttributeError。
+        """
+        mock_gtm = MagicMock()
+        mock_gtm.get_workers_status.return_value = {
+            "1001": {"pid": "1001", "status": "running", "cpu_percent": 1.5, "memory_mb": 128.0, "tasks": 3},
+            "1002": {"pid": "1002", "status": "idle", "cpu_percent": 0.0, "memory_mb": 64.0, "tasks": 0},
+        }
+
+        with patch("ginkgo.libs.core.threading.GinkgoThreadManager", return_value=mock_gtm):
+            result = cli_runner.invoke(worker_cli.app, ["data", "status", "--detailed"])
+        assert result.exit_code == 0
+        assert "All Data Workers" in result.output
         assert "1001" in result.output
         assert "running" in result.output
 


### PR DESCRIPTION
## Summary

修复 #5515：`ginkgo worker data status` 每次崩溃 `AttributeError: 'str' object has no attribute 'get'`。

**根因**：`GinkgoThreadManager.get_workers_status()` 返回 `Dict[pid, dict]`（threading.py:998 `res[pid] = data`），但 worker_cli 的 `for w in worker_list` 默认迭代 dict 拿到 key（pid 字符串），对 str 调 `.get()` 报错。

**双重根因**：`test_worker_cli.py` 的 mock 写成 `list[dict]`，与真实实现脱节——`for w in [dict]` 恰好拿到 dict 永绿，掩盖了真实崩溃。

**修复**：
- `worker_cli.py:123,147` 两处迭代改 `.values()`（汇总统计 + detailed 表格）
- `test_worker_cli.py` mock 从 list[dict] 改为真实 `Dict[pid, dict]`，激活回归保护
- 新增 detailed 分支哨兵测试

## Test plan

- [x] `pytest tests/unit/client/test_worker_cli.py` → 13 passed
- [x] TDD RED 复现：mock 真实 dict 结构时旧代码 `AttributeError` exit=1
- [x] GREEN 验证：改 `.values()` 后全绿
- [x] grep 确认无残留 `for w in worker_list` 裸迭代

Closes #5515