### PR TITLE
fix: DataSync 同步结果改读后端 failed 计数 (#6071)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -633,6 +633,7 @@ async def sync_data(request: DataUpdateRequest):
                 raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for bars update")
 
             bar_service = get_bar_service()
+            failed = 0  # #6071: 统计失败 code 数，供前端判断 success（旧版 data 无此字段致硬编码误报）
             for code in codes:
                 rec = sync_svc.record_start(sync_type="bars", code=code)
                 started_at = _time.time()
@@ -641,12 +642,13 @@ async def sync_data(request: DataUpdateRequest):
                     if rec.is_success():
                         _record_sync_result(sync_svc, rec.data["uuid"], result, started_at)
                 except Exception as e:
+                    failed += 1
                     if rec.is_success():
                         sync_svc.record_fail(uuid=rec.data["uuid"], error_message=str(e))
 
             return ok(
-                data={"type": "bars", "codes": codes},
-                message=f"Bars update completed for {len(codes)} codes"
+                data={"type": "bars", "codes": codes, "total": len(codes), "failed": failed, "success_count": len(codes) - failed},
+                message=f"Bars update completed for {len(codes)} codes" + (f" ({failed} failed)" if failed else "")
             )
 
         elif request.type == "ticks":
@@ -658,6 +660,7 @@ async def sync_data(request: DataUpdateRequest):
             start_dt = datetime.fromisoformat(request.start_date) if request.start_date else None
             end_dt = datetime.fromisoformat(request.end_date) if request.end_date else None
 
+            failed = 0  # #6071: 统计失败 code 数，供前端判断 success
             for code in codes:
                 rec = sync_svc.record_start(sync_type="ticks", code=code)
                 started_at = _time.time()
@@ -666,12 +669,13 @@ async def sync_data(request: DataUpdateRequest):
                     if rec.is_success():
                         _record_sync_result(sync_svc, rec.data["uuid"], result, started_at)
                 except Exception as e:
+                    failed += 1
                     if rec.is_success():
                         sync_svc.record_fail(uuid=rec.data["uuid"], error_message=str(e))
 
             return ok(
-                data={"type": "ticks", "codes": codes},
-                message=f"Ticks update completed for {len(codes)} codes"
+                data={"type": "ticks", "codes": codes, "total": len(codes), "failed": failed, "success_count": len(codes) - failed},
+                message=f"Ticks update completed for {len(codes)} codes" + (f" ({failed} failed)" if failed else "")
             )
 
         elif request.type in ("adjustfactor", "adjustfactors"):

--- a/tests/api/test_data_sync_codes_field.py
+++ b/tests/api/test_data_sync_codes_field.py
@@ -106,3 +106,68 @@ class TestSyncDataCodeField:
                 pytest.fail(f"ticks 分支单数 code 应路由成功，却抛 HTTPException: {e.detail}")
 
         mock_svc.sync_smart.assert_called_once_with("000001.SZ", start_date=None, end_date=None)
+
+
+class TestSyncDataPartialFailureReporting:
+    """#6071: bars/ticks 部分失败时 response.data 须含 failed 计数。
+
+    后端 bars/ticks 循环里单 code 失败被 except 吞（record_fail 不 raise），
+    整体仍 return ok(200)。若 data 不携带失败计数，前端 sendCommand 拿不到
+    失败信号，硬编码 success:true 误报。本测试锁定后端须上报 failed。
+    """
+
+    @pytest.mark.unit
+    def test_bars_partial_failure_reports_failed_count(self):
+        """bars 多 code 部分失败：response.data.failed 应 == 失败 code 数。
+
+        RED: 当前 return ok(data={type,codes}) 无 failed 字段 → KeyError。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        # 2 个 code：第一个成功，第二个抛异常
+        mock_svc.sync_smart.side_effect = [make_ok_result(), RuntimeError("invalid code")]
+
+        request = DataUpdateRequest(type="bars", codes=["000001.SZ", "INVALID.SZ"])
+
+        with patch("api.data.get_bar_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            result = run_async(sync_data(request))
+
+        assert result["code"] == 0
+        data = result["data"]
+        assert data["failed"] == 1, f"部分失败应上报 failed=1，实际 data={data}"
+
+    @pytest.mark.unit
+    def test_ticks_partial_failure_reports_failed_count(self):
+        """ticks 多 code 部分失败：response.data.failed 应 == 失败 code 数。"""
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_smart.side_effect = [make_ok_result(), RuntimeError("invalid code")]
+
+        request = DataUpdateRequest(type="ticks", codes=["000001.SZ", "INVALID.SZ"])
+
+        with patch("api.data.get_tick_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            result = run_async(sync_data(request))
+
+        assert result["code"] == 0
+        assert result["data"]["failed"] == 1
+
+    @pytest.mark.unit
+    def test_bars_all_success_reports_zero_failed(self):
+        """全部成功时 failed=0，前端据此显示成功（不破坏现有成功路径）。"""
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_svc = MagicMock()
+        mock_svc.sync_smart.return_value = make_ok_result()
+
+        request = DataUpdateRequest(type="bars", codes=["000001.SZ", "000002.SZ"])
+
+        with patch("api.data.get_bar_service", return_value=mock_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            result = run_async(sync_data(request))
+
+        assert result["data"]["failed"] == 0
+        assert result["data"]["success_count"] == 2

--- a/web-ui/src/utils/syncResult.test.ts
+++ b/web-ui/src/utils/syncResult.test.ts
@@ -1,0 +1,30 @@
+// #6071: DataSync.vue sendCommand 不再硬编码 success:true，
+// 改为读后端 ok() 响应里的 failed 计数。本测试锁定提取逻辑。
+//
+// 真实形状：dataApi.sync() 经 request.ts 响应拦截器 `return response.data`
+// 已剥掉 axios 外层，返回后端 ok() body 本身。
+import { describe, it, expect } from 'vitest'
+import { extractSyncFailed } from './syncResult'
+
+describe('extractSyncFailed', () => {
+  it('body.data.failed>0 → 返回该数（部分失败）', () => {
+    const body = { code: 0, data: { type: 'bars', failed: 2, total: 3, success_count: 1 } }
+    expect(extractSyncFailed(body)).toBe(2)
+  })
+
+  it('failed=0 → 0（全部成功，前端显示成功）', () => {
+    const body = { code: 0, data: { type: 'bars', failed: 0, total: 2, success_count: 2 } }
+    expect(extractSyncFailed(body)).toBe(0)
+  })
+
+  it('无 failed 字段（旧后端/非 bars-ticks 分支）→ 0（向后兼容，不误报失败）', () => {
+    const body = { code: 0, data: { type: 'stockinfo' } }
+    expect(extractSyncFailed(body)).toBe(0)
+  })
+
+  it('data 缺失（异常响应）→ 0 不抛错', () => {
+    expect(extractSyncFailed({ code: 0 })).toBe(0)
+    expect(extractSyncFailed(null)).toBe(0)
+    expect(extractSyncFailed(undefined)).toBe(0)
+  })
+})

--- a/web-ui/src/utils/syncResult.ts
+++ b/web-ui/src/utils/syncResult.ts
@@ -1,0 +1,13 @@
+/**
+ * #6071: 从数据同步响应中提取失败的 code 数。
+ *
+ * 真实形状：dataApi.sync() 经 request.ts 响应拦截器 `return response.data`
+ * 已剥掉 axios 外层，sendCommand 拿到的就是后端 ok() body：
+ *   { code: 0, data: { type, codes, total, failed, success_count }, message, trace_id }
+ *
+ * DataSync.vue sendCommand 据此判断 success，不再硬编码 true。
+ */
+export function extractSyncFailed(response: any): number {
+  const inner = response?.data
+  return Number(inner?.failed ?? 0)
+}

--- a/web-ui/src/views/data/DataSync.vue
+++ b/web-ui/src/views/data/DataSync.vue
@@ -107,6 +107,7 @@
 <script setup lang="ts">
 import { ref, reactive, onMounted } from 'vue'
 import { dataApi } from '@/api'
+import { extractSyncFailed } from '@/utils/syncResult'
 
 interface CommandRecord {
   type: string
@@ -147,14 +148,18 @@ const sendCommand = async () => {
       codes,
     })
 
+    // #6071: 读后端 ok() body 里的 failed 计数判断成功，不再硬编码 true。
+    // 后端 bars/ticks 循环里单 code 失败被 except 吞、整体仍 200，
+    // 需凭 data.failed 区分"全部成功"与"部分失败"。
+    const failed = extractSyncFailed(response)
     commandHistory.value.unshift({
       type: command.type,
       codes: codes.join(', '),
       time: new Date().toLocaleString('zh-CN'),
-      success: true,
+      success: failed === 0,
     })
 
-    console.log('命令已发送')
+    console.log(failed > 0 ? `同步完成，${failed} 个 code 失败` : '命令已发送')
   } catch (e: any) {
     commandHistory.value.unshift({
       type: command.type,


### PR DESCRIPTION
## Summary
bars/ticks 部分 code 失败时前端误报成功（#6071）。根因双因：
- 后端 `api/api/data.py` bars/ticks 循环吞单 code 异常，整体仍 `return ok(200)`，data 无失败计数
- 前端 `DataSync.vue` sendCommand 硬编码 `success: true`

## 改动
- 后端：bars/ticks 分支加 `failed`/`success_count` 计数
- 前端：抽 `extractSyncFailed` 纯函数（`request.ts` 拦截器已解包 axios 外层，直接读 `body.data.failed`），sendCommand 据 `failed === 0` 判断成功

## Test plan
- [x] 后端 `tests/api/test_data_sync_codes_field.py` — 6 passed（含 3 新增 partial-failure）
- [x] 前端 `web-ui/src/utils/syncResult.test.ts` — 4 passed（vitest）
- [x] `vue-tsc --noEmit` 无新错（`errorHandler.test.ts` 预存失败，与本 PR 无关）

Closes #6071
