### PR TITLE
fix(#6031): BacktestProcessor 异常处理对齐 GLOG 范式

### DIFF
--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -289,7 +289,10 @@ class BacktestProcessor(Thread):
                 positions = getattr(portfolio, 'positions', {})
                 total_orders = len(positions) if isinstance(positions, dict) else 0
         except Exception as e:
-            pass  # 统计获取失败不影响主流程
+            # 统计获取失败不影响主流程，但仍记录诊断信息（对齐 #6031：不再静默吞异常）
+            GLOG.WARN(
+                f"[{self.task.task_uuid[:8]}] Progress stats gathering failed: {e}"
+            )
 
         # 每2秒上报一次（由ProgressTracker控制频率）
         self.progress_tracker.report_progress(
@@ -402,7 +405,9 @@ class BacktestProcessor(Thread):
         except Exception as e:
             GLOG.ERROR(f"[{self.task.task_uuid[:8]}] Error in result aggregation: {e}")
             import traceback
-            traceback.print_exc()
+            # #6031: 对齐本文件 L128 范式，traceback 经结构化日志落库（后台 worker
+            # 不捕获控制台流），而非 print_exc() 泄漏到 stdout/stderr
+            GLOG.ERROR(traceback.format_exc())
 
     def cancel(self):
         """取消任务"""

--- a/tests/unit/workers/test_task_processor_error_logging.py
+++ b/tests/unit/workers/test_task_processor_error_logging.py
@@ -1,0 +1,123 @@
+"""Tests for BacktestProcessor error-handling logging -- #6031.
+
+两个异常处理反模式必须对齐到本文件既定的 GLOG 范式（参考 L128
+``GLOG.ERROR(traceback.format_exc())``）：
+
+1. ``_on_progress`` 进度统计失败时 ``except: pass`` 完全静默 -> 必须发 WARN。
+2. ``_aggregate_and_save_results`` 汇总失败时 ``traceback.print_exc()`` 输出到
+   控制台流（stderr），后台 worker 模式下不被捕获 -> 必须经 GLOG.ERROR 落库。
+
+行为契约：异常发生时诊断信息进入结构化日志（GLOG），而非被吞掉或泄漏到
+控制台。控制流保持非致命（不影响主流程）。
+"""
+import types
+from datetime import datetime
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
+    from ginkgo.workers.backtest_worker.models import BacktestTask, BacktestConfig
+
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+def _make_processor(task) -> BacktestProcessor:
+    """构造最小可测处理器：跳过 __init__ 的 service 容器装配，
+    仅设置被测方法（_on_progress / _aggregate_and_save_results）读取的属性。
+    方法体真实运行。"""
+    proc = BacktestProcessor.__new__(BacktestProcessor)
+    proc.task = task
+    proc.worker_id = "w-test"
+    proc.progress_tracker = MagicMock()
+    proc._stop_event = Event()
+    proc._engine = None
+    proc._exception = None
+    proc._result = {}
+    return proc
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+@pytest.mark.tdd
+class TestOnProgressLogsOnStatsFailure:
+    """#6031-A: _on_progress 统计获取失败时必须发 WARN，而非静默 pass。"""
+
+    def test_warns_when_portfolio_stats_gather_raises(self, monkeypatch):
+        cfg = BacktestConfig(start_date="2025-01-01", end_date="2025-06-01")
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+
+        # 毒丸 portfolio：worth 为非数值对象 -> float(object()) 抛 TypeError 进入 except
+        poison = types.SimpleNamespace(
+            uuid="ptid", worth=object(), cash=1000.0, strategies=[], positions={}
+        )
+        proc._engine = types.SimpleNamespace(portfolios=[poison])
+
+        warned = []
+        spy = types.SimpleNamespace(
+            WARN=lambda msg: warned.append(msg),
+            ERROR=lambda msg: None,
+            INFO=lambda msg: None,
+            DEBUG=lambda msg: None,
+        )
+        monkeypatch.setattr(
+            "ginkgo.workers.backtest_worker.task_processor.GLOG", spy
+        )
+
+        # 不应抛出（统计失败非致命），且必须发一条 WARN
+        proc._on_progress(0.5, "2025-01-02")
+
+        assert len(warned) == 1, f"expected one WARN, got {warned}"
+        # WARN 必须带 task 上下文，便于 grep 定位
+        assert task.task_uuid[:8] in warned[0]
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+@pytest.mark.tdd
+class TestAggregateResultsRoutesTracebackToGlog:
+    """#6031-B: _aggregate_and_save_results 汇总失败时，完整 traceback 必须经
+    GLOG.ERROR 落库，而非 print_exc() 泄漏到控制台流（后台 worker 不捕获）。"""
+
+    def test_traceback_logged_not_printed(self, monkeypatch, capsys):
+        cfg = BacktestConfig(start_date="2025-01-01", end_date="2025-06-01")
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        task.started_at = datetime(2025, 1, 1)
+        task.completed_at = datetime(2025, 1, 2)
+        proc = _make_processor(task)
+
+        errors = []
+        spy = types.SimpleNamespace(
+            WARN=lambda msg: None,
+            ERROR=lambda msg: errors.append(msg),
+            INFO=lambda msg: None,
+            DEBUG=lambda msg: None,
+        )
+        monkeypatch.setattr(
+            "ginkgo.workers.backtest_worker.task_processor.GLOG", spy
+        )
+
+        # 让汇总入口 analyzer_service() 抛异常，触发外层 except
+        boom = types.SimpleNamespace(
+            analyzer_service=lambda: (_ for _ in ()).throw(
+                RuntimeError("boom-aggregation")
+            ),
+            backtest_task_service=lambda: None,
+        )
+        monkeypatch.setattr("ginkgo.data.containers.container", boom)
+
+        # 不应抛出（异常已被 except 捕获）
+        proc._aggregate_and_save_results()
+
+        captured = capsys.readouterr()
+        console = captured.out + captured.err
+
+        # 完整 traceback 不得泄漏到控制台流（stdout/stderr）
+        assert "Traceback" not in console, "traceback 泄漏到控制台"
+        # 必须经 GLOG.ERROR 落库（含完整 traceback 字符串）
+        assert any("Traceback" in m for m in errors), (
+            f"GLOG.ERROR 未收到 traceback，收到: {errors}"
+        )


### PR DESCRIPTION
## Summary

修复 #6031：`BacktestProcessor` 两处异常处理反模式，对齐本文件既定的 `GLOG.ERROR(traceback.format_exc())` 范式（参考 `task_processor.py` L128）。

| 位置 | 之前 | 之后 |
|---|---|---|
| `_on_progress` 进度统计失败 | `except: pass` 静默吞 | `GLOG.WARN(f"[{uuid[:8]}] Progress stats gathering failed: {e}")` |
| `_aggregate_and_save_results` 汇总失败 | `traceback.print_exc()` 泄漏到控制台流 | `GLOG.ERROR(traceback.format_exc())` |

**为什么**：
- 后台 worker（`worker-backtest`）模式下 stdout/stderr 不被轮转/捕获，`print_exc()` 等于把异常丢进黑洞。
- `except: pass` 完全静默，回测"进度卡住/统计为 0"类问题无线索可查。
- 两处都改为经 `GLOG` 结构化日志，落 `/tmp/ginkgo-backtest.log`，带 `task_uuid` 上下文可 grep。

**控制流不变**：两处仍是非致命路径（统计/汇总失败不影响主回测流程），仅把"静默/控制台"升级为"结构化日志"。

## Test plan

新增 `tests/unit/workers/test_task_processor_error_logging.py`（2 个 TDD 行为测试，均经 RED→GREEN）：

- `test_warns_when_portfolio_stats_gather_raises`：portfolio 统计获取抛异常 → 断言 `GLOG.WARN` 被调用且带 `task_uuid` 上下文。
- `test_traceback_logged_not_printed`：汇总入口抛异常 → 断言完整 traceback 经 `GLOG.ERROR` 落库，且**不泄漏**到 stdout/stderr（capsys 验证）。

本地冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1：`py_compile` src/api 全量通过
- ✅ Layer 2：启动路径点名（user_crud_mock / containers / user_cli）29 passed
- ✅ Layer 3：新测试 + workers 邻居（test_task_helpers / test_progress_tracker）4 passed，无回归

Closes #6031
