### PR TITLE
test(#6017): 补 test run WORKING_PATH=None 回归测试

### DIFF
--- a/tests/unit/client/test_test_cli_list.py
+++ b/tests/unit/client/test_test_cli_list.py
@@ -1,8 +1,8 @@
 """
-#6017: ginkgo test list 在 GCONF.WORKING_PATH 为 None 时不应崩溃。
+#6017: ginkgo test list/run 在 GCONF.WORKING_PATH 为 None 时不应崩溃。
 
 根因：config.py WORKING_PATH property 无 None 保护，配置缺 working_directory
-键时返 None → test_cli.py Path(None) 抛 TypeError。
+键时返 None → test_cli.py Path(None) 抛 TypeError。list(:60) 与 run(:313) 同源。
 
 测试策略：
   - patch GCONF.WORKING_PATH property 为 None（PropertyMock）
@@ -38,3 +38,19 @@ def test_list_normal_path_displays_layers():
     assert result.exit_code == 0
     assert "Ginkgo Test Suite" in result.output
     assert result.exception is None or not isinstance(result.exception, TypeError)
+
+
+def test_run_with_none_working_path_does_not_crash():
+    """WORKING_PATH=None 时 run 命令同样回退到 cwd，不抛 TypeError。
+
+    run :313 与 list :60 同源（#6408 一并加 ``or "."`` 兜底）。run 兜底后 cwd
+    无 ``test/`` 目录 → test_paths 空 → 早退 return，不会调 pytest.main，测试无副作用。
+    """
+    runner = CliRunner()
+    with patch.object(type(GCONF), "WORKING_PATH", new_callable=PropertyMock) as mock_wp:
+        mock_wp.return_value = None
+        result = runner.invoke(app, ["run"], catch_exceptions=True)
+    # catch_exceptions=True 吞异常进 result.exception；不抛 TypeError 是关键
+    assert not isinstance(result.exception, TypeError), (
+        f"WORKING_PATH=None 不应抛 TypeError，got: {result.exception!r}"
+    )


### PR DESCRIPTION
## Summary

补 **`ginkgo test run`** 在 `GCONF.WORKING_PATH=None` 时的回归测试。

#6017 已由 #6408（commit `967c606e`）修复并关闭：
- 实现：`test_cli.py` list(:60) + run(:313) 加 `or "."` 兜底
- 测试：`test_test_cli_list.py` 覆盖 **list**

本 PR 补齐 **run** 同源路径缺失的回归用例。

## 改动

- 新增 `test_run_with_none_working_path_does_not_crash`（`tests/unit/client/test_test_cli_list.py`）
- 仿既有 list 测试风格：`patch.object` + `PropertyMock` mock `WORKING_PATH`，断言走 `isinstance(result.exception, TypeError)`（CliRunner `catch_exceptions` 吞异常进 `result.exception`，见 feedback_test_cli_assertion_channel）
- **无实现改动**（采纳 #6408 的 `or "."`）

## 冲突解决

原分支与 #6408 重复修同一处实现（`os.getcwd()` vs `.`），rebase 后仅保留 run 测试增量，消除实现分歧与重复测试文件。

## Test plan

- [x] 3 passed（含新增 run 用例）：`tests/unit/client/test_test_cli_list.py -o addopts=`
- [x] mergeable: MERGEABLE
