### PR TITLE
fix(#5557): BaseMongoCRUD._get_collection 检查 None 抛 ConnectionError

### DIFF
--- a/src/ginkgo/data/crud/base_mongo_crud.py
+++ b/src/ginkgo/data/crud/base_mongo_crud.py
@@ -438,10 +438,21 @@ class BaseMongoCRUD(Generic[T], ABC):
 
         Returns:
             MongoDB 集合对象
+
+        Raises:
+            ConnectionError: 当 driver 连接失败返回 None 时（#5557）。
+                GinkgoMongo.get_collection() 按降级契约在连接未建立时返 None，
+                透传会让 CRUD 方法 None.find_one() 抛误导性的 AttributeError；
+                这里转成有意义的连接错误，让调用方能区分"连接问题"与"代码 bug"。
         """
-        return self._driver.get_collection(
-            self.model_class.get_collection_name()
-        )
+        collection_name = self.model_class.get_collection_name()
+        collection = self._driver.get_collection(collection_name)
+        if collection is None:
+            raise ConnectionError(
+                f"MongoDB collection '{collection_name}' 不可用："
+                f"driver 连接未建立或已断开（{type(self._driver).__name__}）"
+            )
+        return collection
 
     def exists(self, uuid: str) -> bool:
         """

--- a/tests/unit/data/test_base_mongo_crud_collection_check.py
+++ b/tests/unit/data/test_base_mongo_crud_collection_check.py
@@ -1,0 +1,52 @@
+"""
+TDD tests for BaseMongoCRUD._get_collection None check (#5557)。
+
+#5557: GinkgoMongo.get_collection() 连接失败时按降级契约返回 None（docstring 明示
+"调用方应检查"），但 BaseMongoCRUD._get_collection() 直接透传 None 给 CRUD 方法，
+导致 .find_one()/.insert_one() 等对 None 调用 → AttributeError 而非有意义的连接错误。
+
+修复：_get_collection() 在 driver 返 None 时抛 ConnectionError（含 collection 名），
+让调用方收到明确的"MongoDB 不可用"信号而非误导性的 AttributeError。
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.data.crud.base_mongo_crud import BaseMongoCRUD
+
+
+class _FakeModel:
+    """最小 model 替身：只需 get_collection_name()（_get_collection 的唯一 model 依赖）。"""
+
+    @classmethod
+    def get_collection_name(cls) -> str:
+        return "test_collection"
+
+
+def _make_crud(driver_return):
+    """构造 BaseMongoCRUD 实例，driver.get_collection 返回 driver_return。"""
+    driver = MagicMock()
+    driver.get_collection.return_value = driver_return
+    return BaseMongoCRUD(model_class=_FakeModel, driver=driver)
+
+
+@pytest.mark.unit
+class TestGetCollectionNoneCheck:
+    def test_raises_connection_error_when_driver_returns_none(self):
+        """#5557: driver 连接失败返 None 时，_get_collection 应抛 ConnectionError 而非透传 None。
+
+        旧行为：透传 None → CRUD 方法 None.find_one() → AttributeError（误导性，看不出是连接问题）。
+        """
+        crud = _make_crud(None)
+        with pytest.raises(ConnectionError, match="test_collection"):
+            crud._get_collection()
+
+    def test_returns_collection_when_driver_available(self):
+        """正常路径：driver 返 collection 时透传，None check 不破坏正常流程。"""
+        collection = MagicMock(name="collection")
+        crud = _make_crud(collection)
+        assert crud._get_collection() is collection


### PR DESCRIPTION
## Summary

修复 `BaseMongoCRUD._get_collection()` 透传 driver 的 `None`，导致 CRUD 方法对 `None` 调用抛误导性 `AttributeError`（#5557）。

**调用链**：
```
SomeMongoCRUD.find_one(...)
  → BaseMongoCRUD.find_one
    → _get_collection()
      → self._driver.get_collection(name)   # driver 连接失败时返 None（降级契约）
      → return None                          # 💥 base 未检查，透传 None
    → None.find_one(...)                     # AttributeError: NoneType has no attribute find_one
```

**根因**：`GinkgoMongo.get_collection()` docstring 明确声明"连接失败时返回 None，调用方应检查"——这是有意的降级契约。但 `BaseMongoCRUD._get_collection()` **违反了这个契约**：直接 `return self._driver.get_collection(...)`，未检查 None。所有 MongoCRUD 子类（notification/template/record 等）的 CRUD 方法都受害，瞬态 MongoDB 连接问题以 `AttributeError` 崩溃而非有意义的连接错误。

**修复**：`_get_collection()` 在 driver 返 None 时抛 `ConnectionError`（含 collection 名 + driver 类型）：
```python
collection = self._driver.get_collection(collection_name)
if collection is None:
    raise ConnectionError(
        f"MongoDB collection '{collection_name}' 不可用："
        f"driver 连接未建立或已断开（{type(self._driver).__name__}）"
    )
return collection
```

调用方现在收到明确的"连接问题"信号，而非看不出根因的 `AttributeError`。

## ⚠️ base 禁令破例说明（经用户授权）

CLAUDE.md「禁止擅自修改 Base 类」与 #5557 根因冲突——根因确在 `BaseMongoCRUD` 自身正确性缺陷。用户授权破例，理由：

1. **根因在 base 自身正确性**（未遵守协作契约），非功能扩展污染。base 禁令的精神是防"为具体需求污染通用逻辑"，非防"修复 base bug"。
2. **driver 层无解**：driver 的 `get_collection` 返 None 是有意降级（`get_collection_size` line 240 依赖此契约做降级），改 driver 会破坏降级一致性 + `portfolio_mapping_service` 3 处调用方。
3. **任何让 base 不透传 None 的修复都触及 base**——子类覆写 `_get_collection` 不现实（几十个 MongoCRUD 子类）。
4. **一处 base 修复惠及所有子类**，行为是「崩溃 → 明确报错」的纯增益。

## 验收达成

- [x] **① None 检查 + 有意义错误**：`_get_collection` 抛 `ConnectionError`（含 collection 名）
- [x] **③ 优雅降级**：抛明确异常让调用方区分连接问题（可 catch + 重试/告警）而非 AttributeError 误导
- [ ] **② 瞬态失败重试**：留 driver 层（超本次 base 修复范围）。driver `get_collection` catch `ConnectionFailure/ServerSelectionTimeoutError` 后返 None 是降级；真正的重试应在连接建立层（`GinkgoMongo` 初始化/`_client` 重连），属于 driver 连接管理范畴，与本次 base None-check 修复正交

## Test plan

- [x] TDD 垂直切片 2 个（RED→GREEN 逐切片）：
  - `test_raises_connection_error_when_driver_returns_none`：driver 返 None → 抛 `ConnectionError(match=collection_name)`
  - `test_returns_collection_when_driver_available`：正常路径透传（None check 不破坏正常流程）
- [x] **RED 确认**：切片 1 `DID NOT RAISE`（旧代码透传 None 不抛）
- [x] `py_compile base_mongo_crud.py` 通过
- [x] **回归 51 passed**：新测试 2 + `test_mongodb_driver_comprehensive.py` 49（driver 层未受影响，因未改 driver）
- [x] 变更覆盖率：`base_mongo_crud.py` → `test_base_mongo_crud_collection_check.py`

## 变更文件

- `src/ginkgo/data/crud/base_mongo_crud.py` — `_get_collection()` 加 None 检查抛 `ConnectionError`（经授权破例改 base，根因在 base 自身正确性）
- `tests/unit/data/test_base_mongo_crud_collection_check.py` — `_get_collection` None 检查回归测试（新建，2 切片）

Closes #5557
