### PR TITLE
fix(#5885): create_component 从 file_info 提取 uuid 修复 500

### DIFF
--- a/api/api/components.py
+++ b/api/api/components.py
@@ -261,7 +261,11 @@ async def create_component(data: ComponentCreate):
             )
 
         # 获取创建的文件记录
-        file_uuid = result.data.get("uuid") if result.data else None
+        # #5885: FileService.add 返回 data={"file_info": {"uuid": ...}}，
+        # uuid 嵌套在 file_info 下。裸 result.data.get("uuid") 取到 None 抛 500，
+        # 但此时记录已在 add 内部 create() 落库，致数据残留 + 重试重复入库。
+        file_info = result.data.get("file_info") if result.data else None
+        file_uuid = file_info.get("uuid") if file_info else None
         if not file_uuid:
             raise HTTPException(
                 status_code=500,

--- a/tests/api/test_components_create_uuid.py
+++ b/tests/api/test_components_create_uuid.py
@@ -1,0 +1,57 @@
+# #5885 — POST /components/ 创建成功但返回 500 "Failed to get created component UUID"
+# Upstream: api.api.components.create_component
+# Downstream: FileService.add
+# Role: 验证 create_component 从 FileService.add 返回的嵌套结构正确提取 uuid
+
+"""
+组件创建 uuid 提取测试
+
+FileService.add 成功返回 ServiceResult(data={"file_info": {"uuid": ..., ...}})，
+uuid 嵌套在 file_info 下。create_component 必须从 file_info 取 uuid，
+直接 result.data.get("uuid") 会取到 None 抛 500（数据已入库的不一致状态）。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(data=None, success=True, message="ok"):
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.data = data
+    result.message = message
+    return result
+
+
+class TestCreateComponentExtractsUuid:
+    """create_component 应从 file_info 嵌套结构提取 uuid（#5885）"""
+
+    def test_extracts_uuid_from_file_info(self):
+        """add 返回 data={"file_info":{"uuid":..}}，create_component 应取到 uuid 传给 get_component。
+
+        根因: components.py:264 ``result.data.get("uuid")`` 跳过了 file_info 层，
+        取到 None 抛 500 "Failed to get created component UUID"，但数据已入库。
+        """
+        mock_service = MagicMock()
+        mock_service.add.return_value = make_mock_result(
+            data={"file_info": {"uuid": "comp-uuid-123", "name": "test"}}
+        )
+        mock_get_component = AsyncMock(
+            return_value={"code": 0, "data": {"uuid": "comp-uuid-123"}}
+        )
+
+        from api.components import create_component, ComponentCreate
+
+        data = ComponentCreate(name="test", component_type="strategy", code="code...")
+        with patch("api.components.get_file_service", return_value=mock_service), \
+             patch("api.components.get_component", mock_get_component):
+            response = run_async(create_component(data))
+
+        # 证明从 file_info 取到了 uuid（传给 get_component 而非抛 500）
+        mock_get_component.assert_called_once_with("comp-uuid-123")
+        assert response["data"]["uuid"] == "comp-uuid-123"


### PR DESCRIPTION
## Summary

修复 #5885：`POST /api/v1/components/` 创建组件返回 500 `Failed to get created component UUID`。

**根因**：`create_component`（`api/api/components.py:264`）用 `result.data.get("uuid")` 直接取顶层 uuid。但 `FileService.add`（`file_service.py:194-197`）返回的结构是 `ServiceResult(data={"file_info": {"uuid": ..., "name": ..., "type": ..., ...}})`——uuid 嵌套在 `file_info` 下，顶层根本没有 `uuid` 键。于是 `file_uuid = None` → 抛 500。

**危害**：`FileService.add` 内部 `create()`（`file_service.py:176`）**已经落库成功**，500 是在落库之后抛的。用户看到 500 会重试 → 重复创建脏数据。这种"成功后失败"的不一致状态比纯失败更危险。

**调用链**：

```
POST /components/ → create_component
  → file_service.add()        ✅ create() 落库成功，返回 {"file_info":{"uuid":...}}
  → result.data.get("uuid")   ❌ None（uuid 在 file_info 下，不在顶层）
  → raise HTTPException 500   💥 "Failed to get created component UUID"
```

**修复**：两步提取 `file_info.uuid`：

```python
file_info = result.data.get("file_info") if result.data else None
file_uuid = file_info.get("uuid") if file_info else None
```

## scope

- ✅ 主验收：`create_component` 从 `file_info` 嵌套结构正确提取 uuid，不再误抛 500
- ✅ 保留 500 兜底：若 service 返回结构异常（缺 file_info 或 uuid），仍抛 500 暴露问题，不静默吞

## Test plan

- [x] 新增 `TestCreateComponentExtractsUuid::test_extracts_uuid_from_file_info`：mock `FileService.add` 返回**真实的嵌套结构** `{"file_info":{"uuid":"comp-uuid-123",...}}`（镜像 `file_service.py:194`），断言 `get_component` 被以正确 uuid 调用，而非抛 500
- [x] RED 阶段确认：修复前测试抛 `HTTPException: 500: Failed to get created component UUID`（根因现场复现）
- [x] GREEN 阶段：修复后测试通过
- [x] `tests/api/test_components_pagination.py`（同模块分页测试 4 个）+ 新测试合跑 5 passed，无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest \
  tests/api/test_components_pagination.py tests/api/test_components_create_uuid.py -o addopts= -q
# 5 passed
```

Closes #5885
