### PR TITLE
fix: 删除 ATRSizer 遗留调试日志 GLOG.INFO(df) (#6019)

### DIFF
--- a/src/ginkgo/trading/sizers/atr_sizer.py
+++ b/src/ginkgo/trading/sizers/atr_sizer.py
@@ -79,7 +79,6 @@ class ATRSizer(BaseSizer):
             if not result.success or not result.data:
                 return None
             df = result.data.to_dataframe()
-            GLOG.INFO(df)
 
             # 检查数据是否足够
             if df is None or len(df) < self.period + 1:

--- a/tests/unit/trading/sizers/test_atr_sizer.py
+++ b/tests/unit/trading/sizers/test_atr_sizer.py
@@ -142,3 +142,36 @@ class TestATRSizerNearZeroFloor:
 
         assert order is not None
         assert order.volume == 50000
+
+
+class TestATRSizerDoesNotLogDataFrame:
+    """#6019: ATRSizer 不得以 INFO 级别输出完整 DataFrame（遗留调试日志）。
+
+    历史：原始 `print(df)` 调试代码被机械地替换为 `GLOG.INFO(df)`，
+    导致每次 cal() 都把完整行情 DataFrame（高/低/收 多行）写日志。
+    验收：cal() 执行后，GLOG.INFO 的所有调用参数中不得出现
+    pandas.DataFrame 实例（"Order Generated." 字符串、Order 对象等
+    正常业务日志不受影响）。
+    """
+
+    def test_cal_does_not_log_full_dataframe(self, sizer):
+        df = _bar_df(15, high=11.0, low=10.0, close=10.0)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog, \
+             patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+
+            sizer.cal(info, signal)
+
+        info_args = [c.args[0] for c in mock_glog.INFO.call_args_list if c.args]
+        dataframe_logged = any(isinstance(a, pd.DataFrame) for a in info_args)
+        assert not dataframe_logged, (
+            f"#6019: ATRSizer 仍以 INFO 输出完整 DataFrame: {info_args}"
+        )


### PR DESCRIPTION
## Summary

`src/ginkgo/trading/sizers/atr_sizer.py:82` 的 `GLOG.INFO(df)` 是遗留调试代码（原始 `print(df)` 被机械替换为 `GLOG.INFO(df)`），导致每次 `cal()` 仓位计算都把完整行情 DataFrame（高/低/收 多行）写入 INFO 级日志，污染回测日志。

删除该调试日志。`df = result.data.to_dataframe()` 计算保留——下游 ATR 计算（line 85 长度检查、90-92 高/低/收 `.tolist()`、101 `df.iloc[-1]["close"]`）仍依赖它。

仅删一行，无行为/逻辑变更。

## Test plan

- [x] 新增 `TestATRSizerDoesNotLogDataFrame::test_cal_does_not_log_full_dataframe`：mock `container.bar_service` 返回真实 DataFrame，patch `GLOG`，调 `cal()`，断言所有 `GLOG.INFO` 调用参数中不含 `pandas.DataFrame` 实例（"Order Generated." 字符串、Order 对象等正常日志不受影响）。
- [x] RED 验证：删行前测试失败（`assert not True`，证明 line 82 确以 DataFrame 调 INFO）。
- [x] GREEN 验证：删行后 `test_atr_sizer.py` 全文件 5 passed，0 回归（#5490 near-zero floor 4 测试不受影响）。

Closes #6019
