### PR TITLE
fix: portfolio 创建 initial_cash 未转发给 service (#5407 #5380)

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -413,6 +413,7 @@ async def create_portfolio(data: PortfolioCreate):
         saga = PortfolioSagaFactory.create_portfolio_saga(
             name=data.name,
             mode=mode_int,
+            initial_cash=data.initial_cash,
             selectors=data.selectors,
             sizer=sizer_data,
             strategies=data.strategies,

--- a/api/services/saga_transaction.py
+++ b/api/services/saga_transaction.py
@@ -231,6 +231,7 @@ class PortfolioSagaFactory:
     def create_portfolio_saga(
         name: str,
         mode: int = 0,
+        initial_cash: Optional[float] = None,
         selectors: List[Dict[str, Any]] = None,
         sizer: Optional[Dict[str, Any]] = None,
         strategies: List[Dict[str, Any]] = None,
@@ -242,6 +243,7 @@ class PortfolioSagaFactory:
         Args:
             name: Portfolio 名称
             mode: 运行模式 (0=BACKTEST, 1=PAPER, 2=LIVE)
+            initial_cash: 初始资金（None 时由 service 回退默认 1000000.0）
             selectors: 选股器列表 [{"component_uuid": "...", "config": {...}}]
             sizer: 仓位管理器 {"component_uuid": "...", "config": {...}}
             strategies: 策略列表 [{"component_uuid": "...", "config": {...}}]
@@ -268,7 +270,8 @@ class PortfolioSagaFactory:
 
         # ==================== 步骤 1: 创建 Portfolio ====================
         def create_portfolio():
-            result = portfolio_service.add(name=name, mode=mode)
+            # #5407 #5380: 转发 initial_cash -> initial_capital，否则 service 回退默认值
+            result = portfolio_service.add(name=name, mode=mode, initial_capital=initial_cash)
             if not result.is_success():
                 raise Exception(f"Failed to create portfolio: {result.error}")
             context['portfolio_result'] = result.data

--- a/tests/api/test_portfolio_create_initial_cash.py
+++ b/tests/api/test_portfolio_create_initial_cash.py
@@ -1,0 +1,85 @@
+# #5407 #5380 — Portfolio 创建时 initial_cash 被忽略（默认 1000000）/ 缩水 10 倍
+"""
+验证 POST /api/v1/portfolios/ 创建组合时，请求体的 initial_cash 被正确传递：
+1. Saga 工厂 create_portfolio_saga 接受 initial_cash，并在 create 步骤里
+   以 initial_capital=<值> 转发给 portfolio_service.add。
+2. 端点 create_portfolio 把 data.initial_cash 传给 Saga 工厂。
+
+同根因：create_portfolio_saga (api/services/saga_transaction.py) 此前根本不接收
+initial_cash，create 步骤只调 portfolio_service.add(name, mode)，导致 service
+回退到默认 1000000.0。update 路径正确（update_portfolio_saga 已转发 initial_cash）。
+"""
+import pytest
+from unittest.mock import Mock, AsyncMock, patch
+
+from models.portfolio import PortfolioCreate
+
+
+def _mock_saga(uuid: str = "portfolio-uuid"):
+    """构造一个执行成功的 mock saga（镜像 test_portfolio_create_mode 用法）。"""
+    saga = Mock()
+    saga.execute = AsyncMock(return_value=True)
+    step = Mock()
+    step.result = {"uuid": uuid}
+    saga.steps = [step]
+    saga.error = None
+    return saga
+
+
+class TestCreateSagaForwardsInitialCash:
+    """create_portfolio_saga 应把 initial_cash 以 initial_capital 转发给 add()"""
+
+    def test_initial_cash_forwarded_to_add(self):
+        from services.saga_transaction import PortfolioSagaFactory
+
+        portfolio_service = Mock()
+        portfolio_result = Mock()
+        portfolio_result.is_success.return_value = True
+        portfolio_result.data.uuid = "portfolio-uuid"
+        portfolio_service.add.return_value = portfolio_result
+
+        mock_container = Mock()
+        mock_container.portfolio_service.return_value = portfolio_service
+        mock_container.portfolio_mapping_service.return_value = Mock()
+
+        # container 是 dependency_injector 单例；saga 函数体内
+        # `from ginkgo.data.containers import container` 在调用时读取该模块属性，
+        # 故替换模块属性 container 即可拦截（参考 tests/unit/services 多处用法）。
+        with patch("ginkgo.data.containers.container", mock_container):
+            saga = PortfolioSagaFactory.create_portfolio_saga(
+                name="t",
+                mode=0,
+                initial_cash=200000,
+                selectors=[],
+                strategies=[],
+                risk_managers=[],
+                analyzers=[],
+            )
+
+            # 只执行 create 步骤（steps[0] 恒为 create_portfolio）
+            saga.steps[0].execute()
+
+        portfolio_service.add.assert_called_once_with(
+            name="t", mode=0, initial_capital=200000
+        )
+
+
+class TestEndpointPassesInitialCash:
+    """create_portfolio 端点应把 data.initial_cash 传给 Saga 工厂"""
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio.get_portfolio", new_callable=AsyncMock)
+    @patch("services.saga_transaction.PortfolioSagaFactory")
+    async def test_endpoint_passes_initial_cash(self, mock_factory, mock_get_portfolio):
+        from api.portfolio import create_portfolio
+
+        mock_factory.create_portfolio_saga.return_value = _mock_saga()
+        mock_get_portfolio.return_value = {"uuid": "portfolio-uuid", "initial_cash": 200000}
+
+        data = PortfolioCreate(name="test_cash", initial_cash=200000)
+        await create_portfolio(data)
+
+        _, kwargs = mock_factory.create_portfolio_saga.call_args
+        assert kwargs.get("initial_cash") == 200000, (
+            f"initial_cash 应为 200000，实际为 {kwargs.get('initial_cash')}"
+        )


### PR DESCRIPTION
## Summary

POST /api/v1/portfolios/ 创建组合时，请求体的 `initial_cash` 被忽略（#5407）/ 缩水 10 倍（#5380）。两者同根因：

`create_portfolio_saga`（api/services/saga_transaction.py）此前**不接收** `initial_cash` 参数，create 步骤只调 `portfolio_service.add(name, mode)`，service 因 `initial_capital=None` 回退到默认 `1000000.0`。而 `update_portfolio_saga` 路径已正确转发，create 路径是遗漏。

### 修复（3 点，照搬 update 路径已有模式）
- `PortfolioSagaFactory.create_portfolio_saga` 增加 `initial_cash: Optional[float] = None` 参数
- create 步骤 `portfolio_service.add(name, mode, initial_capital=initial_cash)`
- 端点 `create_portfolio` 传 `initial_cash=data.initial_cash`

`add()` 本就接受 `initial_capital`（默认 1000000.0），`None` 安全回退默认值，向后兼容。

## Test plan
- [x] `tests/api/test_portfolio_create_initial_cash.py` — saga 层（initial_cash=200000 → add 收到 initial_capital=200000）+ endpoint 层（data.initial_cash 透传工厂）
- [x] `tests/api/test_portfolio_create_mode.py` 仍 3/3 通过（mode 转发未受影响）
- 基线对比：`tests/api/test_saga_transaction.py` 与 `test_saga_integration.py` 各自既有失败（stale `is_live=` kwarg + 错误 patch target）均与本改动无关，stash 验证无回归

## 验收
POST `{initial_cash: 200000}` → 存储/返回 200000（不再被默认值覆盖）。

Closes #5407
Closes #5380
