### PR TITLE
fix(#6004): backtest create --cash 校验非正与范围外警告

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -38,6 +38,17 @@ def create_task(
     from ginkgo.data.containers import container
     from ginkgo.workers.backtest_worker.task_helpers import load_portfolio_components
 
+    # 校验 cash 为正（#5983/#6004：拒绝非正现金，避免回测以零/负资金运行）
+    if cash <= 0:
+        console.print(f":x: cash 必须为正数，当前：{cash}")
+        raise typer.Exit(1)
+
+    # 范围外警告（#6004：极端 cash 警告但不阻断，建议合理范围 1,000~10,000,000,000）
+    if cash < 1000 or cash > 10_000_000_000:
+        console.print(
+            f":warning: 警告：cash={cash} 超出建议范围（1,000~10,000,000,000），结果可能无意义"
+        )
+
     # 校验 portfolio 存在
     portfolio_service = container.portfolio_service()
     portfolio_result = portfolio_service.get(portfolio_id=portfolio)

--- a/tests/unit/client/test_backtest_cli_cash_validation.py
+++ b/tests/unit/client/test_backtest_cli_cash_validation.py
@@ -1,0 +1,70 @@
+"""TDD tests for #6004: ginkgo backtest create --cash 无上下界校验。
+
+create_task 应在 portfolio 校验前拒绝非正 cash（#5983 安全核心），
+并对范围外（<1,000 或 >100亿）发出警告（#6004 合理范围）。
+"""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import re
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+class TestBacktestCreateCashValidation:
+    """#6004 backtest create --cash 校验"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_rejects_nonpositive_cash(self, mock_container):
+        """#5983/#6004 cash=0 与 cash=-1 应被拒绝（exit 1，消息提及 cash）"""
+        from ginkgo.client.backtest_cli import app
+
+        for bad_cash in ["0", "-1"]:
+            result = runner.invoke(app, [
+                "create", "--portfolio", "p-1",
+                "--start", "2025-05-07", "--end", "2026-05-07",
+                "--cash", bad_cash,
+            ])
+            assert result.exit_code == 1, f"cash={bad_cash} 应被拒绝（exit 1）"
+            plain = _strip_ansi(result.output).lower()
+            assert "cash" in plain, f"cash={bad_cash} 拒绝消息应提及 cash，实际：{plain!r}"
+
+    @patch("ginkgo.workers.backtest_worker.task_helpers.load_portfolio_components")
+    @patch("ginkgo.data.containers.container")
+    def test_create_warns_extreme_high_cash(self, mock_container, mock_load):
+        """#6004 极端高 cash（>100亿）应警告但仍创建"""
+        from ginkgo.client.backtest_cli import app
+
+        mock_ps = MagicMock()
+        pr = MagicMock()
+        pr.is_success.return_value = True
+        mock_ps.get.return_value = pr
+        mock_container.portfolio_service.return_value = mock_ps
+        mock_load.return_value = None  # 组件加载成功
+
+        mock_bs = MagicMock()
+        cr = MagicMock()
+        cr.is_success.return_value = True
+        cr.data = MagicMock(uuid="bt-1")
+        mock_bs.create.return_value = cr
+        mock_container.backtest_task_service.return_value = mock_bs
+
+        result = runner.invoke(app, [
+            "create", "--portfolio", "p-1",
+            "--start", "2025-05-07", "--end", "2026-05-07",
+            "--cash", "999999999999",
+        ])
+        assert result.exit_code == 0, "极端 cash 应警告但仍创建"
+        plain = _strip_ansi(result.output)
+        assert "警告" in plain or "warn" in plain.lower(), f"极端 cash 应有警告，实际：{plain!r}"


### PR DESCRIPTION
## Summary

修复 #6004：`ginkgo backtest create --cash` 无上下界校验。

`create_task` 在 portfolio 校验前增加 cash 两层校验：
- **cash <= 0 硬拒绝**（exit 1）：#5983 安全核心，避免回测以零/负资金运行（无意义结果）
- **范围外警告**（<1,000 或 >10,000,000,000）但不阻断：#6004 合理范围建议，避免阻塞合法的小额/大额测试

## 根因

`backtest_cli.py:create_task` 的 `cash` 参数（`typer.Option(100000)`）无任何校验，直接进 `config_snapshot["initial_cash"]`。子 issue #5983 报 cash=0 无拒绝；#6004 进一步要求处理极端值。此前 #5983 "被 #6004 吞并"，#6004 被手动关闭但无 commit 落地（PR #6255 标题 `fix(#5984)` 实改 portfolio_cli.py，与 backtest_cli.py 无关）。

## Test plan

- [x] `test_create_rejects_nonpositive_cash`：cash=0 与 cash=-1 → exit 1 + 消息含 "cash"
- [x] `test_create_warns_extreme_high_cash`：cash=999999999999（万亿）→ exit 0（仍创建）+ 消息含 "警告"
- [x] 既有 `test_backtest_cli.py`（cat/list 4 测试）不回归

```bash
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$(pwd):$(pwd)/src python -m pytest \
  tests/unit/client/test_backtest_cli_cash_validation.py \
  tests/unit/client/test_backtest_cli.py -o "addopts=" -q
# 6 passed
```

Closes #6004
