### PR TITLE
fix(#5931): config set/get 补 quiet/log_path/working_path 接线

### DIFF
--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -80,6 +80,12 @@ def get(
                 console.print(f":white_check_mark: quiet: {GCONF.QUIET}")
             elif key.lower() == 'cpu_ratio':
                 console.print(f":white_check_mark: cpu_ratio: {GCONF.CPURATIO*100:.1f}%")
+            elif key.lower() == 'log_path':
+                # #5931: list 显示的 key 也须可 get（显示名 log_path ↔ 属性 LOGGING_PATH）
+                console.print(f":white_check_mark: log_path: {GCONF.LOGGING_PATH}")
+            elif key.lower() == 'working_path':
+                # #5931: list 显示的 key 也须可 get（显示名 working_path ↔ 属性 WORKING_PATH）
+                console.print(f":white_check_mark: working_path: {GCONF.WORKING_PATH}")
             else:
                 console.print(f":x: Configuration key '{key}' not found")
         else:
@@ -177,6 +183,14 @@ def set(
             cpu_value = float(value) / 100.0
             GCONF.set_cpu_ratio(cpu_value)
             console.print(f":white_check_mark: Set {key} = {value}%")
+        elif key.lower() == 'log_path':
+            # #5931: 接线到已存在的 set_logging_path（list 显示名 log_path ↔ setter 名 set_logging_path 命名漂移）
+            GCONF.set_logging_path(value)
+            console.print(f":white_check_mark: Set {key} = {value}")
+        elif key.lower() == 'working_path':
+            # #5931: 接线到已存在的 set_work_path（list 显示名 working_path ↔ setter 名 set_work_path 命名漂移）
+            GCONF.set_work_path(value)
+            console.print(f":white_check_mark: Set {key} = {value}")
         else:
             console.print(f":x: Configuration key '{key}' not found")
 

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -834,6 +834,13 @@ class GinkgoConfig(object):
             os.environ[key] = quiet
         return quiet.upper() == "TRUE"
 
+    def set_quiet(self, value: bool) -> None:
+        """设置静默模式并持久化（#5931：config set quiet 此前因此方法缺失而 AttributeError）。"""
+        key = "GINKGO_QUIET"
+        if isinstance(value, bool):
+            self._write_config("quiet", value)
+            os.environ[key] = str(value)
+
     @property
     def PYTHONPATH(self) -> str:
         """Python路径（环境标识，有默认值）"""

--- a/tests/unit/client/test_config_cli.py
+++ b/tests/unit/client/test_config_cli.py
@@ -135,6 +135,20 @@ class TestConfigGet:
         assert result.exit_code == 0
         assert "not found" in result.output or "not found" in result.output.lower()
 
+    def test_get_log_path_shows_logging_path(self, cli_runner, mock_gconf):
+        """#5931: get log_path 显示 GCONF.LOGGING_PATH（与 list 显示一致）"""
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(config_cli.app, ["get", "log_path"])
+        assert result.exit_code == 0
+        assert "/tmp/ginkgo/logs" in result.output
+
+    def test_get_working_path_shows_working_path(self, cli_runner, mock_gconf):
+        """#5931: get working_path 显示 GCONF.WORKING_PATH（与 list 显示一致）"""
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(config_cli.app, ["get", "working_path"])
+        assert result.exit_code == 0
+        assert "/home/kaoru/Ginkgo" in result.output
+
     def test_get_handles_exception(self, cli_runner):
         """get 命令异常时优雅处理"""
         # Use a real object whose attribute access raises to trigger the
@@ -213,6 +227,22 @@ class TestConfigSet:
             result = cli_runner.invoke(config_cli.app, ["set", "bad_key", "value"])
         assert result.exit_code == 0
         assert "not found" in result.output.lower()
+
+    def test_set_log_path_calls_set_logging_path(self, cli_runner, mock_gconf):
+        """#5931: set log_path 接线到已存在的 GCONF.set_logging_path（命名漂移修复）"""
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(config_cli.app, ["set", "log_path", "/tmp/ginkgo/logs"])
+        assert result.exit_code == 0
+        mock_gconf.set_logging_path.assert_called_once_with("/tmp/ginkgo/logs")
+        assert "log_path" in result.output.lower()
+
+    def test_set_working_path_calls_set_work_path(self, cli_runner, mock_gconf):
+        """#5931: set working_path 接线到已存在的 GCONF.set_work_path（命名漂移修复）"""
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(config_cli.app, ["set", "working_path", "/tmp/ws"])
+        assert result.exit_code == 0
+        mock_gconf.set_work_path.assert_called_once_with("/tmp/ws")
+        assert "working_path" in result.output.lower()
 
     def test_set_handles_exception(self, cli_runner):
         """set 命令异常时优雅处理"""

--- a/tests/unit/libs/test_config_setters.py
+++ b/tests/unit/libs/test_config_setters.py
@@ -1,0 +1,70 @@
+"""
+TDD tests for GinkgoConfig setters (#5931).
+
+config list 列出 5 个 key，但 quiet/log_path/working_path 无法 config set：
+- quiet: GinkgoConfig 缺 set_quiet（真实调用 AttributeError；现有 CLI 测试用
+  MagicMock 掩盖了此 bug，见 feedback_magicmock_method_attr_mask）
+- log_path/working_path: set_logging_path/set_work_path 已存在，但 config_cli
+  从未接线（命名漂移）
+
+本文件用【真实 GinkgoConfig + tmp config.yml】测 setter 落盘行为，不 mock，
+直击 set_quiet 缺失的真实 bug。
+"""
+
+import os
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def tmp_config(tmp_path, monkeypatch):
+    """指向 tmp 的真实 config.yml + 新建 GinkgoConfig 单例。
+
+    set_GINKGO_DIR=tmp_path 使 setting_path=tmp_path/config.yml；
+    预置 '{}' 因 _write_config 先 open('r') 读现有内容。
+    """
+    config_file = tmp_path / "config.yml"
+    config_file.write_text("{}\n")
+    monkeypatch.setenv("GINKGO_DIR", str(tmp_path))
+
+    from ginkgo.libs.core.config import GinkgoConfig
+
+    if hasattr(GinkgoConfig, "_instance"):
+        del GinkgoConfig._instance
+    cfg = GinkgoConfig()
+    return cfg, config_file
+
+
+# ---------------------------------------------------------------------------
+# set_quiet（#5931 核心：方法此前完全缺失）
+# ---------------------------------------------------------------------------
+
+
+class TestSetQuiet:
+    """set_quiet 须持久化到 config.yml 并同步 env（仿 set_python_path）。"""
+
+    def test_set_quiet_true_persists_to_config_yml(self, tmp_config):
+        cfg, config_file = tmp_config
+        cfg.set_quiet(True)
+        data = yaml.safe_load(config_file.read_text())
+        assert data["quiet"] is True
+
+    def test_set_quiet_false_persists_to_config_yml(self, tmp_config):
+        cfg, config_file = tmp_config
+        cfg.set_quiet(False)
+        data = yaml.safe_load(config_file.read_text())
+        assert data["quiet"] is False
+
+    def test_set_quiet_updates_env(self, tmp_config, monkeypatch):
+        monkeypatch.delenv("GINKGO_QUIET", raising=False)
+        cfg, _ = tmp_config
+        cfg.set_quiet(True)
+        assert os.environ["GINKGO_QUIET"] == "True"
+
+    def test_set_quiet_non_bool_no_write(self, tmp_config):
+        """非 bool 入参不落盘（isinstance 守卫，对称 set_cpu_ratio/set_python_path）。"""
+        cfg, config_file = tmp_config
+        cfg.set_quiet("yes")  # type: ignore[arg-type]
+        data = yaml.safe_load(config_file.read_text())
+        assert "quiet" not in data


### PR DESCRIPTION
## Summary

修复 config list 列出但 config set/get 无法操作的 3 个 key（#5931）。

**根因（命名漂移 + 方法缺失）**：config list 显示 5 key，但 set/get 分支与 GinkgoConfig setter 命名三处不一致：

| key | config list | config set（旧） | 根因 |
|---|---|---|---|
| quiet | ✅ | ❌ AttributeError | GinkgoConfig **完全缺 set_quiet** |
| log_path | ✅ | ❌ "not found" | set_logging_path 已存在但 CLI 从未接线 |
| working_path | ✅ | ❌ "not found" | set_work_path 已存在但 CLI 从未接线 |

**修复**：
1. GinkgoConfig 新增 `set_quiet`（仿 `set_python_path`：`_write_config` 持久化 + env `GINKGO_QUIET` 同步）
2. config_cli set 补 log_path/working_path 分支，调已存在的 `set_logging_path`/`set_work_path`
3. config_cli get 补 log_path/working_path 分支（list 显示的 key 也须可 get）

**记忆约束应用**：
- 现有 `test_set_quiet_on/off` 用 MagicMock mock GCONF，`set_quiet` 自动存在掩盖了真实 bug（feedback_magicmock_method_attr_mask）→ 新增真实 GinkgoConfig + tmp config.yml 落盘测试直击 set_quiet 缺失
- `set_logging_path`/`set_work_path` 已存在（非重复造轮子），仅 CLI 接线

## Test plan

- [x] TDD 垂直切片 3 组（RED→GREEN 逐组）：
  - `TestSetQuiet` ×4（真实落盘）：true/false 持久化、env 同步、非 bool 守卫
  - `TestConfigSet` ×2：log_path→set_logging_path、working_path→set_work_path 接线
  - `TestConfigGet` ×2：log_path/working_path 显示
- [x] **RED 确认**：set_quiet 4 测试 AttributeError；set/get log_path/working_path 走 else "not found"（Called 0 times）
- [x] `py_compile` 两源文件通过
- [x] 全量回归 `test_config_setters` + `test_config_cli` **52 passed**（无回归）
- [x] 变更覆盖率：config.py → test_config_setters.py；config_cli.py → test_config_cli.py

## 变更文件

- `src/ginkgo/libs/core/config.py` — 新增 `set_quiet`（持久化 + env）
- `src/ginkgo/client/config_cli.py` — get/set 补 log_path/working_path 分支（4 处接线）
- `tests/unit/libs/test_config_setters.py` — set_quiet 真实落盘测试（新建，4 切片）
- `tests/unit/client/test_config_cli.py` — log_path/working_path get/set 接线测试（+4）

Closes #5931
