### PR TITLE
fix(#5335): deploy info 按 deployment_id 查询

### DIFF
--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -67,14 +67,14 @@ def deploy(
 
 @app.command("info")
 def info(
-    portfolio_id: Annotated[str, typer.Argument(help="部署后的Portfolio ID")],
+    deployment_id: Annotated[str, typer.Argument(help="部署记录 ID (Deployment ID)")],
 ):
     """查看部署详情"""
     try:
         from ginkgo.trading.containers import trading_container
 
         svc = trading_container.deployment_service()
-        result = svc.get_deployment_info(portfolio_id)
+        result = svc.get_deployment_by_id(deployment_id)
 
         if result.success:
             data = result.data

--- a/src/ginkgo/data/crud/deployment_crud.py
+++ b/src/ginkgo/data/crud/deployment_crud.py
@@ -25,3 +25,7 @@ class DeploymentCRUD(BaseCRUD):
     def get_by_source_portfolio(self, portfolio_id: str):
         """根据源Portfolio ID查询部署记录"""
         return self.find(filters={"source_portfolio_id": portfolio_id})
+
+    def get_by_uuid(self, deployment_id: str):
+        """根据部署记录 UUID 查询（#5335：deploy info 按 deployment_id 查）"""
+        return self.find(filters={"uuid": deployment_id})

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -296,6 +296,26 @@ class DeploymentService(BaseService):
             "create_at": str(r.create_at) if r.create_at else None,
         }
 
+    def get_deployment_by_id(self, deployment_id: str) -> ServiceResult:
+        """按部署记录 UUID 获取部署信息（#5335：deploy info <deployment_id>）"""
+        records = self._deployment_crud.get_by_uuid(deployment_id)
+        if not records:
+            return ServiceResult(success=False, error="未找到部署记录")
+
+        deployment = records[0]
+        result = ServiceResult(success=True)
+        result.data = {
+            "source_task_id": deployment.source_task_id,
+            "target_portfolio_id": deployment.target_portfolio_id,
+            "source_portfolio_id": deployment.source_portfolio_id,
+            "mode": deployment.mode,
+            "account_id": deployment.account_id,
+            "status": deployment.status,
+            "status_name": _status_name(deployment.status),  # #6285
+            "create_at": str(deployment.create_at) if deployment.create_at else None,
+        }
+        return result
+
     def list_deployments(self, portfolio_id: str = None) -> ServiceResult:
         """列出部署记录"""
         if portfolio_id:

--- a/tests/unit/client/test_deploy_cli_info.py
+++ b/tests/unit/client/test_deploy_cli_info.py
@@ -1,0 +1,56 @@
+# #5335 deploy info 始终返回未找到部署记录
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import re
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+class TestDeployInfoByDeploymentId:
+    """#5335 deploy info 应按 deployment_id 查询"""
+
+    @patch("ginkgo.trading.containers.trading_container")
+    def test_info_queries_by_deployment_id(self, mock_container):
+        """#5335 info <deployment_id> 应调 get_deployment_by_id（非 get_deployment_info 按 portfolio_id）"""
+        from ginkgo.client.deploy_cli import app
+
+        mock_svc = MagicMock()
+        mock_container.deployment_service.return_value = mock_svc
+        r = MagicMock()
+        r.success = True
+        r.data = {
+            "source_task_id": "task-1",
+            "source_portfolio_id": "src-port-1234",
+            "target_portfolio_id": "tgt-port-5678",
+            "mode": 1,
+            "account_id": "acc-1",
+            "status": "running",
+            "create_at": "2025-01-01",
+        }
+        mock_svc.get_deployment_by_id.return_value = r
+
+        deployment_id = "d90b32ab6b5149f49802754ce0c1f0ef"
+        result = runner.invoke(app, ["info", deployment_id])
+        assert result.exit_code == 0, f"info 应成功：{result.output}"
+
+        # 关键：按 deployment_id 调 get_deployment_by_id
+        mock_svc.get_deployment_by_id.assert_called_once_with(deployment_id)
+        # 旧路径 get_deployment_info 不应被调用
+        mock_svc.get_deployment_info.assert_not_called()
+
+        plain = _strip_ansi(result.output)
+        assert "src-port-1234" in plain or "tgt-port-5678" in plain, (
+            f"应显示源/目标 portfolio，实际：{plain!r}"
+        )


### PR DESCRIPTION
## Summary

修复 #5335：`ginkgo deploy info <deployment_id>` 始终返回"未找到部署记录"。

## 根因

`deploy deploy` 返回 **Deployment ID**（uuid），但 `deploy info` 命令把传入参数当 **target_portfolio_id** 查：

```
info(portfolio_id) → svc.get_deployment_info(portfolio_id)
                  → crud.get_by_target_portfolio(portfolio_id)
```

deployment_id 非任何 portfolio_id → 查询空 → "未找到部署记录"。`deploy list` 正常因其用 `list_deployments`（find 全表）。

## 修复

| 层 | 改动 |
|---|---|
| `deployment_crud.py` | 加 `get_by_uuid(deployment_id)`：`find(filters={"uuid": deployment_id})` |
| `deployment_service.py` | 加 `get_deployment_by_id(deployment_id)`，复用详情装配 |
| `deploy_cli.py` | `info` 参数 `portfolio_id` → `deployment_id`，调 `get_deployment_by_id` |

API 层 `api/api/deployment.py` 的 `get_deployment_info(portfolio_id)` **不变**（保持按 portfolio 查的语义，与 CLI 解耦）。

## Test plan

- [x] `test_info_queries_by_deployment_id`：info 按 deployment_id 调 `get_deployment_by_id`（关键断言），不调旧 `get_deployment_info`；输出含源/目标 portfolio
- [x] 既有 `test_deployment_service.py` + `test_deployment_crud_mock.py`（13 测试）不回归

```bash
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$(pwd):$(pwd)/src python -m pytest \
  tests/unit/client/test_deploy_cli_info.py \
  tests/unit/trading/services/test_deployment_service.py \
  tests/unit/data/crud/test_deployment_crud_mock.py -o "addopts=" -q
# 14 passed
```

Closes #5335
