### PR TITLE
fix(#6083): backtest create 日期校验（格式/end<start/未来日期）

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -37,6 +37,29 @@ def create_task(
     """:plus: Create a backtest task."""
     from ginkgo.data.containers import container
     from ginkgo.workers.backtest_worker.task_helpers import load_portfolio_components
+    from datetime import datetime
+
+    # 校验日期格式（#5994/#6083：仅接受 YYYY-MM-DD）
+    try:
+        start_date = datetime.strptime(start, "%Y-%m-%d")
+        end_date = datetime.strptime(end, "%Y-%m-%d")
+    except ValueError:
+        console.print(
+            f":x: 日期格式无效，要求 YYYY-MM-DD；start={start} end={end}"
+        )
+        raise typer.Exit(1)
+
+    # 校验日期范围（#5993：end 早于 start 拒绝）
+    if end_date < start_date:
+        console.print(f":x: 结束日期 {end} 早于开始日期 {start}")
+        raise typer.Exit(1)
+
+    # 未来日期警告（#6009：未来日期无历史数据，警告但不阻断）
+    today = datetime.now().date()
+    if start_date.date() > today or end_date.date() > today:
+        console.print(
+            f":warning: 警告：start={start} 或 end={end} 为未来日期，该区间可能无历史数据"
+        )
 
     # 校验 portfolio 存在
     portfolio_service = container.portfolio_service()

--- a/tests/unit/client/test_backtest_cli_date_validation.py
+++ b/tests/unit/client/test_backtest_cli_date_validation.py
@@ -1,0 +1,86 @@
+# #6083 backtest create 日期校验（#5981/#5993/#5994/#6009）
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import re
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+class TestBacktestCreateDateValidation:
+    """#6083 backtest create --start/--end 日期校验"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_rejects_invalid_date_format(self, mock_container):
+        """#5994 无效日期格式应被拒绝（exit 1，消息提及日期）"""
+        from ginkgo.client.backtest_cli import app
+
+        for bad_date in ["invalid", "2025-13-45", "2025/05/07"]:
+            result = runner.invoke(app, [
+                "create", "--portfolio", "p-1",
+                "--start", bad_date, "--end", "2026-05-07",
+                "--cash", "100000",
+            ])
+            assert result.exit_code == 1, f"start={bad_date!r} 应被拒绝（exit 1）"
+            plain = _strip_ansi(result.output)
+            assert "日期" in plain or "date" in plain.lower(), (
+                f"start={bad_date!r} 拒绝消息应提及日期，实际：{plain!r}"
+            )
+
+    @patch("ginkgo.data.containers.container")
+    def test_create_rejects_end_before_start(self, mock_container):
+        """#5993 end < start 应被拒绝（exit 1）"""
+        from ginkgo.client.backtest_cli import app
+
+        result = runner.invoke(app, [
+            "create", "--portfolio", "p-1",
+            "--start", "2026-05-07", "--end", "2025-05-07",
+            "--cash", "100000",
+        ])
+        assert result.exit_code == 1, "end < start 应被拒绝"
+        plain = _strip_ansi(result.output)
+        assert "结束" in plain or "开始" in plain or "end" in plain.lower() or "start" in plain.lower(), (
+            f"end<start 拒绝消息应说明起止关系，实际：{plain!r}"
+        )
+
+    @patch("ginkgo.workers.backtest_worker.task_helpers.load_portfolio_components")
+    @patch("ginkgo.data.containers.container")
+    def test_create_warns_future_date(self, mock_container, mock_load):
+        """#6009 未来日期应警告但仍创建"""
+        from ginkgo.client.backtest_cli import app
+
+        mock_ps = MagicMock()
+        pr = MagicMock()
+        pr.is_success.return_value = True
+        mock_ps.get.return_value = pr
+        mock_container.portfolio_service.return_value = mock_ps
+        mock_load.return_value = None
+
+        mock_bs = MagicMock()
+        cr = MagicMock()
+        cr.is_success.return_value = True
+        cr.data = MagicMock(uuid="bt-1")
+        mock_bs.create.return_value = cr
+        mock_container.backtest_task_service.return_value = mock_bs
+
+        result = runner.invoke(app, [
+            "create", "--portfolio", "p-1",
+            "--start", "2030-01-01", "--end", "2031-01-01",
+            "--cash", "100000",
+        ])
+        assert result.exit_code == 0, "未来日期应警告但仍创建"
+        plain = _strip_ansi(result.output)
+        assert "警告" in plain or "warn" in plain.lower(), (
+            f"未来日期应有警告，实际：{plain!r}"
+        )


### PR DESCRIPTION
## Summary

完成 #6083 的日期校验子项（#5981/#5993/#5994/#6009，均误关无 PR 落地，源码无实现）。

`create_task` 的 `start`/`end` 此前是裸 `str`，无校验直接进 `config_snapshot`。本 PR 在 portfolio 校验前增加三层校验：
- **格式校验**：仅接受 `YYYY-MM-DD`，无效格式 exit 1（#5994）
- **end < start 拒绝**：exit 1（#5993）
- **未来日期警告**但不阻断：未来区间可能无历史数据（#6009）

错误/警告风格与 cash 校验（PR #6267）一致：`:x:` + `typer.Exit(1)` 拒绝；`:warning: 警告：...` 软提示。

## 根因

#5981/#5993/#5994/#6009 四个子 issue 全部 closed 但无关联 PR（`gh pr list --search` 为空），且 `create_task` 源码 grep 无任何 `strptime`/日期校验——典型的"标 absorbed by #6083 手动关闭但 #6083 未实现"。

## 与 PR #6267 的关系

#6083 验收含 cash（#6004/#5983）+ 日期两部分。cash 在 PR #6267，日期在本 PR。**两者合并后 #6083 验收完整**，届时可关闭 #6083（本 PR 不自动关闭 #6083 以避免 cash 未落地时过早关闭）。

## Test plan

- [x] `test_create_rejects_invalid_date_format`：`invalid`/`2025-13-45`/`2025/05/07` → exit 1 + 消息含"日期"
- [x] `test_create_rejects_end_before_start`：end 早于 start → exit 1 + 消息说明起止
- [x] `test_create_warns_future_date`：2030 区间 → exit 0（仍创建）+ 消息含"警告"
- [x] 既有 `test_backtest_cli.py`（4 测试）不回归

```bash
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$(pwd):$(pwd)/src python -m pytest \
  tests/unit/client/test_backtest_cli_date_validation.py \
  tests/unit/client/test_backtest_cli.py -o "addopts=" -q
# 7 passed
```
