### PR TITLE
fix(#5493): Sizer 佣金改用 SimBroker 实际费率 max(rate×turnover, min)

### DIFF
--- a/src/ginkgo/trading/sizers/fixed_sizer.py
+++ b/src/ginkgo/trading/sizers/fixed_sizer.py
@@ -26,17 +26,46 @@ class FixedSizer(BaseSizer):
     """
     __abstract__ = False
 
-    def __init__(self, name: str = "FixedSizer", volume: str = "150", *args, **kwargs):
+    def __init__(
+        self,
+        name: str = "FixedSizer",
+        volume: str = "150",
+        commission_rate: float = 0.0003,
+        commission_min: float = 5,
+        stamp_tax: float = 0.001,
+        *args,
+        **kwargs,
+    ):
         """
         Args:
             volume(str): The volume of each order.
+            commission_rate(float): 手续费率，默认对齐 SimBroker (0.0003)。
+            commission_min(float): 最小手续费（元），默认对齐 SimBroker (5)。
+            stamp_tax(float): 印花税率（仅卖出收取），默认 0.001；买入估算不计。
         """
         super().__init__(name, *args, **kwargs)
         self._volume = self._convert_to_int(volume, 150)
+        self._commission_rate = Decimal(str(commission_rate))
+        self._commission_min = Decimal(str(commission_min))
+        self._stamp_tax = Decimal(str(stamp_tax))
 
     @property
     def volume(self) -> float:
         return self._volume
+
+    def _estimate_cost(self, last_price: Decimal, size: int) -> Decimal:
+        """
+        估算订单资金占用：成交额 + 手续费（与 SimBroker sim_broker.py:456-457 一致）。
+
+        手续费 = max(成交额 × commission_rate, commission_min)；
+        印花税仅在卖出收取，买入（LONG）估算不计（stamp_tax 预留给卖出场景）。
+        """
+        price = to_decimal(last_price)
+        transaction_money = price * size
+        commission = transaction_money * self._commission_rate
+        if commission < self._commission_min:
+            commission = self._commission_min
+        return transaction_money + commission
 
     def calculate_order_size(
         self, initial_size: int, last_price: Decimal, cash: Decimal, *args, **kwargs
@@ -46,8 +75,7 @@ class FixedSizer(BaseSizer):
         """
         size = initial_size
         while size > 0:
-            last_price = to_decimal(last_price)
-            planned_cost = last_price * size * Decimal("1.003")
+            planned_cost = self._estimate_cost(last_price, size)
             if cash >= planned_cost:
                 return (size, planned_cost)
             size -= 100

--- a/src/ginkgo/trading/sizers/ratio_sizer.py
+++ b/src/ginkgo/trading/sizers/ratio_sizer.py
@@ -24,17 +24,46 @@ class RatioSizer(BaseSizer):
     """
     __abstract__ = False
 
-    def __init__(self, name: str = "RatioSizer", ratio: str = "0.1", *args, **kwargs):
+    def __init__(
+        self,
+        name: str = "RatioSizer",
+        ratio: str = "0.1",
+        commission_rate: float = 0.0003,
+        commission_min: float = 5,
+        stamp_tax: float = 0.001,
+        *args,
+        **kwargs,
+    ):
         """
         Args:
             ratio(str): Ratio of available cash to use for each order (e.g. "0.1" = 10%).
+            commission_rate(float): 手续费率，默认对齐 SimBroker (0.0003)。
+            commission_min(float): 最小手续费（元），默认对齐 SimBroker (5)。
+            stamp_tax(float): 印花税率（仅卖出收取），默认 0.001；买入估算不计。
         """
         super().__init__(name, *args, **kwargs)
         self._ratio = float(ratio)
+        self._commission_rate = Decimal(str(commission_rate))
+        self._commission_min = Decimal(str(commission_min))
+        self._stamp_tax = Decimal(str(stamp_tax))
 
     @property
     def ratio(self) -> float:
         return self._ratio
+
+    def _estimate_cost(self, last_price: Decimal, size: int) -> Decimal:
+        """
+        估算订单资金占用：成交额 + 手续费（与 SimBroker sim_broker.py:456-457 一致）。
+
+        手续费 = max(成交额 × commission_rate, commission_min)；
+        印花税仅在卖出收取，买入（LONG）估算不计（stamp_tax 预留给卖出场景）。
+        """
+        price = to_decimal(last_price)
+        transaction_money = price * size
+        commission = transaction_money * self._commission_rate
+        if commission < self._commission_min:
+            commission = self._commission_min
+        return transaction_money + commission
 
     def calculate_order_size(
         self, ratio: float, last_price: Decimal, cash: Decimal, *args, **kwargs
@@ -42,11 +71,12 @@ class RatioSizer(BaseSizer):
         """
         Calculate the order size based on cash ratio.
         """
-        budget = cash * Decimal(str(ratio))
-        size = int(budget / (last_price * Decimal("1.003")))
+        budget = to_decimal(cash) * Decimal(str(ratio))
+        # 粗估可买股数上限（忽略手续费，偏大），后续循环按真实成本递减校正
+        size = int(budget / to_decimal(last_price))
         size = (size // 100) * 100  # round down to nearest 100 (A-share lot size)
         while size > 0:
-            planned_cost = last_price * size * Decimal("1.003")
+            planned_cost = self._estimate_cost(last_price, size)
             if budget >= planned_cost:
                 return (size, planned_cost)
             size -= 100

--- a/tests/unit/trading/sizers/test_sizer_commission.py
+++ b/tests/unit/trading/sizers/test_sizer_commission.py
@@ -1,0 +1,91 @@
+"""
+Sizer 佣金费率修复单元测试 (#5493)
+
+FixedSizer / RatioSizer 原硬编码 Decimal("1.003")（0.3% 佣金估计），
+与 SimBroker 实际费率 max(成交额×0.0003, 5) 不符。验证改为可配置的
+真实 broker 费率计算。
+
+Related: #5493
+"""
+
+import sys
+_path = "/home/kaoru/Ginkgo/src"
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from decimal import Decimal
+
+from ginkgo.trading.sizers.fixed_sizer import FixedSizer
+from ginkgo.trading.sizers.ratio_sizer import RatioSizer
+
+
+class TestFixedSizerCommission:
+    """#5493: FixedSizer 佣金计算"""
+
+    def test_small_order_uses_commission_min(self):
+        """小单（成交额×费率 < min 5）佣金按 min 5 计，非 0.3% 估计"""
+        s = FixedSizer(volume="100")
+        # 100 股 @ 10 = 成交额 1000; 0.0003×1000=0.3 < min 5 → 佣金 5
+        # 旧: 100×10×1.003 = 1003; 新: 1000 + 5 = 1005
+        size, cost = s.calculate_order_size(100, Decimal("10"), Decimal("100000"))
+        assert size == 100
+        assert cost == Decimal("1005")
+
+    def test_large_order_uses_commission_rate(self):
+        """大单按 commission_rate 计（0.0003），远低于旧 0.3% 估计"""
+        s = FixedSizer(volume="1000")
+        # 1000 @ 100 = 100000; 0.0003×100000=30 > min 5 → 佣金 30
+        # 旧: 1000×100×1.003 = 100300; 新: 100000 + 30 = 100030
+        size, cost = s.calculate_order_size(1000, Decimal("100"), Decimal("1000000"))
+        assert size == 1000
+        assert cost == Decimal("100030")
+
+    def test_defaults_match_simbroker(self):
+        """默认费率对齐 SimBroker（commission_rate=0.0003, min=5, stamp=0.001）"""
+        s = FixedSizer()
+        assert s._commission_rate == Decimal("0.0003")
+        assert s._commission_min == Decimal("5")
+        assert s._stamp_tax == Decimal("0.001")
+
+    def test_custom_commission_params(self):
+        """自定义费率参数生效"""
+        s = FixedSizer(commission_rate=0.001, commission_min=1)
+        # 100 @ 10 = 1000; 0.001×1000=1 >= min 1 → 佣金 1; 成本 1001
+        size, cost = s.calculate_order_size(100, Decimal("10"), Decimal("100000"))
+        assert size == 100
+        assert cost == Decimal("1001")
+
+    def test_reduces_size_when_cash_insufficient(self):
+        """资金不足时按 100 股递减至可负担"""
+        s = FixedSizer(volume="300")
+        # 300 @ 10 = 3000+5=3005 > cash 2005 → 递减；200 @ 10 = 2000+5=2005 == cash
+        size, cost = s.calculate_order_size(300, Decimal("10"), Decimal("2005"))
+        assert size == 200
+        assert cost == Decimal("2005")
+
+
+class TestRatioSizerCommission:
+    """#5493: RatioSizer 佣金计算"""
+
+    def test_small_order_uses_commission_min(self):
+        """小单佣金按 min 5 计"""
+        s = RatioSizer(ratio="1.0")
+        # budget=1005; 100 @ 10 = 1000+5=1005
+        size, cost = s.calculate_order_size(1.0, Decimal("10"), Decimal("1005"))
+        assert size == 100
+        assert cost == Decimal("1005")
+
+    def test_large_order_uses_commission_rate(self):
+        """大单按 commission_rate 计"""
+        s = RatioSizer(ratio="1.0")
+        # budget=100030; 1000 @ 100 = 100000+30=100030
+        size, cost = s.calculate_order_size(1.0, Decimal("100"), Decimal("100030"))
+        assert size == 1000
+        assert cost == Decimal("100030")
+
+    def test_defaults_match_simbroker(self):
+        """默认费率对齐 SimBroker"""
+        s = RatioSizer()
+        assert s._commission_rate == Decimal("0.0003")
+        assert s._commission_min == Decimal("5")
+        assert s._stamp_tax == Decimal("0.001")


### PR DESCRIPTION
## Summary
`FixedSizer`/`RatioSizer` 原硬编码 `Decimal("1.003")`（0.3% 佣金估计），与 SimBroker 实际费率不符：`commission = max(成交额×0.0003, 5)`（`sim_broker.py:456-457`）。小单（min 5 主导）低估 ~40%，大单高估 10×，可能导致资金校验失败。

改为可配置的真实费率计算：
- 新增 `_estimate_cost()`：`成交额 + max(成交额×commission_rate, commission_min)`
- 接受 `commission_rate/commission_min/stamp_tax` 构造参数，默认对齐 SimBroker（0.0003/5/0.001）
- 买入（LONG）估算不计印花税（仅卖出收取，`sim_broker.py:512`）
- 移除 `ratio_sizer` 初始估计的 1.003，改粗估上限 + 循环递减（成本非线性时仍正确）

## Test plan
- [x] 新增 `tests/unit/trading/sizers/test_sizer_commission.py`（8 用例：小单/大单/默认/自定义/递减 × Fixed+Ratio）
- [x] `tests/unit/trading/sizers/` 全目录 18 passed（既有 10 不破）
- [x] RED（旧 1.003=1003）→ GREEN（新 1005）

Closes #5493