### PR TITLE
fix: data/bars code 必填422 + 交易所后缀自动补全 (#5760)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, model_validator
 from typing import List, Optional, Dict, Any
 from datetime import datetime
+import re
 import time as _time
 
 from ginkgo.data.containers import container
@@ -308,6 +309,33 @@ async def get_stockinfo(
         )
 
 
+def _normalize_bar_code(code: Optional[str]) -> str:
+    """#5760: 校验 code 必填 + 补全交易所后缀。
+
+    - None/空/空白 → HTTPException(422)（验收3：缺 code 报错而非空数据）
+    - 6 位数字按首位推断交易所：5/6→.SH（上证/科创/基金），0/3→.SZ（深证主板/创业板），8/4/9→.BJ（北交所）
+    - 已含后缀（含 "."）原样返回，大小写统一转大写
+    - 非 6 位数字的其他格式原样返回，交由下游 service 判断
+    """
+    if not code or not code.strip():
+        raise HTTPException(
+            status_code=422,
+            detail="code 参数必填，需带交易所后缀，例如 000001.SZ 或 000001（自动补全）",
+        )
+    code = code.strip().upper()
+    if "." in code:
+        return code
+    if re.match(r"^\d{6}$", code):
+        first = code[0]
+        if first in ("5", "6"):
+            return code + ".SH"
+        if first in ("0", "3"):
+            return code + ".SZ"
+        if first in ("8", "4", "9"):
+            return code + ".BJ"
+    return code
+
+
 @router.get("/bars")
 async def get_bars(
     code: Optional[str] = None,
@@ -317,6 +345,8 @@ async def get_bars(
     page_size: int = 100
 ):
     """获取K线数据列表（分页）"""
+    # #5760: code 必填校验 + 交易所后缀归一化（000001 → 000001.SZ）
+    code = _normalize_bar_code(code)
     try:
         bar_service = get_bar_service()
 

--- a/api/api/data.py
+++ b/api/api/data.py
@@ -313,7 +313,7 @@ def _normalize_bar_code(code: Optional[str]) -> str:
     """#5760: 校验 code 必填 + 补全交易所后缀。
 
     - None/空/空白 → HTTPException(422)（验收3：缺 code 报错而非空数据）
-    - 6 位数字按首位推断交易所：5/6→.SH（上证/科创/基金），0/3→.SZ（深证主板/创业板），8/4/9→.BJ（北交所）
+    - 6 位数字按首位推断交易所（对齐 mootdx get_stock_market）：5/6/9→.SH（沪基金/A股/B股），0/1/2/3→.SZ（深A股/ETF/B股），4/8→.BJ（北交所，mootdx 未覆盖独立判）
     - 已含后缀（含 "."）原样返回，大小写统一转大写
     - 非 6 位数字的其他格式原样返回，交由下游 service 判断
     """
@@ -327,11 +327,12 @@ def _normalize_bar_code(code: Optional[str]) -> str:
         return code
     if re.match(r"^\d{6}$", code):
         first = code[0]
-        if first in ("5", "6"):
+        # 首位规则对齐 mootdx get_stock_market (裁判); 4/8 北交所 mootdx 未覆盖独立判 #5760 review
+        if first in ("5", "6", "9"):  # 5 沪基金/ETF, 6 沪 A 股, 9 沪 B (900xxx)
             return code + ".SH"
-        if first in ("0", "3"):
+        if first in ("0", "1", "2", "3"):  # 0/3 深 A 股, 1 深 ETF (159xxx), 2 深 B (200xxx)
             return code + ".SZ"
-        if first in ("8", "4", "9"):
+        if first in ("4", "8"):  # 北交所
             return code + ".BJ"
     return code
 

--- a/tests/api/test_data_bars_500_fix.py
+++ b/tests/api/test_data_bars_500_fix.py
@@ -63,7 +63,7 @@ class TestGetBarsBareListFix:
 
         with patch("api.data.get_bar_service", return_value=mock_service):
             # 修复前：line 339 bars_list=[] → line 358 [bar].count() TypeError → 500
-            result = run_async(get_bars())
+            result = run_async(get_bars(code="000001.SZ"))
 
         assert result.get("code") == 0
 
@@ -77,7 +77,7 @@ class TestGetBarsBareListFix:
         from api.data import get_bars
 
         with patch("api.data.get_bar_service", return_value=mock_service):
-            result = run_async(get_bars())
+            result = run_async(get_bars(code="000001.SZ"))
 
         # 修复前：line 339 bars_list=[] → items=[]（数据丢失）
         assert result.get("code") == 0
@@ -94,7 +94,7 @@ class TestGetBarsBareListFix:
         from api.data import get_bars
 
         with patch("api.data.get_bar_service", return_value=mock_service):
-            result = run_async(get_bars())
+            result = run_async(get_bars(code="000001.SZ"))
 
         assert result.get("code") == 0
         assert result["meta"]["total"] == 2

--- a/tests/api/test_data_bars_code_normalize.py
+++ b/tests/api/test_data_bars_code_normalize.py
@@ -100,3 +100,39 @@ class TestGetBarsCodeNormalization:
             run_async(get_bars(code="   "))
 
         assert exc.value.status_code == 422
+
+    def test_sz_etf_code_159_normalized_to_sz(self):
+        """#5760 review: 深 ETF 159xxx (首位1) → .SZ。对齐 mootdx '15'→sz。
+
+        旧规则首位 1 无分支 → 原样返回查空 (DB 存 159915.SZ)。
+        """
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars(code="159915"))
+
+        called_code = mock_service.get.call_args.kwargs.get("code")
+        assert called_code == "159915.SZ", (
+            f"#5760: 深ETF首位1应补 .SZ, got {called_code!r}"
+        )
+
+    def test_sh_b_code_900_normalized_to_sh(self):
+        """#5760 review: 沪 B 900xxx (首位9) → .SH 非 .BJ。对齐 mootdx 首位9→sh。
+
+        旧规则首位 9→.BJ 错标 (沪 B 实属上交所)。
+        """
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars(code="900901"))
+
+        called_code = mock_service.get.call_args.kwargs.get("code")
+        assert called_code == "900901.SH", (
+            f"#5760: 沪B首位9应补 .SH 非 .BJ, got {called_code!r}"
+        )

--- a/tests/api/test_data_bars_code_normalize.py
+++ b/tests/api/test_data_bars_code_normalize.py
@@ -1,0 +1,102 @@
+# Issue: #5760 — GET /api/v1/data/bars 需精确代码格式 + 缺 code 返回空
+# Upstream: api.api.data.get_bars
+# Downstream: BarService.get(code=...) — DB code 列存 000001.SZ
+# Role: 验证 get_bars 入口校验 code 必填(422) + 归一化交易所后缀(000001→000001.SZ)
+
+"""
+data/bars code 归一化 + 必填校验测试 (#5760 验收 1 + 3)。
+
+根因：
+1. get_bars code 参数 Optional[str]=None，缺失时静默走 None 查询返回空（验收3）
+2. code 无交易所后缀归一化，裸 000001 查不到 DB 的 000001.SZ（验收1）
+
+修复：get_bars 入口调 _normalize_bar_code(code)：
+- None/空 → HTTPException(422)
+- 6 位数字按首位推断交易所后缀 (.SH/.SZ/.BJ)
+- 已含后缀原样返回
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+from fastapi import HTTPException
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(data=None, success=True):
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.data = data
+    return result
+
+
+class TestGetBarsCodeNormalization:
+    """#5760: get_bars code 必填(422) + 交易所后缀归一化。"""
+
+    def test_plain_sz_code_normalized_to_sz_suffix(self):
+        """验收1: code=000001 应归一化为 000001.SZ 传给 bar_service（DB 存 .SZ）。"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars(code="000001"))
+
+        called_code = mock_service.get.call_args.kwargs.get("code")
+        assert called_code == "000001.SZ", (
+            f"#5760: 000001 未补全深交所后缀, bar_service.get 收到 code={called_code!r}"
+        )
+
+    def test_plain_sh_code_normalized_to_sh_suffix(self):
+        """验收1: 上证代码 600000 → 600000.SH。"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars(code="600000"))
+
+        called_code = mock_service.get.call_args.kwargs.get("code")
+        assert called_code == "600000.SH", (
+            f"#5760: 600000 未补全上证后缀, got {called_code!r}"
+        )
+
+    def test_already_suffixed_code_unchanged(self):
+        """已含后缀的 code 不被二次处理（000001.SZ 原样传入）。"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars(code="000001.SZ"))
+
+        called_code = mock_service.get.call_args.kwargs.get("code")
+        assert called_code == "000001.SZ"
+
+    def test_missing_code_raises_422(self):
+        """验收3: 缺少 code 参数应返回 422 而非空数据。"""
+        from api.data import get_bars
+
+        with pytest.raises(HTTPException) as exc:
+            run_async(get_bars())
+
+        assert exc.value.status_code == 422, (
+            f"#5760: 缺 code 应 422, got {exc.value.status_code}"
+        )
+
+    def test_empty_code_raises_422(self):
+        """验收3: 空 code（空串/空白）同样 422。"""
+        from api.data import get_bars
+
+        with pytest.raises(HTTPException) as exc:
+            run_async(get_bars(code="   "))
+
+        assert exc.value.status_code == 422


### PR DESCRIPTION
## Summary

`GET /api/v1/data/bars` 两个用户体验缺陷（#5760 验收 1 + 3）：

1. **code 缺失静默返回空**：`code: Optional[str]=None` 让无 code 调用走 None 查询返回空 paginated，用户无感知参数缺失（验收3）。
2. **code 无交易所后缀查不到**：`000001` 直传 `bar_service.get(code="000001")`，而 DB code 列存 `000001.SZ`，查询未命中返回空（验收1）。

## 修复

get_bars 入口新增纯函数 `_normalize_bar_code(code)`：
- **None/空/空白 → HTTPException(422)**（验收3，detail 提示正确格式）
- **6 位数字按首位推断交易所**：`5/6`→`.SH`（上证/科创/基金）、`0/3`→`.SZ`（深证主板/创业板）、`8/4/9`→`.BJ`（北交所）
- **已含后缀**（含 `.`）原样返回，统一转大写
- **非 6 位数字**其他格式原样交下游判断

get_bars 在 try 前调用一行 `code = _normalize_bar_code(code)`。

验收2（stockinfo 分页统一）此前已修（`paginated(items,total)`），本 PR 不涉及。

## 兼容性

适配 `test_data_bars_500_fix.py` 3 处 `get_bars()` 无 code 调用为 `get_bars(code="000001.SZ")`——该测试目的是裸 list[MBar] 处理（#5599/#5610），与 code 参数无关；#5760 契约演进使无 code 调用为 422，旧用法现非法，传 code 保留原测试意图。`_normalize_bar_code` 对已含后缀原样返回，不影响裸 list 逻辑。

## Test plan

- [x] 新增 `tests/api/test_data_bars_code_normalize.py`（5 测试）：000001→.SZ、600000→.SH、已含后缀不变、缺 code→422、空白 code→422。
- [x] RED 验证：实现前 4 failed（sz/sh 归一化、missing/empty 422），1 passed（已含后缀不变行为）。
- [x] GREEN 验证：实现后 data bars 全套 11 passed（新5 + 500_fix3 + pagination3），0 回归。

Closes #5760
