### PR TITLE
fix(#5984): portfolio create 校验 --capital 为正

### DIFF
--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -277,6 +277,13 @@ def create(
     """
     from ginkgo.data.containers import container
 
+    # #5984: 初始资本必须为正，拒绝非正输入（负数/零）。
+    if initial_capital <= 0:
+        console.print(
+            f":x: Invalid --capital: must be greater than 0 (got {initial_capital})"
+        )
+        raise typer.Exit(1)
+
     console.print(f":heavy_plus_sign: Creating portfolio: {name}")
 
     try:

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -272,6 +272,50 @@ class TestPortfolioCreate:
         assert result.exit_code == 1
         assert "Error" in result.output
 
+    # #5984: --capital 必须 > 0，拒绝负数和零。
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_rejects_negative_capital(self, mock_container, cli_runner):
+        """#5984 --capital 为负数时拒绝创建"""
+        mock_service = MagicMock()
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "create", "--name", "EdgeNeg", "--capital", "-1"
+        ])
+        assert result.exit_code == 1
+        assert "capital" in _strip_ansi(result.output).lower()
+        # 负资本绝不应触达 service
+        mock_service.add.assert_not_called()
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_rejects_zero_capital(self, mock_container, cli_runner):
+        """#5984 --capital 为零时拒绝创建（边界）"""
+        mock_service = MagicMock()
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "create", "--name", "EdgeZero", "--capital", "0"
+        ])
+        assert result.exit_code == 1
+        assert "capital" in _strip_ansi(result.output).lower()
+        mock_service.add.assert_not_called()
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_accepts_positive_capital(self, mock_container, cli_runner):
+        """#5984 正资本仍正常创建（回归守护）"""
+        mock_service = MagicMock()
+        mock_service.add.return_value = ServiceResult.success(
+            data={"uuid": "ok-uuid", "name": "Ok"}
+        )
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "create", "--name", "Ok", "--capital", "0.01"
+        ])
+        assert result.exit_code == 0
+        assert "created successfully" in _strip_ansi(result.output)
+
 
 # ============================================================================
 # 4. Get 测试


### PR DESCRIPTION
## Summary

`ginkgo portfolio create --capital` 不校验金额，接受负数和零（如 `--capital -1` 成功创建 `Initial Capital: ¥-1.00`）。

## 改动

- `src/ginkgo/client/portfolio_cli.py`：`create()` 入口加 `initial_capital <= 0` 守卫，拒绝并打印明确错误，遵循本文件既有 `:x:` + `raise typer.Exit(1)` 范式（与 `test_create_service_error` 同 idiom）。早失败，负值不触达 service。
- `tests/unit/client/test_portfolio_cli.py`：新增 3 个 `#5984` 测试——拒绝负数、拒绝零（边界）、正资本回归守护。

## Test plan

- [x] 新增 3 测试 RED→GREEN 全通过
- [x] `test_portfolio_cli.py` 全量 35 passed（1 预存在失败 `TestGenerateBaselinePagination` 在 master 同样失败，与本次无关）
- [x] `mock_service.add.assert_not_called()` 确认负/零资本不触达 service

## 备注

兄弟 #5983（backtest create --cash 负数）已 CLOSED 但 backtest_cli.py 似未加同类校验，本 PR 仅修 portfolio 层（#5984 验收范围）。

Closes #5984