### PR TITLE
fix: tdx tick code 无市场后缀自动推断防崩溃 (#5999)

### DIFF
--- a/src/ginkgo/data/sources/ginkgo_tdx.py
+++ b/src/ginkgo/data/sources/ginkgo_tdx.py
@@ -23,6 +23,27 @@ console = Console()
 import random
 
 
+def _parse_a_share_code(code: str) -> "tuple[str, str] | None":
+    """解析A股代码为 (code_num, code_market)，无后缀时按前缀推断市场。
+
+    #5999: ``code.split(".")[1]`` 在无市场后缀（如 "000001"）时 IndexError 崩溃。
+    tdx 仅支持 SH/SZ，按 A 股代码前缀规则推断：
+      - 6 开头 → SH（沪市主板/科创板）
+      - 0/3 开头 → SZ（深市主板/创业板）
+      - 其他 → None（北交所等 tdx 不支持，交调用方友好处理）
+    有后缀时原样返回（upper 归一）。
+    """
+    parts = code.split(".")
+    code_num = parts[0]
+    if len(parts) > 1:
+        return code_num, parts[1].upper()
+    if code_num.startswith("6"):
+        return code_num, "SH"
+    if code_num.startswith(("0", "3")):
+        return code_num, "SZ"
+    return None
+
+
 class GinkgoTDX(GinkgoSourceBase):
     def __init__(self):
         self.client = Quotes.factory(market="std", bestip=False, timeout=15, quiet=True, verbose=0)
@@ -118,9 +139,12 @@ class GinkgoTDX(GinkgoSourceBase):
             time = datetime.datetime.strptime(time, "%H:%M").time()
             return datetime.datetime.combine(new_date, time)
 
-        code_num = code.split(".")[0]
-        code_market = code.split(".")[1]
-        if code_market.upper() not in ["SH", "SZ"]:
+        parsed = _parse_a_share_code(code)
+        if parsed is None:
+            console.print(f":warning: 无法解析 {code} 的市场后缀，请使用完整格式（如 000001.SZ）")
+            return
+        code_num, code_market = parsed
+        if code_market not in ["SH", "SZ"]:
             console.print("TDX api just support SH and SZ now.")
             return
         date = datetime_normalize(date)

--- a/tests/unit/data/sources/test_ginkgo_tdx.py
+++ b/tests/unit/data/sources/test_ginkgo_tdx.py
@@ -170,3 +170,60 @@ class TestTDXFetchLive:
         mock_client.quotes.assert_called_once()
         call_kwargs = mock_client.quotes.call_args[1]
         assert "symbol" in call_kwargs
+
+
+@pytest.mark.unit
+class TestParseAShareCode:
+    """#5999 解析A股代码，无市场后缀时按前缀推断，避免 code.split('.')[1] 崩溃"""
+
+    def test_no_suffix_0_prefix_infers_sz(self):
+        """000001（无后缀）→ 推断 SZ（深市主板 0 开头）"""
+        from ginkgo.data.sources.ginkgo_tdx import _parse_a_share_code
+        assert _parse_a_share_code("000001") == ("000001", "SZ")
+
+    def test_no_suffix_3_prefix_infers_sz(self):
+        """300001（创业板无后缀）→ 推断 SZ"""
+        from ginkgo.data.sources.ginkgo_tdx import _parse_a_share_code
+        assert _parse_a_share_code("300001") == ("300001", "SZ")
+
+    def test_no_suffix_6_prefix_infers_sh(self):
+        """600000（沪市无后缀）→ 推断 SH"""
+        from ginkgo.data.sources.ginkgo_tdx import _parse_a_share_code
+        assert _parse_a_share_code("600000") == ("600000", "SH")
+
+    def test_with_suffix_uppercases(self):
+        """000001.sz（小写后缀）→ upper 归一为 SZ"""
+        from ginkgo.data.sources.ginkgo_tdx import _parse_a_share_code
+        assert _parse_a_share_code("000001.sz") == ("000001", "SZ")
+
+    def test_uninferable_returns_none(self):
+        """88888（北交所，tdx 不支持）→ None，交调用方友好处理"""
+        from ginkgo.data.sources.ginkgo_tdx import _parse_a_share_code
+        assert _parse_a_share_code("88888") is None
+
+
+@pytest.mark.unit
+class TestTDXFetchHistoryDetailNoSuffix:
+    """#5999 集成：fetch_history_transaction_detail 裸代码不再 IndexError 崩溃"""
+
+    @patch("ginkgo.data.sources.ginkgo_tdx.Quotes")
+    def test_bare_code_does_not_crash(self, mock_quotes):
+        """000001（无后缀）→ 推断 SZ，不再 IndexError，symbol 传纯数字"""
+        mock_client = MagicMock()
+        mock_quotes.factory.return_value = mock_client
+        mock_client.transactions.return_value = pd.DataFrame()
+        tdx = GinkgoTDX()
+        tdx.fetch_history_transaction_detail("000001", "2024-01-01")
+        # 不崩溃即通过；推断后 symbol 传纯数字给 mootdx
+        assert mock_client.transactions.called
+        assert mock_client.transactions.call_args[1]["symbol"] == "000001"
+
+    @patch("ginkgo.data.sources.ginkgo_tdx.Quotes")
+    def test_unsupported_market_returns_none(self, mock_quotes):
+        """88888（北交所 tdx 不支持）→ 解析失败友好返回，不调 client"""
+        mock_client = MagicMock()
+        mock_quotes.factory.return_value = mock_client
+        tdx = GinkgoTDX()
+        result = tdx.fetch_history_transaction_detail("88888", "2024-01-01")
+        assert result is None
+        assert not mock_client.transactions.called


### PR DESCRIPTION
## Summary

修复 #5999：`ginkgo sync tick --code 000001` 传入**无市场后缀**的裸代码时 IndexError 崩溃。

**根因**：`ginkgo_tdx.py:122` `code_market = code.split(".")[1]` 无长度检查。裸 code `"000001"` 经 split 只返回 1 个元素，`[1]` 越界 → IndexError。

> 注：issue 报告文件名 `tick_service.py:122` 有误，实际崩溃在数据源层 `ginkgo_tdx.py:122`，`tick_service` 只是调用方；行号恰好吻合。已在认领评论更正。

**调用链**：

```
ginkgo sync tick --code 000001
  → tick_service → GinkgoTDX.fetch_history_transaction_detail("000001", ...)
    → code.split(".")[1]   ❌ IndexError（split 只 1 元素）
```

**修复**：提取模块级 helper `_parse_a_share_code(code)`，按 A 股代码前缀规则推断市场：

- 有后缀 → 原样返回（upper 归一）
- `6` 开头 → SH（沪市主板/科创板）
- `0`/`3` 开头 → SZ（深市主板/创业板）
- 其他 → `None`（北交所等 tdx 不支持，交调用方友好返回）

接入 `fetch_history_transaction_detail`，解析为 None 时 console 提示并返回（不抛异常）。

## scope

- ✅ 主验收：裸代码不再 IndexError，按前缀推断市场
- ✅ 友好兜底：北交所等 tdx 不支持的代码 → 提示 + 返回 None（非崩溃）
- ⏭️ 未改 `fetch_latest_bar` / `fetch_history_daybar` / `fetch_adjustfactor`（它们用 `split(".")[0]` 取代码数字，`[0]` 对裸 code 安全不崩；仅 tick detail 用 `[1]` 才崩）

## Test plan

- [x] TDD slice 1 — helper 单元测 5 个（0/3 前缀→SZ、6 前缀→SH、小写后缀 upper 归一、不可推断→None）
- [x] TDD slice 2 — 集成测 2 个（裸 `000001` 不崩 + symbol 传纯数字 / 北交所 `88888` 返回 None 不调 client）
- [x] slice 1 RED 确认（ImportError：helper 未存在，5 failed）→ GREEN
- [x] `tests/unit/data/sources/test_ginkgo_tdx.py` 全 17 测通过（10 旧 + 5 helper + 2 集成），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/data/sources/test_ginkgo_tdx.py -o addopts= -q
# 17 passed
```

Closes #5999
