### PR TITLE
fix: data get status 友好 stub 替代 Unknown data type (#5992)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -446,6 +446,10 @@ def get(
                 ":information: calendar is planned but not yet implemented. "
                 "See `ginkgo data get --help`."
             )
+        elif data_type == "status":
+            # #5992: data get status 友好 stub，提示用 top-level 'data status' 命令，
+            # 而非落 else 分支报 'Unknown data type: status'。
+            console.print(":information: Data status check not yet implemented. Use 'ginkgo data status'.")
 
         else:
             console.print(f":x: Unknown data type: {data_type}")

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -640,3 +640,17 @@ class TestMisc:
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo"])
         assert result.exit_code == 0
         assert "No stock records" in result.output
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestDataGetStatusStub:
+    """#5992 data get status 返回友好 stub，而非 'Unknown data type: status'"""
+
+    def test_get_status_returns_friendly_not_unknown(self, cli_runner):
+        """data get status → exit 0，不含 'Unknown data type'，友好提示 status"""
+        result = cli_runner.invoke(data_cli.app, ["get", "status"])
+        assert result.exit_code == 0
+        assert "Unknown data type" not in result.output
+        out_lower = result.output.lower()
+        assert "status" in out_lower


### PR DESCRIPTION
## Summary

修复 #5992：`ginkgo data get status` 报 `Unknown data type: status`，改为友好 stub 消息。

**根因**：`data_cli.py` 的 `get` 命令 type dispatcher（if/elif 链）注册了 `stockinfo/day/tick/adjustfactor/sources` 五类，但漏 `status` → 落 `:417 else` 报 `Unknown data type: status` + `Exit(1)`。

而 top-level `data status` 命令（`:427 status()`）已有友好 stub `Data status check not yet implemented`——用户输入 `data get status`（get 的 status 子类型）却撞 Unknown，体验不一致。

**调用链**：

```
ginkgo data get status
  → get(data_type="status")
    → dispatcher: stockinfo? day? tick? adjustfactor? sources? 都不匹配
    → else → "Unknown data type: status" + Exit(1)  ❌
```

**修复**：dispatcher 加 `status` 分支，友好 stub + 提示用 `ginkgo data status`：

```python
elif data_type == "status":
    console.print(":information: Data status check not yet implemented. Use 'ginkgo data status'.")
```

## scope

- ✅ 主验收：`data get status` 返回友好 stub，不再 Unknown
- ✅ 提示用户正确的 top-level 命令 `data status`
- ⏭️ 未实现真实 status 查询（stub 状态，与 sources 等其他未实现子命令一致）

## Test plan

- [x] TDD RED：`test_get_status_returns_friendly_not_unknown` 修复前 `exit_code=1`（落 else Unknown）→ fail
- [x] TDD GREEN：修复后 `exit_code=0`、不含 `Unknown data type`、output 含 `status`
- [x] `tests/unit/client/test_data_cli.py` 全 45 测通过（44 旧 + 1 新），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_data_cli.py -o addopts= -q
# 45 passed
```

Closes #5992
