### PR TITLE
fix: 组件系统 4 缺陷修复 (name 过滤/loader 映射/engine 类型/参数落库对齐)

### DIFF
--- a/api/api/components.py
+++ b/api/api/components.py
@@ -71,6 +71,7 @@ COMPONENT_FILE_TYPE_MAP = {
     "risk": FILE_TYPES.RISKMANAGER,
     "sizer": FILE_TYPES.SIZER,
     "selector": FILE_TYPES.SELECTOR,
+    "engine": FILE_TYPES.ENGINE,
 }
 
 FILE_TYPE_TO_COMPONENT_TYPE = {
@@ -79,6 +80,7 @@ FILE_TYPE_TO_COMPONENT_TYPE = {
     FILE_TYPES.RISKMANAGER.value: "risk",
     FILE_TYPES.SIZER.value: "sizer",
     FILE_TYPES.SELECTOR.value: "selector",
+    FILE_TYPES.ENGINE.value: "engine",
 }
 
 

--- a/api/api/components.py
+++ b/api/api/components.py
@@ -94,12 +94,21 @@ async def list_components(
     component_type: Optional[str] = None,
     is_active: Optional[bool] = None,
     keyword: Optional[str] = None,
+    name: Optional[str] = None,
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
 ):
-    """获取组件列表（服务端分页）"""
+    """获取组件列表（服务端分页）
+
+    name 与 keyword 同义：均下推到 service 层做 name__like 过滤。
+    提供 name 是为了让 ?name=xxx（前端常用）与 ?keyword=xxx 行为一致，
+    不再被 FastAPI 当未知 query 参数静默丢弃（#5880 缺陷2）。
+    """
     try:
         file_service = get_file_service()
+
+        # name 作为 keyword 的别名（前端发 ?name=，CLI/内部发 ?keyword=）
+        effective_keyword = name if name else keyword
 
         # 构建类型列表
         if component_type:
@@ -115,7 +124,7 @@ async def list_components(
         # 调用 service 层分页查询
         result = file_service.list_components(
             file_types=types_to_check,
-            keyword=keyword,
+            keyword=effective_keyword,
             is_del=False if is_active else (not is_active if is_active is not None else False),
             page=page - 1,
             page_size=page_size,

--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -691,25 +691,35 @@ class PortfolioMappingService(BaseService):
         mapping_uuid: str,
         params: Dict[str, Any],
     ) -> None:
-        """同步参数到指定的 mapping"""
+        """同步参数到指定的 mapping（落库格式与 CLI create_component_parameters 对齐）
+
+        value 序列化：字符串原样存（对齐 CLI 原样 str），非字符串才 json.dumps，
+        这样读端 json.loads+fallback（component_loader 约定）能正确还原类型。
+        原实现一律 json.dumps，字符串 value 会多一层引号，与 CLI 同值产出类型分歧。
+        """
         # 将参数字典转换为扁平列表
         param_list = []
         for key, value in params.items():
-            try:
-                value_str = json.dumps(value, ensure_ascii=False)
-            except Exception as e:
-                GLOG.ERROR(f"序列化参数值失败: {e}")
-                value_str = str(value)
+            if isinstance(value, str):
+                value_str = value
+            else:
+                try:
+                    value_str = json.dumps(value, ensure_ascii=False)
+                except Exception as e:
+                    GLOG.ERROR(f"序列化参数值失败: {e}")
+                    value_str = str(value)
             param_list.append({"key": key, "value": value_str})
 
         # 删除旧参数
         self._param_service.remove_by_mapping(mapping_uuid)
 
-        # 添加新参数
-        for idx, param in enumerate(param_list):
+        # 添加新参数：index 取自 params 的 key（逻辑位置），与 CLI
+        # create_component_parameters 的 MParam(index=key) 对齐；enumerate 顺序位
+        # 会在 key 跳号时丢失逻辑位置（#5880 缺陷5）。
+        for param in param_list:
             self._param_service.add_param(
                 mapping_id=mapping_uuid,
-                index=idx,
+                index=int(param["key"]),
                 value=param["value"],
                 source=SOURCE_TYPES.SIM,
             )

--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -14,6 +14,21 @@ import json
 from typing import Dict, Any, List
 from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.trading.portfolios import PortfolioT1Backtest
+from ginkgo.enums import FILE_TYPES
+
+
+# 源码回退导入映射：动态加载失败时，按组件类型从对应源码包回退导入。
+# key 必须用 FILE_TYPES 的 .value（int），与传入的 component_type(int) 比较一致。
+# NOTE: ENGINE(=7) 不在此映射 —— engine 是内置回测/实盘引擎，非用户上传 .py 组件，
+# 无需源码回退。原实现 key 7 错指 risk_managements（7=ENGINE 却映射到 risk），
+# 已修正为 key 3（RISKMANAGER）—— 见 #5880 缺陷4a。
+SOURCE_FALLBACK_IMPORT_MAP = {
+    FILE_TYPES.STRATEGY.value: ("ginkgo.trading.strategies", "strategies"),
+    FILE_TYPES.SELECTOR.value: ("ginkgo.trading.selectors", "selectors"),
+    FILE_TYPES.SIZER.value: ("ginkgo.trading.sizers", "sizers"),
+    FILE_TYPES.RISKMANAGER.value: ("ginkgo.trading.risk_managements", "risk_managements"),
+    FILE_TYPES.ANALYZER.value: ("ginkgo.trading.analysis.analyzers", "analyzers"),
+}
 
 
 def resolve_param_kwargs(
@@ -345,13 +360,7 @@ class ComponentLoader:
                         else:
                             return None, f"Failed to get file info for fallback: {file_result.error}"
 
-                        source_import_map = {
-                            6: ("ginkgo.trading.strategies", "strategies"),
-                            4: ("ginkgo.trading.selectors", "selectors"),
-                            5: ("ginkgo.trading.sizers", "sizers"),
-                            7: ("ginkgo.trading.risk_managements", "risk_managements"),
-                            1: ("ginkgo.trading.analysis.analyzers", "analyzers"),
-                        }
+                        source_import_map = SOURCE_FALLBACK_IMPORT_MAP
 
                         if component_type not in source_import_map:
                             return None, f"No source fallback for component type {component_type}"

--- a/tests/api/test_components_engine_type.py
+++ b/tests/api/test_components_engine_type.py
@@ -1,0 +1,51 @@
+# Issue #5880 缺陷4b: GET /components/?component_type=engine 返回 0 / 抛 400
+# Upstream: api.api.components.COMPONENT_FILE_TYPE_MAP / FILE_TYPE_TO_COMPONENT_TYPE
+# Downstream: list_components 的 component_type 校验 + types_to_check 构建
+# Role: engine 是 file-based 组件（file_crud 支持 ENGINE），API 类型映射应覆盖 engine，
+#       否则 ?component_type=engine 命中 400 Invalid component type。
+#       注意缺陷4a 已修正 loader 源码回退映射，此处是 API 层的类型字典。
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(total=0):
+    result = MagicMock()
+    result.is_success.return_value = True
+    result.data = {"data": [], "total": total}
+    return result
+
+
+class TestComponentsEngineType:
+    """缺陷4b: engine 类型在 API 类型映射中可用"""
+
+    def test_engine_in_component_file_type_map(self):
+        from api.components import COMPONENT_FILE_TYPE_MAP
+        from ginkgo.enums import FILE_TYPES
+
+        assert "engine" in COMPONENT_FILE_TYPE_MAP
+        assert COMPONENT_FILE_TYPE_MAP["engine"] == FILE_TYPES.ENGINE
+
+    def test_engine_reverse_mapping(self):
+        from api.components import FILE_TYPE_TO_COMPONENT_TYPE
+        from ginkgo.enums import FILE_TYPES
+
+        assert FILE_TYPE_TO_COMPONENT_TYPE[FILE_TYPES.ENGINE.value] == "engine"
+
+    def test_list_components_engine_not_400(self):
+        """?component_type=engine 不再抛 400，且 ENGINE 被加入 types_to_check 下推 service"""
+        mock_service = MagicMock()
+        mock_service.list_components.return_value = make_mock_result(total=0)
+
+        from api.components import list_components
+        from ginkgo.enums import FILE_TYPES
+
+        with patch("api.components.get_file_service", return_value=mock_service):
+            result = run_async(list_components(component_type="engine", page=1, page_size=20))
+
+        call_kwargs = mock_service.list_components.call_args.kwargs
+        assert FILE_TYPES.ENGINE in call_kwargs.get("file_types", [])

--- a/tests/api/test_components_name_filter.py
+++ b/tests/api/test_components_name_filter.py
@@ -1,0 +1,36 @@
+# Issue #5880 缺陷2: GET /components/?name=xxx 名称过滤失效
+# Upstream: api.api.components.list_components
+# Downstream: FileService.list_components(keyword=...) -> filters["name__like"]
+# Role: ?name=xxx 应作为 keyword 下推到 service 层做 name__like 过滤，
+#       而非被 FastAPI 当未知 query 参数静默丢弃
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(total=0):
+    result = MagicMock()
+    result.is_success.return_value = True
+    result.data = {"data": [], "total": total}
+    return result
+
+
+class TestComponentsNameFilter:
+    """缺陷2: GET /components/?name=xxx 名称过滤"""
+
+    def test_name_param_passed_as_keyword_to_service(self):
+        """?name=moving_average 应作为 keyword 传给 service（复用 name__like 过滤）"""
+        mock_service = MagicMock()
+        mock_service.list_components.return_value = make_mock_result(total=0)
+
+        from api.components import list_components
+
+        with patch("api.components.get_file_service", return_value=mock_service):
+            run_async(list_components(name="moving_average", page=1, page_size=20))
+
+        call_kwargs = mock_service.list_components.call_args.kwargs
+        assert call_kwargs.get("keyword") == "moving_average"

--- a/tests/unit/data/services/test_portfolio_mapping_params_sync.py
+++ b/tests/unit/data/services/test_portfolio_mapping_params_sync.py
@@ -1,0 +1,74 @@
+# Issue #5880 缺陷5: API 绑参数落库与 CLI 不一致
+# Upstream: ginkgo.data.services.portfolio_mapping_service._sync_params_for_mapping
+# Downstream: ParamService.add_param -> MParam(index=..., value=...)
+# Role: API 写入的参数必须与 CLI create_component_parameters 产出相同的 MParam 格式，
+#       即用 params 的 key（逻辑位置索引）作 index，而非 enumerate 顺序位。
+#       原 bug: _sync_params_for_mapping 用 enumerate(param_list) 的 idx 作 index，
+#       当 key 非连续（如 {"0":..,"2":..}）时丢失逻辑位置，回测/读端取到错位参数。
+# 对齐基准: mapping_service.create_component_parameters 用 MParam(index=key, value=value)。
+
+from unittest.mock import MagicMock
+
+from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+
+
+def _make_svc():
+    mock_mapping = MagicMock()
+    mock_param = MagicMock()
+    mock_mongo = MagicMock()
+    mock_file = MagicMock()
+    svc = PortfolioMappingService(
+        mapping_crud=mock_mapping,
+        param_service=mock_param,
+        mongo_driver=mock_mongo,
+        file_service=mock_file,
+    )
+    return svc, mock_param
+
+
+class TestSyncParamsIndexFromKey:
+    """缺陷5: index 必须取自 params 的 key（逻辑位置），与 CLI 对齐"""
+
+    def test_non_sequential_keys_preserve_logical_index(self):
+        """key 跳号时（{"0":..,"2":..}）index 应为 0 和 2，而非 enumerate 的 0 和 1"""
+        svc, mock_param = _make_svc()
+
+        svc._sync_params_for_mapping(
+            mapping_uuid="map-1",
+            params={"0": "a", "2": "c"},
+        )
+
+        indices = sorted(call.kwargs["index"] for call in mock_param.add_param.call_args_list)
+        assert indices == [0, 2], f"逻辑 index 应保留 key（0,2），实际 {indices}"
+
+
+class TestSyncParamsValueRawString:
+    """缺陷5: 字符串 value 原样存，不双重 json.dumps（对齐 CLI 原样 str）
+
+    CLI create_component_parameters 存原始 str（如 "0.5"、"StrategyName"），
+    读端 json.loads+fallback 反解。API 若再 json.dumps 字符串会得到 '"0.5"'（带引号），
+    读端 json.loads 出来是 str 而非 number，与 CLI 同值产出类型分歧。
+    """
+
+    def test_string_value_stored_raw_not_double_quoted(self):
+        svc, mock_param = _make_svc()
+
+        svc._sync_params_for_mapping(
+            mapping_uuid="map-1",
+            params={"0": "0.5"},
+        )
+
+        value = mock_param.add_param.call_args.kwargs["value"]
+        assert value == "0.5", f"字符串 value 应原样存，实际 {value!r}"
+
+    def test_number_value_json_encoded_for_round_trip(self):
+        """非字符串（number）经 json.dumps 存，读端 json.loads 还原为 number"""
+        svc, mock_param = _make_svc()
+
+        svc._sync_params_for_mapping(
+            mapping_uuid="map-1",
+            params={"1": 0.3},
+        )
+
+        value = mock_param.add_param.call_args.kwargs["value"]
+        assert value == "0.3", f"number 应 json.dumps 成字符串供往返还原，实际 {value!r}"

--- a/tests/unit/trading/services/test_component_loader_source_fallback.py
+++ b/tests/unit/trading/services/test_component_loader_source_fallback.py
@@ -1,0 +1,47 @@
+# Issue #5880 缺陷4a: component_loader source_import_map 类型映射错位
+# Upstream: ginkgo.trading.services._assembly.component_loader.SOURCE_FALLBACK_IMPORT_MAP
+# Downstream: _instantiate_component_from_file 的源码回退分支
+# Role: 动态加载失败时，按组件类型从正确的源码包回退导入。
+#       原 bug: key 7(=ENGINE) 映射到 risk_managements，而 RISKMANAGER=3 缺失，
+#       导致 risk 组件 fallback 错导入 engine 包路径、risk 类型无回退。
+
+from ginkgo.trading.services._assembly.component_loader import (
+    SOURCE_FALLBACK_IMPORT_MAP,
+)
+from ginkgo.enums import FILE_TYPES
+
+
+class TestSourceFallbackImportMap:
+    """缺陷4a: 源码回退类型映射正确性"""
+
+    def test_riskmanager_fallback_maps_to_risk_managements_package(self):
+        """RISKMANAGER(=3) 源码回退应从 ginkgo.trading.risk_managements 导入"""
+        assert FILE_TYPES.RISKMANAGER.value in SOURCE_FALLBACK_IMPORT_MAP
+        assert SOURCE_FALLBACK_IMPORT_MAP[FILE_TYPES.RISKMANAGER.value] == (
+            "ginkgo.trading.risk_managements",
+            "risk_managements",
+        )
+
+    def test_engine_not_misassigned_to_risk_managements(self):
+        """ENGINE(=7) 不应映射到 risk_managements（原 bug: key 7 错指 risk）"""
+        # engine 是内置回测/实盘引擎，非用户上传 .py 组件，不应有源码回退条目
+        assert FILE_TYPES.ENGINE.value not in SOURCE_FALLBACK_IMPORT_MAP
+
+    def test_strategy_selector_sizer_analyzer_mappings_intact(self):
+        """其余类型映射保持不变（回归保护）"""
+        assert SOURCE_FALLBACK_IMPORT_MAP[FILE_TYPES.STRATEGY.value] == (
+            "ginkgo.trading.strategies",
+            "strategies",
+        )
+        assert SOURCE_FALLBACK_IMPORT_MAP[FILE_TYPES.SELECTOR.value] == (
+            "ginkgo.trading.selectors",
+            "selectors",
+        )
+        assert SOURCE_FALLBACK_IMPORT_MAP[FILE_TYPES.SIZER.value] == (
+            "ginkgo.trading.sizers",
+            "sizers",
+        )
+        assert SOURCE_FALLBACK_IMPORT_MAP[FILE_TYPES.ANALYZER.value] == (
+            "ginkgo.trading.analysis.analyzers",
+            "analyzers",
+        )


### PR DESCRIPTION
## Summary

修复 #5880 的 4 个组件系统缺陷（缺陷3 由并行 PR#6247 覆盖，本 PR 不重叠）：

- **缺陷2 — `GET /components/?name=` 名称过滤失效**：`list_components` 加 `name` 参数作 `keyword` 别名下推 service 层，不再被 FastAPI 当未知 query 静默丢弃。
- **缺陷4a — loader 源码回退类型映射错位**：`_instantiate_component_from_file` 的 fallback 映射 key `7`(ENGINE) 错指 `risk_managements`，而 `RISKMANAGER=3` 缺失。抽成可测常量 `SOURCE_FALLBACK_IMPORT_MAP` 并修正。
- **缺陷4b — `?component_type=engine` 抛 400**：`COMPONENT_FILE_TYPE_MAP` / `FILE_TYPE_TO_COMPONENT_TYPE` 补 engine（engine 是 file-based 组件，file_crud 支持）。
- **缺陷5 — API 绑参数落库与 CLI 不一致**：`_sync_params_for_mapping` 改用 params 的 key 作 index（逻辑位置，对齐 `create_component_parameters` 的 `MParam(index=key)`），字符串 value 原样存而非 `json.dumps` 双重引号，读端 `json.loads+fallback` 往返一致。

## Test plan

- [x] `tests/api/test_components_name_filter.py` — name 作为 keyword 下推
- [x] `tests/api/test_components_engine_type.py` — engine 类型映射 + `?component_type=engine` 不再 400
- [x] `tests/unit/trading/services/test_component_loader_source_fallback.py` — RISKMANAGER 回退映射、其余不变
- [x] `tests/unit/data/services/test_portfolio_mapping_params_sync.py` — index 取自 key、字符串 value 原样、number 往返
- [x] 既有 smoke + mapping crud 回归 26 passed
- [x] api 与 unit 分开跑（混跑触发已知 core.logging namespace 污染，非回归）
- [x] 全部模块 import 冒烟通过

## Notes

- 缺陷1（#5880 第1点）此前已由他处修复，本 PR 不重复。
- 缺陷3（参数端点）由并行开放的 PR#6247 处理，本 PR 未触碰相关端点以避免冲突。

Closes #5880
