### PR TITLE
fix(#6020): dev test/lint 指向 tests/ 而非不存在的 test/

### DIFF
--- a/src/ginkgo/client/dev_cli.py
+++ b/src/ginkgo/client/dev_cli.py
@@ -215,7 +215,7 @@ def dev_test(
     if pattern:
         cmd.extend(["-k", pattern])
 
-    cmd.append("test/")
+    cmd.append("tests/")
 
     # Run tests
     subprocess.run(cmd, cwd=GCONF.WORKING_PATH)
@@ -250,12 +250,12 @@ def dev_lint(
     # Run formatting tools
     if fix:
         console.print(":wrench: Auto-fixing code formatting...")
-        subprocess.run(["black", "src/", "test/"])
-        subprocess.run(["isort", "src/", "test/"])
+        subprocess.run(["black", "src/", "tests/"])
+        subprocess.run(["isort", "src/", "tests/"])
 
     # Run linting
     console.print(":mag: Checking code style...")
-    subprocess.run(["flake8", "src/", "test/"])
+    subprocess.run(["flake8", "src/", "tests/"])
 
 
 @app.command("profile")

--- a/tests/unit/client/test_dev_cli.py
+++ b/tests/unit/client/test_dev_cli.py
@@ -1,0 +1,60 @@
+# #6020 — dev test/lint 引用错误目录 test/ 应为 tests/
+"""
+验证 ginkgo dev test / dev lint 命令指向真实存在的 tests/ 目录，
+而非不存在的 test/（项目测试目录统一为 tests/，见 CLAUDE.md）。
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestDevTestCommandTargetsTestsDir:
+    """dev test 应把 tests/ 作为 pytest 目标"""
+
+    @patch("subprocess.run")
+    @patch("ginkgo.libs.GCONF")
+    def test_dev_test_cmd_targets_tests_dir(self, mock_gconf, mock_run):
+        mock_gconf.DEBUGMODE = True
+        mock_gconf.WORKING_PATH = "/tmp"
+
+        from ginkgo.client.dev_cli import dev_test
+        dev_test()
+
+        assert mock_run.called, "dev_test 未调用 subprocess.run"
+        cmd = mock_run.call_args[0][0]
+        assert "tests/" in cmd, f"#6020: dev test 未指向 tests/, cmd={cmd}"
+        assert "test/" not in cmd, f"#6020: dev test 仍指向 test/, cmd={cmd}"
+
+    @patch("subprocess.run")
+    @patch("ginkgo.libs.GCONF")
+    def test_dev_test_verbose_pattern_still_targets_tests_dir(self, mock_gconf, mock_run):
+        """组合参数时 tests/ 仍应在 cmd 末尾"""
+        mock_gconf.DEBUGMODE = True
+        mock_gconf.WORKING_PATH = "/tmp"
+
+        from ginkgo.client.dev_cli import dev_test
+        dev_test(verbose=True, pattern="smoke")
+
+        cmd = mock_run.call_args[0][0]
+        assert "tests/" in cmd, f"cmd={cmd}"
+        assert "test/" not in cmd, f"cmd={cmd}"
+
+
+class TestDevLintCommandTargetsTestsDir:
+    """dev lint / lint --fix 应把 tests/ 纳入 black/isort/flake8 范围"""
+
+    @patch("subprocess.run")
+    def test_dev_lint_fix_targets_tests_dir(self, mock_run):
+        from ginkgo.client.dev_cli import dev_lint
+        dev_lint(fix=True)
+
+        # 收集所有 black/isort/flake8 调用的参数（排除 --version 探测）
+        all_args = [c[0][0] for c in mock_run.call_args_list]
+        tool_calls = [
+            a for a in all_args
+            if a and a[0] in ("black", "isort", "flake8")
+            and not (len(a) == 2 and a[1] == "--version")
+        ]
+        assert tool_calls, f"未找到 lint 工具调用: {all_args}"
+        for call in tool_calls:
+            assert "tests/" in call, f"#6020: {call[0]} 未含 tests/: {call}"
+            assert "test/" not in call, f"#6020: {call[0]} 仍含 test/: {call}"


### PR DESCRIPTION
## Summary

修复 (#6020)：`dev_cli.py` 4 处硬编码 `test/`，但项目测试目录统一为 `tests/`（CLAUDE.md）。

**根因**：纯字符串拼写错误，`dev_test`/`dev_lint` 指向不存在的 `test/` 目录。

**影响**：
- `ginkgo dev test` → pytest 找不到目录，不运行任何测试
- `ginkgo dev lint` / `lint --fix` → black/isort/flake8 跳过整个测试目录

**修复**：`dev_cli.py:218/253/254/258` 四处 `test/` → `tests/`。

## Test plan

新增 `tests/unit/client/test_dev_cli.py`（3 测试，RED→GREEN）：
- `dev_test` 构造的 pytest cmd 含 `tests/`（verbose/pattern 组合亦然）
- `dev_lint --fix` 的 black/isort/flake8 调用含 `tests/`（mock `subprocess.run` 捕获，过滤 `--version` 探测）

Closes #6020
