### PR TITLE
fix: create_paper_account 透传 initial_capital (#6046)

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -217,6 +217,7 @@ async def create_paper_account(data: CreatePaperAccountRequest):
             name=data.name,
             mode=PORTFOLIO_MODE_TYPES.PAPER,
             description=f"Paper trading account, initial_capital={data.initial_capital}",
+            initial_capital=data.initial_capital,
         )
 
         if not result.is_success():

--- a/tests/api/test_paper_account_initial_capital.py
+++ b/tests/api/test_paper_account_initial_capital.py
@@ -1,0 +1,35 @@
+# #6046 — create_paper_account 必须把 initial_capital 透传给 portfolio_service.add
+"""
+表象：POST /accounts 创建模拟盘时传 initial_capital=500000，
+      但账户实际初始资金是 1,000,000（service.add 的 None 回退默认）。
+根因：api/api/trading.py create_paper_account 调 portfolio_service.add()
+      只传 name/mode/description，initial_capital 仅拼进 description 字符串，
+      从未作为参数透传 → service 收到 None → 回退 1,000,000。
+契约：create_paper_account(initial_capital=X) → service.add 被以 initial_capital=X 调用。
+
+注：api/ 非 Python 包，经 tests/api/conftest 的 api_modules fixture 临时加入
+    sys.path，import 须延迟到测试函数内。
+"""
+import asyncio
+from unittest.mock import Mock
+
+
+def test_create_paper_account_passes_initial_capital(api_modules, monkeypatch):
+    """create_paper_account 必须把 initial_capital 透传给 portfolio_service.add"""
+    from api import trading as trading_api
+    from api.trading import CreatePaperAccountRequest
+
+    mock_service = Mock()
+    result = Mock()
+    result.is_success.return_value = True
+    result.data = {"uuid": "paper-uuid-1"}
+    mock_service.add.return_value = result
+    monkeypatch.setattr(trading_api, "_get_portfolio_service", lambda: mock_service)
+
+    req = CreatePaperAccountRequest(name="paper-test", initial_capital=500000.0)
+    asyncio.run(trading_api.create_paper_account(req))
+
+    call_kwargs = mock_service.add.call_args.kwargs
+    assert call_kwargs.get("initial_capital") == 500000.0, (
+        f"initial_capital 未透传给 service.add, 实际 kwargs: {call_kwargs}"
+    )


### PR DESCRIPTION
## Summary
#6046 `create_paper_account` 调 `portfolio_service.add()` 未传 `initial_capital`，用户资金仅拼进 description 字符串；service 收到 None 回退默认 1,000,000，用户设置的初始资金完全不生效（连 schema 默认 100000 都不是）。

修复（api/api/trading.py，+1 行）：透传 `initial_capital=data.initial_capital`。service.add 写路径已正确（#5349 验证），仅 API 层透传遗漏。

## Test plan
- [x] tests/api/test_paper_account_initial_capital.py：断言 service.add 被以 initial_capital=500000 调用
- [x] 现有 paper account 测试无回归（12 passed）

Closes #6046
