### PR TITLE
fix(#5496): DualThrust Decimal/numpy.float64 类型混用致 TypeError

### DIFF
--- a/src/ginkgo/trading/strategies/dual_thrust.py
+++ b/src/ginkgo/trading/strategies/dual_thrust.py
@@ -8,7 +8,6 @@
 
 
 import datetime
-from decimal import Decimal
 from ginkgo.trading.strategies.strategy_base import BaseStrategy
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.entities import Signal
@@ -30,10 +29,10 @@ class StrategyDualThrust(BaseStrategy):
     ):
         super().__init__(name, *args, **kwargs)
         self._spans = spans
-        self._k_buy = Decimal(str(k_buy))
-        self._k_sell = Decimal(str(k_sell))
+        self._k_buy = float(k_buy)
+        self._k_sell = float(k_sell)
 
-    def _calculate_range(self, df: pd.DataFrame) -> Decimal:
+    def _calculate_range(self, df: pd.DataFrame) -> float:
         """
         Calculates the range for the Dual Thrust strategy.
         """

--- a/tests/unit/trading/strategies/test_dual_thrust.py
+++ b/tests/unit/trading/strategies/test_dual_thrust.py
@@ -1,0 +1,133 @@
+"""
+Dual Thrust 策略单元测试
+
+覆盖范围:
+- TestDualThrustCal: 突破信号生成（LONG/SHORT/无信号）
+- #5496: Decimal * numpy.float64 类型混用导致 cal() 抛 TypeError 的回归防护
+
+Related: #5496
+"""
+
+import sys
+_path = "/home/kaoru/Ginkgo/src"
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pandas as pd
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from ginkgo.trading.strategies.dual_thrust import StrategyDualThrust
+from ginkgo.enums import DIRECTION_TYPES
+
+
+def _make_price_event(code="000001.SZ"):
+    ev = MagicMock()
+    ev.code = code
+    return ev
+
+
+def _make_portfolio_info(now=None, interested_codes=None, positions=None):
+    if now is None:
+        now = datetime(2024, 1, 20)
+    if positions is None:
+        positions = {}
+    return {
+        "uuid": "portfolio-001",
+        "engine_id": "engine-001",
+        "task_id": "run-001",
+        "now": now,
+        "interested_codes": interested_codes or ["000001.SZ"],
+        "positions": positions,
+    }
+
+
+# 多头突破：历史窗口 range 小，昨日收低于开，今日大涨收（突破买入线）
+LONG_BREAKOUT_DF = pd.DataFrame({
+    "open":  [100.0, 100.0, 100.0, 100.0, 100.0],
+    "high":  [100.1, 100.1, 100.1, 100.1, 101.0],
+    "low":   [ 99.9,  99.9,  99.9,  99.9,  99.0],
+    "close": [ 99.5,  99.5,  99.5,  99.5, 105.0],
+})
+
+# 空头跌破：历史窗口 range 小，昨日收高于开，今日大跌收（跌破卖出线）
+SHORT_BREAKDOWN_DF = pd.DataFrame({
+    "open":  [100.0, 100.0, 100.0, 100.0, 100.0],
+    "high":  [100.1, 100.1, 100.1, 100.1, 101.0],
+    "low":   [ 99.9,  99.9,  99.9,  99.9,  99.0],
+    "close": [100.5, 100.5, 100.5, 100.5,  95.0],
+})
+
+# 横盘：无明显突破
+FLAT_DF = pd.DataFrame({
+    "open":  [100.0, 100.0, 100.0, 100.0, 100.0],
+    "high":  [100.1, 100.1, 100.1, 100.1, 100.1],
+    "low":   [ 99.9,  99.9,  99.9,  99.9,  99.9],
+    "close": [100.0, 100.0, 100.0, 100.0, 100.0],
+})
+
+
+def _make_strategy(df, spans=3, k_buy=0.5, k_sell=0.5):
+    s = StrategyDualThrust(spans=spans, k_buy=k_buy, k_sell=k_sell)
+    feeder = MagicMock()
+    feeder.get_historical_data.return_value = df
+    s.bind_data_feeder(feeder)
+    ctx = MagicMock()
+    ctx.portfolio_id = "portfolio-001"
+    ctx.engine_id = "engine-001"
+    ctx.task_id = "run-001"
+    s._context = ctx
+    return s
+
+
+class TestDualThrustCal:
+    """DualThrust cal 方法信号生成测试 (#5496)"""
+
+    def test_generates_long_on_breakout(self):
+        """#5496: 价格突破买入线 → LONG 信号，且 cal() 不抛 TypeError"""
+        s = _make_strategy(LONG_BREAKOUT_DF)
+        info = _make_portfolio_info(positions={})
+        result = s.cal(info, _make_price_event("000001.SZ"))
+        assert len(result) == 1
+        assert result[0].direction == DIRECTION_TYPES.LONG
+        assert result[0].code == "000001.SZ"
+
+    def test_generates_short_on_breakdown_with_position(self):
+        """#5496: 持仓且价格跌破卖出线 → SHORT 信号"""
+        s = _make_strategy(SHORT_BREAKDOWN_DF)
+        info = _make_portfolio_info(positions={"000001.SZ": {}})
+        result = s.cal(info, _make_price_event("000001.SZ"))
+        assert len(result) == 1
+        assert result[0].direction == DIRECTION_TYPES.SHORT
+
+    def test_no_signal_in_flat_market(self):
+        """#5496: 横盘无突破 → 无信号"""
+        s = _make_strategy(FLAT_DF)
+        info = _make_portfolio_info(positions={})
+        result = s.cal(info, _make_price_event("000001.SZ"))
+        assert result == []
+
+
+class TestDualThrustTypeConsistency:
+    """#5496: 数值类型一致性回归防护（防止重新引入 Decimal/numpy 混用）"""
+
+    def test_k_buy_k_sell_stored_as_float(self):
+        """k_buy/k_sell 必须存为 float，不得包 Decimal（与 numpy/pandas 算术兼容）"""
+        from decimal import Decimal
+        s = StrategyDualThrust(spans=3, k_buy=0.5, k_sell=0.7)
+        assert isinstance(s._k_buy, float)
+        assert isinstance(s._k_sell, float)
+        assert not isinstance(s._k_buy, Decimal)
+
+    def test_calculate_range_returns_float(self):
+        """_calculate_range 返回值须为 float（与 _k_buy 算术兼容）"""
+        s = _make_strategy(LONG_BREAKOUT_DF)
+        r = s._calculate_range(LONG_BREAKOUT_DF)
+        assert isinstance(r, (float, int)), f"期望 float，实际 {type(r)}"
+
+    def test_arithmetic_chain_no_typeerror_with_fractional_k(self):
+        """分数 k 值（如 0.3）下整条算术链不得抛 TypeError"""
+        s = _make_strategy(LONG_BREAKOUT_DF, k_buy=0.3, k_sell=0.3)
+        info = _make_portfolio_info(positions={})
+        # 不抛 TypeError 即通过
+        s.cal(info, _make_price_event("000001.SZ"))


### PR DESCRIPTION
## Summary
`StrategyDualThrust` 的 `_k_buy/_k_sell` 存为 `Decimal`，而 `_calculate_range` 返回 `numpy.float64`（pandas rolling 产物），`cal()` 中 `Decimal * numpy.float64` 触发 `TypeError`，策略无法产出突破信号。

改为统一 float 链（与下游 `df.iloc["open"]`、`df["close"]` 比较的 numpy.float64 一致）：移除 `Decimal` import，`_k_buy/_k_sell` 存 `float`，修正 `_calculate_range` 返回注解 `-> float`。

## 根因
`dual_thrust.py:75` `today_buy_line = open + k_buy * today_r`，`k_buy`(Decimal) × `today_r`(numpy.float64) → TypeError。

## Test plan
- [x] 新增 `tests/unit/trading/strategies/test_dual_thrust.py`（6 用例：LONG/SHORT/无信号 + 类型一致性回归防护）
- [x] `tests/unit/trading/strategies/` 全目录 59 passed
- [x] RED 复现 TypeError → GREEN 修复

Closes #5496