### PR TITLE
feat: 补齐实盘账户 CLI account create/list/get (#6284)

### DIFF
--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ def _register_all_commands():
         return LazyTyper(module_name, app_name).app
 
     # 新的模块化命令架构 - 使用独立的CLI文件
-    from ginkgo.client import data_cli, engine_cli, portfolio_cli, param_cli, kafka_cli, worker_cli, mongo_cli, user_cli, group_cli, templates_cli, notify_cli, livecore_cli, execution_cli, scheduler_cli, tasktimer_cli, config_cli, serve_cli, logging_cli, deploy_cli, backtest_cli, comparison_cli, record_cli, dev_cli, test_cli, cache_cli
+    from ginkgo.client import data_cli, engine_cli, portfolio_cli, param_cli, kafka_cli, worker_cli, mongo_cli, user_cli, group_cli, templates_cli, notify_cli, livecore_cli, execution_cli, scheduler_cli, tasktimer_cli, config_cli, serve_cli, logging_cli, deploy_cli, backtest_cli, comparison_cli, record_cli, dev_cli, test_cli, cache_cli, account_cli
 
     _main_app.add_typer(data_cli.app, name="data", help=":page_facing_up: Data management")
     _main_app.add_typer(engine_cli.app, name="engine", help=":fire: Engine management")
@@ -125,6 +125,7 @@ def _register_all_commands():
     _main_app.add_typer(config_cli.app, name="config", help=":gear: Configuration management")
     _main_app.add_typer(logging_cli.app, name="logging", help=":memo: Logging management")
     _main_app.add_typer(deploy_cli.app, name="deploy", help="Deploy backtest to paper/live trading")
+    _main_app.add_typer(account_cli.app, name="account", help=":credit_card: Live account management (实盘账户)")
     _main_app.add_typer(backtest_cli.app, name="backtest", help=":chart_with_upwards_trend: Backtest task management")
 
     # Serve commands (api, webui, worker-data, worker-backtest, etc.)

--- a/src/ginkgo/client/account_cli.py
+++ b/src/ginkgo/client/account_cli.py
@@ -1,0 +1,149 @@
+# Upstream: CLI入口 (ginkgo account 命令组)
+# Downstream: data_container.live_account_service()
+# Role: 实盘账户管理 CLI — 创建/列出/查看实盘账户
+#
+# #6284: LiveAccountService/CRUD 已就绪，补 CLI 层。
+# 创建的 account_uuid 供 `ginkgo deploy --mode live --account <uuid>` 使用（见 deploy_cli.py）。
+
+import typer
+from typing import Optional
+from typing_extensions import Annotated
+from rich.console import Console
+from rich.table import Table
+
+app = typer.Typer(help="Live account management (实盘账户管理)")
+console = Console()
+
+
+@app.command("create")
+def create(
+    user_id: Annotated[str, typer.Argument(help="用户ID")],
+    exchange: Annotated[str, typer.Option("--exchange", "-e", help="交易所: okx / binance")],
+    name: Annotated[str, typer.Option("--name", "-n", help="账号名称")],
+    api_key: Annotated[str, typer.Option("--api-key", help="API Key")],
+    api_secret: Annotated[str, typer.Option("--api-secret", help="API Secret")],
+    passphrase: Annotated[Optional[str], typer.Option("--passphrase", help="Passphrase (OKX 必填)")] = None,
+    environment: Annotated[str, typer.Option("--environment", help="环境: production / testnet")] = "testnet",
+    description: Annotated[Optional[str], typer.Option("--description", help="账号描述")] = None,
+    auto_validate: Annotated[bool, typer.Option("--auto-validate", help="创建时自动验证凭证")] = False,
+):
+    """创建实盘账户（凭证经 EncryptionService 加密入库）"""
+    try:
+        from ginkgo.data.containers import container
+
+        svc = container.live_account_service()
+        result = svc.create_account(
+            user_id=user_id,
+            exchange=exchange,
+            name=name,
+            api_key=api_key,
+            api_secret=api_secret,
+            passphrase=passphrase,
+            environment=environment,
+            description=description,
+            auto_validate=auto_validate,
+        )
+
+        if result.get("success"):
+            account_uuid = result.get("data", {}).get("account_uuid", "")
+            console.print(f"[green]实盘账户创建成功[/green]")
+            console.print(f"  Account UUID: [cyan]{account_uuid}[/cyan]")
+            console.print(f"  交易所: {exchange}  环境: {environment}")
+            console.print(f"  (供 [dim]ginkgo deploy --mode live --account {account_uuid}[/dim] 使用)")
+        else:
+            console.print(f"[red]创建失败: {result.get('error') or result.get('message')}[/red]")
+            raise typer.Exit(1)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command("list")
+def list_accounts(
+    user_id: Annotated[str, typer.Argument(help="用户ID")],
+    page: Annotated[int, typer.Option("--page", help="页码（从1开始）")] = 1,
+    page_size: Annotated[int, typer.Option("--page-size", help="每页数量")] = 20,
+    exchange: Annotated[Optional[str], typer.Option("--exchange", "-e", help="按交易所筛选")] = None,
+    environment: Annotated[Optional[str], typer.Option("--environment", help="按环境筛选")] = None,
+    status: Annotated[Optional[str], typer.Option("--status", help="按状态筛选")] = None,
+):
+    """列出用户的实盘账户（不回显凭据）"""
+    try:
+        from ginkgo.data.containers import container
+
+        svc = container.live_account_service()
+        result = svc.get_user_accounts(
+            user_id=user_id,
+            page=page,
+            page_size=page_size,
+            exchange=exchange,
+            environment=environment,
+            status=status,
+        )
+
+        if not result.get("success"):
+            console.print(f"[red]查询失败: {result.get('error') or result.get('message')}[/red]")
+            raise typer.Exit(1)
+
+        data = result.get("data", {})
+        accounts = data.get("accounts", [])
+        if not accounts:
+            console.print("[yellow]无实盘账户记录[/yellow]")
+            return
+
+        table = Table(title=f"实盘账户 (共 {data.get('total', 0)} 条)")
+        table.add_column("UUID", style="cyan")
+        table.add_column("名称")
+        table.add_column("交易所")
+        table.add_column("环境")
+        table.add_column("状态")
+        for acc in accounts:
+            table.add_row(
+                str(acc.get("uuid", ""))[:12],
+                str(acc.get("name", "")),
+                str(acc.get("exchange", "")),
+                str(acc.get("environment", "")),
+                str(acc.get("status", "")),
+            )
+        console.print(table)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
+@app.command("get")
+def get_account(
+    account_uuid: Annotated[str, typer.Argument(help="实盘账户 UUID")],
+):
+    """查看实盘账户详情（不回显凭据）"""
+    try:
+        from ginkgo.data.containers import container
+
+        svc = container.live_account_service()
+        result = svc.get_account_by_uuid(account_uuid)
+
+        if not result.get("success"):
+            console.print(f"[red]查询失败: {result.get('error') or result.get('message')}[/red]")
+            raise typer.Exit(1)
+
+        acc = result.get("data") or {}
+        table = Table(title="实盘账户详情")
+        table.add_column("字段", style="cyan")
+        table.add_column("值")
+        for key in ("uuid", "name", "exchange", "environment", "status",
+                    "description", "validation_status", "last_validated_at", "create_at"):
+            if key in acc:
+                table.add_row(key, str(acc.get(key, "")))
+        console.print(table)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)

--- a/tests/unit/client/test_account_cli.py
+++ b/tests/unit/client/test_account_cli.py
@@ -1,0 +1,127 @@
+"""#6284: 补齐实盘账户 CLI (account create/list/get)
+
+背景: LiveAccountService/CRUD 已就绪（create_account/get_user_accounts/get_account_by_uuid），
+但无 CLI 入口 —— 用户无法通过 ginkgo 命令行创建实盘账户，导致 `deploy --mode live --account <uuid>`
+的 uuid 无从获得（#6281 已暴露此断点）。
+
+收敛: 新建 account_cli.py，走 `data_container.live_account_service()`，在 main.py 注册 `account` 命令组。
+验收: 创建的 uuid 能被 deploy 接受; list/get 不回显 api_key/api_secret/passphrase 明文。
+"""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client.account_cli import app
+
+runner = CliRunner()
+
+
+class TestAccountCreate:
+    """ginkgo account create 直调 live_account_service.create_account"""
+
+    @pytest.mark.unit
+    def test_create_account_calls_service_and_prints_uuid(self):
+        """account create 应调 create_account 并回显 account_uuid（deploy 需此 uuid）
+
+        RED: account_cli 尚不存在 → ImportError。
+        """
+        mock_svc = MagicMock()
+        # service 返回纯 dict（非 ServiceResult），用真实 dict 避免 MagicMock auto-truthy 陷阱
+        mock_svc.create_account.return_value = {
+            "success": True,
+            "data": {"account_uuid": "abc123def456"},
+            "message": "created",
+            "error": "",
+        }
+
+        with patch("ginkgo.data.containers.container.live_account_service", return_value=mock_svc):
+            result = runner.invoke(app, [
+                "create", "user-001",
+                "--exchange", "okx",
+                "--name", "MyOKX",
+                "--api-key", "k1",
+                "--api-secret", "s1",
+                "--passphrase", "p1",
+            ])
+
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        mock_svc.create_account.assert_called_once()
+        _, kwargs = mock_svc.create_account.call_args
+        assert kwargs["user_id"] == "user-001"
+        assert kwargs["exchange"] == "okx"
+        assert kwargs["name"] == "MyOKX"
+        assert kwargs["api_key"] == "k1"
+        assert kwargs["api_secret"] == "s1"
+        assert kwargs["passphrase"] == "p1"
+        # 回显 account_uuid（deploy --account 需要它）
+        assert "abc123def456" in result.output
+
+
+class TestAccountList:
+    """ginkgo account list 直调 live_account_service.get_user_accounts"""
+
+    @pytest.mark.unit
+    def test_list_accounts_calls_service_and_no_credentials(self):
+        """account list 应调 get_user_accounts 且输出不含 api_secret/api_key 明文（to_dict 已脱敏）
+
+        RED: list 命令不存在 → 命令组无法解析。
+        """
+        mock_svc = MagicMock()
+        mock_svc.get_user_accounts.return_value = {
+            "success": True,
+            "data": {
+                "accounts": [
+                    {"uuid": "acc-aaa", "name": "MyOKX", "exchange": "okx",
+                     "environment": "testnet", "status": "active"},
+                ],
+                "total": 1, "page": 1, "page_size": 20, "total_pages": 1,
+            },
+        }
+
+        with patch("ginkgo.data.containers.container.live_account_service", return_value=mock_svc):
+            result = runner.invoke(app, ["list", "user-001"])
+
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        mock_svc.get_user_accounts.assert_called_once()
+        assert mock_svc.get_user_accounts.call_args.kwargs["user_id"] == "user-001"
+        # 输出含账号名（可读性），不含凭据明文（安全验收）
+        assert "MyOKX" in result.output
+        assert "api_secret" not in result.output.lower()
+        assert "api_key" not in result.output.lower()
+
+
+class TestAccountGet:
+    """ginkgo account get 直调 live_account_service.get_account_by_uuid"""
+
+    @pytest.mark.unit
+    def test_get_account_calls_service_and_no_credentials(self):
+        """account get 应调 get_account_by_uuid 且输出不含 api_secret/api_key 明文"""
+        mock_svc = MagicMock()
+        mock_svc.get_account_by_uuid.return_value = {
+            "success": True,
+            "data": {
+                "uuid": "acc-aaa", "name": "MyOKX", "exchange": "okx",
+                "environment": "testnet", "status": "active",
+            },
+        }
+
+        with patch("ginkgo.data.containers.container.live_account_service", return_value=mock_svc):
+            result = runner.invoke(app, ["get", "acc-aaa"])
+
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        mock_svc.get_account_by_uuid.assert_called_once_with("acc-aaa")
+        assert "MyOKX" in result.output
+        assert "acc-aaa" in result.output
+        assert "api_secret" not in result.output.lower()
+        assert "api_key" not in result.output.lower()


### PR DESCRIPTION
## Summary

修复 #6284：补齐实盘账户 CLI（`ginkgo account create/list/get`）。

### 背景
`LiveAccountService` / `LiveAccountCRUD` 已就绪（`create_account` / `get_user_accounts` / `get_account_by_uuid`），但**无 CLI 入口** —— 用户无法通过命令行创建实盘账户。这导致 `ginkgo deploy --mode live --account <uuid>`（#6281 已暴露）所需的 `account_uuid` 无从获得，实盘部署链路在 CLI 层断裂。

### 实现（纯 CLI 适配层，不碰 service/crud/base）
- **`account create`**：调 `live_account_service().create_account(...)`，回显 `account_uuid`（并提示用于 `deploy --account`）。凭证经 `EncryptionService` 加密入库（service 层既有逻辑）。
- **`account list`**：调 `get_user_accounts(user_id, page, ...)`，表格输出 uuid/名称/交易所/环境/状态。
- **`account get`**：调 `get_account_by_uuid(uuid)`，详情表格。
- 走 `from ginkgo.data.containers import container` → `container.live_account_service()`，与 data_cli 同源（分层 CLI→Service→CRUD）。
- `main.py` 注册 `_main_app.add_typer(account_cli.app, name="account")`。

### 凭据安全（验收要点）
`MLiveAccount.to_dict()` 只返回元数据（uuid/name/exchange/environment/status/...），**不含** `api_key`/`api_secret`/`passphrase`（注释明示「隐藏敏感信息」）。`get_user_accounts`/`get_account_by_uuid` 均经 `to_dict()`，CLI 表格只渲染这些字段。

## Test plan

- [x] `test_create_account_calls_service_and_prints_uuid`：create 调对 service kwargs + 回显 uuid
- [x] `test_list_accounts_calls_service_and_no_credentials`：list 调 `get_user_accounts`，输出含名称、**不含** api_key/api_secret
- [x] `test_get_account_calls_service_and_no_credentials`：get 调 `get_account_by_uuid`，输出**不含**凭据
- [x] 全文件 3 passed
- [x] py_compile 通过
- [x] 启动路径冒烟：`ginkgo account --help` 列出 create/list/get 三子命令；`account create --help` 参数解析正确

## 串联验收（create→list→get，需真实 DB）

```bash
ginkgo system config set --debug on
UUID=$(ginkgo account create user1 --exchange okx --name t1 --api-key k --api-secret s --passphrase p | grep -oP '[0-9a-f]{32}' | head -1)
ginkgo account list user1
ginkgo account get "$UUID"
# 该 UUID 可被 deploy 接受: ginkgo deploy <portfolio> --mode live --account "$UUID"
```

Closes #6284
