### PR TITLE
fix(#5996): backtest completed 进度兜底 100%

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -23,6 +23,18 @@ app = typer.Typer(
 )
 
 
+def _display_progress(status_val, raw_progress):
+    """completed 状态语义上进度必为 100%。
+
+    #5996: 旧任务 DB progress 字段可能为 0（完成回调未覆盖历史数据），
+    但 status==completed 时进度语义上必然完成，CLI 输出层兜底显示 100%，
+    而非原样输出 DB 里的陈旧 0%。
+    """
+    if str(status_val).lower() == "completed":
+        return 100
+    return raw_progress
+
+
 @app.command("create")
 def create_task(
     portfolio: str = typer.Option(..., "--portfolio", "-p", help="Portfolio UUID (required)"),
@@ -366,7 +378,8 @@ def list_tasks(
             else str(task.get("portfolio_id", ""))[:12]
         )
         status_val = task.status if hasattr(task, "status") else task.get("status", "")
-        progress = task.progress if hasattr(task, "progress") else task.get("progress", 0)
+        raw_progress = task.progress if hasattr(task, "progress") else task.get("progress", 0)
+        progress = _display_progress(status_val, raw_progress)
         created = str(task.create_at)[:19] if hasattr(task, "create_at") else ""
 
         status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(
@@ -438,7 +451,8 @@ def cat_task(
         status_val, "white"
     )
     info_lines.append(f"[bold]Status:[/bold]       [{status_style}]{status_val}[/{status_style}]")
-    info_lines.append(f"[bold]Progress:[/bold]     {task.progress}%")
+    display_progress = _display_progress(status_val, task.progress)
+    info_lines.append(f"[bold]Progress:[/bold]     {display_progress}%")
     info_lines.append(f"[bold]Created:[/bold]      {task.create_at}")
 
     if task.start_time:

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -86,6 +86,7 @@ class TestBacktestListProgressFormat:
 
         task = _mock_task()
         task.progress = 50
+        task.status = "running"  # progress=50 进行中；避免 completed 兜底(#5996)干扰格式化断言
 
         mock_service = MagicMock()
         list_result = MagicMock()
@@ -154,3 +155,59 @@ class TestBacktestCatNoTradesWarning:
 
         plain = _strip_ansi(invoke_result.output)
         assert "No trades" in plain or "未产生" in plain or "no trades" in plain.lower()
+
+
+class TestBacktestCompletedProgressFallback:
+    """#5996 completed 回测即使 DB progress=0（旧任务完成回调未更新）也应兜底显示 100%"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_completed_zero_progress_shows_100(self, mock_container):
+        """#5996 list: status=completed + progress=0 → 兜底 100%（复现 issue 现场）
+
+        根因: backtest_cli.py:369 原样输出 task.progress，无 completed 语义兜底。
+        990 条历史 completed 任务 DB progress=0，全显 0%。
+        """
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.status = "completed"
+        task.progress = 0  # 旧任务 DB 未被完成回调更新，复现 issue 现场
+
+        mock_service = MagicMock()
+        list_result = MagicMock()
+        list_result.is_success.return_value = True
+        list_result.data = {"data": [task], "total": 1}
+        mock_service.list.return_value = list_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["list"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        # 兜底: completed 必显 100%，而非原样 0%
+        assert "100%" in plain
+
+    @patch("ginkgo.data.containers.container")
+    def test_cat_completed_zero_progress_shows_100(self, mock_container):
+        """#5996 cat: status=completed + progress=0 → 兜底 100%
+
+        与 list 同根因，cat 输出层也须兜底，保证两命令一致。
+        """
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.status = "completed"
+        task.progress = 0  # 旧任务 DB 未更新
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = True
+        result.data = task
+        mock_service.get_by_id.return_value = result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "abc123456789"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        assert "100%" in plain


### PR DESCRIPTION
## Summary

修复 #5996：`backtest list` / `backtest cat` 对 status=completed 的回测进度显示 0%，应为 100%。

**根因**：`backtest_cli.py` 的 list（`:369`）与 cat（`:441`）直接取 `task.progress` 原样输出，无 `status==completed → 100` 语义兜底。仅 `backtest run` 命令运行时的完成回调（`:193/:218`）会设 progress=100，**已落库的旧任务** progress 仍为创建时的默认 0 → 990 条历史 completed 全显 0%，量化研究员无法区分"刚完成"和"尚未开始"。

**调用链**：

```
backtest list/cat → task.progress (DB 原值，旧任务=0) → 原样输出 → 0% ❌
                                                ↓ (本 PR)
                                  _display_progress(completed, 0) → 100% ✅
```

**修复**：提取模块级 helper `_display_progress(status_val, raw_progress)`，`completed` 兜底 100%，接入 list 与 cat 两处。**纯 CLI 显示层兜底，不动 DB 历史 progress 数据**——验收第 3 条"历史数据也能正确显示"靠此实现，无需迁移。

```python
def _display_progress(status_val, raw_progress):
    if str(status_val).lower() == "completed":
        return 100
    return raw_progress
```

## scope

- ✅ 验收 1：completed 进度显示 100%（list + cat 双测覆盖）
- ✅ 验收 2：list 与 cat 一致（共用同一 helper）
- ✅ 验收 3：历史数据也正确（CLI 层兜底，非改 DB）
- ⏭️ 未做 DB 数据迁移（progress 字段值不动）——CLI 层兜底已满足验收，迁移 990 条历史数据风险/收益不划算

## 附带修复（mock 一致性）

`test_list_shows_correct_progress_percentage`（#5323）复用 `_mock_task()` 默认 `status="completed"` 但只改 `progress=50`，产生 `completed+50%` 的矛盾 mock 数据。旧代码原样输出掩盖了矛盾；本 PR 的 completed 兜底正确暴露它。修测试显式 `status="running"`（progress=50 进行中），恢复数据一致性。不改变 #5323 的格式化断言意图。

## Test plan

- [x] `test_list_completed_zero_progress_shows_100`：status=completed + **progress=0**（复现 issue 现场）→ 断言输出含 "100%"
- [x] `test_cat_completed_zero_progress_shows_100`：cat 同场景 → "100%"
- [x] TDD 双 slice 各自 RED（原样输出 0% 测试 fail）→ GREEN（兜底后 pass）
- [x] `tests/unit/client/test_backtest_cli.py` 全 6 测试通过（3 旧 + 2 新兜底 + 1 mock 一致性修），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_backtest_cli.py -o addopts= -q
# 6 passed
```

Closes #5996
