### PR TITLE
fix(#6073): deploy 检查 live_account_id 回写返回值，失败终止部署

### DIFF
--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -150,11 +150,15 @@ class DeploymentService(BaseService):
         GLOG.INFO(f"创建新Portfolio: {new_portfolio_id} (mode={mode.value})")
 
         # 5c. Live模式: 回写 live_account_id 到 Portfolio
+        # #6073: 检查 update 返回值，失败时终止部署（否则 live_account_id 未写入但部署仍标记成功）
         if mode == PORTFOLIO_MODE_TYPES.LIVE and account_id:
-            self._portfolio_service.update(
+            update_result = self._portfolio_service.update(
                 portfolio_id=new_portfolio_id,
                 live_account_id=account_id,
             )
+            if not update_result.success:
+                GLOG.ERROR(f"回写 live_account_id 失败: {update_result.error}")
+                raise RuntimeError(f"回写 live_account_id 失败: {update_result.error}")
 
         # 5. 引用组件: Mapping(新建, 引用源file_id) + Param(原始值复制)
         for mapping in mappings:

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -110,6 +110,55 @@ class TestDeploymentServiceDeploy:
         svc._deployment_crud.add.assert_called_once()
         svc._deploy_core.assert_called_once()
 
+    def test_deploy_live_fails_when_account_update_fails(self):
+        """#6073 LIVE 部署回写 live_account_id 失败时 deploy 应返回 error，不应静默成功。
+
+        根因: _deploy_core step5c 调 portfolio_service.update 后丢弃返回值，
+        update 失败时 live_account_id 未写入但部署仍标记成功，portfolio 与 account 关联丢失。
+        """
+        svc = _make_svc()
+        source = MagicMock()
+        source.name = "Src"
+        source.initial_capital = 100000
+        svc._portfolio_service.get.return_value = MagicMock(success=True, data=[source])
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        svc._broker_instance_crud.get_broker_by_live_account.return_value = []  # 无冲突
+        # _deploy_core 依赖
+        svc._mapping_service.get_portfolio_mappings.return_value = MagicMock(success=True, data=[])
+        svc._portfolio_service.add.return_value = MagicMock(success=True, data={"uuid": "new_pid"})
+        # 关键: 回写 live_account_id 失败
+        svc._portfolio_service.update.return_value = MagicMock(success=False, error="update failed")
+        svc._deployment_crud.modify.return_value = None
+
+        result = svc.deploy(portfolio_id="src", mode=PORTFOLIO_MODE_TYPES.LIVE, account_id="acc-1")
+
+        # 失败时 deploy 必须返回 error，不得静默成功
+        assert not result.success, f"update 失败时 deploy 不应静默成功: {result.error}"
+        # 行为断言: update 被调用且传了 live_account_id
+        svc._portfolio_service.update.assert_called_once()
+        _, kwargs = svc._portfolio_service.update.call_args
+        assert kwargs.get("live_account_id") == "acc-1"
+
+    def test_deploy_live_succeeds_when_account_update_succeeds(self):
+        """#6073 回归保护: update 成功时 LIVE 部署应正常完成，不得因检查逻辑误伤 happy path。"""
+        svc = _make_svc()
+        source = MagicMock()
+        source.name = "Src"
+        source.initial_capital = 100000
+        svc._portfolio_service.get.return_value = MagicMock(success=True, data=[source])
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        svc._broker_instance_crud.get_broker_by_live_account.return_value = []
+        svc._mapping_service.get_portfolio_mappings.return_value = MagicMock(success=True, data=[])
+        svc._portfolio_service.add.return_value = MagicMock(success=True, data={"uuid": "new_pid"})
+        # update 成功
+        svc._portfolio_service.update.return_value = MagicMock(success=True)
+        svc._broker_instance_crud.add_broker_instance.return_value = MagicMock(success=True)
+        svc._deployment_crud.modify.return_value = None
+
+        result = svc.deploy(portfolio_id="src", mode=PORTFOLIO_MODE_TYPES.LIVE, account_id="acc-1")
+
+        assert result.success, f"update 成功时 LIVE 部署应成功: {result.error}"
+
 
 class TestDeploymentServiceErrorMessages:
     """#5327 错误信息不应重复"""


### PR DESCRIPTION
## Summary

修复 #6073：`deployment_service._deploy_core` step5c 回写 `live_account_id` 后丢弃 `portfolio_service.update` 返回值。

**根因**：`_deploy_core` step5c（LIVE 模式）调用 `self._portfolio_service.update(portfolio_id, live_account_id=account_id)` 后不检查返回值。update 静默失败时，`live_account_id` 未写入 Portfolio，但部署流程继续创建 broker instance（step7）并标记 deployment DEPLOYED（step8），最终返回成功——留下一个"看似部署成功但 account 关联丢失"的 LIVE portfolio，实盘链路断。

对比同函数 step5（建组合，line 147 `raise RuntimeError`）与 step7（建 broker，line 209 `raise RuntimeError`）都检查并 raise，唯独 step5c 漏检。

**修复**：捕获 `update` 返回值，失败时 `GLOG.ERROR` 记录 + `raise RuntimeError`（与 step5/step7 一致）。`deploy` 公共方法已有的 try/except 包装层会捕获该异常、标记 deployment FAILED 并返回 `ServiceResult.error`。

## Test plan

- [x] `test_deploy_live_fails_when_account_update_fails`：mock update 返回失败，断言 deploy 返回 error（非静默成功）且 update 被调用时带了 `live_account_id`
- [x] `test_deploy_live_succeeds_when_account_update_succeeds`：happy path 回归保护，update 成功时 LIVE 部署正常完成
- [x] `tests/unit/trading/services/test_deployment_service.py` 全 8 测试通过（6 旧 + 2 新），无回归
- [x] 导入检查通过（编辑后无语法错误）

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/trading/services/test_deployment_service.py -o addopts= -q
# 8 passed
```

Closes #6073
