### PR TITLE
fix: SimBroker 一字板 high==low 显式 guard，消除 scipy scale=0 隐式依赖 (#5491)

### DIFF
--- a/src/ginkgo/trading/brokers/sim_broker.py
+++ b/src/ginkgo/trading/brokers/sim_broker.py
@@ -407,6 +407,12 @@ class SimBroker(BaseBroker):
         """
         low = float(to_decimal(low))
         high = float(to_decimal(high))
+        # #5491: 一字板（涨停/跌停，high == low）成交价确定，直接返回限价。
+        # 否则 std_dev = (high-low)/6 = 0，scipy norm/skewnorm 以 scale=0 调用，
+        # 虽当前 scipy 版本退化为常量返回 loc，但属未文档化的隐式行为；
+        # 显式 guard 消除对 scipy 版本的依赖，且避免无意义的随机源消耗。
+        if high == low:
+            return to_decimal(round(high, 2))
         mean = (low + high) / 2
         std_dev = (high - low) / 6
 

--- a/tests/unit/trading/brokers/test_sim_broker_limit_board.py
+++ b/tests/unit/trading/brokers/test_sim_broker_limit_board.py
@@ -1,0 +1,53 @@
+import sys
+import os
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import patch
+
+from ginkgo.trading.brokers import sim_broker as sb_module
+from ginkgo.trading.brokers.sim_broker import SimBroker
+from ginkgo.enums import DIRECTION_TYPES, ATTITUDE_TYPES
+
+
+class TestLimitBoardPriceGuard:
+    """一字板（high == low）价格生成：价格确定，不应触发随机分布调用。
+
+    #5491: std_dev = (high - low) / 6 在一字板为 0，scale=0 依赖 scipy 退化行为。
+    加固后 high == low 时直接返回限价，跳过 scipy.rvs，消除隐式依赖。
+    """
+
+    @pytest.mark.parametrize("direction", [DIRECTION_TYPES.LONG, DIRECTION_TYPES.SHORT])
+    def test_limit_board_random_skips_rvs(self, direction):
+        """RANDOM 态度下一字板不调用 norm.rvs，直接返回限价"""
+        broker = SimBroker(random_seed=42, attitude=ATTITUDE_TYPES.RANDOM)
+        with patch.object(sb_module.stats.norm, "rvs", wraps=sb_module.stats.norm.rvs) as spy_norm:
+            price = broker._get_random_transaction_price(
+                direction, 10.0, 10.0, ATTITUDE_TYPES.RANDOM
+            )
+        assert float(price) == 10.0
+        spy_norm.assert_not_called()
+
+    @pytest.mark.parametrize("direction", [DIRECTION_TYPES.LONG, DIRECTION_TYPES.SHORT])
+    @pytest.mark.parametrize("attitude", [ATTITUDE_TYPES.OPTIMISTIC, ATTITUDE_TYPES.PESSIMISTIC])
+    def test_limit_board_skew_skips_rvs(self, direction, attitude):
+        """OPTIMISTIC/PESSIMISTIC 态度下一字板不调用 skewnorm.rvs，直接返回限价"""
+        broker = SimBroker(random_seed=42, attitude=attitude)
+        with patch.object(sb_module.stats.skewnorm, "rvs", wraps=sb_module.stats.skewnorm.rvs) as spy_skew:
+            price = broker._get_random_transaction_price(
+                direction, 10.0, 10.0, attitude
+            )
+        assert float(price) == 10.0
+        spy_skew.assert_not_called()
+
+    def test_non_limit_board_still_uses_rvs(self):
+        """非一字板（high != low）仍走随机分布——回归守护，防 guard 误吞正常区间"""
+        broker = SimBroker(random_seed=42, attitude=ATTITUDE_TYPES.RANDOM)
+        with patch.object(sb_module.stats.norm, "rvs", wraps=sb_module.stats.norm.rvs) as spy_norm:
+            price = broker._get_random_transaction_price(
+                DIRECTION_TYPES.LONG, 10.0, 11.0, ATTITUDE_TYPES.RANDOM
+            )
+        assert 10.0 <= float(price) <= 11.0
+        spy_norm.assert_called_once()


### PR DESCRIPTION
## Summary

修复 #5491：`SimBroker._get_random_transaction_price` 一字板（涨跌停 `high==low`）时 `std_dev=(high-low)/6=0`，原以 `scale=0` 调 scipy `norm.rvs`/`skewnorm.rvs`，依赖 scipy 退化为常量返回 `loc` 的未文档化行为（当前不崩但脆弱）。加 `high==low` 早退 guard，直接返回限价，跳过随机分布调用，消除版本依赖与随机源空耗。

## 根因

`sim_broker.py:411` 无 `high==low` 早退分支，把"价格确定"的一字板场景误走随机路径。

## Test plan

- [x] 新增 6 组参数化测试（RANDOM/OPTIMISTIC/PESSIMISTIC × LONG/SHORT）：一字板不调 scipy.rvs 且返回限价（`patch.object(..., wraps=...)` spy 断言 `assert_not_called`）
- [x] 回归守护：非一字板（`high!=low`）仍调 rvs（防 guard 误吞）
- [x] `test_sim_broker_reproducibility.py` 8 个全绿；brokers 目录 114 passed（2 个 OKX 失败为既有 SDK `timeout` kwarg 兼容问题，与本次无关）

TDD：spy 测试先 RED（无 guard 时 rvs 被调 `call(scale=0)`）→ 加 guard 后 GREEN。

Closes #5491
