### PR TITLE
fix(#5980): execution cleanup 扫描所有节点非硬编码

### DIFF
--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -465,9 +465,28 @@ def _display_single_node_status(node_id: str, heartbeat_ttl: int, metrics: dict)
     console.print(f"  :chart_with_upwards_trend: Total Events: {total_events}")
 
 
+def _cleanup_node(redis_client, node_id: str) -> tuple:
+    """清理单个 ExecutionNode 的 heartbeat + metrics（#5980 deep module）。
+
+    返回 (heartbeat_deleted, metrics_deleted)，调用方据此决定输出与计数。
+    抽出此纯逻辑使 cleanup 命令能在「指定节点」与「扫描所有节点」两路径复用。
+    """
+    from ginkgo.data.redis_schema import RedisKeyBuilder
+
+    heartbeat_key = RedisKeyBuilder.execution_node_heartbeat(node_id)
+    metrics_key = f"node:metrics:{node_id}"
+    heartbeat_exists = redis_client.exists(heartbeat_key)
+    metrics_exists = redis_client.exists(metrics_key)
+    if heartbeat_exists:
+        redis_client.delete(heartbeat_key)
+    if metrics_exists:
+        redis_client.delete(metrics_key)
+    return bool(heartbeat_exists), bool(metrics_exists)
+
+
 @app.command()
 def cleanup(
-    node_id: str = typer.Option("execution_node_1", "--node-id", "-n", help="ExecutionNode ID to cleanup"),
+    node_id: Optional[str] = typer.Option(None, "--node-id", "-n", help="ExecutionNode ID to cleanup (default: scan all nodes from heartbeats)"),
 ):
     """
     :broom: Cleanup stale data for an ExecutionNode.
@@ -475,44 +494,70 @@ def cleanup(
     Remove heartbeat and metrics data from Redis for a node that has stopped.
     Useful when a process exits abnormally and leaves stale data.
 
+    Without --node-id, scans all heartbeat keys and cleans every node
+    (consistent with `execution status`). With --node-id, cleans only that node.
+
     Examples:
-      ginkgo execution cleanup
-      ginkgo execution cleanup --node-id execution_node_1
+      ginkgo execution cleanup                      # Clean all stale nodes
+      ginkgo execution cleanup --node-id node_1     # Clean specific node only
     """
     try:
         from ginkgo.data.crud import RedisCRUD
-
-        console.print(f":information: Cleaning up data for ExecutionNode '{node_id}'...")
+        from ginkgo.data.redis_schema import (
+            RedisKeyPattern,
+            RedisKeyPrefix,
+            extract_id_from_key,
+        )
 
         # Get Redis client
         redis_crud = RedisCRUD()
         redis_client = redis_crud.redis
 
-        # Keys to cleanup
-        from ginkgo.data.redis_schema import RedisKeyBuilder
-        heartbeat_key = RedisKeyBuilder.execution_node_heartbeat(node_id)
-        metrics_key = f"node:metrics:{node_id}"
+        if node_id is None:
+            # #5980: 扫描所有 heartbeat keys（与 status 一致），逐个清理
+            console.print(":information: Cleaning up data for [bold]all[/bold] ExecutionNodes...")
+            heartbeat_keys = redis_client.keys(RedisKeyPattern.EXECUTION_NODE_HEARTBEAT_ALL)
 
-        # Check what exists
-        heartbeat_exists = redis_client.exists(heartbeat_key)
-        metrics_exists = redis_client.exists(metrics_key)
+            if not heartbeat_keys:
+                console.print("[yellow]:warning: No ExecutionNodes running (no heartbeats found)[/yellow]")
+                return
 
-        if not heartbeat_exists and not metrics_exists:
-            console.print(f"[dim]:information: No data found for ExecutionNode '{node_id}'[/dim]")
-            return
+            node_ids = [
+                extract_id_from_key(key.decode('utf-8'), f"{RedisKeyPrefix.EXECUTION_NODE_HEARTBEAT}:")
+                for key in heartbeat_keys
+            ]
 
-        # Delete heartbeat
-        if heartbeat_exists:
-            redis_client.delete(heartbeat_key)
-            console.print(f":white_check_mark: [green]Deleted heartbeat data[/green]")
+            total_hb = 0
+            total_mt = 0
+            for nid in node_ids:
+                hb_deleted, mt_deleted = _cleanup_node(redis_client, nid)
+                if hb_deleted:
+                    total_hb += 1
+                if mt_deleted:
+                    total_mt += 1
+                console.print(f":white_check_mark: [green]Cleaned ExecutionNode '{nid}'[/green]")
 
-        # Delete metrics
-        if metrics_exists:
-            redis_client.delete(metrics_key)
-            console.print(f":white_check_mark: [green]Deleted metrics data[/green]")
+            console.print(
+                f"\n:information: Cleanup completed: {total_hb} heartbeat(s), "
+                f"{total_mt} metrics removed across {len(node_ids)} node(s)"
+            )
+            console.print("[dim]Scheduler will detect these nodes as offline on next schedule loop[/dim]")
+        else:
+            console.print(f":information: Cleaning up data for ExecutionNode '{node_id}'...")
 
-        console.print(f"\n:information: Cleanup completed for ExecutionNode '{node_id}'")
-        console.print(f"[dim]Scheduler will detect this node as offline on next schedule loop[/dim]")
+            hb_deleted, mt_deleted = _cleanup_node(redis_client, node_id)
+
+            if not hb_deleted and not mt_deleted:
+                console.print(f"[dim]:information: No data found for ExecutionNode '{node_id}'[/dim]")
+                return
+
+            if hb_deleted:
+                console.print(":white_check_mark: [green]Deleted heartbeat data[/green]")
+            if mt_deleted:
+                console.print(":white_check_mark: [green]Deleted metrics data[/green]")
+
+            console.print(f"\n:information: Cleanup completed for ExecutionNode '{node_id}'")
+            console.print("[dim]Scheduler will detect this node as offline on next schedule loop[/dim]")
 
     except Exception as e:
         console.print(f"[red]:x: Error cleaning up ExecutionNode data: {e}[/red]")

--- a/tests/unit/client/test_execution_cli_cleanup.py
+++ b/tests/unit/client/test_execution_cli_cleanup.py
@@ -1,0 +1,124 @@
+"""
+TDD tests for execution cleanup 命令（#5980）。
+
+#5980: execution cleanup 硬编码 node_id="execution_node_1"，但实际节点用
+hostname/自定义 ID，cleanup 不带 --node-id 时永远清不存在的节点。
+
+修复：
+- 提取 _cleanup_node(redis_client, node_id) deep module（清单个节点）
+- cleanup 默认 node_id=None → 扫描所有 heartbeat keys（复用 status 的
+  RedisKeyPattern.EXECUTION_NODE_HEARTBEAT_ALL）逐个清理
+- 指定 --node-id 时只清该节点
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client.execution_cli import _cleanup_node, app
+from ginkgo.data.redis_schema import (
+    RedisKeyPattern,
+    RedisKeyPrefix,
+)
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_node deep module
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCleanupNode:
+    """_cleanup_node：清单个节点的 heartbeat + metrics，返回删除标志。"""
+
+    def test_deletes_heartbeat_and_metrics_when_exist(self):
+        redis = MagicMock()
+        redis.exists.return_value = 1  # heartbeat 与 metrics 两次 exists 均命中
+        hb_deleted, mt_deleted = _cleanup_node(redis, "node-a")
+        assert hb_deleted is True
+        assert mt_deleted is True
+        assert redis.delete.call_count == 2
+
+    def test_no_data_returns_false_and_skips_delete(self):
+        redis = MagicMock()
+        redis.exists.return_value = 0
+        hb_deleted, mt_deleted = _cleanup_node(redis, "node-x")
+        assert hb_deleted is False
+        assert mt_deleted is False
+        redis.delete.assert_not_called()
+
+    def test_heartbeat_only_deletes_heartbeat(self):
+        redis = MagicMock()
+        redis.exists.side_effect = [1, 0]  # heartbeat 存在, metrics 不存在
+        hb_deleted, mt_deleted = _cleanup_node(redis, "node-hb")
+        assert hb_deleted is True
+        assert mt_deleted is False
+        assert redis.delete.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# cleanup 命令端到端（#5980：默认 node_id 应扫描所有节点，非硬编码 execution_node_1）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCleanupCommand:
+    """cleanup 命令：不带 --node-id 扫描所有节点；指定 --node-id 只清该节点。"""
+
+    def test_no_node_id_scans_all_nodes(self, cli_runner):
+        """#5980: 不带 --node-id 应扫描所有 heartbeat keys 逐个清理（非硬编码 execution_node_1）"""
+        redis = MagicMock()
+        prefix = f"{RedisKeyPrefix.EXECUTION_NODE_HEARTBEAT}:"
+        redis.keys.return_value = [
+            f"{prefix}node-a".encode(),
+            f"{prefix}node-b".encode(),
+        ]
+        redis.exists.return_value = 1  # 每节点 heartbeat+metrics 均存在
+
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = redis
+            result = cli_runner.invoke(app, ["cleanup"])
+
+        assert result.exit_code == 0
+        redis.keys.assert_called_once_with(RedisKeyPattern.EXECUTION_NODE_HEARTBEAT_ALL)
+        # 2 节点 × (heartbeat + metrics) = 4 次 delete
+        assert redis.delete.call_count == 4
+        assert "node-a" in result.output
+        assert "node-b" in result.output
+
+    def test_with_node_id_cleans_only_specified(self, cli_runner):
+        """指定 --node-id 只清该节点，不扫描所有"""
+        redis = MagicMock()
+        redis.exists.return_value = 1
+
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = redis
+            result = cli_runner.invoke(app, ["cleanup", "--node-id", "my-host"])
+
+        assert result.exit_code == 0
+        redis.keys.assert_not_called()
+        assert redis.delete.call_count == 2  # heartbeat + metrics
+        assert "my-host" in result.output
+
+    def test_no_nodes_found_shows_warning(self, cli_runner):
+        """无节点时提示，不崩溃"""
+        redis = MagicMock()
+        redis.keys.return_value = []
+
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = redis
+            result = cli_runner.invoke(app, ["cleanup"])
+
+        assert result.exit_code == 0
+        assert "No ExecutionNodes" in result.output or "no heartbeat" in result.output.lower()


### PR DESCRIPTION
## Summary

修复 `execution cleanup` 硬编码 `node_id="execution_node_1"` 导致清不到真实节点（#5980）。

**根因（三处 node_id 来源不一致）**：

| 命令 | node_id 来源 | 后果 |
|---|---|---|
| `start` | `socket.gethostname()` / `GINKGO_NODE_ID` env | 实际节点名 ≠ execution_node_1 |
| `status` | `redis.keys(HEARTBEAT_ALL)` 扫描 | 能看到真实节点 |
| `cleanup`（旧） | **硬编码 `execution_node_1`** | 不带 --node-id 时永远清不存在的节点 |

`start` 写入的 heartbeat key 用 hostname，但 `cleanup` 去删 `execution_node_*` 的 key，根本删不到。

**修复**：
1. 提取 `_cleanup_node(redis_client, node_id) -> (hb_deleted, mt_deleted)` **deep module**（清单个节点 heartbeat + metrics，纯逻辑）
2. `cleanup` 默认 `node_id=None` → 扫描所有 heartbeat keys（复用 `status` 的 `RedisKeyPattern.EXECUTION_NODE_HEARTBEAT_ALL` + `extract_id_from_key`），逐个走 `_cleanup_node`
3. 指定 `--node-id` 时只清该节点（同样走 `_cleanup_node`，逻辑复用）

与 `status` 命令的节点发现逻辑统一，消除三处来源不一致。

**记忆约束应用**：
- `start`/`status`/`cleanup` 三处 node_id 来源不一致是反模式 → 以 `status` 的 keys() 扫描为准（最贴近真实运行态），cleanup 对齐之
- `_cleanup_node` 为 deep module（小接口、纯函数、可独立 TDD），把"清单个节点 hb+metrics"收敛其内，扫描路径与指定路径共用
- 零 service/crud/Base 改动，仅 CLI 层

## Test plan

- [x] TDD 垂直切片 2 组（RED→GREEN 逐切片）：
  - `TestCleanupNode` ×3（deep module）：hb+metrics 均存 / 均无跳过 delete / 仅 hb 存
  - `TestCleanupCommand` ×3（端到端）：不带 --node-id 扫描所有节点逐个清 / 带 --node-id 只清指定不扫描 / 无节点提示不崩溃
- [x] **RED 确认**：切片 4 端到端 `keys` 调用 0 次（硬编码路径从不扫描）；切片 1 `ImportError: cannot import name '_cleanup_node'`
- [x] `py_compile execution_cli.py` 通过
- [x] 同模块回归 **6 passed**（无既有 execution_cli 测试，仅新测试）
- [x] CLI 命令注册冒烟（`invoke(app, ["cleanup"])` exit_code=0）
- [x] 变更覆盖率：`execution_cli.py` → `test_execution_cli_cleanup.py`

## 变更文件

- `src/ginkgo/client/execution_cli.py` — 新增 `_cleanup_node` deep module；重写 `cleanup` 命令（默认扫描所有节点，指定 --node-id 只清单个）
- `tests/unit/client/test_execution_cli_cleanup.py` — cleanup 命令 + _cleanup_node 回归测试（新建，6 切片）

Closes #5980
