### PR TITLE
fix: 组件参数端点动态提取 + 单数仪表盘重定向 (#5408 #5792)

### DIFF
--- a/api/api/components.py
+++ b/api/api/components.py
@@ -7,15 +7,11 @@ from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 import ast
-import inspect
 
 from ginkgo.data.containers import container
-from ginkgo.enums import FILE_TYPES, COMPONENT_TYPES
-from ginkgo.data.services.component_parameter_extractor import get_component_parameter_names
+from ginkgo.enums import FILE_TYPES
 from core.logging import logger
 from core.response import ok, paginated
-from services.component_parameter_service import get_component_parameter_service
-from models.component import ComponentParameter
 
 router = APIRouter()
 
@@ -168,6 +164,96 @@ async def list_components(
         raise HTTPException(
             status_code=500,
             detail="Failed to list components"
+        )
+
+
+# ==================== 组件参数端点 ====================
+# 注意: GET /parameters* 必须在 GET /{uuid} 之前注册，否则 Starlette 按声明
+# 顺序匹配时会将 /parameters 当成 uuid 吞掉 (#5408)
+
+
+@router.get("/parameters")
+async def get_all_component_parameters():
+    """获取所有组件的参数定义（#5408: 动态从源码提取，key 为文件名）"""
+    try:
+        file_service = get_file_service()
+
+        list_result = file_service.list_components(page=0, page_size=10000)
+        if not list_result.is_success() or not list_result.data:
+            return ok(data={})
+        files = list_result.data.get("data", []) or []
+
+        definitions: Dict[str, List[Dict[str, Any]]] = {}
+        for file_record in files:
+            content_result = file_service.get_content(file_record.uuid)
+            code = None
+            if content_result.is_success() and content_result.data:
+                raw = content_result.data
+                code = raw.decode("utf-8", errors="ignore") if isinstance(raw, bytes) else str(raw)
+            if not code:
+                continue
+            component_type = FILE_TYPE_TO_COMPONENT_TYPE.get(file_record.type, "unknown")
+            params = extract_component_parameters(file_record.name, code, component_type)
+            if params:
+                definitions[file_record.name] = params
+        return ok(data=definitions)
+    except Exception as e:
+        logger.error(f"Error getting all component parameters: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get component parameters: {str(e)}"
+        )
+
+
+@router.get("/parameters/{component_name}")
+async def get_component_parameters(component_name: str):
+    """获取组件的参数定义（#5408: 从源码动态提取，与 /components/{uuid} 同源）"""
+    try:
+        file_service = get_file_service()
+
+        # 按文件名查 MFile（get_by_name 返回复数列表，取首条）
+        name_result = file_service.get_by_name(component_name)
+        if not name_result.is_success() or not name_result.data:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Component not found: {component_name}"
+            )
+        files = name_result.data.get("files", [])
+        if not files:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Component not found: {component_name}"
+            )
+        file_record = files[0]
+
+        # 读源码
+        content_result = file_service.get_content(file_record.uuid)
+        code = None
+        if content_result.is_success() and content_result.data:
+            raw = content_result.data
+            code = raw.decode("utf-8", errors="ignore") if isinstance(raw, bytes) else str(raw)
+        if not code:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Component source empty: {component_name}"
+            )
+
+        # 动态提取参数（复用 /components/{uuid} 同一提取器，废弃过时硬编码表）
+        component_type = FILE_TYPE_TO_COMPONENT_TYPE.get(file_record.type, "unknown")
+        params = extract_component_parameters(component_name, code, component_type)
+        if not params:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Component parameters not found: {component_name}"
+            )
+        return ok(data=params)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting component parameters for {component_name}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to get component parameters: {str(e)}"
         )
 
 
@@ -358,44 +444,6 @@ async def delete_component(uuid: str):
         raise HTTPException(
             status_code=500,
             detail="Failed to delete component"
-        )
-
-
-# ==================== 组件参数端点 ====================
-
-@router.get("/parameters/{component_name}")
-async def get_component_parameters(component_name: str):
-    """获取组件的参数定义"""
-    try:
-        service = get_component_parameter_service()
-        params = service.get_component_parameters(component_name)
-        if not params:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component parameters not found: {component_name}"
-            )
-        return ok(data=params)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting component parameters for {component_name}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get component parameters"
-        )
-
-
-@router.get("/parameters")
-async def get_all_component_parameters():
-    """获取所有组件的参数定义"""
-    try:
-        service = get_component_parameter_service()
-        return ok(data=service.get_all_component_definitions())
-    except Exception as e:
-        logger.error(f"Error getting all component parameters: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get component parameters"
         )
 
 

--- a/tests/api/test_component_parameters_5408.py
+++ b/tests/api/test_component_parameters_5408.py
@@ -1,0 +1,158 @@
+# Issue: #5408 组件参数端点名称映射断裂，类名 vs 文件名导致全部 404
+# Upstream: api.api.components.get_component_parameters / get_all_component_parameters
+# Downstream: file_service.get_by_name / extract_component_parameters
+# Role: 参数端点复用动态 AST 提取器(与 /components/{uuid} 同源)，废弃过时硬编码死表
+
+"""
+组件参数端点测试 (#5408)
+
+实测确认的根因：
+1. 路由顺序: api/api/components.py 中 /{uuid} 先声明，吞噬字面量
+   /parameters 与 /parameters/{name}。
+2. 数据源错接: /parameters 端点经 ComponentParameterService 查硬编码死表
+   (COMPONENT_PARAMETER_DEFINITIONS, 10 个过时 PascalCase key，且与实际
+   组件库脱节)；而组件实例化(ComponentLoader)与 /components/{uuid} 用的是
+   动态 AST 提取器。两套不一致，前端拿文件名查死表必然 404/空。
+
+修复方向：
+1. /{uuid} 后置于 /parameters 之后（切片1，本文件）
+2. 参数端点直接组合 file_service + extract_component_parameters（同源动态提取）
+3. #5792 dashboard 单数→复数重定向（见 test_dashboard_5792.py）
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestRouteOrderNotSwallowingParameters:
+    """切片1: /{uuid} 不得吞噬 /parameters 字面量路由"""
+
+    def test_get_all_parameters_returns_200_not_404(self):
+        """GET /components/parameters 命中 get_all 端点(200)，而非被 /{uuid} 当 uuid 查成 404"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api import components
+
+        app = FastAPI()
+        app.include_router(components.router, prefix="/components")
+        client = TestClient(app)
+
+        # mock file_service: 若 /{uuid} 误吞 "parameters"，get_by_uuid 应失败得 404
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = False  # 显式 False（MagicMock 默认 truthy 陷阱）
+        mock_result.data = None
+        mock_fs = MagicMock()
+        mock_fs.get_by_uuid.return_value = mock_result
+
+        with patch.object(components, "get_file_service", return_value=mock_fs):
+            resp = client.get("/components/parameters")
+
+        assert resp.status_code == 200, (
+            f"应命中 get_all_component_parameters(200)，实际 {resp.status_code} "
+            f"(疑似被 /{{uuid}} 路由吞掉)"
+        )
+
+
+class TestDynamicExtractionFromSource:
+    """切片2: /parameters/{name} 从源码动态提取参数（与 /components/{uuid} 同源）"""
+
+    def test_get_parameters_extracts_from_source_not_dead_table(self):
+        """查死表里没有的组件名 → 应从源码动态提取，而非查过时硬编码表"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api import components
+
+        # 假组件源码（类名含 component_name，确保 extract 能匹配到 __init__）
+        fake_code = (
+            "class FakeTestStrategy:\n"
+            "    def __init__(self, buy_threshold=0.5, period=20):\n"
+            "        self.buy_threshold = buy_threshold\n"
+            "        self.period = period\n"
+        )
+
+        app = FastAPI()
+        app.include_router(components.router, prefix="/components")
+        client = TestClient(app)
+
+        # get_by_name 返回 {files: [...]}（复数列表，注意非 get_by_uuid 的 file 单数）
+        mock_file = MagicMock()
+        mock_file.name = "fake_test_strategy"
+        mock_file.type = 6  # FILE_TYPES.STRATEGY
+        mock_file.uuid = "fake-uuid-1234"
+
+        mock_name_result = MagicMock()
+        mock_name_result.is_success.return_value = True
+        mock_name_result.data = {"files": [mock_file], "count": 1}
+
+        # get_content 返回 data=bytes（直接，不包 dict）
+        mock_content_result = MagicMock()
+        mock_content_result.is_success.return_value = True
+        mock_content_result.data = fake_code.encode("utf-8")
+
+        mock_fs = MagicMock()
+        mock_fs.get_by_name.return_value = mock_name_result
+        mock_fs.get_content.return_value = mock_content_result
+
+        with patch.object(components, "get_file_service", return_value=mock_fs):
+            resp = client.get("/components/parameters/fake_test_strategy")
+
+        assert resp.status_code == 200, f"实际 {resp.status_code}: {resp.text}"
+        param_names = [p["name"] for p in resp.json()["data"]]
+        assert "buy_threshold" in param_names, f"应从源码提取，实际 {param_names}"
+        assert "period" in param_names
+
+    def test_get_all_parameters_extracts_from_source(self):
+        """GET /components/parameters 返回所有组件动态提取的参数 dict（key=文件名）"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api import components
+
+        code_a = (
+            "class FakeStratA:\n"
+            "    def __init__(self, fast=5):\n"
+            "        self.fast = fast\n"
+        )
+        code_b = (
+            "class FakeStratB:\n"
+            "    def __init__(self, slow=20):\n"
+            "        self.slow = slow\n"
+        )
+
+        mock_file_a = MagicMock()
+        mock_file_a.name = "fake_strat_a"
+        mock_file_a.type = 6
+        mock_file_a.uuid = "uuid-a"
+
+        mock_file_b = MagicMock()
+        mock_file_b.name = "fake_strat_b"
+        mock_file_b.type = 6
+        mock_file_b.uuid = "uuid-b"
+
+        mock_list_result = MagicMock()
+        mock_list_result.is_success.return_value = True
+        mock_list_result.data = {"data": [mock_file_a, mock_file_b], "total": 2}
+
+        code_map = {"uuid-a": code_a.encode("utf-8"), "uuid-b": code_b.encode("utf-8")}
+
+        def content_side_effect(file_id):
+            r = MagicMock()
+            r.is_success.return_value = True
+            r.data = code_map[file_id]
+            return r
+
+        mock_fs = MagicMock()
+        mock_fs.list_components.return_value = mock_list_result
+        mock_fs.get_content.side_effect = content_side_effect
+
+        app = FastAPI()
+        app.include_router(components.router, prefix="/components")
+        client = TestClient(app)
+
+        with patch.object(components, "get_file_service", return_value=mock_fs):
+            resp = client.get("/components/parameters")
+
+        assert resp.status_code == 200, f"实际 {resp.status_code}: {resp.text}"
+        data = resp.json()["data"]
+        assert "fake_strat_a" in data, f"key 应为文件名，实际 {list(data.keys())}"
+        assert "fake_strat_b" in data
+        assert any(p["name"] == "fast" for p in data["fake_strat_a"])


### PR DESCRIPTION
## Summary

两个前端 404 类问题，同批处理（均在 API 路由层）。

### #5408 组件参数端点名称映射断裂
- **根因（双重）**：
  1. 路由顺序 —— `/{uuid}` 先于 `/parameters` 声明，字面量路由被通配符 `/{uuid}` 吞噬，`GET /components/parameters` 被当 uuid 查成 404。
  2. 数据源错接 —— `/parameters/{name}` 经 `ComponentParameterService` 查硬编码死表 `COMPONENT_PARAMETER_DEFINITIONS`（10 个过时 PascalCase key，与真实组件库脱节）；而组件实例化（`ComponentLoader`）与 `GET /components/{uuid}` 用的是动态 AST 提取器。两套不一致，前端拿文件名查死表必然 404/空。
- **修复**：
  - `/{uuid}` 后置于 `/parameters*` 之后（字面量优先匹配）。
  - 参数端点改用本地 `extract_component_parameters` 从源码动态提取（与 `/components/{uuid}` 同源），废弃脱节死表。
  - 清理未使用 import（`get_component_parameter_service` / `ComponentParameter` / `get_component_parameter_names` / `inspect` / `COMPONENT_TYPES`）。

### #5792 仪表盘 404
- **根因**：`main.py` 仅注册 `/dashboards`（复数），前端请求 `/api/v1/dashboard`（单数）→ 404 No route。
- **修复**：`dashboard` 模块新增 `redirect_router`（单数 `/dashboard`），`main` include 到 `API_PREFIX` 下，307 相对重定向到 `./dashboards`。独立 router 避免 `include_router` 的 `/dashboards` prefix 把单数路径拼成 `/dashboards/dashboard`。

## Test plan
- [x] `pytest tests/api/test_component_parameters_5408.py` — 3 passed（路由顺序不被吞噬 + 动态提取覆盖死表里没有的组件名 + get_all 遍历提取）
- [x] `pytest tests/api/test_dashboard_5792.py` — 2 passed（单数 307 重定向 + 跟随后命中复数路由）
- [x] `py_compile api/main.py api/api/dashboard.py api/api/components.py` — 三文件语法 OK（启动路径不 break）
- [ ] 人工：启动 API，`curl /api/v1/dashboard` 验 307；前端组件绑定页验参数加载

Closes #5408
Closes #5792
