### PR TITLE
fix(#5809, #5821): node_graph 三 stub 端点实现 (DELETE/duplicate/from-backtest)

### DIFF
--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -221,14 +221,17 @@ async def delete_node_graph(
     graph_uuid: str,
 ):
     """
-    删除节点图
+    删除节点图（清空图配置：删 Mongo 图文档 + engine_portfolio_mapping 行 + 关联 MParam）
+    注：仅删图配置层，不删 Portfolio 实体本身。
     """
     try:
-        # TODO: 实现删除逻辑
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Delete operation not yet implemented"
-        )
+        service = get_portfolio_mapping_service()
+        result = service.delete_graph(graph_uuid)
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=result.error or "Failed to delete node graph"
+            )
     except HTTPException:
         raise
     except Exception as e:
@@ -245,14 +248,17 @@ async def duplicate_node_graph(
     name: str,
 ):
     """
-    复制节点图
+    复制节点图（读源图 → 以新 portfolio_uuid 写入图配置副本）
     """
     try:
-        # TODO: 实现复制逻辑
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Duplicate operation not yet implemented"
-        )
+        service = get_portfolio_mapping_service()
+        result = service.duplicate_graph(graph_uuid, name=name)
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=result.error or "Failed to duplicate node graph"
+            )
+        return ok(data=result.data, message="Graph duplicated successfully")
     except HTTPException:
         raise
     except Exception as e:
@@ -359,14 +365,40 @@ async def create_from_backtest(
     backtest_uuid: str,
 ):
     """
-    从回测配置创建节点图
+    从回测配置读取节点图（查回测 → 取 portfolio_id → 返回该组合的现有图）
+    语义：返回现有图，不创建新图（与 duplicate 区分）。
     """
     try:
-        # TODO: 实现反向编译逻辑
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Not implemented yet"
-        )
+        from ginkgo.data.containers import container
+
+        bt_service = container.backtest_task_service()
+        bt_result = bt_service.get_by_id(backtest_uuid)
+        if not bt_result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Backtest {backtest_uuid} not found"
+            )
+        portfolio_id = getattr(bt_result.data, "portfolio_id", "") or ""
+        if not portfolio_id:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Backtest {backtest_uuid} has no portfolio_id"
+            )
+
+        mapping_service = get_portfolio_mapping_service()
+        graph_result = mapping_service.get_portfolio_graph(portfolio_id)
+        if not graph_result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Node graph for backtest {backtest_uuid} (portfolio {portfolio_id}) not found"
+            )
+
+        return ok(data={
+            "backtest_uuid": backtest_uuid,
+            "portfolio_uuid": portfolio_id,
+            "graph_data": graph_result.data.get("graph_data", {}),
+            "metadata": graph_result.data.get("metadata", {}),
+        })
     except HTTPException:
         raise
     except Exception as e:

--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -323,6 +323,109 @@ class PortfolioMappingService(BaseService):
             GLOG.ERROR(f"移除文件失败: {e}")
             return ServiceResult.error(f"移除文件失败: {str(e)}")
 
+    @retry
+    def delete_graph(
+        self,
+        portfolio_uuid: str,
+    ) -> ServiceResult:
+        """
+        删除投资组合的图配置（保留 portfolio 本身）
+
+        流程：
+        1. 删除该 portfolio 全部 Mapping 及其 MParam
+        2. 删除 MongoDB 中的图文档
+
+        与 remove_file 的删除范式一致（find_by_portfolio → remove_by_mapping
+        → delete_mapping），只是范围从单个 file 扩展到全部。
+
+        Args:
+            portfolio_uuid: 投资组合 UUID（即 graph_uuid）
+
+        Returns:
+            ServiceResult: 包含 portfolio_uuid 与已删除 mapping 数
+        """
+        try:
+            # 1. 删除全部 mapping 及其参数
+            mappings = self._mapping_crud.find_by_portfolio(portfolio_uuid)
+            for mapping in mappings:
+                self._param_service.remove_by_mapping(mapping.uuid)
+                self._mapping_crud.delete_mapping(portfolio_uuid, mapping.file_id)
+
+            # 2. 删除 MongoDB 图文档
+            collection = self._mongo_driver.get_collection("portfolio_graph_data")
+            collection.delete_many({"portfolio_uuid": portfolio_uuid})
+
+            GLOG.INFO(f"删除图配置: {portfolio_uuid} (mappings={len(mappings)})")
+
+            return ServiceResult.success(data={
+                "portfolio_uuid": portfolio_uuid,
+                "deleted_mappings": len(mappings),
+            })
+
+        except Exception as e:
+            GLOG.ERROR(f"删除图配置失败: {e}")
+            return ServiceResult.error(f"删除图配置失败: {str(e)}")
+
+    @retry
+    def duplicate_graph(
+        self,
+        source_uuid: str,
+        name: Optional[str] = None,
+    ) -> ServiceResult:
+        """
+        复制图配置到新的 portfolio_uuid
+
+        流程：
+        1. 读取源图 (get_portfolio_graph)
+        2. 生成新 portfolio_uuid
+        3. 以新 uuid 调 create_from_graph_editor 写入图 + mapping + param
+
+        注：仅复制图配置层（mongo + mapping + param），不创建 Portfolio 实体
+        （create_from_graph_editor 本身不要求 Portfolio 行存在，行为一致）。
+
+        Args:
+            source_uuid: 源投资组合 UUID（即源 graph_uuid）
+            name: 副本名称，缺省时自动生成
+
+        Returns:
+            ServiceResult: 包含 source_uuid / new_portfolio_uuid / mongo_id
+        """
+        try:
+            # 1. 读源图
+            read_result = self.get_portfolio_graph(source_uuid)
+            if not read_result.is_success():
+                return ServiceResult.error(
+                    f"源图不存在: {source_uuid} ({read_result.error})"
+                )
+            graph_data = read_result.data.get("graph_data", {})
+
+            # 2. 生成新 uuid 并创建副本
+            new_uuid = uuid.uuid4().hex
+            new_name = name or f"Copy of {source_uuid[:8]}"
+
+            create_result = self.create_from_graph_editor(
+                portfolio_uuid=new_uuid,
+                graph_data=graph_data,
+                name=new_name,
+            )
+            if not create_result.is_success():
+                return ServiceResult.error(
+                    create_result.error or "复制图配置失败"
+                )
+
+            GLOG.INFO(f"复制图配置: {source_uuid} -> {new_uuid}")
+
+            return ServiceResult.success(data={
+                "source_uuid": source_uuid,
+                "new_portfolio_uuid": new_uuid,
+                "mongo_id": create_result.data.get("mongo_id"),
+                "mappings_count": create_result.data.get("mappings_count", 0),
+            })
+
+        except Exception as e:
+            GLOG.ERROR(f"复制图配置失败: {e}")
+            return ServiceResult.error(f"复制图配置失败: {str(e)}")
+
     # ==================== 查询方法 ====================
 
     def get_portfolio_graph(

--- a/tests/api/test_node_graph_lifecycle.py
+++ b/tests/api/test_node_graph_lifecycle.py
@@ -1,0 +1,160 @@
+"""
+#5809 #5821 — node_graph 三端点（DELETE / duplicate / from-backtest）去 501 验证
+
+验证端点正确委托到 PortfolioMappingService / BacktestTaskService，
+不再返回 501。风格对齐 tests/api/test_portfolio_create_mode.py
+（直接 await async 端点 + mock，函数内 import 规避 api/ sys.path 时机）。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+class TestDeleteNodeGraph:
+    """DELETE /{graph_uuid} → service.delete_graph"""
+
+    @pytest.mark.asyncio
+    async def test_success_calls_service_and_returns_none(self):
+        """成功时委托 delete_graph，204 路径无 body（函数无 return）"""
+        from api.node_graph import delete_node_graph
+
+        mock_svc = MagicMock()
+        mock_svc.delete_graph.return_value = ServiceResult.success(
+            data={"deleted_mappings": 2}
+        )
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            result = await delete_node_graph("graph-1")
+
+        mock_svc.delete_graph.assert_called_once_with("graph-1")
+        assert result is None  # 204 No Content，无返回体
+
+    @pytest.mark.asyncio
+    async def test_failure_raises_400(self):
+        """服务失败抛 400（不再 501）"""
+        from api.node_graph import delete_node_graph
+
+        mock_svc = MagicMock()
+        mock_svc.delete_graph.return_value = ServiceResult.error("boom")
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                await delete_node_graph("graph-1")
+
+        assert exc.value.status_code == 400
+        assert "boom" in exc.value.detail
+
+
+class TestDuplicateNodeGraph:
+    """POST /{graph_uuid}/duplicate → service.duplicate_graph"""
+
+    @pytest.mark.asyncio
+    async def test_success_passes_name_and_returns_new_uuid(self):
+        from api.node_graph import duplicate_node_graph
+
+        mock_svc = MagicMock()
+        mock_svc.duplicate_graph.return_value = ServiceResult.success(data={
+            "new_portfolio_uuid": "new-1",
+            "source_uuid": "src-1",
+        })
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            result = await duplicate_node_graph("src-1", name="copy")
+
+        mock_svc.duplicate_graph.assert_called_once_with("src-1", name="copy")
+        assert isinstance(result, dict)
+        assert result["data"]["new_portfolio_uuid"] == "new-1"
+
+    @pytest.mark.asyncio
+    async def test_failure_raises_400(self):
+        """源图不存在抛 400（不再 501）"""
+        from api.node_graph import duplicate_node_graph
+
+        mock_svc = MagicMock()
+        mock_svc.duplicate_graph.return_value = ServiceResult.error("source missing")
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                await duplicate_node_graph("src-1", name="copy")
+
+        assert exc.value.status_code == 400
+
+
+class TestCreateFromBacktest:
+    """POST /from-backtest/{backtest_uuid} → backtest.portfolio_id → 现有图"""
+
+    @pytest.mark.asyncio
+    async def test_returns_existing_graph_for_backtest_portfolio(self):
+        """查回测拿 portfolio_id，返回该组合的现有图（不创建新图）"""
+        from api.node_graph import create_from_backtest
+
+        mock_bt_svc = MagicMock()
+        task = MagicMock()
+        task.portfolio_id = "port-1"
+        mock_bt_svc.get_by_id.return_value = ServiceResult.success(task)
+
+        mock_mapping = MagicMock()
+        mock_mapping.get_portfolio_graph.return_value = ServiceResult.success(
+            data={"graph_data": {"nodes": []}, "metadata": {"name": "g"}}
+        )
+
+        with patch("ginkgo.data.containers.container.backtest_task_service",
+                   return_value=mock_bt_svc), \
+             patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_mapping):
+            result = await create_from_backtest("bt-1")
+
+        mock_bt_svc.get_by_id.assert_called_once_with("bt-1")
+        mock_mapping.get_portfolio_graph.assert_called_once_with("port-1")
+        assert result["data"]["portfolio_uuid"] == "port-1"
+        assert result["data"]["graph_data"] == {"nodes": []}
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_backtest_missing(self):
+        """回测不存在抛 404（不再 501）"""
+        from api.node_graph import create_from_backtest
+
+        mock_bt_svc = MagicMock()
+        mock_bt_svc.get_by_id.return_value = ServiceResult.error("not found")
+
+        with patch("ginkgo.data.containers.container.backtest_task_service",
+                   return_value=mock_bt_svc):
+            with pytest.raises(HTTPException) as exc:
+                await create_from_backtest("bt-missing")
+
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_backtest_has_no_portfolio(self):
+        """回测无 portfolio_id 抛 404"""
+        from api.node_graph import create_from_backtest
+
+        mock_bt_svc = MagicMock()
+        task = MagicMock()
+        task.portfolio_id = ""
+        mock_bt_svc.get_by_id.return_value = ServiceResult.success(task)
+
+        with patch("ginkgo.data.containers.container.backtest_task_service",
+                   return_value=mock_bt_svc):
+            with pytest.raises(HTTPException) as exc:
+                await create_from_backtest("bt-1")
+
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_raises_404_when_graph_missing(self):
+        """回测存在但组合图不存在抛 404"""
+        from api.node_graph import create_from_backtest
+
+        mock_bt_svc = MagicMock()
+        task = MagicMock()
+        task.portfolio_id = "port-1"
+        mock_bt_svc.get_by_id.return_value = ServiceResult.success(task)
+
+        mock_mapping = MagicMock()
+        mock_mapping.get_portfolio_graph.return_value = ServiceResult.error("no graph")
+
+        with patch("ginkgo.data.containers.container.backtest_task_service",
+                   return_value=mock_bt_svc), \
+             patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_mapping):
+            with pytest.raises(HTTPException) as exc:
+                await create_from_backtest("bt-1")
+
+        assert exc.value.status_code == 404

--- a/tests/unit/services/test_portfolio_mapping_graph_lifecycle.py
+++ b/tests/unit/services/test_portfolio_mapping_graph_lifecycle.py
@@ -1,0 +1,96 @@
+"""
+PortfolioMappingService 图生命周期操作测试 -- #6085
+
+覆盖新增的 delete_graph / duplicate_graph 方法（行为通过公开接口验证，依赖 mock）。
+风格对齐 tests/unit/services/smoke/test_portfolio_mapping_service_smoke.py。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+try:
+    from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+    from ginkgo.data.services.base_service import ServiceResult
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="portfolio_mapping_service not importable")
+class TestPortfolioMappingGraphLifecycle:
+    """delete_graph / duplicate_graph 行为测试"""
+
+    def _make_svc(self):
+        mock_mapping = MagicMock()
+        mock_param = MagicMock()
+        mock_mongo = MagicMock()
+        mock_file = MagicMock()
+        svc = PortfolioMappingService(
+            mapping_crud=mock_mapping,
+            param_service=mock_param,
+            mongo_driver=mock_mongo,
+            file_service=mock_file,
+        )
+        return svc, mock_mapping, mock_param, mock_mongo, mock_file
+
+    # ---------- delete_graph ----------
+
+    def test_delete_graph_removes_all_mappings_and_mongo_doc(self):
+        """delete_graph 对每个 mapping 删参数+删映射，并删 Mongo 图文档"""
+        svc, mock_mapping, mock_param, mock_mongo, _ = self._make_svc()
+
+        m1 = MagicMock(uuid="m1", file_id="f1")
+        m2 = MagicMock(uuid="m2", file_id="f2")
+        mock_mapping.find_by_portfolio.return_value = [m1, m2]
+        mock_collection = MagicMock()
+        mock_mongo.get_collection.return_value = mock_collection
+
+        result = svc.delete_graph("portfolio-1")
+
+        assert result.is_success()
+        # 删了两个 mapping 的参数
+        mock_param.remove_by_mapping.assert_any_call("m1")
+        mock_param.remove_by_mapping.assert_any_call("m2")
+        # 删了两个 mapping
+        mock_mapping.delete_mapping.assert_any_call("portfolio-1", "f1")
+        mock_mapping.delete_mapping.assert_any_call("portfolio-1", "f2")
+        # 删了 Mongo 文档
+        mock_mongo.get_collection.assert_called_with("portfolio_graph_data")
+        mock_collection.delete_many.assert_called_once_with({"portfolio_uuid": "portfolio-1"})
+
+    # ---------- duplicate_graph ----------
+
+    def test_duplicate_graph_copies_source_to_new_uuid(self):
+        """duplicate_graph 读源图并以新 uuid 创建副本，新 uuid 不等于源"""
+        svc, *_ = self._make_svc()
+        graph_data = {"nodes": [{"id": "n1"}], "edges": []}
+
+        with patch.object(svc, "get_portfolio_graph",
+                          return_value=ServiceResult.success(data={"graph_data": graph_data})) as mock_get, \
+             patch.object(svc, "create_from_graph_editor",
+                          return_value=ServiceResult.success(
+                              data={"mongo_id": "mongo-1", "mappings_count": 1})) as mock_create:
+            result = svc.duplicate_graph("source-1", name="copy")
+
+        assert result.is_success()
+        mock_get.assert_called_once_with("source-1")
+        # create 以「新 uuid」调用，不能等于源
+        _, kwargs = mock_create.call_args
+        new_uuid = kwargs["portfolio_uuid"]
+        assert new_uuid != "source-1"
+        assert kwargs["graph_data"] == graph_data
+        assert kwargs["name"] == "copy"
+        # 返回里带新 uuid 且与传入 create 的一致
+        assert result.data["new_portfolio_uuid"] == new_uuid
+        assert result.data["source_uuid"] == "source-1"
+
+    def test_duplicate_graph_returns_error_when_source_missing(self):
+        """源图不存在时 duplicate_graph 返回失败，且不创建副本"""
+        svc, *_ = self._make_svc()
+        with patch.object(svc, "get_portfolio_graph",
+                          return_value=ServiceResult.error("not found")) as mock_get, \
+             patch.object(svc, "create_from_graph_editor") as mock_create:
+            result = svc.duplicate_graph("missing-1", name="copy")
+
+        assert not result.is_success()
+        mock_get.assert_called_once_with("missing-1")
+        mock_create.assert_not_called()


### PR DESCRIPTION
## Summary

实现 `api/api/node_graph.py` 三个 501 stub 端点，补齐 service 层能力（`PortfolioMappingService`）。

| 端点 | 实现 |
|---|---|
| `DELETE /{graph_uuid}` | `delete_graph`：删 Mongo 图文档 + `engine_portfolio_mapping` 行 + 关联 MParam（仅清图配置，不删 Portfolio 实体） |
| `POST /{graph_uuid}/duplicate` | `duplicate_graph`：读源图 → 生成新 portfolio_uuid → 调 `create_from_graph_editor` 写副本 |
| `POST /from-backtest/{backtest_uuid}` | 查回测 `.portfolio_id` → 返回该组合现有图（不新建，与 duplicate 语义区分） |

service 新增 `delete_graph` / `duplicate_graph`，加 `@retry`（与既有 mutation 方法一致）。

## Test plan

- [x] service lifecycle：`tests/unit/services/test_portfolio_mapping_graph_lifecycle.py`（3）
- [x] API 接线：`tests/api/test_node_graph_lifecycle.py`（8，覆盖成功/失败/404 路径）
- [x] 启动 import 验证：router 12 routes / service 能力 / 三端点函数存在（确认加载 worktree 代码）
- [x] 无 501 残留：`grep 501_NOT_IMPLEMENTED api/api/node_graph.py` 无命中
- [x] 回归：portfolio_mapping service smoke + node_graph file_type 既有（全绿）

Closes #5809
Closes #5821
