### PR TITLE
test(#6279): deploy 克隆完整性回归测试

### DIFF
--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -9,7 +9,7 @@ if _path not in sys.path:
 
 import pytest
 from unittest.mock import MagicMock
-from ginkgo.enums import PORTFOLIO_MODE_TYPES
+from ginkgo.enums import PORTFOLIO_MODE_TYPES, FILE_TYPES
 
 # #3626 已修: MDeployment() 实例化不再触发 MUserCredential mapper 错误, 全部测试可跑。
 # deploy→_deploy_core 路径现可经公共接口测(见 test_deploy_propagates_source_initial_capital)。
@@ -128,3 +128,80 @@ class TestDeploymentServiceErrorMessages:
         assert not result.success
         # service error 不应有 "部署失败:" 前缀（CLI 层加）
         assert not result.error.startswith("部署失败:")
+
+
+class TestDeploymentServiceCloneCompleteness:
+    """#6279 回归测试: deploy 克隆须完整镜像源组合全部组件绑定(含 strategy/sizer)。
+
+    背景: issue 报告 paper 部署后 Strategies:0(只见 risk+selector 2 类)。
+    验证当前 _deploy_core 经 deploy() 公共接口完整复制 4 类 mapping + 参数。
+    #6164 曾修 deploy 丢参, 本测试锁定克隆完整性防回归。
+    """
+
+    @staticmethod
+    def _four_mappings():
+        """源组合 4 类完整绑定(selector/strategy/sizer/risk)"""
+        return [
+            {"uuid": "m_sel", "file_id": "f_sel", "type": FILE_TYPES.SELECTOR.value, "name": "sel"},
+            {"uuid": "m_str", "file_id": "f_str", "type": FILE_TYPES.STRATEGY.value, "name": "strat"},
+            {"uuid": "m_siz", "file_id": "f_siz", "type": FILE_TYPES.SIZER.value, "name": "sizer"},
+            {"uuid": "m_rsk", "file_id": "f_rsk", "type": FILE_TYPES.RISKMANAGER.value, "name": "risk"},
+        ]
+
+    @staticmethod
+    def _make_clone_svc():
+        svc = _make_svc()
+        svc._portfolio_service.get.return_value = _mock_portfolio_found()
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        svc._mapping_service.get_portfolio_mappings.return_value = MagicMock(
+            success=True, data=TestDeploymentServiceCloneCompleteness._four_mappings()
+        )
+        svc._portfolio_service.add.return_value = MagicMock(success=True, data={"uuid": "new_pid"})
+        svc._mapping_service.add_file.return_value = MagicMock(
+            success=True, data={"mapping_id": "new_m"}
+        )
+        svc._deployment_crud.add.return_value = MagicMock(success=True, data=MagicMock(uuid="d1"))
+        svc._deployment_crud.modify.return_value = None
+        svc._mapping_service.get_portfolio_graph.return_value = MagicMock(
+            success=True, data={"nodes": [], "edges": []}
+        )
+        svc._mapping_service.create_from_graph_editor.return_value = MagicMock(success=True)
+        svc._param_crud.find_by_mapping_id.return_value = []
+        return svc
+
+    def test_deploy_paper_clones_all_four_component_types(self):
+        """PAPER 部署须复制全部 4 类组件绑定(含 strategy/sizer), 不得漏类型。
+
+        防回归: issue 指控 strategy/sizer 被漏(只复制 risk+selector)。
+        """
+        svc = self._make_clone_svc()
+        result = svc.deploy(portfolio_id="src", mode=PORTFOLIO_MODE_TYPES.PAPER, name="Clone")
+        assert result.success, f"deploy 应成功: {result.error}"
+        # 核心: add_file 须被调用 4 次(4 类全复制)
+        assert svc._mapping_service.add_file.call_count == 4, (
+            f"应复制 4 类 mapping, 实际 {svc._mapping_service.add_file.call_count}"
+        )
+        cloned_types = {
+            c.kwargs.get("file_type") for c in svc._mapping_service.add_file.call_args_list
+        }
+        # 防回归重点: strategy 和 sizer 必须在复制结果(issue 指控漏的两类)
+        assert FILE_TYPES.STRATEGY in cloned_types, f"strategy 未被克隆: {cloned_types}"
+        assert FILE_TYPES.SIZER in cloned_types, f"sizer 未被克隆: {cloned_types}"
+        assert cloned_types == {
+            FILE_TYPES.SELECTOR, FILE_TYPES.STRATEGY, FILE_TYPES.SIZER, FILE_TYPES.RISKMANAGER,
+        }, f"克隆类型集合不符: {cloned_types}"
+
+    def test_deploy_paper_clones_mapping_params(self):
+        """部署须复制每个 mapping 的参数(_copy_params_raw 对每个源 mapping 触发)"""
+        svc = self._make_clone_svc()
+        fake_param = MagicMock()
+        svc._param_crud.find_by_mapping_id.return_value = [fake_param]
+        result = svc.deploy(portfolio_id="src", mode=PORTFOLIO_MODE_TYPES.PAPER, name="Clone")
+        assert result.success, f"deploy 应成功: {result.error}"
+        # find_by_mapping_id 须对每个源 mapping 调用(4 类 params 各读取一次)
+        assert svc._param_crud.find_by_mapping_id.call_count == 4, (
+            f"应读取 4 个 mapping 的 params, 实际 "
+            f"{svc._param_crud.find_by_mapping_id.call_count}"
+        )
+        # 参数须写入新 mapping(_copy_params_raw 调 param_crud.add)
+        assert svc._param_crud.add.called, "参数未复制到新 mapping"


### PR DESCRIPTION
## Summary

补回归测试锁定 `deploy` 克隆完整性(#6279 验收第4条)。

**调查结论**: issue 报 paper 部署后 Strategies:0(只见 risk+selector 2 类)。验证当前代码**不复现**——`_deploy_core` 完整复制 4 类 mapping, 路径无类型过滤(`deployment_service.py:160-191`)。疑 `#6164 fix(deploy): 回测→模拟盘 deploy 丢 param` 已修。

## 变更

`TestDeploymentServiceCloneCompleteness`(2 测试, 锁定防回归):
- `test_deploy_paper_clones_all_four_component_types`: 4 类全复制(含 issue 指控漏的 strategy/sizer)
- `test_deploy_paper_clones_mapping_params`: 每个 mapping 参数同步复制

## Test plan

- [x] 2 新测试通过
- [x] 全文件 8 passed 无回归
- [x] 仅测试文件变更, 无 src 改动

## 说明

本 PR **不 Closes #6279**: deploy 层验证正确, 但 worker 装配 `Strategies:0` 若持续, 根因可能在装配层或数据层(超本 issue 范围), 需另行排查。请 review 确认是否 stale。
