### PR TITLE
fix: backtest 创建校验 portfolio 存在与日期顺序 (#5462)

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -164,16 +164,25 @@ def create_backtest_task(data: BacktestTaskCreate) -> dict:
 
     按照 Engine 装配逻辑组织配置，支持多个 Portfolio
     """
+    # #5462: 校验日期顺序 —— 在建任务前拒绝 start_date 晚于 end_date。
+    # ISO "YYYY-MM-DD" 字符串字典序 == 时间序，可直接比较。
+    start_date = data.engine_config.start_date
+    end_date = data.engine_config.end_date
+    if start_date and end_date and start_date > end_date:
+        raise ValidationError(
+            "start_date must be before end_date",
+            field="end_date",
+        )
+
     # 构建配置
     config = build_backtest_config(data)
 
     # 获取 Portfolio 名称（主Portfolio）
+    # #5462: 不吞 NotFoundError —— 无效 portfolio UUID 应在建任务前报错，
+    # 而非回填 "Unknown Portfolio" 继续创建一个指向不存在组合的任务。
     primary_portfolio_uuid = data.portfolio_uuids[0]
-    try:
-        portfolio_info = get_portfolio_info(primary_portfolio_uuid)
-        portfolio_name = portfolio_info["name"]
-    except NotFoundError:
-        portfolio_name = "Unknown Portfolio"
+    portfolio_info = get_portfolio_info(primary_portfolio_uuid)
+    portfolio_name = portfolio_info["name"]
 
     # 使用服务层创建任务
     # #5577 #5443: engine_config 日期映射到 task 级别字段
@@ -386,7 +395,7 @@ async def create_backtest(data: BacktestTaskCreate):
         # 立即返回响应，不等待 Kafka
         return ok(data=task, message="Backtest task created successfully")
 
-    except (NotFoundError, BusinessError):
+    except (NotFoundError, ValidationError, BusinessError):
         raise
     except Exception as e:
         logger.error(f"Error creating backtest: {str(e)}")

--- a/tests/api/test_backtest_input_validation.py
+++ b/tests/api/test_backtest_input_validation.py
@@ -1,0 +1,107 @@
+# #5462 — backtest 创建应在建任务前校验 portfolio 存在 + 日期顺序
+"""
+验证 create_backtest_task 的输入校验：
+1. 无效 portfolio UUID → 抛 NotFoundError，不建任务（而非吞错回填 "Unknown Portfolio"）
+2. start_date > end_date → 抛 ValidationError，不建任务
+3. 正常输入仍建任务（回归保护）
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from core.exceptions import NotFoundError, ValidationError
+
+
+class TestCreateBacktestTaskRejectsInvalidPortfolio:
+    """无效 portfolio UUID 应在建任务前抛 NotFoundError，不调用 service.create"""
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_invalid_portfolio_raises_not_found_and_no_task_created(
+        self, mock_get_service, mock_portfolio
+    ):
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        mock_portfolio.side_effect = NotFoundError("Portfolio", "nonexistent-uuid")
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["nonexistent-uuid"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+
+        with pytest.raises(NotFoundError):
+            create_backtest_task(data)
+
+        # 关键：不应创建任务
+        mock_service.create.assert_not_called()
+
+
+class TestCreateBacktestTaskRejectsReversedDates:
+    """start_date > end_date 应在建任务前抛 ValidationError，不调用 service.create"""
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_reversed_dates_raises_validation_error_and_no_task_created(
+        self, mock_get_service, mock_portfolio
+    ):
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        # 即使 portfolio 存在，日期倒序也应在建任务前被拒
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_service = MagicMock()
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-12-31",
+                end_date="2025-06-01",
+            ),
+        )
+
+        with pytest.raises(ValidationError):
+            create_backtest_task(data)
+
+        mock_service.create.assert_not_called()
+
+
+class TestCreateBacktestTaskAcceptsValidInput:
+    """正常输入仍应建任务（回归保护）"""
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_valid_input_creates_task(
+        self, mock_get_service, mock_portfolio
+    ):
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+
+        result = create_backtest_task(data)
+
+        mock_service.create.assert_called_once()
+        assert result["uuid"] == "task-uuid"


### PR DESCRIPTION
## Summary
#5462 `create_backtest_task` 用 `try/except NotFoundError` 吞错回填 "Unknown Portfolio"，且无日期校验。无效 UUID 和倒序日期都被静默接受。

修复（api/api/backtest.py，+15/-6）：
- 移除吞错，无效 portfolio UUID → NotFoundError(404)
- 新增 `start_date > end_date` 校验 → ValidationError(400)，字段 end_date
- `create_backtest` 端点 re-raise 元组加入 ValidationError，保留字段级错误

注：issue 建议 422，本仓库 ValidationError 约定为 400（与异常分类一致）。

## Test plan
- [x] tests/api/test_backtest_input_validation.py（3 例：无效 UUID / 倒序日期 / 正常回归）
- [x] date_mapping + backtest_api_fixes 无回归（18 passed）

Closes #5462
