### PR TITLE
fix(#6018): dev shell 动态构建 src 路径

### DIFF
--- a/src/ginkgo/client/dev_cli.py
+++ b/src/ginkgo/client/dev_cli.py
@@ -121,9 +121,12 @@ def dev_shell():
     from ginkgo.libs import GCONF
     
     # Create startup script
-    startup_script = """
+    # #6018: 动态构建 src 路径，与 dev_server（GCONF.WORKING_PATH + "/api"）范式一致，
+    # 不再硬编码旧路径 /home/kaoru/Applications/Ginkgo/src
+    src_path = os.path.join(GCONF.WORKING_PATH, "src")
+    startup_script = f"""
 import sys
-sys.path.insert(0, '/home/kaoru/Applications/Ginkgo/src')
+sys.path.insert(0, {src_path!r})
 
 # Import commonly used Ginkgo modules
 from ginkgo.libs import GCONF, GLOG, GTM

--- a/tests/unit/client/test_dev_shell_command.py
+++ b/tests/unit/client/test_dev_shell_command.py
@@ -1,0 +1,53 @@
+# #6018 — dev shell 硬编码 src 路径
+"""
+验证 ginkgo dev shell 启动脚本的 sys.path 指向 GCONF.WORKING_PATH 动态构建
+的 src 目录，而非硬编码的旧路径 /home/kaoru/Applications/Ginkgo/src。
+"""
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestDevShellStartupScriptUsesDynamicSrc:
+    """dev_shell 构造的 startup_script 应动态注入 src 路径"""
+
+    @patch("os.unlink")
+    @patch("subprocess.run")
+    @patch("ginkgo.libs.GCONF")
+    def test_startup_script_contains_working_path_src(
+        self, mock_gconf, mock_run, mock_unlink, tmp_path
+    ):
+        mock_gconf.WORKING_PATH = str(tmp_path)
+        mock_gconf.PYTHONPATH = "/usr/bin/python3"
+
+        from ginkgo.client.dev_cli import dev_shell
+        dev_shell()
+
+        # subprocess.run([python, "-i", startup_file]) — 第三个参数是临时脚本路径
+        assert mock_run.called, "dev_shell 未调用 subprocess.run"
+        startup_file = mock_run.call_args[0][0][2]
+        content = open(startup_file).read()  # os.unlink 被 mock，文件保留
+
+        expected_src = f"{tmp_path}/src"
+        assert expected_src in content, (
+            f"#6018: startup_script 未含动态 src 路径 {expected_src}"
+        )
+
+    @patch("os.unlink")
+    @patch("subprocess.run")
+    @patch("ginkgo.libs.GCONF")
+    def test_startup_script_does_not_contain_hardcoded_old_path(
+        self, mock_gconf, mock_run, mock_unlink, tmp_path
+    ):
+        mock_gconf.WORKING_PATH = str(tmp_path)
+        mock_gconf.PYTHONPATH = "/usr/bin/python3"
+
+        from ginkgo.client.dev_cli import dev_shell
+        dev_shell()
+
+        startup_file = mock_run.call_args[0][0][2]
+        content = open(startup_file).read()
+
+        assert "/home/kaoru/Applications/Ginkgo/src" not in content, (
+            f"#6018: startup_script 仍含硬编码旧路径"
+        )


### PR DESCRIPTION
## Summary

修复 (#6018)：`dev_cli.py:126` startup_script 硬编码旧路径 `/home/kaoru/Applications/Ginkgo/src`（实际项目在 `/home/kaoru/Ginkgo/src`），致 `ginkgo dev shell` 交互环境所有 Ginkgo import 失败。

**根因**：硬编码绝对路径，未用 GCONF 动态构建。

**修复**：父进程用 `os.path.join(GCONF.WORKING_PATH, "src")` 构建路径，f-string `{src_path!r}` 注入 startup_script，与同文件 `dev_server`（`GCONF.WORKING_PATH + "/api"`）范式一致。

## Test plan

新增 `tests/unit/client/test_dev_shell_command.py`（2 测试，RED→GREEN）：
mock `GCONF.WORKING_PATH=tmp_path` + `subprocess.run` + `os.unlink`，捕获临时启动脚本内容，断言：
- 含动态 src 路径 `f"{tmp_path}/src"`
- 不含硬编码旧路径 `/home/kaoru/Applications/Ginkgo/src`

Closes #6018
