### PR TITLE
fix(#5840): Portfolio 创建返回 created 消息（不再透传 get 的 retrieved）

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -442,6 +442,9 @@ async def create_portfolio(data: PortfolioCreate):
             raise BusinessError("Failed to get portfolio UUID after creation")
 
         response = await get_portfolio(portfolio_uuid)
+        # #5840: get_portfolio 复用其组装好的 data，但 message 是 "retrieved" 语义，
+        # 创建动作必须覆盖为 "created"，否则 POST /portfolios/ 谎报 retrieved。
+        response["message"] = "Portfolio created successfully"
         return response
 
     except BusinessError:

--- a/tests/api/test_portfolio_create_mode.py
+++ b/tests/api/test_portfolio_create_mode.py
@@ -68,3 +68,36 @@ class TestCreatePortfolioPassesMode:
 
         _, kwargs = mock_factory.create_portfolio_saga.call_args
         assert kwargs["mode"] == 0, f"默认应映射为 0(BACKTEST)，实际为 {kwargs['mode']}"
+
+
+# #5840 — POST /portfolios/ 创建成功但 message 为 "retrieved successfully"
+class TestCreatePortfolioReturnsCreatedMessage:
+    """create_portfolio 应返回 created 语义的 message，而非透传 get_portfolio 的 retrieved。
+
+    根因: create_portfolio 末尾 `return await get_portfolio(uuid)` 复用了 get 的完整
+    response dict（含 message="Portfolio retrieved successfully"），未覆盖语义字段。
+    """
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio.get_portfolio", new_callable=AsyncMock)
+    @patch("services.saga_transaction.PortfolioSagaFactory")
+    async def test_create_returns_created_message(self, mock_factory, mock_get_portfolio):
+        from api.portfolio import create_portfolio
+
+        mock_factory.create_portfolio_saga.return_value = _mock_saga()
+        # 模拟真实 get_portfolio 返回（含 retrieved message，即 bug 现场）
+        mock_get_portfolio.return_value = {
+            "code": 0,
+            "data": {"uuid": "portfolio-uuid", "mode": "BACKTEST"},
+            "message": "Portfolio retrieved successfully",
+            "trace_id": "t-1",
+        }
+
+        data = PortfolioCreate(name="test_msg", initial_cash=100000)
+        response = await create_portfolio(data)
+
+        assert response["message"] == "Portfolio created successfully", (
+            f"创建应返回 created 语义，实际为 {response['message']!r}"
+        )
+        # data 应保留（复用 get 的数据组装，不破坏）
+        assert response["data"]["uuid"] == "portfolio-uuid"


### PR DESCRIPTION
## Summary

修复 #5840：`POST /api/v1/portfolios/` 创建成功但响应 `message` 为 `"Portfolio retrieved successfully"`。

**根因**：`create_portfolio`（`api/api/portfolio.py:444-445`）末尾 `return await get_portfolio(portfolio_uuid)` 复用了 `get_portfolio` 组装好的完整 response dict。该 dict 在 `get_portfolio:377` 用 `ok(data, message="Portfolio retrieved successfully")` 构造，`create_portfolio` 直接透传，未覆盖语义字段——创建动作谎报 "retrieved"。

**修复**：复用 `get_portfolio` 组装的 `data`（保留组件分组、参数映射等复杂逻辑的复用价值），仅覆盖 `response["message"] = "Portfolio created successfully"`。

**scope**：仅主验收（POST 创建返回 created 消息）。issue 的 "Additional issues"（`initial_cash` vs `--capital` 字段名一致性、list 返回 status null）涉及 schema 设计决策，属 scope 外，不在本 PR。

## 附带发现（未修，scope 外）

`update_portfolio`（`portfolio.py:497-498`）也有相同模式（复用 `get_portfolio` 返回，message 透传 retrieved）。语义上 update 应返回 "updated"，但 #5840 acceptance 仅覆盖 create，本 PR 不一并改。建议后续 issue 统一处理。

## Test plan

- [x] 新增 `TestCreatePortfolioReturnsCreatedMessage::test_create_returns_created_message`：mock get_portfolio 返回含 "retrieved" message 的真实 response（bug 现场），断言 create_portfolio 返回的 `message == "Portfolio created successfully"`，且 `data` 保留
- [x] `tests/api/test_portfolio_create_mode.py` 全 4 测试通过（3 旧 mode 测试 + 1 新），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/api/test_portfolio_create_mode.py -o addopts= -q
# 4 passed
```

**注**：`tests/api/test_saga_integration.py::test_portfolio_saga_factory_structure` 在本 PR 上失败，但 stash 对照确认 **master 基线同样失败**（`TypeError: create_portfolio_saga() got an unexpected keyword argument 'is_live'`）——这是 #5622/#5859 mode 重构时遗漏更新的旧测试，与本次 message 修复无关，非回归。

Closes #5840
