### PR TITLE
fix(#5653): stockinfo 分页行偏移转 0-based 页码

### DIFF
--- a/src/ginkgo/data/services/stockinfo_service.py
+++ b/src/ginkgo/data/services/stockinfo_service.py
@@ -391,12 +391,23 @@ class StockinfoService(BaseService):
 
     def _build_query(self, limit=None, offset=None, order_by=None,
                      desc_order: bool = False) -> dict:
-        """从分页/排序参数构造 CRUD find 查询参数。三出口共用。"""
+        """从分页/排序参数构造 CRUD find 查询参数。三出口共用。
+
+        #5653: ``offset`` 是行偏移（API 传 ``(page-1)*page_size``），
+        BaseCRUD.find 的 ``page`` 是 0-based 页码（内部 ``offset(page*page_size)``）。
+        直接 ``page=offset`` 会把行偏移当页码，第2页 ``offset=50→page=50→offset(2500)``
+        跳过 2500 行。需用 ``page = offset // page_size`` 还原页码。
+        """
         query_params = {}
         if limit is not None:
             query_params['page_size'] = limit
         if offset is not None:
-            query_params['page'] = offset
+            if limit is not None and limit > 0:
+                query_params['page'] = offset // limit
+            else:
+                # 无 page_size 无法换算页码（生产调用方总 limit+offset 成对传），
+                # 退化为直接传 offset（保持旧行为，不引入破坏性变更）。
+                query_params['page'] = offset
         if order_by is not None:
             query_params['order_by'] = order_by
             query_params['desc_order'] = desc_order

--- a/tests/unit/data/services/test_stockinfo_service_mock.py
+++ b/tests/unit/data/services/test_stockinfo_service_mock.py
@@ -228,16 +228,51 @@ class TestGet:
 
     @pytest.mark.unit
     def test_get_with_pagination(self, service, mock_deps):
-        """分页参数正确传递给 crud_repo"""
+        """分页参数正确传递给 crud_repo（#5653: offset 行偏移转 0-based 页码）"""
         mock_model_list = MagicMock()
         mock_model_list.__len__ = MagicMock(return_value=10)
         mock_deps["crud_repo"].find.return_value = mock_model_list
 
-        result = service.get(limit=10, offset=2)
+        # offset=20(行偏移) / limit=10 → page=2（0-based 第3页）
+        result = service.get(limit=10, offset=20)
         assert result.success is True
         call_kwargs = mock_deps["crud_repo"].find.call_args
         assert call_kwargs[1]["page_size"] == 10
         assert call_kwargs[1]["page"] == 2
+
+    @pytest.mark.unit
+    def test_get_offset_is_row_offset_converted_to_page(self, service, mock_deps):
+        """#5653: service 层 offset 是行偏移（API 传 (page-1)*page_size），
+        须转换成 0-based 页码下传给 crud_repo.find。
+
+        BaseCRUD.find 的 page 是 0-based 页码（内部 offset(page*page_size)）。
+        若直接 page=offset，第2页 offset=50→page=50→offset(2500)，跳过 2500 行。
+        """
+        mock_model_list = MagicMock()
+        mock_model_list.__len__ = MagicMock(return_value=50)
+        mock_deps["crud_repo"].find.return_value = mock_model_list
+
+        # API 第2页: offset=(2-1)*50=50（行偏移）
+        service.get(limit=50, offset=50)
+
+        call_kwargs = mock_deps["crud_repo"].find.call_args[1]
+        assert call_kwargs["page_size"] == 50
+        assert call_kwargs["page"] == 1, (
+            f"offset=50(行偏移) / limit=50 应得 page=1（0-based 第2页），"
+            f"实际 page={call_kwargs.get('page')}（行偏移当页码致跳过 2500 行）"
+        )
+
+    @pytest.mark.unit
+    def test_get_offset_zero_is_first_page(self, service, mock_deps):
+        """#5653: offset=0（第1页）转换后 page=0，保持第1页正确。"""
+        mock_model_list = MagicMock()
+        mock_model_list.__len__ = MagicMock(return_value=50)
+        mock_deps["crud_repo"].find.return_value = mock_model_list
+
+        service.get(limit=50, offset=0)
+
+        call_kwargs = mock_deps["crud_repo"].find.call_args[1]
+        assert call_kwargs["page"] == 0
 
     @pytest.mark.unit
     def test_get_with_sorting(self, service, mock_deps):


### PR DESCRIPTION
## Summary

修复 `GET /api/v1/data/stocks` 分页错位/返回空（#5653）。

**根因**：`stockinfo_service._build_query` 把 service 层的 `offset`（**行偏移**语义，API 传 `(page-1)*page_size`）直接赋给 `BaseCRUD.find` 的 `page`（**0-based 页码**语义，内部 `offset(page*page_size)`）。

| 页码 | API 传 offset | 修复前 page（行偏移当页码） | find 实际 offset | 结果 |
|---|---|---|---|---|
| 1 | 0 | 0 | 0 | 偶然正确 |
| 2 | 50 | 50 | 2500 | 跳过 2500 行 |
| N | (N-1)·50 | (N-1)·50 | (N-1)·2500 | 指数级跳过 |

第2页起返回错位数据或空，与 `/stats` 的 7650 不一致。

**修复**：`page = offset // page_size`（当 `limit` 已知）。三出口（`get`/`get_stockinfos`/`get_stockinfos_df`）共用 `_build_query`，一并修复。无 `limit` 时退化为旧行为（生产调用方 `api/api/data.py:266` 总 limit+offset 成对传，不触发 fallback）。

**附带修正**：`test_get_with_pagination` 原断言 `offset=2→page==2` 固化了 bug（行偏移当页码），改为 `offset=20→page==2`（真实行偏移语义）。

## Test plan

- [x] 新增 `test_get_offset_is_row_offset_converted_to_page`：`offset=50,limit=50→page==1`
- [x] 新增 `test_get_offset_zero_is_first_page`：`offset=0→page==0`
- [x] 修正 `test_get_with_pagination`：`offset=20,limit=10→page==2`
- [x] stockinfo service 全量测试 82 passed（mock + multiexit + service）无回归
- [ ] 手动验证：`GET /api/v1/data/stocks?page=2` 返回第2页数据（非空，与 stats total 一致）

## 变更文件

- `src/ginkgo/data/services/stockinfo_service.py` — `_build_query` 行偏移→页码转换
- `tests/unit/data/services/test_stockinfo_service_mock.py` — 修正固化 bug 的测试 + 补转换正确性测试

Closes #5653
