### PR TITLE
fix: BacktestTaskCreate 加顶层 start_date/end_date 可选字段 (#5581)

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -120,10 +120,14 @@ def get_portfolio_info(portfolio_uuid: str) -> dict:
 
 def build_backtest_config(data: BacktestTaskCreate) -> dict:
     """构建回测配置（不访问数据库）"""
+    # #5581: 顶层 start_date/end_date 优先于 engine_config，保证 config_snapshot
+    # 与 task 字段（backtest_start_date/backtest_end_date）一致，回测引擎据此取数。
+    start_date = data.start_date or data.engine_config.start_date
+    end_date = data.end_date or data.engine_config.end_date
     config = {
         # Engine 配置
-        "start_date": data.engine_config.start_date,
-        "end_date": data.engine_config.end_date,
+        "start_date": start_date,
+        "end_date": end_date,
         "commission_rate": data.engine_config.commission_rate,
         "slippage_rate": data.engine_config.slippage_rate,
         "broker_attitude": data.engine_config.broker_attitude,
@@ -176,17 +180,20 @@ def create_backtest_task(data: BacktestTaskCreate) -> dict:
         portfolio_name = "Unknown Portfolio"
 
     # 使用服务层创建任务
-    # #5577 #5443: engine_config 日期映射到 task 级别字段
+    # #5577 #5443 #5581: 日期映射到 task 级别字段；顶层 start_date/end_date
+    # 优先于 engine_config（与 build_backtest_config 同源 effective 日期）。
+    effective_start = data.start_date or data.engine_config.start_date
+    effective_end = data.end_date or data.engine_config.end_date
     create_kwargs = {
         "name": data.name,
         "portfolio_id": primary_portfolio_uuid,
         "portfolio_name": portfolio_name,
         "config_snapshot": config,
     }
-    if data.engine_config.start_date:
-        create_kwargs["backtest_start_date"] = data.engine_config.start_date
-    if data.engine_config.end_date:
-        create_kwargs["backtest_end_date"] = data.engine_config.end_date
+    if effective_start:
+        create_kwargs["backtest_start_date"] = effective_start
+    if effective_end:
+        create_kwargs["backtest_end_date"] = effective_end
 
     task_service = get_backtest_task_service()
     result = task_service.create(**create_kwargs)

--- a/src/ginkgo/data/services/backtest_task_schemas.py
+++ b/src/ginkgo/data/services/backtest_task_schemas.py
@@ -179,6 +179,14 @@ class BacktestTaskCreate(BaseModel):
     component_config: Optional[ComponentConfig] = None
     # 旧字段兼容：旧客户端可能发送 portfolio_id (str) 而非 portfolio_uuids (list)
     portfolio_id: Optional[str] = Field(None, exclude=True, description="[已废弃] 请使用 portfolio_uuids")
+    # #5581: 顶层可选日期字段，优先级高于 engine_config 中的值；
+    # 未传时由 create_backtest_task 回退到 engine_config.start_date/end_date。
+    start_date: Optional[str] = Field(
+        None, description="[可选] 回测开始日期 (YYYY-MM-DD)，提供时优先于 engine_config.start_date"
+    )
+    end_date: Optional[str] = Field(
+        None, description="[可选] 回测结束日期 (YYYY-MM-DD)，提供时优先于 engine_config.end_date"
+    )
 
     @model_validator(mode='before')
     @classmethod

--- a/tests/api/test_backtest_toplevel_dates.py
+++ b/tests/api/test_backtest_toplevel_dates.py
@@ -1,0 +1,146 @@
+# #5581 — BacktestTaskCreate 顶层 start_date/end_date 可选字段
+"""
+验证 BacktestTaskCreate schema 接受可选顶层 start_date/end_date，
+并在创建任务时顶层优先、engine_config 回退。
+
+与 test_backtest_date_mapping.py (#5577 engine_config→task 映射) 互补：
+#5577 保证 engine_config 日期能落到 task 字段；#5581 在此之上加顶层显式入口。
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestBacktestTaskCreateToplevelDates:
+    """#5581: schema 接受可选顶层 start_date/end_date 字段"""
+
+    def test_schema_accepts_toplevel_start_and_end_dates(self):
+        """顶层 start_date/end_date 应被接受为可选字段。
+
+        RED: 当前 BacktestTaskCreate 无 start_date/end_date 字段 →
+        pydantic ignore extra，data.start_date 抛 AttributeError。
+        """
+        from api.backtest import BacktestTaskCreate, EngineConfig
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+        assert data.start_date == "2024-01-01"
+        assert data.end_date == "2024-12-31"
+
+    def test_toplevel_dates_default_to_none_when_omitted(self):
+        """未传顶层日期时为 None（向后兼容，不破坏现有 engine_config 路径）。"""
+        from api.backtest import BacktestTaskCreate, EngineConfig
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+        assert data.start_date is None
+        assert data.end_date is None
+
+
+class TestCreateBacktestTaskToplevelDatePriority:
+    """#5581: 顶层日期优先于 engine_config，未传时回退 engine_config。"""
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_toplevel_start_date_overrides_engine_config(self, mock_get_service, mock_portfolio):
+        """顶层 start_date 提供时，backtest_start_date 用顶层值而非 engine_config。"""
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",  # engine_config 值
+                end_date="2025-12-31",
+            ),
+            start_date="2024-01-01",  # 顶层值（应优先）
+            end_date="2024-12-31",
+        )
+
+        create_backtest_task(data)
+
+        call_kwargs = mock_service.create.call_args.kwargs
+        assert call_kwargs["backtest_start_date"] == "2024-01-01", \
+            "顶层 start_date 应优先于 engine_config"
+        assert call_kwargs["backtest_end_date"] == "2024-12-31"
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_falls_back_to_engine_config_when_no_toplevel(self, mock_get_service, mock_portfolio):
+        """顶层日期未传时，回退到 engine_config（保留 #5577 行为）。"""
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+            # 不传顶层 start_date/end_date
+        )
+
+        create_backtest_task(data)
+
+        call_kwargs = mock_service.create.call_args.kwargs
+        assert call_kwargs["backtest_start_date"] == "2025-06-01"
+        assert call_kwargs["backtest_end_date"] == "2025-12-31"
+
+
+class TestBuildBacktestConfigEffectiveDates:
+    """#5581: config_snapshot 应反映有效日期（顶层优先），保证回放一致。"""
+
+    def test_config_uses_toplevel_dates_when_provided(self):
+        """顶层日期提供时，config.start_date/end_date 也用顶层值。"""
+        from api.backtest import build_backtest_config, BacktestTaskCreate, EngineConfig
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+        config = build_backtest_config(data)
+        assert config["start_date"] == "2024-01-01", \
+            "config_snapshot 应反映顶层日期（回测引擎据此跑数据，须与 task 字段一致）"
+        assert config["end_date"] == "2024-12-31"
+


### PR DESCRIPTION
## Summary
`BacktestTaskCreate` 此前只能经 `engine_config.start_date/end_date` 传日期（#5577 已修该映射）。#5581 要求 schema 支持顶层可选 `start_date`/`end_date`，优先级高于 engine_config。

## 改动
- `backtest_task_schemas.py`: BacktestTaskCreate 加可选顶层 `start_date`/`end_date`（Field 带 description，OpenAPI 自动纳入）
- `api/api/backtest.py`: `build_backtest_config` 与 `create_backtest_task` 同源计算 effective 日期（`data.start_date or data.engine_config.start_date`），保证 config_snapshot 与 task 的 `backtest_start_date`/`backtest_end_date` 一致
- 未传顶层时回退 engine_config，行为同前（向后兼容）

## Test plan
- [x] `tests/api/test_backtest_toplevel_dates.py` — 5 passed（schema 接受字段、顶层优先、engine_config 回退、config 一致）
- [x] 回归 `test_backtest_date_mapping.py` + `test_backtest_api_fixes.py` + pagination — 25 passed

## Acceptance（#5581）
- [x] schema 加可选 start_date/end_date
- [x] 顶层直接映射 backtest_start_date/backtest_end_date
- [x] 顶层未传时从 engine_config 提取
- [x] OpenAPI 反映新字段（pydantic Field 自动）

Closes #5581
