### PR TITLE
fix(#5386): engine_config.frequency 不再被丢弃

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -133,18 +133,20 @@ def build_backtest_config(data: BacktestTaskCreate) -> dict:
         "initial_cash": data.engine_config.initial_cash,
         # 分析器配置（Engine 级别）
         "analyzers": [a.dict() for a in (data.engine_config.analyzers or [])],
+        # #5386: frequency 为 Engine 级数据频率（与 CLI 一致），从 engine_config 取值
+        "frequency": data.engine_config.frequency,
         # Portfolio 列表
         "portfolio_uuids": data.portfolio_uuids,
     }
 
     # 添加组件配置（如果有）
+    # 注：frequency 已迁移至 EngineConfig，此处不再从 component_config 映射，避免覆盖引擎权威值
     if data.component_config:
         config.update({
             "max_position_ratio": data.component_config.max_position_ratio,
             "stop_loss_ratio": data.component_config.stop_loss_ratio,
             "take_profit_ratio": data.component_config.take_profit_ratio,
             "benchmark_return": data.component_config.benchmark_return,
-            "frequency": data.component_config.frequency,
         })
 
     # 如果提供了 Engine，获取其信息

--- a/src/ginkgo/data/services/backtest_task_schemas.py
+++ b/src/ginkgo/data/services/backtest_task_schemas.py
@@ -159,6 +159,9 @@ class EngineConfig(BaseModel):
     broker_attitude: int = Field(2, ge=1, le=3, description="Broker态度")
     commission_min: Optional[int] = Field(5, ge=0, description="最小手续费")
     analyzers: Optional[List[AnalyzerConfig]] = Field(default_factory=list, description="分析器列表")
+    # #5386: frequency 是 Engine 级数据频率（与 CLI backtest_cli.py 一致），
+    # 此前误置于 ComponentConfig 致客户端 engine_config.frequency 被 Pydantic 静默丢弃。
+    frequency: Optional[str] = Field("DAY", description="数据频率 (DAY/MIN 等)")
 
 
 class ComponentConfig(BaseModel):
@@ -167,7 +170,8 @@ class ComponentConfig(BaseModel):
     stop_loss_ratio: Optional[float] = Field(0.05, ge=0, le=1, description="止损比例")
     take_profit_ratio: Optional[float] = Field(0.15, ge=0, le=1, description="止盈比例")
     benchmark_return: Optional[float] = Field(0.0, description="基准收益率")
-    frequency: Optional[str] = Field("DAY", description="数据频率")
+    # frequency 保留字段以兼容旧客户端入参，但映射以 EngineConfig.frequency 为准。
+    frequency: Optional[str] = Field("DAY", description="[已迁移至 EngineConfig] 数据频率")
 
 
 class BacktestTaskCreate(BaseModel):

--- a/tests/api/test_backtest_engine_config_frequency.py
+++ b/tests/api/test_backtest_engine_config_frequency.py
@@ -1,0 +1,65 @@
+# #5386 — engine_config.frequency 被丢弃
+"""
+验证 API 创建回测时 engine_config.frequency 被正确捕获并写入 config，
+而非被 Pydantic 静默丢弃。
+
+根因：frequency 定义在 ComponentConfig（误置），EngineConfig 无此字段，
+客户端 POST engine_config.frequency 时 Pydantic ignore 多余字段 → 丢弃。
+build_backtest_config 只在 component_config 存在时映射 frequency。
+"""
+import pytest
+
+
+class TestEngineConfigRetainsFrequency:
+    """EngineConfig 应接受并保留 frequency 字段"""
+
+    def test_engine_config_accepts_frequency(self):
+        from api.backtest import EngineConfig
+
+        cfg = EngineConfig(
+            start_date="2025-06-01",
+            end_date="2025-12-31",
+            frequency="MIN",
+        )
+        assert cfg.frequency == "MIN"
+
+    def test_engine_config_frequency_defaults_to_day(self):
+        from api.backtest import EngineConfig
+
+        cfg = EngineConfig(start_date="2025-06-01", end_date="2025-12-31")
+        assert cfg.frequency == "DAY"
+
+
+class TestBuildBacktestConfigIncludesFrequency:
+    """build_backtest_config 应把 engine_config.frequency 写入 config（顶层）"""
+
+    def test_config_contains_frequency_from_engine_config(self):
+        from api.backtest import build_backtest_config, BacktestTaskCreate, EngineConfig
+
+        data = BacktestTaskCreate(
+            name="test",
+            portfolio_uuids=["p-uuid-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+                frequency="MIN",
+            ),
+        )
+        config = build_backtest_config(data)
+        assert "frequency" in config, "engine_config.frequency 未写入 config"
+        assert config["frequency"] == "MIN"
+
+    def test_config_frequency_defaults_to_day_without_component_config(self):
+        """仅 engine_config（无 component_config）时，frequency 仍应落入 config"""
+        from api.backtest import build_backtest_config, BacktestTaskCreate, EngineConfig
+
+        data = BacktestTaskCreate(
+            name="test",
+            portfolio_uuids=["p-uuid-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+        config = build_backtest_config(data)
+        assert config["frequency"] == "DAY"


### PR DESCRIPTION
## Summary

修复 (#5386)：API 创建回测时 `engine_config.frequency` 被 Pydantic 静默丢弃。

**根因**：`frequency` 误置于 `ComponentConfig`，`EngineConfig` 无此字段。客户端 POST `engine_config.frequency` 时 BaseModel 默认 ignore 多余字段 → 丢弃，无报错。`build_backtest_config` 仅在 `component_config` 存在时映射 frequency，故仅传 engine_config 时 config 缺 frequency（config_snapshot 也缺，start_task 恢复路径只在 mock 里手动塞了才绿）。

**修复**：
- `EngineConfig` 增加 `frequency` 字段（默认 `DAY`，与 `backtest_cli.py` 一致）
- `build_backtest_config` 改从 `engine_config.frequency` 取值（engine 权威），组件块不再覆盖
- `ComponentConfig.frequency` 保留字段以兼容旧客户端入参（不报 422），但不再映射

## Test plan

新增 `tests/api/test_backtest_engine_config_frequency.py`（4 测试）：
- EngineConfig 接受并保留 frequency（含默认 DAY）
- build_backtest_config 写入 engine_config.frequency（含无 component_config 时默认 DAY）

回归：`test_backtest_date_mapping.py`（4）、`test_backtest_task_start_config.py`（4）单独跑全绿。

Closes #5386
