### PR TITLE
fix(#5629): MLiveAccount.validation_status 列 String(100) 改 Text

### DIFF
--- a/src/ginkgo/data/models/model_live_account.py
+++ b/src/ginkgo/data/models/model_live_account.py
@@ -65,7 +65,7 @@ class MLiveAccount(MMysqlBase):
     # 状态字段
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="enabled", comment="账号状态")
     last_validated_at: Mapped[Optional[datetime.datetime]] = mapped_column(DateTime(timezone=True), comment="上次验证时间")
-    validation_status: Mapped[Optional[str]] = mapped_column(String(100), comment="验证状态消息")
+    validation_status: Mapped[Optional[str]] = mapped_column(Text, comment="验证状态消息")
 
     def __init__(self, **kwargs):
         """初始化MLiveAccount实例"""

--- a/tests/unit/data/models/test_live_account_model.py
+++ b/tests/unit/data/models/test_live_account_model.py
@@ -1,0 +1,57 @@
+"""
+MLiveAccount model 列类型测试（#5629）。
+
+性能: <1s, 单元测试 [PASS]
+"""
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from sqlalchemy import inspect, Text
+
+from ginkgo.data.models.model_live_account import MLiveAccount
+
+
+class TestLiveAccountValidationStatusColumn:
+    """#5629: validation_status 列长度不足，验证错误无法持久化。"""
+
+    @pytest.mark.unit
+    def test_validation_status_is_text_not_short_varchar(self):
+        """validation_status 应为 Text，容纳米超长验证错误信息（如 OKX 详细错误）。
+
+        原 String(100) 致 MySQL 报 `Data too long for column
+        'validation_status'`，验证结果（success/failed: <msg>）无法持久化，
+        列始终 NULL。同表 description 已用 Text，此列对齐。
+        """
+        col = inspect(MLiveAccount).columns["validation_status"]
+        assert isinstance(col.type, Text), (
+            f"validation_status 应为 Text（容纳米超长错误信息），"
+            f"实际 {type(col.type).__name__}(length={getattr(col.type, 'length', None)})"
+        )
+
+    @pytest.mark.unit
+    def test_validation_status_accepts_long_message(self):
+        """构造 >100 字符的验证错误消息赋给 validation_status，model 层应接受。
+
+        #5629 复现：OKX testnet 无真实 API key，验证错误消息远超 100 字符。
+        列改 Text 后，model 实例可承载任意长消息（DB 层不再截断）。
+        """
+        long_message = "failed: " + "x" * 200  # 208 字符，远超 String(100)
+        account = MLiveAccount(
+            user_id="u1",
+            exchange="okx",
+            environment="testnet",
+            name="test",
+            api_key="k",
+            api_secret="s",
+        )
+        # model 层赋值不应因长度报错（DB 层类型决定是否截断）
+        account.validation_status = long_message
+        assert account.validation_status == long_message
+        assert len(account.validation_status) > 100


### PR DESCRIPTION
## Summary

修复 `POST /api/v1/accounts/{id}/validate` 写 `validation_status` 失败（#5629）：`(1406, "Data too long for column 'validation_status' at row 1")`。

**根因**：`model_live_account.py:68` `validation_status: String(100)` 过短。验证错误信息（OKX testnet 无真实 API key 的详细错误）远超 100 字符 → MySQL 截断失败 → 列始终 NULL，验证结果无法持久化。

**修复**：`String(100)` → `Text`。同表 `description` 已用 Text，此列对齐。`crud.update_status` 与 `service.record_validation_failure` 直接透传 message 无截断逻辑，列类型是唯一瓶颈。

**注意**：`create_all` 只建表不 alter 已存在表的列（arch_create_all_no_alter_drift）。新 DB 自动 `Text`；旧 DB 需重建或手动 `ALTER TABLE live_accounts MODIFY COLUMN validation_status Text`（用户侧操作，非本 PR 范围）。

## Test plan

- [x] 新增 `test_validation_status_is_text_not_short_varchar`：SQLAlchemy inspect 断言列类型为 Text（RED 确认原 String(100) 失败 → GREEN 通过）
- [x] 新增 `test_validation_status_accepts_long_message`：208 字符 message 赋值 model 实例不报错
- [x] live_account 相关 65 passed 无回归
- [ ] **pre-existing 失败**（与本 PR 无关）：`test_live_account_crud_mock.py::test_get_live_account_by_uuid` 在 master 同样失败（KeyError，`get_live_account_by_uuid` 的 is_del filter 问题），stash 验证确认非本 PR 引入

## 变更文件

- `src/ginkgo/data/models/model_live_account.py` — `validation_status: String(100)` → `Text`
- `tests/unit/data/models/test_live_account_model.py` — 列类型契约测试（新建）

Closes #5629
