### PR TITLE
fix(#5952): deploy info 按 deployment uuid 查询非 target_portfolio_id

### DIFF
--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -65,20 +65,21 @@ def deploy(
 
 @app.command("info")
 def info(
-    portfolio_id: Annotated[str, typer.Argument(help="部署后的Portfolio ID")],
+    deployment_id: Annotated[str, typer.Argument(help="Deployment ID（deploy deploy 返回、deploy list 列出的 ID）")],
 ):
     """查看部署详情"""
     try:
         from ginkgo.trading.containers import trading_container
 
         svc = trading_container.deployment_service()
-        result = svc.get_deployment_info(portfolio_id)
+        result = svc.get_deployment_info(deployment_id)
 
         if result.success:
             data = result.data
             table = Table(title="部署详情")
             table.add_column("字段", style="cyan")
             table.add_column("值")
+            table.add_row("Deployment ID", data.get("deployment_id", ""))
             table.add_row("源回测任务", data.get("source_task_id", ""))
             table.add_row("源Portfolio", data.get("source_portfolio_id", ""))
             table.add_row("目标Portfolio", data.get("target_portfolio_id", ""))

--- a/src/ginkgo/data/crud/deployment_crud.py
+++ b/src/ginkgo/data/crud/deployment_crud.py
@@ -25,3 +25,11 @@ class DeploymentCRUD(BaseCRUD):
     def get_by_source_portfolio(self, portfolio_id: str):
         """根据源Portfolio ID查询部署记录"""
         return self.find(filters={"source_portfolio_id": portfolio_id})
+
+    def get_by_uuid(self, deployment_id: str):
+        """根据部署记录 uuid(deployment_id) 查询。
+
+        #5952/#5939: deploy deploy 返回的 ID 即记录 uuid（list_deployments
+        输出的 deployment_id）。deploy info 应按此查，不可与 target_portfolio_id 混淆。
+        """
+        return self.find(filters={"uuid": deployment_id})

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -244,15 +244,21 @@ class DeploymentService(BaseService):
         }
         return result
 
-    def get_deployment_info(self, portfolio_id: str) -> ServiceResult:
-        """获取部署信息"""
-        records = self._deployment_crud.get_by_target_portfolio(portfolio_id)
+    def get_deployment_info(self, deployment_id: str) -> ServiceResult:
+        """获取部署信息。
+
+        #5952/#5939: 按 deployment 记录 uuid（即 deploy deploy 返回、list_deployments
+        输出的 deployment_id）查询，而非 target_portfolio_id。两者字段错配会导致
+        “对存在的 ID 返回未找到”。
+        """
+        records = self._deployment_crud.get_by_uuid(deployment_id)
         if not records:
             return ServiceResult(success=False, error="未找到部署记录")
 
         deployment = records[0]
         result = ServiceResult(success=True)
         result.data = {
+            "deployment_id": deployment.uuid,
             "source_task_id": deployment.source_task_id,
             "target_portfolio_id": deployment.target_portfolio_id,
             "source_portfolio_id": deployment.source_portfolio_id,

--- a/tests/unit/client/test_deploy_cli_info.py
+++ b/tests/unit/client/test_deploy_cli_info.py
@@ -1,0 +1,58 @@
+# Related: #5952, #5939
+# deploy info 命令应把 deployment_id 转发给 service.get_deployment_info，
+# 不再误用 portfolio_id 语义。覆盖 deploy_cli.py info 命令薄层。
+import sys
+from pathlib import Path
+project_root = Path(__file__).parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client import deploy_cli
+
+
+def _found(deployment_id="dep-uuid-123"):
+    return MagicMock(
+        success=True,
+        data={
+            "deployment_id": deployment_id,
+            "source_task_id": "t",
+            "source_portfolio_id": "sp",
+            "target_portfolio_id": "tp",
+            "mode": 1,
+            "account_id": "acc",
+            "status": "ACTIVE",
+            "create_at": None,
+        },
+    )
+
+
+class TestDeployCliInfo:
+
+    def test_info_forwards_deployment_id_to_service(self):
+        """#5952: info 命令把参数作为 deployment_id 转发给 service"""
+        fake_svc = MagicMock()
+        fake_svc.get_deployment_info.return_value = _found()
+        with patch("ginkgo.trading.containers.trading_container") as mock_container:
+            mock_container.deployment_service.return_value = fake_svc
+            result = CliRunner().invoke(deploy_cli.app, ["info", "dep-uuid-123"])
+
+        assert result.exit_code == 0
+        fake_svc.get_deployment_info.assert_called_once_with("dep-uuid-123")
+        assert "dep-uuid-123" in result.stdout
+
+    def test_info_shows_error_when_not_found(self):
+        """#5952: 未找到时显示错误并退出码 1"""
+        fake_svc = MagicMock()
+        fake_svc.get_deployment_info.return_value = MagicMock(
+            success=False, error="未找到部署记录"
+        )
+        with patch("ginkgo.trading.containers.trading_container") as mock_container:
+            mock_container.deployment_service.return_value = fake_svc
+            result = CliRunner().invoke(deploy_cli.app, ["info", "nonexistent"])
+
+        assert result.exit_code == 1
+        assert "未找到" in result.stdout

--- a/tests/unit/trading/services/test_deployment_service_get_info.py
+++ b/tests/unit/trading/services/test_deployment_service_get_info.py
@@ -1,0 +1,74 @@
+# Related: #5952, #5939
+# deploy info 传 deployment uuid（记录主键），不应被当 target_portfolio_id 查。
+# get_deployment_info 改用 get_by_uuid，返回结果补 deployment_id 字段。
+import sys
+from pathlib import Path
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from unittest.mock import MagicMock
+
+from ginkgo.enums import PORTFOLIO_MODE_TYPES
+from ginkgo.trading.services.deployment_service import DeploymentService
+
+
+def _make_svc(**overrides):
+    svc = DeploymentService.__new__(DeploymentService)
+    svc._portfolio_service = overrides.get("portfolio_service", MagicMock())
+    svc._mapping_service = overrides.get("mapping_service", MagicMock())
+    svc._file_service = overrides.get("file_service", MagicMock())
+    svc._deployment_crud = overrides.get("deployment_crud", MagicMock())
+    svc._broker_instance_crud = overrides.get("broker_instance_crud", MagicMock())
+    svc._live_account_service = overrides.get("live_account_service", MagicMock())
+    svc._mongo_driver = overrides.get("mongo_driver", None)
+    svc._param_crud = overrides.get("param_crud", MagicMock())
+    return svc
+
+
+def _mock_record(uuid="d00112621a4e406a8b87b8842ca82968"):
+    record = MagicMock()
+    record.uuid = uuid
+    record.source_task_id = "src-task-1"
+    record.target_portfolio_id = "tp-1"
+    record.source_portfolio_id = "sp-1"
+    record.mode = PORTFOLIO_MODE_TYPES.PAPER
+    record.account_id = "acc-1"
+    record.status = "ACTIVE"
+    record.create_at = None
+    return record
+
+
+class TestDeploymentServiceGetInfo:
+
+    def test_get_by_uuid_called_with_deployment_id(self):
+        """#5952: get_deployment_info 按 deployment uuid 查询，不得用 target_portfolio_id 字段"""
+        svc = _make_svc()
+        svc._deployment_crud.get_by_uuid.return_value = [_mock_record()]
+
+        svc.get_deployment_info("d00112621a4e406a8b87b8842ca82968")
+
+        svc._deployment_crud.get_by_uuid.assert_called_once_with("d00112621a4e406a8b87b8842ca82968")
+        svc._deployment_crud.get_by_target_portfolio.assert_not_called()
+
+    def test_returns_record_with_deployment_id_field(self):
+        """#5952: 返回结果必须含 deployment_id（与 list_deployments 输出对齐）"""
+        svc = _make_svc()
+        svc._deployment_crud.get_by_uuid.return_value = [_mock_record()]
+
+        result = svc.get_deployment_info("d00112621a4e406a8b87b8842ca82968")
+
+        assert result.success
+        assert result.data["deployment_id"] == "d00112621a4e406a8b87b8842ca82968"
+        assert result.data["target_portfolio_id"] == "tp-1"
+
+    def test_not_found_returns_error(self):
+        """#5952: uuid 无匹配记录时返回失败"""
+        svc = _make_svc()
+        svc._deployment_crud.get_by_uuid.return_value = []
+
+        result = svc.get_deployment_info("nonexistent")
+
+        assert not result.success
+        assert "未找到" in result.error


### PR DESCRIPTION
## Summary
`deploy info <deployment_id>` 对 list 中存在的 ID 返回"未找到部署记录"。

**根因**：`get_deployment_info` 用 `get_by_target_portfolio` 按 `target_portfolio_id` 字段查，但 CLI 传入的是 deployment 记录 uuid（`deploy deploy` 返回、`list_deployments` 输出的 `deployment_id`），字段错配。

**修复**：
- `deployment_crud` 新增 `get_by_uuid`
- `deployment_service.get_deployment_info` 改按 uuid 查，返回补 `deployment_id` 字段
- `deploy_cli info` 参数 `portfolio_id` → `deployment_id`，help/表格同步

与 #5939 同根因重复，一并关闭。

## Test plan
- [x] service 层 3 测试（调 get_by_uuid 非 target_portfolio / 返回含 deployment_id / 未找到报错）
- [x] CLI 层 2 测试（info 转发 deployment_id / 未找到退出码 1）
- [x] deployment 回归 23 passed；CLI `info --help` 启动冒烟通过

Closes #5952
Closes #5939