### PR TITLE
fix: trading API _query_orders 多状态过滤展开为多 enum 查询 (#6047)

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -566,32 +566,57 @@ def _compute_position_value(positions: list) -> float:
         return 0.0
 
 
+def _expand_status_enums(status_filter: Optional[List[str]]) -> list:
+    """将状态过滤字符串列表展开为 ORDERSTATUS_TYPES enum 列表（去重、保序）。
+
+    #6047: 多状态查询须展开所有匹配 enum（如 pending → NEW + SUBMITTED），
+    不再只取首个状态组或同组首个 enum。返回空列表表示无过滤（查全部）。
+    """
+    from ginkgo.enums import ORDERSTATUS_TYPES
+
+    if not status_filter:
+        return []
+
+    status_mapping = {
+        "pending": [ORDERSTATUS_TYPES.NEW, ORDERSTATUS_TYPES.SUBMITTED],
+        "partial": [ORDERSTATUS_TYPES.PARTIAL_FILLED],
+        "filled": [ORDERSTATUS_TYPES.FILLED],
+        "cancelled": [ORDERSTATUS_TYPES.CANCELED],
+        "rejected": [ORDERSTATUS_TYPES.REJECTED],
+    }
+
+    expanded: list = []
+    seen = set()
+    for s in status_filter:
+        for enum in status_mapping.get(s, []):
+            if enum not in seen:
+                seen.add(enum)
+                expanded.append(enum)
+    return expanded
+
+
 def _query_orders(account_id: str, status_filter: Optional[List[str]] = None) -> list:
     """查询指定账户的订单列表"""
     try:
-        from ginkgo.enums import ORDERSTATUS_TYPES
-
         result_service = _get_result_service()
 
-        # 构建状态筛选
-        status_enum = None
-        if status_filter:
-            status_mapping = {
-                "pending": [ORDERSTATUS_TYPES.NEW, ORDERSTATUS_TYPES.SUBMITTED],
-                "partial": [ORDERSTATUS_TYPES.PARTIAL_FILLED],
-                "filled": [ORDERSTATUS_TYPES.FILLED],
-                "cancelled": [ORDERSTATUS_TYPES.CANCELED],
-                "rejected": [ORDERSTATUS_TYPES.REJECTED],
-            }
-            first_status = status_filter[0]
-            enums = status_mapping.get(first_status, [])
-            if enums:
-                status_enum = enums[0]
+        # #6047: 展开多状态过滤为 enum 集合，每个 enum 各查一次合并。
+        # 旧逻辑 first_status=status_filter[0] + enums[0] 双层截断，多状态查询只返回首个。
+        allowed_enums = _expand_status_enums(status_filter)
 
-        orders_result = result_service.get_orders_by_portfolio(
-            account_id, status=status_enum.value if status_enum else None, page_size=100,
-        )
-        records = orders_result.data.get("data", []) if orders_result.success else []
+        records: list = []
+        if allowed_enums:
+            for enum in allowed_enums:
+                orders_result = result_service.get_orders_by_portfolio(
+                    account_id, status=enum.value, page_size=100,
+                )
+                if orders_result.success:
+                    records.extend(orders_result.data.get("data", []) or [])
+        else:
+            orders_result = result_service.get_orders_by_portfolio(
+                account_id, status=None, page_size=100,
+            )
+            records = orders_result.data.get("data", []) if orders_result.success else []
 
         orders = []
         for r in (records or []):

--- a/tests/api/test_query_orders_multi_status.py
+++ b/tests/api/test_query_orders_multi_status.py
@@ -1,0 +1,140 @@
+# Issue: #6047
+# Upstream: api.trading._expand_status_enums, api.trading._query_orders
+# Downstream: pytest
+# Role: _query_orders 多状态过滤修复 — status 列表须全部生效，非仅首个
+
+"""
+_query_orders 多状态过滤测试
+
+根因：_query_orders 第 590 行 first_status=status_filter[0] 只取首个状态组，
+第 593 行 enums[0] 只取同组首个 enum。两层截断致多状态过滤失效
+（?status=pending&status=filled 只返回 pending 的 NEW，丢弃 SUBMITTED + FILLED）。
+
+修复：抽纯函数 _expand_status_enums 完整展开所有匹配 enum；
+_query_orders 对每个 enum 各查一次合并。
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+from types import SimpleNamespace
+
+
+class TestExpandStatusEnums:
+    """验证 _expand_status_enums 把状态字符串列表完整展开为 enum 列表"""
+
+    def test_pending_expands_to_both_new_and_submitted(self):
+        """#6047: pending 须映射到 [NEW, SUBMITTED] 全组，非仅首个 enum"""
+        from api.trading import _expand_status_enums
+        from ginkgo.enums import ORDERSTATUS_TYPES
+
+        result = _expand_status_enums(["pending"])
+        assert ORDERSTATUS_TYPES.NEW in result
+        assert ORDERSTATUS_TYPES.SUBMITTED in result
+        assert len(result) == 2
+
+    def test_multiple_status_groups_all_expanded(self):
+        """#6047: [pending, filled] 须展开为 3 个 enum（NEW + SUBMITTED + FILLED），非仅首个状态组"""
+        from api.trading import _expand_status_enums
+        from ginkgo.enums import ORDERSTATUS_TYPES
+
+        result = _expand_status_enums(["pending", "filled"])
+        assert set(result) == {
+            ORDERSTATUS_TYPES.NEW,
+            ORDERSTATUS_TYPES.SUBMITTED,
+            ORDERSTATUS_TYPES.FILLED,
+        }
+        assert len(result) == 3
+
+    def test_duplicates_deduped_order_preserved(self):
+        """#6047: 重复状态去重，且按 status_filter 首次出现顺序排列"""
+        from api.trading import _expand_status_enums
+        from ginkgo.enums import ORDERSTATUS_TYPES
+
+        result = _expand_status_enums(["filled", "pending", "filled"])
+        assert result == [
+            ORDERSTATUS_TYPES.FILLED,
+            ORDERSTATUS_TYPES.NEW,
+            ORDERSTATUS_TYPES.SUBMITTED,
+        ]
+
+    def test_none_or_empty_returns_empty(self):
+        """#6047: 无过滤（None/空列表）返回空列表，表示查全部"""
+        from api.trading import _expand_status_enums
+
+        assert _expand_status_enums(None) == []
+        assert _expand_status_enums([]) == []
+
+    def test_unknown_status_ignored(self):
+        """#6047: 未识别的状态字符串静默忽略，不报错"""
+        from api.trading import _expand_status_enums
+
+        assert _expand_status_enums(["unknown_status"]) == []
+        # 混合：有效 + 无效，仅有效的展开
+        from ginkgo.enums import ORDERSTATUS_TYPES
+        result = _expand_status_enums(["filled", "bogus"])
+        assert result == [ORDERSTATUS_TYPES.FILLED]
+
+
+class TestQueryOrdersMultiStatus:
+    """端到端：_query_orders 多状态过滤须返回所有匹配状态的订单"""
+
+    @staticmethod
+    def _make_record(uuid, status_enum, code="000001.SZ"):
+        """构造一条订单记录（status 存 enum 的 int 值，模拟 DB 行）"""
+        return SimpleNamespace(
+            uuid=uuid, code=code, status=status_enum.value,
+            direction=1, limit_price=10.0, volume=100,
+            transaction_volume=0, transaction_price=0,
+            business_timestamp=None, timestamp=None,
+        )
+
+    def test_multi_status_returns_orders_from_all_groups(self):
+        """#6047: [pending, filled] 须返回 NEW+SUBMITTED+FILLED 三类订单，非仅首个状态"""
+        from api.trading import _query_orders
+        from ginkgo.enums import ORDERSTATUS_TYPES
+
+        new_rec = self._make_record("o-new", ORDERSTATUS_TYPES.NEW)
+        sub_rec = self._make_record("o-sub", ORDERSTATUS_TYPES.SUBMITTED)
+        fill_rec = self._make_record("o-fill", ORDERSTATUS_TYPES.FILLED)
+
+        def fake_get(account_id, status=None, page_size=None):
+            bucket = {
+                ORDERSTATUS_TYPES.NEW.value: [new_rec],
+                ORDERSTATUS_TYPES.SUBMITTED.value: [sub_rec],
+                ORDERSTATUS_TYPES.FILLED.value: [fill_rec],
+            }
+            data = bucket.get(status, [])
+            result = MagicMock()
+            result.success = True
+            result.data = {"data": data, "total": len(data)}
+            return result
+
+        mock_service = MagicMock()
+        mock_service.get_orders_by_portfolio.side_effect = fake_get
+
+        with patch("api.trading._get_result_service", return_value=mock_service):
+            orders = _query_orders("acct-1", ["pending", "filled"])
+
+        # 三类订单都出现（修复前只返回 NEW 一个）
+        uuids = {o["order_id"] for o in orders}
+        assert uuids == {"o-new", "o-sub", "o-fill"}
+        # service 按 enum 逐个查询（3 次），非旧逻辑的单次 first_status
+        assert mock_service.get_orders_by_portfolio.call_count == 3
+
+    def test_no_filter_queries_once_with_none_status(self):
+        """#6047: 无 status 过滤时单次查询 status=None（不退化为多次）"""
+        from api.trading import _query_orders
+
+        result = MagicMock()
+        result.success = True
+        result.data = {"data": [], "total": 0}
+        mock_service = MagicMock()
+        mock_service.get_orders_by_portfolio.return_value = result
+
+        with patch("api.trading._get_result_service", return_value=mock_service):
+            _query_orders("acct-1", None)
+
+        assert mock_service.get_orders_by_portfolio.call_count == 1
+        # status 参数为 None
+        called_kwargs = mock_service.get_orders_by_portfolio.call_args
+        assert called_kwargs.kwargs.get("status") is None


### PR DESCRIPTION
## Summary

修复 trading API `_query_orders` 多状态过滤只生效首个状态（#6047）。

**根因（双层截断）**：`api/api/trading.py` `_query_orders` 原逻辑
- 第 590 行 `first_status = status_filter[0]` —— 多状态查询 `?status=pending&status=filled` 只取首个状态组（pending），丢弃 filled
- 第 593 行 `enums[0]` —— 同组多 enum 也只取首个（pending 组的 SUBMITTED 被丢）

两层截断叠加，`?status=pending&status=filled` 实际只返回 `NEW` 状态订单，SUBMITTED 与 FILLED 全缺。

**修复**：
- 抽纯函数 `_expand_status_enums(status_filter) -> List[ORDERSTATUS_TYPES]`：把状态字符串列表完整展开为 enum 列表（去重、保序），如 `["pending","filled"]` → `[NEW, SUBMITTED, FILLED]`
- `_query_orders` 改用之：展开后对每个 enum 各调一次 `get_orders_by_portfolio` 并合并结果；无过滤时维持原单次 `status=None` 全查

**记忆约束应用**：
- `BaseCRUD.find` 虽支持 `field__in`（base_crud.py:359），但 CLAUDE.md「API 禁止直调 CRUD，须经 Service」，且 `get_orders_by_portfolio` 签名只收单 `status:int` → 选择 API 层多次查询合并，**零 service/crud/Base 改动**
- `_expand_status_enums` 为 deep module（小接口、零外部依赖、纯函数可独立 TDD），把"字符串→enum 映射 + 去重保序"的复杂度收敛其内

## Test plan

- [x] TDD 垂直切片 7 个（RED→GREEN 逐切片）：
  - `TestExpandStatusEnums` ×5：pending 全组展开 / 多状态组全展开 / 去重保序 / None 与空返回空 / 无效状态忽略
  - `TestQueryOrdersMultiStatus` ×2：多状态端到端返回全部匹配订单 + service 按 enum 逐查；无过滤单次 `status=None`
- [x] **RED 确认**：切片 6 端到端在旧 `first_status[0]` 逻辑下仅返回 `o-new`（缺 o-sub/o-fill），改后 3 个全返回
- [x] `py_compile api/api/trading.py` 通过
- [x] 同模块回归：`test_paper_trading_status.py` + 新测试合跑 **13 passed**（无回归）
- [x] 变更覆盖率：`api/api/trading.py` → `tests/api/test_query_orders_multi_status.py`（覆盖 `_query_orders` + `_expand_status_enums`）

## 变更文件

- `api/api/trading.py` — 新增 `_expand_status_enums` 纯函数；`_query_orders` 改用多 enum 查询合并（移除 `first_status[0]`/`enums[0]` 双层截断）
- `tests/api/test_query_orders_multi_status.py` — 多状态过滤回归测试（新建，7 切片）

Closes #6047
