### PR TITLE
fix: MeanReversion RSI 改用 Wilder EMA 平滑 (#5489)

### DIFF
--- a/src/ginkgo/trading/strategies/mean_reversion.py
+++ b/src/ginkgo/trading/strategies/mean_reversion.py
@@ -105,10 +105,10 @@ class MeanReversion(BaseStrategy, StrategyDataMixin):
         code = event.code
 
         try:
-            # 获取足够的历史数据计算 RSI（需要 rsi_period + 1 根 bar）
+            # 获取足够的历史数据计算 Wilder RSI（2*period+1 根起递推充分）
             bars = self.get_bars_cached(
                 symbol=code,
-                count=self.rsi_period + 1,
+                count=2 * self.rsi_period + 1,
                 frequency=self.frequency,
                 use_cache=True,
             )
@@ -152,17 +152,23 @@ class MeanReversion(BaseStrategy, StrategyDataMixin):
 
     def _calculate_rsi(self, bars: List) -> Optional[float]:
         """
-        计算 RSI (Relative Strength Index)
+        计算 RSI (Relative Strength Index)，采用 Wilder 平滑（行业标准）。
+
+        #5489: 旧实现用 SMA（sum/period，即 Cutler's RSI），与标准 Wilder RSI
+        在震荡市可差 5-10 点，导致超买/超卖阈值（默认 30/70）误触发。
+        Wilder 平滑：前 period 个变化做 SMA 种子，后续按 EMA 递推
+        avg = (prev_avg * (period-1) + cur) / period（等价 alpha=1/period）。
+        bars 越多递推越充分；bars 恰为 period+1 时退化为 SMA 种子（与旧实现一致）。
 
         Args:
-            bars: K线数据列表（至少 rsi_period + 1 根）
+            bars: K线数据列表（至少 rsi_period + 1 根；2*period+1 根起递推充分）
 
         Returns:
             Optional[float]: RSI 值 (0-100)，计算失败返回 None
         """
         try:
-            # 提取收盘价
-            closes = [bar.close for bar in bars[-(self.rsi_period + 1):]]
+            # 提取收盘价（用全部 bars，给 Wilder 递推足够历史）
+            closes = [bar.close for bar in bars]
 
             # 计算价格变化
             changes = [closes[i] - closes[i - 1] for i in range(1, len(closes))]
@@ -170,16 +176,17 @@ class MeanReversion(BaseStrategy, StrategyDataMixin):
             if len(changes) < self.rsi_period:
                 return None
 
-            # 只看最近 rsi_period 个变化
-            changes = changes[-self.rsi_period:]
+            # 前 period 个变化做 SMA 种子
+            seed = changes[: self.rsi_period]
+            avg_gain = sum(max(c, 0.0) for c in seed) / self.rsi_period
+            avg_loss = sum(abs(min(c, 0.0)) for c in seed) / self.rsi_period
 
-            # 分离涨跌
-            gains = [float(max(c, 0.0)) for c in changes]
-            losses = [float(abs(min(c, 0.0))) for c in changes]
-
-            # 计算平均涨跌幅
-            avg_gain = sum(gains) / self.rsi_period
-            avg_loss = sum(losses) / self.rsi_period
+            # 后续变化按 Wilder EMA 递推（alpha=1/period）
+            for c in changes[self.rsi_period:]:
+                gain = float(max(c, 0.0))
+                loss = float(abs(min(c, 0.0)))
+                avg_gain = (avg_gain * (self.rsi_period - 1) + gain) / self.rsi_period
+                avg_loss = (avg_loss * (self.rsi_period - 1) + loss) / self.rsi_period
 
             # RS 计算
             if avg_loss == 0:

--- a/tests/unit/trading/strategies/test_mean_reversion_wilder_rsi.py
+++ b/tests/unit/trading/strategies/test_mean_reversion_wilder_rsi.py
@@ -1,0 +1,63 @@
+# Related: #5489
+# _calculate_rsi 应使用 Wilder EMA 平滑（行业标准 alpha=1/period），非 SMA。
+# tracer bullet: period=3, 6 根 bar 给出 5 个 changes（种子3 + 递推2），
+# Wilder RSI≈54.17；旧 SMA（最近 3 个 changes）=60.0，区分明显。
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from unittest.mock import MagicMock
+
+from ginkgo.trading.strategies.mean_reversion import MeanReversion
+
+
+def _make_bar(close_price):
+    bar = MagicMock()
+    bar.close = close_price
+    return bar
+
+
+def _make_strategy(period=3):
+    return MeanReversion(rsi_period=period, oversold=20, overbought=80)
+
+
+class TestWilderRsi:
+
+    def test_wilder_ema_recurrence_not_sma(self):
+        """#5489: RSI 用 Wilder EMA 递推（alpha=1/period），非 SMA。
+        period=3, closes=[100,103,102,104,105,103] → changes=[3,-1,2,1,-2]
+        Wilder: 种子 avg_gain=5/3, avg_loss=1/3；递推后 RS=13/11 → RSI≈54.17
+        旧 SMA(最近 3 个 [2,1,-2]): RS=1.5 → RSI=60.0，新旧可区分。"""
+        strategy = _make_strategy(period=3)
+        bars = [_make_bar(c) for c in [100, 103, 102, 104, 105, 103]]
+        rsi = strategy._calculate_rsi(bars)
+        assert rsi is not None
+        assert abs(rsi - 54.17) < 0.5  # Wilder 值
+        assert abs(rsi - 60.0) > 1.0   # 显著区别于旧 SMA
+
+    def test_degenerates_to_sma_when_exactly_period_changes(self):
+        """#5489: bars 恰为 period+1（changes 数 == period）时全做 SMA 种子、
+        无递推，Wilder 退化为 SMA —— 保证现有信号测试行为兼容。"""
+        strategy = _make_strategy(period=3)
+        # changes=[2,-1,3]，全部做种子
+        bars = [_make_bar(c) for c in [100, 102, 101, 104]]
+        rsi = strategy._calculate_rsi(bars)
+        # avg_gain=5/3, avg_loss=1/3 → RS=5 → RSI≈83.33
+        assert rsi is not None
+        assert abs(rsi - 83.33) < 0.5
+
+    def test_all_gains_returns_100(self):
+        """#5489: 持续上涨 avg_loss=0 → RSI=100"""
+        strategy = _make_strategy(period=3)
+        bars = [_make_bar(c) for c in [100, 101, 102, 103, 104, 105]]
+        assert strategy._calculate_rsi(bars) == 100.0
+
+    def test_all_losses_returns_0(self):
+        """#5489: 持续下跌 avg_gain=0 → RS=0 → RSI=0"""
+        strategy = _make_strategy(period=3)
+        bars = [_make_bar(c) for c in [105, 104, 103, 102, 101, 100]]
+        assert strategy._calculate_rsi(bars) == 0.0


### PR DESCRIPTION
## Summary
`_calculate_rsi` 旧用 SMA（`sum/period`，即 Cutler's RSI），震荡市与标准 Wilder RSI 差 5-10 点，致 30/70 阈值误触发。

改为 **Wilder 平滑**：前 period 个变化 SMA 种子 + 后续 EMA 递推（`avg=(prev*(period-1)+cur)/period`，等价 alpha=1/period）。`count` 从 `period+1` 加大到 `2*period+1` 给递推空间。

## 兼容性
bars 恰为 `period+1` 时 changes 数 == period，全做种子零递推，Wilder 退化为 SMA —— 现有 15 个信号测试行为不变。

## Test plan
- [x] 新增 4 用例：Wilder 递推（RSI≈54.17 vs SMA 60.0）/ 退化 SMA / 全涨 100 / 全跌 0
- [x] 现有 15 信号测试全过（退化兼容）
- [x] 冒烟：默认 period=14 实盘路径 RSI 可算

Closes #5489