### PR TITLE
feat: 添加 CI 测试流水线，防语法错误合入 master (#6015)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: ci
+
+# CI 测试流水线 (#6015)。
+# 背景：#6013 —— PR #5333 合并时无 CI 拦截，user_crud.py IndentationError
+# 直接进 master 瘫痪所有 CLI 命令。此前 .github/workflows/ 仅有 label 清理，
+# 零测试流水线。本 workflow 最低限度补齐：语法检查 + 关键 mock/import smoke。
+#
+# 分层（记忆约束）：
+#   - py_compile 全 src/api：零依赖、秒级，直接抓 IndentationError/SyntaxError
+#   - smoke-tests：装依赖跑 user_crud_mock（验收点名）+ containers import。
+#     严禁跑全量（test_oom_investigation: ~20GB OOM）；不混 api/unit 测试
+#     (project_api_unit_test_namespace_pollution: ModuleNotFoundError)。
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  syntax-check:
+    name: Syntax check (py_compile)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: py_compile src/ and api/
+        run: |
+          set -uo pipefail
+          # 对 src/ + api/ 下所有 .py 跑字节码编译。
+          # py_compile 不 import 依赖，纯语法/缩进检查 —— 零误报、抓 #6013 回归。
+          fail=0
+          while IFS= read -r -d '' f; do
+            if ! python -m py_compile "$f" 2> /tmp/pyc_err; then
+              echo "::error file=${f},line=1::py_compile 失败"
+              cat /tmp/pyc_err
+              fail=1
+            fi
+          done < <(find src api -name "*.py" -not -path "*/__pycache__/*" -print0)
+          if [ "$fail" -ne 0 ]; then
+            echo "❌ 存在语法/缩进错误，拒绝合并（防 #6013 回归）"
+            exit 1
+          fi
+          echo "✅ 所有 src/api .py 通过 py_compile"
+
+  smoke-tests:
+    name: Smoke tests (mock + import)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+      - name: Install (editable)
+        run: pip install -e . -q
+      - name: user_crud mock tests (#6015 点名)
+        run: |
+          python -m pytest tests/unit/data/crud/test_user_crud_mock.py \
+            -q -o "addopts=" --no-header --tb=short
+      - name: containers import smoke (#6015 点名)
+        # test_containers.py 本身是 features.containers 的 import smoke（带 ImportError 容错 skip）
+        run: |
+          python -m pytest tests/unit/features/test_containers.py \
+            -q -o "addopts=" --no-header --tb=short

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,3 +70,10 @@ jobs:
         run: |
           python -m pytest tests/unit/features/test_containers.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: user_cli tests (#6015 点名)
+        # test_user_cli.py 覆盖 #6013 崩溃链 CLI 层（CLI → containers → user_crud），
+        # user_crud.py IndentationError 时必失败。单文件 pytest 不触发 client 全目录
+        # 跨测试污染（记忆 project-client-test-state-pollution：污染仅在 client 全目录跑时发生）。
+        run: |
+          python -m pytest tests/unit/client/test_user_cli.py \
+            -q -o "addopts=" --no-header --tb=short


### PR DESCRIPTION
## Summary

添加 CI 测试流水线，防止 #6013 类语法错误再次直接合入 master（#6015）。

**背景**：#6013 —— PR #5333 合并时无 CI 测试检查，`user_crud.py` IndentationError 直接进 master 瘫痪几乎所有 CLI 命令。此前 `.github/workflows/` 仅有 `issue-state-label-cleanup.yml`，**零测试流水线**。

**新增 `.github/workflows/ci.yml`**，两 job：

| Job | 内容 | 依赖 | 作用 |
|---|---|---|---|
| `syntax-check` | `py_compile` 全 `src/api` 的 `.py` | 零依赖（纯字节码编译） | 秒级抓 IndentationError/SyntaxError，直接防 #6013 |
| `smoke-tests` | `pip install -e .` + `test_user_crud_mock.py` + `test_containers.py` | 全量依赖（179，带 pip cache） | 验收点名的 mock + import smoke |

**记忆约束应用**：
- 严禁跑全量测试（`test_oom_investigation`: ~20GB OOM）→ 只跑验收点名文件
- 不混 api/unit 测试（`project_api_unit_test_namespace_pollution`: ModuleNotFoundError）→ 仅 unit
- `tests/unit/client/` 跨测试污染（`project-client-test-state-pollution`）→ 不纳入

## Test plan

- [x] **TDD 等价验证**：本地构造 #6013 类 IndentationError 临时 `.py`，跑 workflow 的 py_compile 逻辑 → `exit=1`（确认能拦截）；好文件 → `exit=0`
- [x] `syntax-check` 对当前仓库全 `src/api` py_compile 干净（CI 跑起来不会误红）
- [x] `smoke-tests` 本地预演：`test_user_crud_mock.py` + `test_containers.py` **13 passed**（venv）
- [x] YAML 合法性校验通过
- [x] `features.containers` import 路径验证（triage 假设的 `ginkgo.containers` 不存在，实际 `ginkgo.features.containers.FeatureContainer`）
- [ ] **CI 实跑验证**：本 PR 提交后触发 ci.yml，两 job 应全绿
- [ ] **验收 #3 完整达成**：管理员在 Settings → Branches → master protection 把 `ci/syntax-check` 设为 required status check（代码 PR 提供了 check，settings 配置超代码范围）

## 变更文件

- `.github/workflows/ci.yml` — 新增 CI 测试流水线（syntax-check + smoke-tests 两 job）

Closes #6015
