### PR TITLE
fix(#6279): deploy 克隆保留全部组件绑定（strategy/sizer 不被图同步删除）

### DIFF
--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -78,6 +78,7 @@ class PortfolioMappingService(BaseService):
         portfolio_uuid: str,
         graph_data: Dict[str, Any],
         name: str,
+        sync_mysql: bool = True,
     ) -> ServiceResult:
         """
         从图编辑器创建配置
@@ -91,6 +92,10 @@ class PortfolioMappingService(BaseService):
             portfolio_uuid: 投资组合 UUID
             graph_data: 图数据 {"nodes": [...], "edges": [...], "viewport": {...}}
             name: 配置名称
+            sync_mysql: 是否回写 MySQL Mapping/MParam。图编辑器场景为 True（以图为权威，
+                删除图外孤立映射）；deploy 克隆场景传 False —— MySQL 映射已由 deploy
+                源组合权威复制，此处仅需搬运 Mongo 图供 UI，绝不能按（可能不完整的）
+                源图删除已建的 strategy/sizer 映射。#6279
 
         Returns:
             ServiceResult: 包含 mongo_id、mappings_count、params_count
@@ -115,13 +120,7 @@ class PortfolioMappingService(BaseService):
             ... )
         """
         try:
-            # 1. 提取图中的文件映射
-            file_mappings = self._extract_files_from_graph(graph_data)
-
-            # 2. 提取图中的节点参数
-            node_params = self._extract_params_from_graph(graph_data)
-
-            # 3. 保存到 MongoDB
+            # 1. 保存到 MongoDB（图文档本体，UI 可视化用）
             mongo_id = self._save_graph_to_mongo(
                 portfolio_uuid=portfolio_uuid,
                 graph_data=graph_data,
@@ -129,24 +128,31 @@ class PortfolioMappingService(BaseService):
                 source="GRAPH_EDITOR"
             )
 
-            # 4. 同步到 MySQL Mapping
-            # 5. 同步到 MySQL MParam
-            # 下游 MySQL sync 失败时补偿删 Mongo 孤儿（#5559）：
-            # Mongo 已在步骤3写入，若 MySQL sync 抛异常，反向删除已写的 Mongo 文档，
-            # 保持跨库一致性。raise 让外层 @retry/except 决定重试或返错。
-            try:
-                mapping_sync_result = self._sync_mappings_from_files(
-                    portfolio_uuid=portfolio_uuid,
-                    file_mappings=file_mappings
-                )
+            # 2. MySQL 同步（图编辑器权威；deploy 克隆传 False 跳过以保 step5 已建映射）
+            file_mappings: list = []
+            node_params: list = []
+            if sync_mysql:
+                file_mappings = self._extract_files_from_graph(graph_data)
+                node_params = self._extract_params_from_graph(graph_data)
 
-                param_sync_result = self._sync_params_from_nodes(
-                    portfolio_uuid=portfolio_uuid,
-                    node_params=node_params
-                )
-            except Exception:
-                self._delete_graph_from_mongo(mongo_id)
-                raise
+                # 下游 MySQL sync 失败时补偿删 Mongo 孤儿（#5559）：
+                # Mongo 已在步骤1写入，若 MySQL sync 抛异常，反向删除已写的 Mongo 文档，
+                # 保持跨库一致性。raise 让外层 @retry/except 决定重试或返错。
+                try:
+                    # 同步到 MySQL Mapping
+                    self._sync_mappings_from_files(
+                        portfolio_uuid=portfolio_uuid,
+                        file_mappings=file_mappings
+                    )
+
+                    # 同步到 MySQL MParam
+                    self._sync_params_from_nodes(
+                        portfolio_uuid=portfolio_uuid,
+                        node_params=node_params
+                    )
+                except Exception:
+                    self._delete_graph_from_mongo(mongo_id)
+                    raise
 
             GLOG.INFO(f"从图编辑器创建配置: {portfolio_uuid} ({mongo_id})")
             GLOG.DEBUG(f"  同步了 {len(file_mappings)} 个文件映射")

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -357,4 +357,8 @@ class DeploymentService(BaseService):
             portfolio_uuid=target_portfolio_id,
             graph_data=graph_result.data,
             name=f"deploy_{target_portfolio_id[:8]}",
+            # #6279: MySQL 映射已由 _deploy_core step5 从源组合权威复制（全类型+原始参数）。
+            # 此处仅搬运 Mongo 图供 UI，绝不能按（经 CLI bind-component 绑定时可能不完整的）
+            # 源图删除已建的 strategy/sizer 映射，否则 paper 组合装配 Strategies:0。
+            sync_mysql=False,
         )

--- a/tests/unit/services/test_portfolio_mapping_service_deploy_sync.py
+++ b/tests/unit/services/test_portfolio_mapping_service_deploy_sync.py
@@ -1,0 +1,102 @@
+# Related: #6279
+# deploy 克隆丢组件绑定根因: _copy_graph 调 create_from_graph_editor,
+# 其 _sync_mappings_from_files 会删除"图中不存在"的既有映射,
+# 而 CLI bind-component 绑定的 strategy/sizer 不在 Mongo 图里 → 被删 → paper Strategies:0。
+# 修复: create_from_graph_editor 增 sync_mysql 开关, deploy 图拷贝传 False (MySQL 已由 deploy step5 权威复制)。
+import sys
+from pathlib import Path
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock
+from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+
+
+def _make_svc():
+    mock_mapping = MagicMock()
+    mock_param = MagicMock()
+    mock_mongo = MagicMock()
+    mock_file = MagicMock()
+    svc = PortfolioMappingService(
+        mapping_crud=mock_mapping,
+        param_service=mock_param,
+        mongo_driver=mock_mongo,
+        file_service=mock_file,
+    )
+    return svc, mock_mapping, mock_param, mock_mongo, mock_file
+
+
+def _existing_mapping(file_id, type_value):
+    """构造一条已存在的 MySQL mapping (模拟 deploy step5 已复制的绑定)"""
+    m = MagicMock()
+    m.file_id = file_id
+    m.uuid = f"map_{file_id}"
+    m.type = type_value
+    m.name = file_id
+    return m
+
+
+class TestCreateFromGraphEditorSyncMysqlFlag:
+    """#6279: sync_mysql 开关控制是否回写 MySQL mapping/param"""
+
+    def test_sync_mysql_false_does_not_delete_mappings_absent_from_graph(self):
+        """sync_mysql=False 时, deploy step5 已建的映射(图外)不被图同步删除"""
+        svc, mock_mapping, mock_param, mock_mongo, _ = _make_svc()
+        # 目标组合已有 4 条映射 (selector/strategy/sizer/risk, deploy step5 权威复制)
+        mock_mapping.find_by_portfolio.return_value = [
+            _existing_mapping("f_selector", 4),
+            _existing_mapping("f_strategy", 6),
+            _existing_mapping("f_sizer", 5),
+            _existing_mapping("f_risk", 3),
+        ]
+        # 源 Mongo 图只有 selector+risk 两节点 (CLI 绑定的 strategy/sizer 不在图)
+        graph_data = {
+            "nodes": [
+                {"id": "n1", "type": "SELECTOR", "data": {"file_id": "f_selector"}},
+                {"id": "n2", "type": "RISKMANAGER", "data": {"file_id": "f_risk"}},
+            ],
+            "edges": [],
+        }
+        mock_mongo.get_collection.return_value.update_one.return_value = MagicMock()
+
+        svc.create_from_graph_editor(
+            portfolio_uuid="target_pid",
+            graph_data=graph_data,
+            name="deploy_target",
+            sync_mysql=False,
+        )
+
+        # 关键断言: 图外的 strategy/sizer 映射绝不被删除 (否则 paper Strategies:0)
+        mock_mapping.delete_mapping.assert_not_called()
+        # sync_mysql=False 时连参数删除都不该触发
+        mock_param.remove_by_mapping.assert_not_called()
+
+    def test_sync_mysql_true_default_still_deletes_absent_mappings(self):
+        """sync_mysql=True (默认, 图编辑器语义) 仍删除图外映射 — 不破坏既有行为"""
+        svc, mock_mapping, mock_param, mock_mongo, _ = _make_svc()
+        mock_mapping.find_by_portfolio.return_value = [
+            _existing_mapping("f_keep", 4),
+            _existing_mapping("f_orphan", 6),  # 图里没有 → 应删
+        ]
+        graph_data = {
+            "nodes": [
+                {"id": "n1", "type": "SELECTOR", "data": {"file_id": "f_keep"}},
+            ],
+            "edges": [],
+        }
+        mock_mongo.get_collection.return_value.update_one.return_value = MagicMock()
+
+        svc.create_from_graph_editor(
+            portfolio_uuid="p1",
+            graph_data=graph_data,
+            name="edited",
+            # 不传 sync_mysql → 默认 True
+        )
+
+        # 图编辑器语义: 孤立映射应被删
+        mock_mapping.delete_mapping.assert_called_once()
+        args, _ = mock_mapping.delete_mapping.call_args
+        assert args[1] == "f_orphan", f"应删除图外映射 f_orphan, 实删 {args}"

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -177,3 +177,88 @@ class TestDeploymentServiceErrorMessages:
         assert not result.success
         # service error 不应有 "部署失败:" 前缀（CLI 层加）
         assert not result.error.startswith("部署失败:")
+
+
+class TestDeploymentCloneKeepsAllBindings:
+    """#6279: deploy 克隆必须保留全部组件绑定 (strategy/sizer 不被图同步删除)"""
+
+    def _source_mappings(self):
+        """4 类组件源映射 (selector/strategy/sizer/risk), 模拟 CLI bind-component 绑定"""
+        return [
+            {"uuid": "src_map_sel", "file_id": "f_sel", "type": 4, "name": "selector", "params": {}},
+            {"uuid": "src_map_str", "file_id": "f_str", "type": 6, "name": "strategy", "params": {}},
+            {"uuid": "src_map_siz", "file_id": "f_siz", "type": 5, "name": "sizer", "params": {}},
+            {"uuid": "src_map_rsk", "file_id": "f_rsk", "type": 3, "name": "risk", "params": {}},
+        ]
+
+    def test_deploy_copies_all_four_mapping_types(self):
+        """#6279 _deploy_core 必须对 4 类源映射各调一次 add_file + _copy_params_raw,
+        而非只复制 risk/selector。"""
+        svc = _make_svc()
+        svc._mapping_service.get_portfolio_mappings.return_value = MagicMock(
+            success=True, data=self._source_mappings()
+        )
+        svc._portfolio_service.add.return_value = MagicMock(success=True, data={"uuid": "new_pid"})
+        # add_file 每次返回新 mapping_id
+        svc._mapping_service.add_file.side_effect = [
+            MagicMock(success=True, data={"mapping_id": f"new_map_{i}"}) for i in range(4)
+        ]
+        # _copy_params_raw 依赖: 源每条映射 1 个 param
+        svc._param_crud.find_by_mapping_id.return_value = [MagicMock(index=0, value="v", source=0)]
+        svc._deployment_crud.modify.return_value = None
+        # 关闭图拷贝路径以便隔离测 mapping 循环 (图路径单独测)
+        svc._mongo_driver = None
+
+        result = svc._deploy_core(
+            source_portfolio_id="src_pid",
+            mode=PORTFOLIO_MODE_TYPES.PAPER,
+            account_id=None,
+            name="Paper",
+            portfolio_name="Src",
+            deployment_id="d1",
+        )
+
+        assert result.success, f"_deploy_core 应成功: {result.error}"
+        # 4 类组件必须各复制一次 (回归锚点: 旧 bug 只复制 risk/selector 2 类)
+        assert svc._mapping_service.add_file.call_count == 4, (
+            f"应复制全部 4 类映射, 实际 {svc._mapping_service.add_file.call_count}"
+        )
+        # 参数原始复制也要 4 次
+        assert svc._param_crud.add.call_count == 4
+
+    def test_deploy_copy_graph_uses_sync_mysql_false(self):
+        """#6279 图拷贝必须传 sync_mysql=False, 否则 create_from_graph_editor 会删掉
+        deploy step5 已建的 strategy/sizer 映射 (它们不在源 Mongo 图里)。"""
+        svc = _make_svc()
+        svc._mapping_service.get_portfolio_mappings.return_value = MagicMock(
+            success=True, data=self._source_mappings()
+        )
+        svc._portfolio_service.add.return_value = MagicMock(success=True, data={"uuid": "new_pid"})
+        svc._mapping_service.add_file.side_effect = [
+            MagicMock(success=True, data={"mapping_id": f"new_map_{i}"}) for i in range(4)
+        ]
+        svc._param_crud.find_by_mapping_id.return_value = []
+        svc._deployment_crud.modify.return_value = None
+        # 开启图拷贝路径
+        svc._mongo_driver = MagicMock()
+        svc._mapping_service.get_portfolio_graph.return_value = MagicMock(
+            success=True, data={"nodes": [], "edges": []}
+        )
+        svc._mapping_service.create_from_graph_editor.return_value = MagicMock(success=True)
+
+        result = svc._deploy_core(
+            source_portfolio_id="src_pid",
+            mode=PORTFOLIO_MODE_TYPES.PAPER,
+            account_id=None,
+            name="Paper",
+            portfolio_name="Src",
+            deployment_id="d1",
+        )
+
+        assert result.success, f"_deploy_core 应成功: {result.error}"
+        svc._mapping_service.create_from_graph_editor.assert_called_once()
+        _, kwargs = svc._mapping_service.create_from_graph_editor.call_args
+        assert kwargs.get("sync_mysql") is False, (
+            f"deploy 图拷贝必须 sync_mysql=False 以免覆盖 step5 映射, 实际 kwargs={kwargs}"
+        )
+


### PR DESCRIPTION
## 问题

`ginkgo deploy deploy --mode paper` 克隆源组合后，paper 组合装配 `Strategies: 0`，PaperTradingWorker 报 `CRITICAL No strategy found` 并 skip 整个组合。审计发现 deploy 只复制了 risk+selector，丢失 strategy+sizer。

详见 #6279 与审计报告 `docs/e2e-cli-flow-audit.md` Phase 3。

## 根因

双存储真相分裂：MySQL `portfolio_file_mapping` 是执行真相（worker/backtest 都读它），MongoDB graph 是 UI 可视化层。

- `_deploy_core` step5 循环正确复制全部 4 类源映射到目标 MySQL（权威拷贝）。
- 但 step6 `_copy_graph` → `create_from_graph_editor` → `_sync_mappings_from_files` 会按**源 Mongo 图**重同步：删除"图中不存在"的既有映射。
- 经 CLI `bind-component` 绑定的 strategy/sizer **不写 Mongo 图**（只写 MySQL），遂被当作"图外孤立映射"删除 → 目标组合只剩 risk+selector → `Strategies:0`。

执行链路（`collect_portfolio_components` → `file_mapping_crud.find` / `param_crud.find`）读 MySQL 非 Mongo 图，故 MySQL 是真相。

## 修复

`create_from_graph_editor` 增 `sync_mysql: bool = True` 开关：
- 默认 `True`：保留图编辑器"以图为权威删孤立映射"语义（未来 web-ui 图编辑器接入不破坏）。
- deploy 的 `_copy_graph` 传 `sync_mysql=False`：MySQL 映射已由 step5 权威复制，此处仅搬运 Mongo 文档供 UI，不再回写 MySQL，杜绝覆盖。

## 测试

- `test_portfolio_mapping_service_deploy_sync.py`：`sync_mysql=False` 不删图外映射、不删参数；默认 `True` 仍删孤立映射（图编辑器语义不破坏）。
- `test_deployment_service.py::TestDeploymentCloneKeepsAllBindings`：deploy 复制全 4 类映射（`add_file`×4 + `_copy_params_raw`×4）+ 图拷贝传 `sync_mysql=False`。

回归：unit/services + deploy unit 共 171 passed；1 集成测试失败为 master 预存在（需 DB 环境，stash 验证非本 PR 引入）。

## 已知局限（非本 PR 范围）

CLI 绑定的组合其 Mongo 图本就缺 strategy/sizer 节点（预存在的 MySQL/图不一致），故部署后目标 UI 图可能仍不完整。但执行链路读 MySQL，`Strategies` 计数正确。UI 图完整性是独立议题（需让 `bind-component` 同步图）。

Closes #6279
