### PR TITLE
fix: data sync day 增加 skipped_count 计 records_added=0 第三态 (#6052)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -526,6 +526,7 @@ def sync(
             try:
                 success_count = 0
                 error_count = 0
+                skipped_count = 0
 
                 for current_code in codes:
                     try:
@@ -556,6 +557,7 @@ def sync(
                                 success_count += 1
                                 console.print(f":white_check_mark: {current_code} sync completed ({records_added} records)")
                             else:
+                                skipped_count += 1
                                 console.print(f":warning: {current_code} — no data available from source")
                         else:
                             error_count += 1
@@ -567,7 +569,7 @@ def sync(
                         console.print(f":x: Error syncing {current_code}: {str(e)}")
                         continue
 
-                console.print(f":information: Day sync completed. Success: {success_count}, Errors: {error_count}")
+                console.print(f":information: Day sync completed. Success: {success_count}, Skipped: {skipped_count}, Errors: {error_count}")
 
             except Exception as e:
                 console.print(f":x: Error in day sync process: {e}")

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -354,6 +354,40 @@ class TestSync:
         output_clean = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
         assert "000001.SZ" in output_clean
 
+    @patch("ginkgo.service_hub")
+    def test_sync_day_records_added_zero_counts_skipped(self, mock_hub, cli_runner):
+        """records_added=0（源无数据）计入 skipped_count，汇总行含 Skipped"""
+        from ginkgo.libs.data.results.data_sync_result import DataSyncResult
+        from datetime import datetime
+        import re
+
+        mock_bar_service = MagicMock()
+        sync_data = DataSyncResult(
+            entity_type="bars",
+            entity_identifier="SH999999",
+            sync_range=(datetime(2025, 1, 1), datetime(2025, 6, 1)),
+            records_processed=0,
+            records_added=0,
+            records_updated=0,
+            records_skipped=0,
+            records_failed=0,
+            sync_duration=0.5,
+            is_idempotent=True,
+            sync_strategy="smart",
+        )
+        mock_bar_service.sync_smart.return_value = ServiceResult.success(
+            data=sync_data,
+            message="Successfully synced 0 bar records for SH999999",
+        )
+        mock_hub.data.bar_service.return_value = mock_bar_service
+
+        result = cli_runner.invoke(data_cli.app, ["sync", "day", "--code", "SH999999"])
+        assert result.exit_code == 0
+        output_clean = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
+        # 第三态：源无数据，计入 Skipped 而非漏统计
+        assert "Skipped: 1" in output_clean
+        assert "Success: 0" in output_clean
+
     def test_sync_day_unknown_type_error(self, cli_runner):
         """sync 未知数据类型返回错误"""
         result = cli_runner.invoke(data_cli.app, ["sync", "nonexistent"])


### PR DESCRIPTION
## Summary

修复 #6052：`ginkgo data sync day` 汇总行漏统计 `records_added=0` 的第三态。

**根因**：`data_cli.py` day 分支用二态计数（`success_count`/`error_count`）。当 `bar_service.sync_smart` 返回 `is_success=True` 但 `records_added=0`（源无数据）时，代码走进 `:559` warning 分支打印 `no data available`，却**既不计入 success 也不计入 error**。汇总行 `Day sync completed. Success: N, Errors: M` 的总数少于实际处理的 code 数，产出 `Success: 0, Errors: 0` 的误导性零信号。

**调用链**：

```
ginkgo data sync day -c SH999999
  → sync(data_type="day", code="SH999999")
    → bar_service.sync_smart(code="SH999999")
      → ServiceResult(is_success=True, records_added=0)   # 源无数据
    → records_added=0 → warning "no data available"        # 不计任何计数 ❌
  → 汇总 "Success: 0, Errors: 0"                           # 处理了 1 个 code 却全 0
```

**修复**：新增 `skipped_count` 计 `records_added=0` 的「成功但无数据」第三态，汇总改三态：

```python
skipped_count = 0
...
if records_added > 0:
    success_count += 1
else:
    skipped_count += 1                      # ← 新增第三态计数
...
# 汇总：Success + Skipped + Errors = 处理的 code 总数
console.print(f"Day sync completed. Success: {success_count}, Skipped: {skipped_count}, Errors: {error_count}")
```

## scope

- ✅ day 分支新增 `skipped_count`，`records_added=0` 时递增
- ✅ 汇总行改为 `Success: N, Skipped: S, Errors: M`（三态和 = 处理 code 总数）
- ⏭️ 未改 tick/adjustfactor 分支（同模式但验收只要求 day，不扩范围）

## Test plan

- [x] TDD RED：`test_sync_day_records_added_zero_counts_skipped` mock `records_added=0` → 修复前 `Skipped: 1` 不在 output → fail
- [x] TDD GREEN：修复后 output 含 `Skipped: 1` + `Success: 0`
- [x] `tests/unit/client/test_data_cli.py` 全 45 测通过（44 旧 + 1 新），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_data_cli.py -o addopts= -q
# 45 passed
```

Closes #6052
