### PR TITLE
feat(#6282): backtest run 前数据预检，sparse 前置阻断

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -99,6 +99,8 @@ def run_task(
         build_engine_data,
         load_portfolio_components,
         build_portfolio_config,
+        preflight_data_coverage,
+        build_preflight_warning,
     )
     from ginkgo.libs import GinkgoLogger
     from ginkgo.trading.time.clock import now as clock_now
@@ -145,6 +147,17 @@ def run_task(
     )
 
     portfolio_uuid = task.portfolio_id
+
+    # #6282: 回测前数据预检 — 在标 running 前查 selector codes 的 bar 覆盖，
+    # 数据缺失/稀疏时前置阻断，避免跑完整个回测才给模糊警告。
+    preflight_report = preflight_data_coverage(
+        portfolio_uuid, config.start_date, config.end_date
+    )
+    warning = build_preflight_warning(preflight_report, config.start_date, config.end_date)
+    if warning:
+        console.print(warning)
+        service.update_status(task.uuid, "failed")
+        raise typer.Exit(1)
 
     # 更新状态为 running
     service.update_status(task.uuid, "running")

--- a/src/ginkgo/workers/backtest_worker/task_helpers.py
+++ b/src/ginkgo/workers/backtest_worker/task_helpers.py
@@ -8,11 +8,12 @@ Backtest Task Helpers
 从 TaskProcessor 提取的通用回测逻辑，供 CLI 和 Worker 复用。
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, List, Tuple
 
 from ginkgo.data.containers import container as data_container
 from ginkgo.enums import FILE_TYPES
 from ginkgo.libs import GLOG
+from ginkgo.libs.data.normalize import datetime_normalize
 
 
 def build_engine_data(config, task_id: str = None) -> Dict[str, Any]:
@@ -113,6 +114,188 @@ def load_portfolio_components(portfolio_id: str, task_uuid: str = "cli") -> Dict
               f"risk_managers={risk_names}, "
               f"sizers={sizer_names}")
     return components
+
+
+# ---- #6282: 回测前数据预检 -------------------------------------------------
+# 回测前预查 selector codes 的 day bar 覆盖，数据缺失/稀疏时前置阻断，
+# 避免跑完整个回测才给模糊警告「selector may have returned empty symbols」。
+
+# 股票代码 token 正则：6 位数字 + 可选 .SZ/.SH/.BJ 后缀（兼容逗号/空格/分号分隔）
+_CODE_TOKEN_RE = __import__("re").compile(r"\b(\d{6}(?:\.(?:SZ|SH|BJ|sz|sh|bj))?)\b")
+
+
+def check_data_coverage(
+    codes: List[str],
+    start_date: Any,
+    end_date: Any,
+    bar_crud: Any,
+    min_bars: int = 10,
+) -> Tuple[Dict[str, int], List[str]]:
+    """预查 codes 在 [start_date, end_date] 窗口的 day bar 覆盖。
+
+    Args:
+        codes: 待预查的股票代码列表
+        start_date / end_date: 窗口边界（str 或 datetime，内部 normalize）
+        bar_crud: day bar CRUD（须支持 count(filters)）
+        min_bars: 视为「数据充足」的最小 bar 条数阈值
+
+    Returns:
+        (coverage, sparse):
+          coverage = {code: bar_count}
+          sparse   = bar_count < min_bars 的 code 列表（按字典序）
+    """
+    start_dt = datetime_normalize(start_date)
+    end_dt = datetime_normalize(end_date)
+    coverage: Dict[str, int] = {}
+    for code in codes:
+        try:
+            n = bar_crud.count(
+                {"code": code, "timestamp__gte": start_dt, "timestamp__lte": end_dt}
+            )
+        except Exception as e:
+            GLOG.WARNING(f"[preflight] count bar failed for {code}: {e}")
+            n = 0
+        coverage[code] = n or 0
+    sparse = sorted(c for c, n in coverage.items() if n < min_bars)
+    return coverage, sparse
+
+
+def _extract_codes_from_value(value: Any) -> List[str]:
+    """从单个 param 值中提取股票代码 token（兼容 str/list/json 序列化）。"""
+    import json as _json
+
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple)):
+        tokens = []
+        for item in value:
+            tokens.extend(_extract_codes_from_value(item))
+        return tokens
+    if not isinstance(value, str):
+        value = str(value)
+    # 尝试 json 反序列化（param 可能存了 '["000001.SZ","000002.SZ"]'）
+    stripped = value.strip()
+    if stripped.startswith("[") or stripped.startswith("{"):
+        try:
+            decoded = _json.loads(stripped)
+            if decoded:
+                return _extract_codes_from_value(decoded)
+        except Exception:
+            pass
+    return _CODE_TOKEN_RE.findall(value)
+
+
+def resolve_selector_codes(
+    portfolio_id: str,
+    mapping_crud: Any = None,
+    param_crud: Any = None,
+) -> List[str]:
+    """解析 portfolio 的 FixedSelector 显式 codes（供数据预检）。
+
+    动态 selector（cn_all/momentum/popularity）无显式 codes → 返回空列表，
+    调用方应跳过预检（无法按 code 预查）。
+
+    Args:
+        portfolio_id: 组合 UUID
+        mapping_crud: portfolio_file_mapping CRUD（默认 data_container）
+        param_crud: param CRUD（默认 data_container）
+
+    Returns:
+        去重后的 codes 列表（仅含 SELECTOR 类型 mapping 的 param 中识别到的代码）
+    """
+    if mapping_crud is None:
+        mapping_crud = data_container.cruds.portfolio_file_mapping()
+    if param_crud is None:
+        param_crud = data_container.cruds.param()
+
+    try:
+        mappings = mapping_crud.find(
+            filters={"portfolio_id": portfolio_id, "is_del": False}
+        )
+    except Exception as e:
+        GLOG.WARNING(f"[preflight] load mappings failed: {e}")
+        return []
+
+    codes: List[str] = []
+    for mapping in mappings:
+        if getattr(mapping, "type", None) != FILE_TYPES.SELECTOR.value:
+            continue
+        mapping_uuid = getattr(mapping, "uuid", None)
+        if not mapping_uuid:
+            continue
+        try:
+            params = param_crud.find_by_mapping_id(mapping_uuid)
+        except Exception as e:
+            GLOG.WARNING(f"[preflight] load params for {mapping_uuid} failed: {e}")
+            continue
+        for p in params:
+            codes.extend(_extract_codes_from_value(getattr(p, "value", None)))
+
+    # 去重保序
+    seen = set()
+    unique: List[str] = []
+    for c in codes:
+        if c not in seen:
+            seen.add(c)
+            unique.append(c)
+    return unique
+
+
+def preflight_data_coverage(
+    portfolio_id: str,
+    start_date: Any,
+    end_date: Any,
+    bar_crud: Any = None,
+    mapping_crud: Any = None,
+    param_crud: Any = None,
+    min_bars: int = 10,
+) -> Dict[str, Any]:
+    """回测前数据预检：解析 selector codes → 按窗口计数 bar → 返回覆盖报告。
+
+    Returns:
+        {
+            "codes": List[str],          # 预查的 codes（空=动态 selector，无法预查）
+            "coverage": {code: count},
+            "sparse": List[str],         # bar_count < min_bars 的 code
+            "ok": bool,                  # 无稀疏（或无可预查 codes）时 True
+        }
+    """
+    codes = resolve_selector_codes(portfolio_id, mapping_crud, param_crud)
+    if not codes:
+        # 动态 selector（cn_all/momentum 等）无显式 codes → 无法按 code 预查，放行
+        return {"codes": [], "coverage": {}, "sparse": [], "ok": True}
+
+    if bar_crud is None:
+        bar_crud = data_container.cruds.bar()
+    coverage, sparse = check_data_coverage(
+        codes, start_date, end_date, bar_crud, min_bars=min_bars
+    )
+    return {"codes": codes, "coverage": coverage, "sparse": sparse, "ok": not sparse}
+
+
+def build_preflight_warning(report: Dict[str, Any], start_date: Any, end_date: Any) -> Any:
+    """将 preflight 报告转为人可读的阻断消息。
+
+    Returns:
+        str: sparse 非空时的人可读消息（含 code + 窗口 + bar 条数 + 建议）
+        None: 无稀疏（或动态 selector 无可预查 codes）→ 调用方应放行
+    """
+    sparse = report.get("sparse") or []
+    if not sparse:
+        return None
+    coverage = report.get("coverage", {}) or {}
+    lines = [
+        f":warning: Data preflight failed: {len(sparse)} symbol(s) have insufficient bars",
+        f"   Window: {start_date} ~ {end_date}",
+    ]
+    for code in sparse:
+        n = coverage.get(code, 0)
+        lines.append(f"   - {code}: {n} bar(s)")
+    lines.append(
+        ":bulb: Tip: sync day bars first — "
+        "`ginkgo data sync --code <CODE>` or widen the backtest window."
+    )
+    return "\n".join(lines)
 
 
 def build_portfolio_config(portfolio_id: str, portfolio_data, initial_cash: float) -> Dict[str, Any]:

--- a/tests/unit/workers/test_backtest_preflight.py
+++ b/tests/unit/workers/test_backtest_preflight.py
@@ -1,0 +1,212 @@
+"""#6282: backtest run 前数据预检
+
+回测前预查 selector codes 的 day bar 覆盖，数据缺失/稀疏时前置阻断，
+而非跑完整个回测才给模糊警告「selector may have returned empty symbols」。
+
+模块: task_helpers.check_data_coverage + resolve_selector_codes, backtest_cli.run_task 调用。
+"""
+import sys
+from pathlib import Path
+from datetime import datetime
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.enums import FILE_TYPES
+from ginkgo.workers.backtest_worker.task_helpers import (
+    check_data_coverage,
+    resolve_selector_codes,
+    build_preflight_warning,
+)
+
+
+class TestCheckDataCoverage:
+    """check_data_coverage: 按 code + 窗口计数 bar，标记稀疏/缺失"""
+
+    @pytest.mark.unit
+    def test_flags_sparse_and_missing_keeps_sufficient(self):
+        """覆盖不均（000001:3 / 000002:0 / 600036:244）应分别标 sparse/missing/ok
+
+        RED: check_data_coverage 尚不存在 → ImportError。
+        """
+        bar_crud = MagicMock()
+        counts = {"000001.SZ": 3, "000002.SZ": 0, "600036.SH": 244}
+
+        def fake_count(filters):
+            return counts[filters["code"]]
+
+        bar_crud.count.side_effect = fake_count
+
+        coverage, sparse = check_data_coverage(
+            codes=["000001.SZ", "000002.SZ", "600036.SH"],
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2026, 1, 1),
+            bar_crud=bar_crud,
+            min_bars=10,
+        )
+
+        assert coverage == {"000001.SZ": 3, "000002.SZ": 0, "600036.SH": 244}
+        # 稀疏(3<10) + 缺失(0<10) 被标，充足(244) 不标
+        assert set(sparse) == {"000001.SZ", "000002.SZ"}
+        assert "600036.SH" not in sparse
+
+    @pytest.mark.unit
+    def test_count_called_with_code_and_window_filters(self):
+        """bar_crud.count 须带 code + timestamp 窗口过滤（否则查全表非窗口）"""
+        bar_crud = MagicMock()
+        bar_crud.count.return_value = 100
+
+        check_data_coverage(
+            codes=["000001.SZ"],
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2026, 1, 1),
+            bar_crud=bar_crud,
+        )
+
+        bar_crud.count.assert_called_once()
+        filters = bar_crud.count.call_args.args[0]
+        assert filters["code"] == "000001.SZ"
+        assert filters["timestamp__gte"] == datetime(2025, 1, 1)
+        assert filters["timestamp__lte"] == datetime(2026, 1, 1)
+
+    @pytest.mark.unit
+    def test_count_exception_treated_as_zero(self):
+        """查 bar 抛异常（如表不存在）应降级为 0 条，不阻断预检流程"""
+        bar_crud = MagicMock()
+        bar_crud.count.side_effect = RuntimeError("table missing")
+
+        coverage, sparse = check_data_coverage(
+            codes=["000001.SZ"],
+            start_date=datetime(2025, 1, 1),
+            end_date=datetime(2026, 1, 1),
+            bar_crud=bar_crud,
+            min_bars=10,
+        )
+        assert coverage["000001.SZ"] == 0
+        assert "000001.SZ" in sparse
+
+
+class TestResolveSelectorCodes:
+    """resolve_selector_codes: 从 FixedSelector params 提取显式 codes"""
+
+    @staticmethod
+    def _mapping(uuid, type_):
+        m = MagicMock()
+        m.uuid = uuid
+        m.type = type_
+        return m
+
+    @staticmethod
+    def _param(value):
+        p = MagicMock()
+        p.value = value
+        return p
+
+    @pytest.mark.unit
+    def test_extracts_codes_from_fixed_selector_comma_string(self):
+        """FixedSelector codes 存为逗号分隔串 → 提取全部 code"""
+        mapping_crud = MagicMock()
+        sel = self._mapping("map-sel", FILE_TYPES.SELECTOR.value)
+        mapping_crud.find.return_value = [sel]
+        param_crud = MagicMock()
+        param_crud.find_by_mapping_id.return_value = [
+            self._param("default_selector"),  # name（非 code）
+            self._param("000001.SZ,000002.SZ,600036.SH"),  # codes
+        ]
+
+        codes = resolve_selector_codes("pid", mapping_crud, param_crud)
+
+        assert set(codes) == {"000001.SZ", "000002.SZ", "600036.SH"}
+
+    @pytest.mark.unit
+    def test_extracts_codes_from_json_list_value(self):
+        """codes 存为 json 序列化的 list 串 → 反序列化后提取"""
+        mapping_crud = MagicMock()
+        mapping_crud.find.return_value = [self._mapping("map-sel", FILE_TYPES.SELECTOR.value)]
+        param_crud = MagicMock()
+        param_crud.find_by_mapping_id.return_value = [
+            self._param('["000001.SZ", "000002.SZ"]'),
+        ]
+
+        codes = resolve_selector_codes("pid", mapping_crud, param_crud)
+
+        assert set(codes) == {"000001.SZ", "000002.SZ"}
+
+    @pytest.mark.unit
+    def test_dynamic_selector_no_codes_returns_empty(self):
+        """动态 selector（cn_all/momentum，params 无 code token）→ 返回空（调用方跳过预检）"""
+        mapping_crud = MagicMock()
+        mapping_crud.find.return_value = [self._mapping("map-sel", FILE_TYPES.SELECTOR.value)]
+        param_crud = MagicMock()
+        param_crud.find_by_mapping_id.return_value = [
+            self._param("cn_all"),  # 无 6 位代码 token
+        ]
+
+        codes = resolve_selector_codes("pid", mapping_crud, param_crud)
+
+        assert codes == []
+
+    @pytest.mark.unit
+    def test_only_selector_mappings_scanned_not_strategy(self):
+        """strategy mapping 的 params 不应被扫（仅 SELECTOR 类型）"""
+        mapping_crud = MagicMock()
+        mapping_crud.find.return_value = [
+            self._mapping("map-strat", FILE_TYPES.STRATEGY.value),
+            self._mapping("map-sel", FILE_TYPES.SELECTOR.value),
+        ]
+        param_crud = MagicMock()
+        # 不同 mapping_uuid 返回不同 params
+        def by_id(mid):
+            if mid == "map-strat":
+                return [self._param("000999.SZ")]  # strategy 的 code-like 值，不应被提
+            return [self._param("000001.SZ")]
+        param_crud.find_by_mapping_id.side_effect = by_id
+
+        codes = resolve_selector_codes("pid", mapping_crud, param_crud)
+
+        assert codes == ["000001.SZ"]
+
+
+class TestBuildPreflightWarning:
+    """build_preflight_warning: sparse 报告 → 人可读阻断消息"""
+
+    @pytest.mark.unit
+    def test_sparse_report_yields_message_naming_code_window_count(self):
+        """sparse 非空 → 消息须含 code、窗口、bar 条数、建议"""
+        report = {
+            "codes": ["000001.SZ", "000002.SZ"],
+            "coverage": {"000001.SZ": 3, "000002.SZ": 0},
+            "sparse": ["000001.SZ", "000002.SZ"],
+            "ok": False,
+        }
+        msg = build_preflight_warning(report, "2025-01-01", "2026-01-01")
+        assert msg is not None
+        assert "000001.SZ" in msg
+        assert "000002.SZ" in msg
+        assert "2025-01-01" in msg
+        assert "2026-01-01" in msg
+        # 条数须体现，让用户知道是「几乎没数据」还是「完全没数据」
+        assert "3" in msg
+        assert "0" in msg
+
+    @pytest.mark.unit
+    def test_ok_report_returns_none(self):
+        """ok=True（无稀疏）→ 返回 None（调用方放行）"""
+        report = {
+            "codes": ["000001.SZ"],
+            "coverage": {"000001.SZ": 244},
+            "sparse": [],
+            "ok": True,
+        }
+        assert build_preflight_warning(report, "2025-01-01", "2026-01-01") is None
+
+    @pytest.mark.unit
+    def test_dynamic_selector_ok_report_returns_none(self):
+        """动态 selector（codes 空）→ 无可预查 → 返回 None（放行，不误阻断）"""
+        report = {"codes": [], "coverage": {}, "sparse": [], "ok": True}
+        assert build_preflight_warning(report, "2025-01-01", "2026-01-01") is None


### PR DESCRIPTION
## Summary

`ginkgo backtest run` 原先直接进 orchestrator，数据缺失时要跑完整个回测才给模糊警告「selector may have returned empty symbols」。本 PR 在 `orchestrator.run` 前插入数据预检：解析 FixedSelector 的显式 codes → 按回测窗口计数 day bar → 稀疏(<10 条)前置阻断，给出含 code + 窗口 + bar 条数 + 同步建议的明确消息。

- **`task_helpers.py`**: 新增 `check_data_coverage` / `resolve_selector_codes` / `preflight_data_coverage` / `build_preflight_warning`，CRUD 全部依赖注入（默认走 container，测试喂 MagicMock）。
- **`backtest_cli.py:run_task`**: config 构建 + portfolio_uuid 解析后、标 running 前调用预检；sparse 非空时标 `failed` + `typer.Exit(1)`（避免 running 僵尸）。
- **动态 selector 放行**: `cn_all`/`momentum` 等无显式 codes → `preflight_data_coverage` 返回 `ok=True`+空 codes → 不误阻断。

## Test plan

- [x] `tests/unit/workers/test_backtest_preflight.py` — 10 例（覆盖计数/窗口过滤/异常降级、codes 提取[逗号串/json list/动态空/仅SELECTOR]、消息生成[含code+窗口+条数/ok放行/动态放行]）
- [x] `tests/unit/client/test_backtest_cli.py` — 4 例既有测试无回归
- [x] 启动路径冒烟 `ginkgo backtest run --help` 装配正常
- [x] CRUD 依赖注入 → 纯单元，不触库

Closes #6282
