### PR TITLE
fix: engine create --description 描述持久化 (#6005)

### DIFF
--- a/src/ginkgo/data/crud/engine_crud.py
+++ b/src/ginkgo/data/crud/engine_crud.py
@@ -84,7 +84,7 @@ class EngineCRUD(BaseCRUD[MEngine]):
         else:
             broker_attitude_value = ATTITUDE_TYPES.validate_input(broker_attitude_value) or 2
 
-        return MEngine(
+        engine_kwargs = dict(
             name=kwargs.get("name", "test_engine"),
             status=status_value,
             is_live=kwargs.get("is_live", False),
@@ -95,8 +95,12 @@ class EngineCRUD(BaseCRUD[MEngine]):
             config_snapshot=kwargs.get("config_snapshot", "{}"),
             backtest_start_date=kwargs.get("backtest_start_date"),
             backtest_end_date=kwargs.get("backtest_end_date"),
-            broker_attitude=broker_attitude_value
+            broker_attitude=broker_attitude_value,
         )
+        # #6005: 仅在显式传入 desc 时转发，避免 None 覆盖 MMysqlBase 模型默认描述
+        if "desc" in kwargs:
+            engine_kwargs["desc"] = kwargs["desc"]
+        return MEngine(**engine_kwargs)
 
     def _convert_input_item(self, item: Any) -> Optional[MEngine]:
         """

--- a/tests/unit/data/crud/test_engine_crud_mock.py
+++ b/tests/unit/data/crud/test_engine_crud_mock.py
@@ -140,6 +140,25 @@ class TestEngineCRUDCreateFromParams:
         assert mengine.source == SOURCE_TYPES.SIM.value
         assert mengine.is_live is False
 
+    @pytest.mark.unit
+    def test_create_from_params_forwards_desc(self, engine_crud):
+        """#6005: desc 透传到 MEngine，而非回落默认值"""
+        mengine = engine_crud._create_from_params(
+            name="bt_engine", desc="我的引擎描述"
+        )
+
+        assert mengine.desc == "我的引擎描述"
+        assert mengine.name == "bt_engine"
+
+    @pytest.mark.unit
+    def test_create_from_params_desc_absent_keeps_model_default(self, engine_crud):
+        """desc 未传时仍保留 MMysqlBase 模型默认值（防 None 覆盖回归）"""
+        mengine = engine_crud._create_from_params(name="bt_engine")
+
+        # None 不得覆盖模型默认描述
+        assert mengine.desc is not None
+        assert mengine.desc != ""
+
 
 # ============================================================
 # Business Helper 测试


### PR DESCRIPTION
## Summary

`engine create --description "xxx"` 设的描述未生效，落库恒为默认串。

**根因**：`engine_crud._create_from_params` 构造 `MEngine` 的字段白名单漏 `desc`，CLI/Service 正确传入的 desc 被丢弃，`MMysqlBase` 回落默认 "This man is lazy..."。

**修复**：在 `_create_from_params` 条件转发 `desc`（仅当显式传入时），避免 None 覆盖模型默认值（保留 direct crud 调用方的默认行为）。

调用链：CLI `engine_cli` → Service `engine_service.add`(总提供非 None desc) → CRUD `_create_from_params`(本 PR 补 desc 转发) → `MEngine`。

## Test plan

- [x] `test_create_from_params_forwards_desc`：传 desc → MEngine.desc == 传入值
- [x] `test_create_from_params_desc_absent_keeps_model_default`：未传 desc → 保留模型默认（防 None 覆盖回归）
- [x] `test_engine_crud_mock.py` 12/12 全绿
- [x] `test_engine_cli.py` 41/41 全绿

Closes #6005