### PR TITLE
fix(#5450): bars sync 已是最新时不抛 ValueError 静默 proc=0

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -578,6 +578,25 @@ def _record_sync_result(service, record_uuid: str, result, started_at: float):
         if isinstance(dsr, list):
             dsr = _aggregate_dsr_list(dsr)
         if hasattr(dsr, 'records_processed'):
+            # #5450: 检测 service 层标记的带 reason 的成功语义（如 already_up_to_date）。
+            # 此时 records_processed=0/skipped=0，旧 #5893 逻辑会误判 partial；但"数据已最新"
+            # 属 success。把 result.message 透传到 error_message（model 唯一 Text 字段，
+            # get_history 端到端返回），不加 schema 字段避免 DB 安全阀。验收标准 2 端到端。
+            _meta = getattr(dsr, 'metadata', None)
+            _reason = _meta.get("reason", "") if isinstance(_meta, dict) else ""
+            if _reason:
+                service.record_complete(
+                    uuid=record_uuid,
+                    status="success",
+                    duration_ms=duration_ms,
+                    records_processed=dsr.records_processed,
+                    records_added=dsr.records_added,
+                    records_updated=dsr.records_updated,
+                    records_failed=dsr.records_failed,
+                    sync_strategy=getattr(dsr, 'sync_strategy', ''),
+                    error_message=getattr(result, 'message', '') or f"已是最新 ({_reason})",
+                )
+                return
             # #5893: success 仅当无错误且有产出（processed>0）或幂等跳过（skipped>0）；
             # 否则报 partial——含"0 条可疑空"和"有 records_failed/errors"。
             # DataSyncResult.is_successful() 只判 has_errors 不看 processed=0，故需此处显式区分。

--- a/src/ginkgo/data/services/bar_service.py
+++ b/src/ginkgo/data/services/bar_service.py
@@ -287,6 +287,22 @@ class BarService(BaseService):
             # Determine date range based on fast_mode
             start_date, end_date = self._get_fetch_date_range(code, fast_mode, frequency)
 
+            # #5450: fast_mode 下若库中数据已是最新（latest_timestamp 已到今天，
+            # 致 start_date=明天 > end_date=今天），明确返回"已是最新"，避免
+            # _validate_and_set_date_range 抛 ValueError 被 except 吞成失败 proc=0。
+            # 验收标准2: 数据已最新时说明为何 0 records。
+            if fast_mode and start_date > end_date:
+                up_to_date_result = DataSyncResult.create_for_entity(
+                    entity_type="bars",
+                    entity_identifier=code,
+                    sync_strategy="smart",
+                )
+                up_to_date_result.set_metadata("reason", "already_up_to_date")
+                return ServiceResult.success(
+                    data=up_to_date_result,
+                    message=f"{code} 数据已是最新，无需同步",
+                )
+
             # Call the new date range method
             sync_result = self.sync_range(code, start_date, end_date, frequency)
 

--- a/tests/api/test_data_sync_result_record.py
+++ b/tests/api/test_data_sync_result_record.py
@@ -1,0 +1,73 @@
+"""#5450: _record_sync_result API 层透传测试。
+
+service 层 (PR #6270) 对"已是最新"返回 `ServiceResult.success(message=...,
+data=DataSyncResult(metadata reason=already_up_to_date))`。API 层 `_record_sync_result`
+须读 `dsr.metadata.reason` 并透传 `result.message`，否则 sync_history 记
+`status=partial/proc=0` 无说明 —— 验收标准 2（端到端 status message explains why
+0 records）未满足。
+
+按 [[arch_api_test_import_collapse]]：conftest `api_modules` 是 autouse session
+fixture，collection 阶段 sys.path 未注入，须函数体内 `import api.data`。
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _make_dsr(
+    records_processed=0,
+    records_added=0,
+    records_updated=0,
+    records_failed=0,
+    records_skipped=0,
+    metadata=None,
+    sync_strategy="smart",
+):
+    """构造 DataSyncResult 替身（只覆盖 _record_sync_result 读取的属性）"""
+    return SimpleNamespace(
+        records_processed=records_processed,
+        records_added=records_added,
+        records_updated=records_updated,
+        records_failed=records_failed,
+        records_skipped=records_skipped,
+        is_successful=lambda: True,
+        metadata=metadata if metadata is not None else {},
+        sync_strategy=sync_strategy,
+    )
+
+
+def test_record_sync_result_already_up_to_date_status_success_with_message(api_modules):
+    """#5450: '已是最新'结果 → status=success（非 partial）+ 说明透传 error_message"""
+    import api.data as data_mod
+    from ginkgo.data.services.base_service import ServiceResult
+
+    dsr = _make_dsr(metadata={"reason": "already_up_to_date"})
+    result = ServiceResult.success(data=dsr, message="000001.SZ 数据已是最新，无需同步")
+
+    sync_svc = MagicMock()
+    data_mod._record_sync_result(sync_svc, "rec-uuid", result, started_at=0.0)
+
+    sync_svc.record_complete.assert_called_once()
+    kwargs = sync_svc.record_complete.call_args.kwargs
+    assert kwargs["status"] == "success", (
+        f"已是最新应为 success 非 partial，实际 {kwargs['status']}"
+    )
+    assert kwargs["error_message"] == "000001.SZ 数据已是最新，无需同步", "说明须透传到 error_message"
+    assert kwargs["records_processed"] == 0
+
+
+def test_record_sync_result_normal_success_no_message_pollution(api_modules):
+    """#5450 回归：正常成功 (records_processed>0, 无 reason) → error_message 不被污染"""
+    import api.data as data_mod
+    from ginkgo.data.services.base_service import ServiceResult
+
+    dsr = _make_dsr(records_processed=5, records_added=5, metadata={})
+    result = ServiceResult.success(data=dsr, message="ok")
+
+    sync_svc = MagicMock()
+    data_mod._record_sync_result(sync_svc, "rec-uuid", result, started_at=0.0)
+
+    kwargs = sync_svc.record_complete.call_args.kwargs
+    assert kwargs["status"] == "success"
+    assert not kwargs.get("error_message"), (
+        f"正常成功不应写 error_message，实际 {kwargs.get('error_message')}"
+    )

--- a/tests/unit/data/services/test_bar_service_mock.py
+++ b/tests/unit/data/services/test_bar_service_mock.py
@@ -341,3 +341,50 @@ class TestBarServiceSyncRange:
         assert result.data.records_processed == 3  # 幂等路径也非 0
         assert result.data.records_skipped == 3
         assert result.data.is_idempotent is True
+
+
+# ============================================================
+# sync_smart 测试
+# ============================================================
+
+class TestBarServiceSyncSmart:
+    """sync_smart 方法测试"""
+
+    @pytest.mark.unit
+    def test_fast_mode_data_up_to_date_returns_already_latest(self, service, mock_deps):
+        """
+        #5450: fast_mode 下库中最新数据已是今天时，sync_smart 应返回 success +
+        '已是最新'说明，而非让 start>end 的 ValueError 被 _validate_and_set_date_range
+        抛出后吞成失败 proc=0。
+
+        复现：000001.SZ 最新 bars timestamp=今天 → _get_fetch_date_range 算出
+        start=明天 > end=今天 → 旧代码 sync_range 抛 ValueError → sync_smart except
+        返回 error，sync_history 记 proc=0 无说明。
+        """
+        # 库中最新 bars 已是今天 → start_date = 明天 > end_date = 今天
+        mock_record = MagicMock()
+        mock_record.timestamp = datetime.now()
+        mock_deps["crud_repo"].find.return_value = [mock_record]
+
+        result = service.sync_smart("000001.SZ", fast_mode=True)
+
+        # 验收标准2: 数据已最新时明确说明为何 0 records
+        assert result.success is True, f"应成功返回'已是最新'，实际 error: {getattr(result, 'error', None)}"
+        assert "最新" in (result.message or ""), f"message 应说明已最新，实际: {result.message}"
+        # 守卫提前返回，不应进 sync_range 调数据源
+        mock_deps["data_source"].fetch_cn_stock_daybar.assert_not_called()
+        # data 是 DataSyncResult，records_processed=0（已最新无新数据）
+        assert result.data is not None
+        assert result.data.records_processed == 0
+
+    @pytest.mark.unit
+    def test_fast_mode_data_up_to_date_metadata_reason(self, service, mock_deps):
+        """#5450: '已是最新'结果应带 metadata(reason=already_up_to_date) 供调用方区分"""
+        mock_record = MagicMock()
+        mock_record.timestamp = datetime.now()
+        mock_deps["crud_repo"].find.return_value = [mock_record]
+
+        result = service.sync_smart("000001.SZ", fast_mode=True)
+
+        assert result.success is True
+        assert result.data.metadata.get("reason") == "already_up_to_date"


### PR DESCRIPTION
## Summary

修复 #5450：`POST /api/v1/data/sync {type:bars, codes:["000001.SZ"]}` 始终 `proc=0/added=0/updated=0`，而 600519.SH 正常 `proc=1`。

## 根因

调用链：`sync_data` → `bar_service.sync_smart(code, fast_mode=True)` → `_get_fetch_date_range` → `sync_range` → `_validate_and_set_date_range`

fast_mode 下 `_get_fetch_date_range`（bar_service.py:907-912）：
```python
latest_timestamp_result = self.get_latest_timestamp(code, frequency)
if latest_timestamp_result.success and latest_timestamp_result.data:
    start_date = latest_timestamp_result.data + timedelta(days=1)
end_date = datetime.now()
```

000001.SZ 库中最新 bars 已是今天（高频更新）→ `start_date = 明天 > end_date = 今天` → `_validate_and_set_date_range`（bar_service.py:1059）抛 `ValueError: Start date ... cannot be later than end date` → sync_smart 的 except（bar_service.py:303）吞异常 → `ServiceResult.error` → API `_record_sync_result` 记 `record_fail(processed=0)`。

600519.SH 最新数据较早 → `start ≤ end` → 正常 fetch `proc=1`。

**影响范围**：任何"数据已更新到今天"的 code 同步都会触发（普遍逻辑缺陷，非 000001.SZ 独有）。

## 修复

`sync_smart` 在 `_get_fetch_date_range` 之后加守卫：`fast_mode and start_date > end_date` 时返回明确的"已是最新"结果，不进 sync_range：

```python
if fast_mode and start_date > end_date:
    up_to_date_result = DataSyncResult.create_for_entity(
        entity_type="bars", entity_identifier=code, sync_strategy="smart")
    up_to_date_result.set_metadata("reason", "already_up_to_date")
    return ServiceResult.success(
        data=up_to_date_result,
        message=f"{code} 数据已是最新，无需同步")
```

满足验收标准 2（"数据已最新时说明为何 0 records"）。API 层 `_record_sync_result` 从 `record_fail` 改善为 `record_complete(partial)` + 明确 message，不再有误导性的 "Start date cannot be later than end date" 错误。

## Test plan

- [x] `test_fast_mode_data_up_to_date_returns_already_latest`：fast_mode + latest=今天 → success + message 含"最新" + data_source 不被调用 + records_processed=0
- [x] `test_fast_mode_data_up_to_date_metadata_reason`：metadata(reason=already_up_to_date)
- [x] 既有 `test_bar_service_mock.py` 17 测试不回归（19 passed）

```bash
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$(pwd):$(pwd)/src python -m pytest \
  tests/unit/data/services/test_bar_service_mock.py -o "addopts=" -q
# 19 passed
```

Closes #5450
