### PR TITLE
fix: 期货合约到期按真实日期判断 (#5542)

### DIFF
--- a/src/ginkgo/trading/brokers/futures_broker.py
+++ b/src/ginkgo/trading/brokers/futures_broker.py
@@ -405,10 +405,22 @@ class FuturesBroker(LiveBrokerBase):
         except Exception:
             return False
 
-    def _is_contract_expired(self, code: str) -> bool:
-        """检查合约是否已到期"""
+    def _is_contract_expired(self, code: str, today=None) -> bool:
+        """检查合约是否已到期。
+
+        #5542: 按合约到期月份末 vs 当前真实日期判断，不再用硬编码日期截止
+        （旧逻辑 `year>2024 or (year==2024 and month>=12)` 会把 2024-12 前的
+        合约一律判到期，拒绝当月合约交易）。
+        today 可注入（默认 date.today()）便于测试不依赖系统时钟。
+        到期日取该月最后一日（calendar.monthrange）——跨品种通用近似，
+        无需市场数据；精确交割日（中金所第三周五等）作为后续增强。
+        """
+        from datetime import date as _date
+        import calendar
+
+        if today is None:
+            today = _date.today()
         try:
-            # 解析到期月份
             if len(code) < 4:
                 return False
 
@@ -416,12 +428,9 @@ class FuturesBroker(LiveBrokerBase):
             year = int(year_month[:2]) + 2000  # 假设为2020年后
             month = int(year_month[2:4])
 
-            # TODO: 实现具体的合约到期检查逻辑
-            # 这里简化处理，假设24年12月之后的合约未到期
-            if year > 2024 or (year == 2024 and month >= 12):
-                return False
-
-            return True  # 假设已到期
+            last_day = calendar.monthrange(year, month)[1]
+            expiry = _date(year, month, last_day)
+            return today > expiry
 
         except Exception:
             return False

--- a/tests/unit/trading/brokers/test_futures_broker_contract_expiry.py
+++ b/tests/unit/trading/brokers/test_futures_broker_contract_expiry.py
@@ -1,0 +1,48 @@
+# Related: #5542
+# _is_contract_expired 不得用硬编码日期截止（2024-12）。
+# 应按合约到期月份末 vs 当前真实日期判断；today 可注入以便测试不依赖系统时钟。
+import sys
+from datetime import date
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.trading.brokers.futures_broker import FuturesBroker
+
+
+def _make_broker():
+    """绕过 __init__；_is_contract_expired 仅依赖 self/code/today，不碰实例属性。"""
+    return FuturesBroker.__new__(FuturesBroker)
+
+
+class TestFuturesContractExpiry:
+
+    def test_current_month_contract_not_expired(self):
+        """#5542: 当月合约在月末前不应判到期。
+        硬编码 `year==2024 and month<12 → 到期` 会误判 IF2406 在 2024-06 到期，
+        拒绝当月合约交易。"""
+        broker = _make_broker()
+        assert broker._is_contract_expired("IF2406", today=date(2024, 6, 15)) is False
+
+    def test_past_contract_is_expired(self):
+        """#5542: 合约月份已过 → 到期（IF2406 在 2024-07 已过 6 月末）"""
+        broker = _make_broker()
+        assert broker._is_contract_expired("IF2406", today=date(2024, 7, 1)) is True
+
+    def test_future_contract_not_expired(self):
+        """#5542: 未来合约未到期（IF2612 在 2026-06 远未到 12 月末）"""
+        broker = _make_broker()
+        assert broker._is_contract_expired("IF2612", today=date(2026, 6, 22)) is False
+
+    def test_short_code_returns_false(self):
+        """#5542: 长度不足 4 的 code 视为无效，不判到期（安全降级）"""
+        broker = _make_broker()
+        assert broker._is_contract_expired("IF", today=date(2026, 6, 22)) is False
+
+    def test_invalid_month_returns_false(self):
+        """#5542: 非法月份（IF2499 → 99 月）解析失败时安全降级返回 False"""
+        broker = _make_broker()
+        assert broker._is_contract_expired("IF2499", today=date(2026, 6, 22)) is False


### PR DESCRIPTION
## Summary
`_is_contract_expired` 硬编码 `year>2024 or (year==2024 and month>=12)`，2024-12 前合约一律判到期，当月合约（如 IF2406 @2024-06）被误拒，阻断期货下单。

改为合约月份末（`calendar.monthrange`）vs 当前真实日期比较。签名加 `today=None`（默认 `date.today()`）便于测试注入。

## 权衡
月末到期日为跨品种通用近似，无需市场数据；精确交割日（中金所第三周五/上期所最后交易日）作为 follow-up。

## Test plan
- [x] 新增 5 用例：当月未过期 / 已过期 / 未来 / 短码 / 非法月份
- [x] brokers 回归（okx 2 既有失败与本改动无关，stash 对照确认）

Closes #5542