### PR TITLE
fix(#5648): Paper Trading 支持关联已有 Portfolio

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -217,6 +217,13 @@ async def create_paper_account(data: CreatePaperAccountRequest):
         # #5648: 关联已有 Portfolio（复用已绑定策略/选股/仓位/风控组件），不新建
         if data.portfolio_uuid:
             _require_portfolio(data.portfolio_uuid)  # 不存在则 raise NotFoundError
+            # #5648 review: 关联时设 mode=PAPER，使 list_paper_accounts 按 mode 过滤能查到
+            # （与新建路径 add(mode=PAPER) 对称；已部署冻结的 update 被拒则穿透 BusinessError）
+            from ginkgo.enums import PORTFOLIO_MODE_TYPES
+            portfolio_service = _get_portfolio_service()
+            upd = portfolio_service.update(data.portfolio_uuid, mode=PORTFOLIO_MODE_TYPES.PAPER)
+            if not upd.is_success():
+                raise BusinessError(f"Failed to link paper account: {upd.error}")
             logger.info(f"Paper account linked to existing portfolio: {data.portfolio_uuid}")
             return ok(
                 data={"account_id": data.portfolio_uuid},

--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -46,6 +46,11 @@ class CreatePaperAccountRequest(BaseModel):
     restrictions: List[str] = Field(default_factory=list, description="交易限制: t1/limit/time")
     data_source: str = Field("paper", description="数据源: replay/paper")
     replay_date: Optional[str] = Field(None, description="回放起始日期")
+    portfolio_uuid: Optional[str] = Field(
+        None,
+        description="#5648: 关联已有 Portfolio（含策略/选股/仓位/风控组件）作为模拟盘账户；"
+                    "提供时校验存在并复用，不新建。未提供则新建空 PAPER 模式 Portfolio（现行行为）",
+    )
 
 
 class StartPaperTradingRequest(BaseModel):
@@ -206,8 +211,18 @@ async def create_paper_account(data: CreatePaperAccountRequest):
     """创建模拟盘账户
 
     创建 PAPER 模式的 Portfolio，并通过 Kafka 通知 Worker。
+    #5648: 若提供 portfolio_uuid，则关联已有 Portfolio（复用其策略组件），不新建。
     """
     try:
+        # #5648: 关联已有 Portfolio（复用已绑定策略/选股/仓位/风控组件），不新建
+        if data.portfolio_uuid:
+            _require_portfolio(data.portfolio_uuid)  # 不存在则 raise NotFoundError
+            logger.info(f"Paper account linked to existing portfolio: {data.portfolio_uuid}")
+            return ok(
+                data={"account_id": data.portfolio_uuid},
+                message="Paper account linked to existing portfolio",
+            )
+
         from ginkgo.enums import PORTFOLIO_MODE_TYPES
         from ginkgo.interfaces.kafka_topics import KafkaTopics
 
@@ -243,6 +258,10 @@ async def create_paper_account(data: CreatePaperAccountRequest):
         )
 
     except BusinessError:
+        raise
+    except NotFoundError:
+        # #5648: _require_portfolio 校验 portfolio_uuid 不存在时穿透为 404，
+        # 不被下方 except Exception 包装成模糊 BusinessError
         raise
     except Exception as e:
         logger.error(f"Error creating paper account: {str(e)}")

--- a/tests/api/test_paper_account_portfolio_uuid.py
+++ b/tests/api/test_paper_account_portfolio_uuid.py
@@ -65,6 +65,32 @@ class TestCreatePaperAccountLinksExistingPortfolio:
         # 返回的 account_id 就是传入的 portfolio_uuid
         assert result["data"]["account_id"] == "exist-uuid"
 
+    def test_linked_portfolio_mode_updated_to_paper(self):
+        """#5648 review: 关联已有 portfolio 时设 mode=PAPER。
+
+        根因：list_paper_accounts 按 mode=PAPER 过滤；关联路径不改 mode，
+        关联的 BACKTEST portfolio 查不到。修复=关联时 update mode=PAPER，
+        与新建路径（add mode=PAPER）对称。
+        """
+        from api.trading import create_paper_account, CreatePaperAccountRequest
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        req = CreatePaperAccountRequest(name="t", portfolio_uuid="exist-uuid")
+        upd_ok = SimpleNamespace(is_success=lambda: True)
+
+        with patch("api.trading._require_portfolio",
+                   return_value=SimpleNamespace(uuid="exist-uuid")), \
+             patch("api.trading._get_portfolio_service") as mock_svc_factory:
+            mock_svc_factory.return_value.update.return_value = upd_ok
+            result = run_async(create_paper_account(req))
+
+        # 关联时 update 被调用，portfolio_id 位置传，mode=PAPER
+        mock_svc_factory.return_value.update.assert_called_once()
+        args, kwargs = mock_svc_factory.return_value.update.call_args
+        assert args[0] == "exist-uuid"
+        assert kwargs.get("mode") == PORTFOLIO_MODE_TYPES.PAPER
+        assert result["data"]["account_id"] == "exist-uuid"
+
     def test_nonexistent_uuid_raises_not_found(self):
         """提供不存在的 portfolio_uuid → NotFoundError（复用 _require_portfolio 校验）。"""
         from api.trading import create_paper_account, CreatePaperAccountRequest

--- a/tests/api/test_paper_account_portfolio_uuid.py
+++ b/tests/api/test_paper_account_portfolio_uuid.py
@@ -1,0 +1,100 @@
+# Issue: #5648 — Paper Trading CreatePaperAccountRequest 缺 portfolio_uuid
+# Upstream: api.api.trading.CreatePaperAccountRequest, create_paper_account
+# Downstream: PortfolioService.add（新建）/ _require_portfolio（关联校验）
+# Role: 验证创建 paper account 时可关联已有 Portfolio（含策略组件）
+
+"""
+Paper Trading portfolio_uuid 关联测试 (#5648)。
+
+根因：CreatePaperAccountRequest 无 portfolio_uuid 字段，create_paper_account
+恒新建空 Portfolio，用户无法复用已绑定策略/选股/仓位/风控组件的 Portfolio。
+
+修复：schema 加 portfolio_uuid: Optional[str]；create 分支——
+- 提供 portfolio_uuid → _require_portfolio 校验存在 + 返回该 uuid（不新建）
+- 未提供 → 现行新建行为不变
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from core.exceptions import NotFoundError
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+class TestCreatePaperAccountRequestSchema:
+    """#5648: schema 接受 portfolio_uuid 字段，默认 None（向后兼容）。"""
+
+    def test_request_accepts_portfolio_uuid(self):
+        """验收: schema 必须接受 portfolio_uuid 字段。"""
+        from api.trading import CreatePaperAccountRequest
+
+        req = CreatePaperAccountRequest(name="t", portfolio_uuid="port-abc-123")
+        assert req.portfolio_uuid == "port-abc-123"
+
+    def test_portfolio_uuid_defaults_none(self):
+        """不传 portfolio_uuid 时默认 None（现行新建行为保持不变）。"""
+        from api.trading import CreatePaperAccountRequest
+
+        req = CreatePaperAccountRequest(name="t")
+        assert req.portfolio_uuid is None
+
+
+class TestCreatePaperAccountLinksExistingPortfolio:
+    """#5648: 提供 portfolio_uuid → 关联已有 Portfolio，不新建。"""
+
+    def test_provided_uuid_returns_it_without_creating_new(self):
+        """验收: 提供已存在 portfolio_uuid → account_id 为该 uuid，portfolio_service.add 不被调用。"""
+        from api.trading import create_paper_account, CreatePaperAccountRequest
+
+        req = CreatePaperAccountRequest(name="t", portfolio_uuid="exist-uuid")
+
+        with patch("api.trading._require_portfolio", return_value=SimpleNamespace(uuid="exist-uuid")) as mock_req, \
+             patch("api.trading._get_portfolio_service") as mock_svc_factory:
+            result = run_async(create_paper_account(req))
+
+        # _require_portfolio 被调用校验存在
+        mock_req.assert_called_once_with("exist-uuid")
+        # 不新建：portfolio_service.add 不应被调用
+        mock_svc_factory.return_value.add.assert_not_called()
+        # 返回的 account_id 就是传入的 portfolio_uuid
+        assert result["data"]["account_id"] == "exist-uuid"
+
+    def test_nonexistent_uuid_raises_not_found(self):
+        """提供不存在的 portfolio_uuid → NotFoundError（复用 _require_portfolio 校验）。"""
+        from api.trading import create_paper_account, CreatePaperAccountRequest
+
+        req = CreatePaperAccountRequest(name="t", portfolio_uuid="nope-uuid")
+
+        with patch("api.trading._require_portfolio",
+                   side_effect=NotFoundError("Paper account", "nope-uuid")), \
+             patch("api.trading._get_portfolio_service") as mock_svc_factory:
+            with pytest.raises(NotFoundError):
+                run_async(create_paper_account(req))
+
+        # 校验失败时不应新建
+        mock_svc_factory.return_value.add.assert_not_called()
+
+    def test_omitted_uuid_creates_new_portfolio(self):
+        """不提供 portfolio_uuid → 现行新建行为（portfolio_service.add 被调用）。"""
+        from api.trading import create_paper_account, CreatePaperAccountRequest
+
+        req = CreatePaperAccountRequest(name="t")  # portfolio_uuid 默认 None
+
+        mock_result = SimpleNamespace(
+            is_success=lambda: True,
+            data=SimpleNamespace(uuid="new-uuid"),
+        )
+
+        with patch("api.trading._get_portfolio_service") as mock_svc_factory:
+            mock_svc_factory.return_value.add.return_value = mock_result
+            result = run_async(create_paper_account(req))
+
+        # 新建路径：add 被调用
+        mock_svc_factory.return_value.add.assert_called_once()
+        assert result["data"]["account_id"] == "new-uuid"


### PR DESCRIPTION
## Summary

`CreatePaperAccountRequest` 缺 `portfolio_uuid` 字段，导致用户无法复用已绑定策略/选股/仓位/风控组件的 Portfolio 作为模拟盘账户——每次只能新建空 Portfolio。

### 变更
- **schema**：`CreatePaperAccountRequest` 加 `portfolio_uuid: Optional[str] = None`（默认 None，向后兼容）
- **create 端点分支**：
  - 提供 `portfolio_uuid` → `_require_portfolio` 校验存在后返回该 uuid（不新建，复用已绑定组件）
  - 未提供 → 现行新建空 PAPER Portfolio 行为不变
- **异常穿透**：except 链加 `except NotFoundError: raise`，让校验失败保持 404 语义，不被 `except Exception` 包装成模糊 BusinessError（NotFoundError 与 BusinessError 平级继承 APIError，原 except 链会误捕）

### 根因调用链
`POST /paper-account` → `create_paper_account()` → 恒走 `portfolio_service.add()` 新建 → 💥 无关联已有 Portfolio 的路径

## Test plan
- [x] `tests/api/test_paper_account_portfolio_uuid.py`（5 测试）：
  - schema 接受 portfolio_uuid 字段
  - 默认 None（向后兼容）
  - 提供已存在 uuid → 返回该 uuid，add 不调用
  - 提供不存在 uuid → NotFoundError（404）
  - 省略 uuid → 现行新建（add 调用）
- [x] 回归 `tests/api/test_paper_trading_status.py`（6 测试）无副作用
- [x] 变更覆盖率：trading.py → portfolio_uuid + paper_trading_status 双向测试覆盖

```
11 passed, 1 warning in 0.19s
```

Closes #5648
