### PR TITLE
fix(#5497): FixedSlippage 低价股卖出 clamp 到 0.01 防负成交价

### DIFF
--- a/src/ginkgo/trading/paper/slippage_models.py
+++ b/src/ginkgo/trading/paper/slippage_models.py
@@ -25,6 +25,7 @@ from decimal import Decimal
 from typing import Union
 
 from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.libs import GLOG
 
 
 class SlippageModel(ABC):
@@ -103,7 +104,16 @@ class FixedSlippage(SlippageModel):
             return price + self.slippage
         else:
             # 卖出：价格下降
-            return price - self.slippage
+            # #5497: 低价股（price < slippage）裸 price-slippage 会产生负成交价，
+            # 负成交金额会污染 cash 余额。clamp 到最小 0.01 并告警。
+            fill_price = price - self.slippage
+            if fill_price < Decimal("0.01"):
+                GLOG.WARNING(
+                    f"FixedSlippage 卖出滑点({self.slippage})>=价格({price})，"
+                    f"成交价 clamp 到 0.01 防止负价"
+                )
+                return Decimal("0.01")
+            return fill_price
 
     def __repr__(self) -> str:
         return f"FixedSlippage(slippage={self.slippage})"

--- a/tests/unit/trading/paper/paper/test_slippage_models.py
+++ b/tests/unit/trading/paper/paper/test_slippage_models.py
@@ -50,6 +50,30 @@ class TestFixedSlippage:
         with pytest.raises(ValueError):
             FixedSlippage(slippage=Decimal("-0.01"))
 
+    def test_sell_low_price_clamps_to_minimum(self):
+        """#5497: 低价股卖出（price < slippage）不应产生负成交价，clamp 到 0.01。
+
+        根因: apply() 卖出分支 `price - slippage`，price=0.03 slippage=0.05 时
+        得 -0.02，负成交价污染 cash 余额。
+        """
+        from ginkgo.trading.paper.slippage_models import FixedSlippage
+        from ginkgo.enums import DIRECTION_TYPES
+
+        model = FixedSlippage(slippage=Decimal("0.05"))
+        result = model.apply(Decimal("0.03"), DIRECTION_TYPES.SHORT)
+        assert result == Decimal("0.01"), f"低价股卖出应 clamp 到 0.01，实际 {result}"
+        assert result > 0, "成交价必须为正"
+
+    def test_sell_price_above_slippage_not_clamped(self):
+        """#5497 回归保护: price > slippage 的正常低价股不触发 clamp。"""
+        from ginkgo.trading.paper.slippage_models import FixedSlippage
+        from ginkgo.enums import DIRECTION_TYPES
+
+        model = FixedSlippage(slippage=Decimal("0.01"))
+        # price=0.05 > slippage=0.01，正常计算 0.04，不应 clamp
+        result = model.apply(Decimal("0.05"), DIRECTION_TYPES.SHORT)
+        assert result == Decimal("0.04")
+
 
 @pytest.mark.financial
 class TestPercentageSlippage:


### PR DESCRIPTION
## Summary

修复 #5497：`FixedSlippage` 低价股卖出产生负成交价。

**根因**：`FixedSlippage.apply`（`slippage_models.py:106`）卖出分支 `return price - self.slippage`，当 `price < slippage`（如 slippage=0.05、price=0.03 的低价股）时结果为负。负成交价 → 负成交金额 → 污染 cash 余额计算。

**修复**：卖出分支计算 `fill_price = price - slippage`，若 `< Decimal("0.01")` 则 clamp 到 0.01 并 `GLOG.WARNING` 记录滑点超价事件。买入分支（`price + slippage`）天然为正，无需改动。

## scope

- ✅ 主验收：clamp 到 `max(0.01, price-slippage)` + warning + 低价边界测试
- ⏭️ acceptance 第 3 条「constructor 校验 slippage < typical price range」：**未做**。"typical price range" 未定义（A股股价 0.1×~千元跨 4 个数量级，无合理统一上限），强加校验会误拒合法的大额滑点配置。属设计决策，留 human 决定。

## 附带发现（未修，scope 外）

`PercentageSlippage.apply`（`slippage_models.py:160`）卖出分支同模式 `price - slippage`。正常情况（percentage<1）`slippage = price*percentage < price` 不会负；但构造器允许任意正 percentage，`percentage≥1` 时仍会负。#5497 只报 FixedSlippage，本 PR 不一并改，建议后续 issue 统一处理。

## Test plan

- [x] `test_sell_low_price_clamps_to_minimum`：slippage=0.05、price=0.03 → 断言 clamp 到 0.01 且为正（复现 bug 现场）
- [x] `test_sell_price_above_slippage_not_clamped`：回归保护，price=0.05 > slippage=0.01 正常算 0.04，不误 clamp
- [x] `tests/unit/trading/paper/paper/test_slippage_models.py` 全 11 测试通过（9 旧 + 2 新），无回归
- [x] py_compile + 模块导入 OK（`apply(0.03, SHORT)` 实测返回 0.01，WARNING 触发）

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/trading/paper/paper/test_slippage_models.py -o addopts= -q
# 11 passed
```

Closes #5497
