### PR TITLE
fix: WebUI order.ts 移除双重解包，订单/持仓视图不再全 undefined (#5544)

### DIFF
--- a/web-ui/src/api/modules/order.test.ts
+++ b/web-ui/src/api/modules/order.test.ts
@@ -1,0 +1,92 @@
+/**
+ * order.ts 双重解包修复测试 (#5544)
+ *
+ * 根因：request.ts 响应拦截器已 `return data`（=后端 body），
+ *   request.get() 返回的已经是 body 本身 {code, data, message}。
+ *   order.ts 4 方法却 `return response.data` 再解一层，
+ *   实际返回的是 body.data（订单/持仓数组），与签名 {data, total} 不符，
+ *   调用方解构 {data, total} 拿到 undefined。
+ *
+ * 修复：移除多余 .data，返回 body 本身（与 data.ts 正确模式一致）。
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../request', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+import request from '../request'
+import { orderApi, positionApi } from './order'
+
+describe('order.ts 双重解包修复 (#5544)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('orderApi.list 返回 body 本身（含 code/data/message），而非订单数组', async () => {
+    const mockOrders = [{ uuid: 'o1', code: '000001.SZ' }]
+    // 后端 ok(data=orders) 的 body 形态
+    const mockBody = { code: 0, data: mockOrders, message: 'Paper orders retrieved successfully' }
+    vi.mocked(request.get).mockResolvedValue(mockBody)
+
+    const result = await orderApi.list()
+
+    // result 应是 body 本身（拦截器已解包），不再是数组
+    expect(result).toBe(mockBody)
+    expect(result.code).toBe(0)
+    expect(result.data).toBe(mockOrders)
+    // 双重解包 bug 下 result 会变成 mockOrders 数组，这里守住
+    expect(Array.isArray(result)).toBe(false)
+  })
+
+  it('orderApi.get 返回 body 本身（含 data=单订单），而非订单对象', async () => {
+    const mockOrder = { uuid: 'o1', code: '000001.SZ', status: 1 }
+    const mockBody = { code: 0, data: mockOrder, message: 'ok' }
+    vi.mocked(request.get).mockResolvedValue(mockBody)
+
+    const result = await orderApi.get('o1')
+
+    expect(result).toBe(mockBody)
+    expect(result.code).toBe(0)
+    expect(result.data).toBe(mockOrder)
+  })
+
+  it('positionApi.list 返回 body 本身（含 data=持仓数组）', async () => {
+    const mockPositions = [{ uuid: 'p1', code: '000001.SZ', volume: 100 }]
+    const mockBody = { code: 0, data: mockPositions, message: 'Paper positions retrieved successfully' }
+    vi.mocked(request.get).mockResolvedValue(mockBody)
+
+    const result = await positionApi.list()
+
+    expect(result).toBe(mockBody)
+    expect(result.code).toBe(0)
+    expect(result.data).toBe(mockPositions)
+    expect(Array.isArray(result)).toBe(false)
+  })
+
+  it('positionApi.get 返回 body 本身（含 data=单持仓）', async () => {
+    const mockPosition = { uuid: 'p1', code: '000001.SZ', volume: 100 }
+    const mockBody = { code: 0, data: mockPosition, message: 'ok' }
+    vi.mocked(request.get).mockResolvedValue(mockBody)
+
+    const result = await positionApi.get('p1')
+
+    expect(result).toBe(mockBody)
+    expect(result.code).toBe(0)
+    expect(result.data).toBe(mockPosition)
+  })
+
+  it('list 请求带 params 参数透传给 request.get', async () => {
+    const mockBody = { code: 0, data: [], message: 'ok' }
+    vi.mocked(request.get).mockResolvedValue(mockBody)
+
+    await orderApi.list({ portfolio_id: 'pf1', status: 'filled' })
+
+    expect(request.get).toHaveBeenCalledWith('/api/v1/orders', {
+      params: { portfolio_id: 'pf1', status: 'filled' },
+    })
+  })
+})

--- a/web-ui/src/api/modules/order.ts
+++ b/web-ui/src/api/modules/order.ts
@@ -59,21 +59,33 @@ export interface PositionListParams {
   size?: number
 }
 
+/**
+ * 后端统一响应信封。
+ * request.ts 响应拦截器已 `return data`（= response.data = 后端 body），
+ * 故 request.get() 返回的已经是 body 本身；API 模块不得再 `.data` 二次解包。
+ * 后端 orders/positions 端点用 ok(data=...)，body = {code, data, message}，
+ * 无 total/meta（分页由调用方自行处理）。
+ */
+export interface ApiResponse<T> {
+  code: number
+  data: T
+  message: string
+  trace_id?: string
+}
+
 export const orderApi = {
   /**
    * 获取订单列表
    */
-  async list(params: OrderListParams = {}): Promise<{ data: Order[], total: number }> {
-    const response = await request.get('/api/v1/orders', { params })
-    return response.data
+  list(params: OrderListParams = {}): Promise<ApiResponse<Order[]>> {
+    return request.get('/api/v1/orders', { params })
   },
 
   /**
    * 获取订单详情
    */
-  async get(orderId: string): Promise<Order> {
-    const response = await request.get(`/api/v1/orders/${orderId}`)
-    return response.data
+  get(orderId: string): Promise<ApiResponse<Order>> {
+    return request.get(`/api/v1/orders/${orderId}`)
   },
 }
 
@@ -81,17 +93,15 @@ export const positionApi = {
   /**
    * 获取持仓列表
    */
-  async list(params: PositionListParams = {}): Promise<{ data: Position[], total: number, summary: PositionSummary }> {
-    const response = await request.get('/api/v1/positions', { params })
-    return response.data
+  list(params: PositionListParams = {}): Promise<ApiResponse<Position[]>> {
+    return request.get('/api/v1/positions', { params })
   },
 
   /**
    * 获取持仓详情
    */
-  async get(positionId: string): Promise<Position> {
-    const response = await request.get(`/api/v1/positions/${positionId}`)
-    return response.data
+  get(positionId: string): Promise<ApiResponse<Position>> {
+    return request.get(`/api/v1/positions/${positionId}`)
   },
 }
 


### PR DESCRIPTION
## Summary

修复 WebUI `order.ts` 双重数据解包导致订单/持仓视图全 `undefined`（#5544）。

**根因**：`request.ts:33` 响应拦截器已 `return data`（= `response.data` = 后端 body），所以 `request.get(url)` 返回的**已经是 body 本身** `{code, data, message}`。但 `order.ts` 4 个方法却 `const response = await request.get(url); return response.data`，多解了一层——实际返回的是 `body.data`（订单/持仓数组或对象本身），而非签名承诺的 `{data, total}` 结构。调用方 `const {data, total} = await orderApi.list()` 解构时拿到 `undefined`。

**对比**：`data.ts` 是正确模式（`return request.get(url)`，直接返回 body）；`order.ts` 是仓库里**唯一**的双重解包异类（已 grep 审计确认零残留）。

**后端事实**：orders/positions 端点均用 `ok(data=...)`，body = `{code, data, message}`，**无 total/meta**。原签名里的 `total`/`summary` 是虚构字段。

**修复**：
- 4 方法（`orderApi.list/get`、`positionApi.list/get`）移除 `response.data`，改为 `return request.get(url)`，与 `data.ts` 一致
- 新增通用 `ApiResponse<T>` 类型，编译时捕获信封结构（`code/data/message`），未来若再误用 `.data` 会在类型层暴露
- 签名从虚构的 `{data, total}` / `{data, total, summary}` 改为真实的 `ApiResponse<Order[]>` 等
- 移除 `async`（无 await 必要，直接 return promise）

## Test plan

- [x] 新增 `order.test.ts` 5 个测试：mock `request.get` 返回 body，断言 `orderApi.list/get` + `positionApi.list/get` 返回 **body 本身**（`result.code===0`、`result.data` 才是数组），而非数组本身（`Array.isArray(result)===false`）
- [x] 含 params 透传测试（`request.get` 收到正确 url + params）
- [x] RED 确认原双重解包代码 4 failed → GREEN 全过 5/5
- [x] 全量 vitest 回归：我的版本 5 failed | 82 passed；master stash 对比 9 failed | 78 passed——失败文件是 `useStatusFormat.test.ts` + `errorHandler.test.ts`（axios/超时/状态码，与 order.ts 零关联），**pre-existing，非本 PR 引入**
- [x] 审计其他 API 模块：grep `const response = await request.(get|post|...)` 零残留，order.ts 是唯一双重解包点

## 变更文件

- `web-ui/src/api/modules/order.ts` — 移除 4 方法双重 `.data` 解包 + 新增 `ApiResponse<T>` 类型 + 签名对齐真实 body
- `web-ui/src/api/modules/order.test.ts` — 双重解包回归测试（新建）

Closes #5544
