### PR TITLE
fix: /health 深度检查联动 SystemService，核心故障降级 unhealthy (#5766)

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -1,0 +1,41 @@
+"""
+深度健康检查 (#5766)
+
+此前 /health 与 /api/health 硬编码返回静态 {status: healthy}，零依赖检查；
+当 /system/status 报 error（如 clock.py import error）时仍谎报健康。
+
+compute_health() 复用 SystemService.get_system_status() 的真实探测
+（含模块加载状态 + 基础设施检查），其报告 error 时降级为 unhealthy。
+健康端点本身永不抛异常 —— 任何意外错误都降级为 unhealthy 而非 500，
+避免健康检查自身成为故障源。
+
+抽成独立模块以便单元测试（避开 FastAPI app 启动的连带副作用）；
+main.py 的 /health、/api/health 端点透传调用本函数。
+"""
+
+from typing import Any, Dict
+
+
+def compute_health() -> Dict[str, Any]:
+    """
+    执行核心依赖检查并返回健康状态。
+
+    Returns:
+        {"status": "healthy"|"unhealthy", "service": str, "error"?: str}
+        - healthy: SystemService 探测正常（status == "running"）
+        - unhealthy: SystemService 报 error，或自身抛异常
+    """
+    service = "ginkgo-api-server"
+    try:
+        from ginkgo.core.services.system_service import SystemService
+
+        status_data = SystemService().get_system_status()
+        if status_data.get("status") == "error":
+            return {
+                "status": "unhealthy",
+                "service": service,
+                "error": status_data.get("error", "unknown error"),
+            }
+        return {"status": "healthy", "service": service}
+    except Exception as e:
+        return {"status": "unhealthy", "service": service, "error": str(e)}

--- a/api/main.py
+++ b/api/main.py
@@ -101,14 +101,16 @@ app.exception_handler(APIError)(global_error_handler)
 
 @app.get("/health")
 async def health_check():
-    """健康检查接口"""
-    return {"status": "healthy", "service": "ginkgo-api-server"}
+    """健康检查接口（深度：联动 SystemService，核心模块出错时降级 unhealthy）"""
+    from health import compute_health
+    return compute_health()
 
 
 @app.get("/api/health")
 async def health_check_api():
-    """健康检查接口（API路径，用于前端代理）"""
-    return {"status": "healthy", "service": "ginkgo-api-server"}
+    """健康检查接口（API路径，用于前端代理；深度检查同 /health）"""
+    from health import compute_health
+    return compute_health()
 
 
 # 路由注册 - 统一使用 /api/v1 前缀

--- a/tests/api/test_health_check.py
+++ b/tests/api/test_health_check.py
@@ -1,0 +1,60 @@
+"""
+#5766: /health 深度健康检查
+
+此前 /health 与 /api/health 硬编码返回静态 {status: healthy}，
+不检查任何核心依赖；当 /system/status 报 error（如 clock.py import error）
+时仍谎报健康。修复让健康端点复用 SystemService.get_system_status()，
+error 时降级为 unhealthy。
+
+测试直接覆盖 compute_health() 逻辑（健康判定核心），避开 FastAPI app
+启动连带副作用；端点本身仅 return compute_health()（透传）。
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.integration
+class TestComputeHealth:
+    """compute_health: 联动 SystemService 的深度健康判定"""
+
+    def test_unhealthy_when_system_status_reports_error(self):
+        """SystemService 报 error（如 clock.py import error）时降级 unhealthy"""
+        from health import compute_health
+
+        with patch(
+            "ginkgo.core.services.system_service.SystemService.get_system_status",
+            return_value={"status": "error", "error": "clock.py import error"},
+        ):
+            result = compute_health()
+
+        assert result["status"] == "unhealthy"
+        assert result["service"] == "ginkgo-api-server"
+        assert "clock.py import error" in result["error"]
+
+    def test_healthy_when_system_status_running(self):
+        """SystemService 正常（status=running）时返回 healthy"""
+        from health import compute_health
+
+        with patch(
+            "ginkgo.core.services.system_service.SystemService.get_system_status",
+            return_value={"status": "running", "modules": {}, "infrastructure": {}},
+        ):
+            result = compute_health()
+
+        assert result["status"] == "healthy"
+        assert result["service"] == "ginkgo-api-server"
+
+    def test_unhealthy_when_systemservice_itself_raises(self):
+        """SystemService 构造/调用异常时降级 unhealthy（健康端点永不 500）"""
+        from health import compute_health
+
+        with patch(
+            "ginkgo.core.services.system_service.SystemService",
+            side_effect=RuntimeError("service hub offline"),
+        ):
+            result = compute_health()
+
+        assert result["status"] == "unhealthy"
+        assert "service hub offline" in result["error"]


### PR DESCRIPTION
## Summary

`/health` 与 `/api/health` 此前硬编码返回静态 `{status:healthy}`，零依赖检查——当 `/system/status` 报 error（如 clock.py import error）时仍谎报健康，健康检查失真。

**根因**：健康端点与 `SystemService.get_system_status()`（真实模块加载+基础设施探测）完全脱节。

**修复**：
- 新增 `api/health.py compute_health()`：复用 `SystemService.get_system_status()`，`status=="error"` 时降级 `unhealthy` 并带 error 描述；外层 try/except 兜底，健康端点永不 500。
- `api/main.py` 两端点透传 `compute_health()`，保留 `service` key（不破坏既有契约）。

## Test plan

- [x] `compute_health` error 分支 → unhealthy（含 error 串）
- [x] `compute_health` running 分支 → healthy
- [x] `compute_health` SystemService 抛异常 → unhealthy（永不 500）
- [x] import 冒烟：实连 SystemService 返回 healthy，懒加载链通

注：端点级 E2E（TestClient）受 pre-existing 根 main.py 遮蔽影响，逻辑由函数级测试覆盖。

Closes #5766