### PR TITLE
fix: start_broker 错误路径守卫 broker 未绑定防 UnboundLocalError (#5552)

### DIFF
--- a/src/ginkgo/trading/brokers/broker_manager.py
+++ b/src/ginkgo/trading/brokers/broker_manager.py
@@ -253,6 +253,11 @@ class BrokerManager:
         """
         broker_crud, _, _ = self._get_cruds()
 
+        # #5552: 前置初始化 broker，避免 CRUD 查询抛异常时 except 块访问
+        # broker.uuid 触发 UnboundLocalError（被内层 except 吞掉，污染诊断日志、
+        # 掩盖原始异常）。
+        broker = None
+
         try:
             broker = broker_crud.get_broker_by_portfolio(portfolio_id)
             if not broker:
@@ -283,15 +288,17 @@ class BrokerManager:
 
         except Exception as e:
             GLOG.ERROR(f"Failed to start broker for portfolio {portfolio_id}: {e}")
-            # 尝试更新状态为错误
-            try:
-                broker_crud.update_broker_instance_status(
-                    broker.uuid,
-                    "error",
-                    error_message=str(e)
-                )
-            except Exception as e:
-                GLOG.ERROR(f"Failed to update broker status to error for portfolio {portfolio_id}: {e}")
+            # 尝试更新状态为错误（仅当 broker 已查到——查询失败时无 broker 可更新，
+            # 强行访问 broker.uuid 会触发 UnboundLocalError，见 #5552）
+            if broker is not None:
+                try:
+                    broker_crud.update_broker_instance_status(
+                        broker.uuid,
+                        "error",
+                        error_message=str(e)
+                    )
+                except Exception as e:
+                    GLOG.ERROR(f"Failed to update broker status to error for portfolio {portfolio_id}: {e}")
             return False
 
     def stop_broker(self, portfolio_id: str) -> bool:

--- a/tests/unit/trading/test_broker_manager_start_broker_errors.py
+++ b/tests/unit/trading/test_broker_manager_start_broker_errors.py
@@ -1,0 +1,87 @@
+"""
+TDD tests for BrokerManager.start_broker error path (#5552).
+
+Behavior under test: when the broker CRUD lookup raises, start_broker must
+return False gracefully instead of masking the original exception with
+UnboundLocalError (``broker`` referenced in the except block before any
+assignment in the try block).
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.trading.brokers.broker_manager import BrokerManager
+
+
+@pytest.fixture
+def broker_manager():
+    """直接构造 BrokerManager——__init__ 仅初始化空状态，无外部依赖。"""
+    return BrokerManager()
+
+
+class TestStartBrokerErrorPath:
+    """#5552: broker CRUD 失败路径不得抛 UnboundLocalError。"""
+
+    @patch("ginkgo.trading.brokers.broker_manager.container.broker_instance_crud")
+    def test_no_unbound_local_noise_when_broker_lookup_raises(
+        self, mock_broker_crud_factory, broker_manager, monkeypatch
+    ):
+        """CRUD 查询 broker 抛异常时，错误路径不得泄漏 UnboundLocalError 噪音。
+
+        #5552：``get_broker_by_portfolio`` 抛异常 → ``broker`` 未绑定 →
+        except 块访问 ``broker.uuid`` 触发 UnboundLocalError。该异常当前被
+        内层 except 吞掉，污染诊断日志（原始 CRUD 异常被 UnboundLocalError 掩盖）。
+        修复后应前置 ``broker = None`` 并以 ``if broker is not None`` 守卫，使
+        原始异常被干净记录。
+        """
+        errors = []
+        monkeypatch.setattr(
+            "ginkgo.trading.brokers.broker_manager.GLOG.ERROR",
+            lambda msg, *a, **k: errors.append(str(msg)),
+        )
+
+        mock_broker_crud = mock_broker_crud_factory.return_value
+        mock_broker_crud.get_broker_by_portfolio.side_effect = RuntimeError("DB connection lost")
+
+        result = broker_manager.start_broker("portfolio-uuid")
+
+        # 仍优雅返回 False
+        assert result is False
+        # 原始 CRUD 异常必须被记录（诊断可见）
+        assert any("DB connection lost" in e for e in errors), errors
+        # 不得泄漏 UnboundLocalError（修复前会在此记录二次异常）。
+        # 跨 Python 版本鲁棒：3.13+ 消息为 "cannot access local variable 'broker'
+        # where it is not associated with a value"，旧版为 "local variable 'broker'
+        # referenced before assignment"——共同锚点是 "local variable" + 变量名。
+        leaked = [
+            e for e in errors
+            if "local variable" in e and "broker" in e
+        ]
+        assert not leaked, f"错误路径泄漏 UnboundLocalError 噪音: {leaked}"
+
+    @patch("ginkgo.trading.brokers.broker_manager.container.broker_instance_crud")
+    def test_updates_status_when_broker_found_but_later_step_raises(
+        self, mock_broker_crud_factory, broker_manager
+    ):
+        """broker 查询成功但后续步骤抛异常时，仍应以正确 uuid 更新状态为 error。
+
+        回归锁（#5552 守卫的对称面）：``if broker is not None`` 守卫不得误伤
+        正常错误路径——broker 已绑定时，状态更新必须仍以正确 uuid 触发。
+        若有人把守卫误写成 ``if broker is None``，本测试会捕获退化。
+        """
+        mock_broker_crud = mock_broker_crud_factory.return_value
+        broker = MagicMock()
+        broker.uuid = "broker-uuid-123"
+        mock_broker_crud.get_broker_by_portfolio.return_value = broker
+
+        # broker 已在内存注册表（通过 L262 ``broker.uuid in self._brokers`` 检查）
+        broker_obj = MagicMock()
+        broker_obj.connect.side_effect = RuntimeError("exchange down")
+        broker_manager._brokers["broker-uuid-123"] = broker_obj
+
+        result = broker_manager.start_broker("portfolio-uuid")
+
+        assert result is False
+        # 外层 except 内：broker 已绑定 → update 仍被调用，uuid 正确
+        mock_broker_crud.update_broker_instance_status.assert_any_call(
+            "broker-uuid-123", "error", error_message="exchange down"
+        )


### PR DESCRIPTION
## Summary

修复 #5552：`BrokerManager.start_broker` 错误路径访问未绑定变量触发 UnboundLocalError。

**根因**：`start_broker` 在 `try` 块内 `broker = broker_crud.get_broker_by_portfolio(portfolio_id)` 赋值，若该 CRUD 调用抛异常，`broker` 未绑定。外层 `except` 块访问 `broker.uuid` 触发 `UnboundLocalError`——该异常被紧邻的内层 `except Exception` 吞掉，污染诊断日志（原始 CRUD 异常被掩盖），且 `update_broker_instance_status` 因参数求值阶段就失败而从未执行。

**修复**（对齐验收标准）：
1. `try` 前置 `broker = None`
2. 外层 `except` 内以 `if broker is not None:` 守卫状态更新——broker 查询失败时（无 uuid 可用）不再尝试状态更新
3. 新增错误路径 TDD 测试

**控制流不变**：broker 查询失败仍优雅返回 `False`；broker 已绑定的正常错误路径（connect 等步骤抛异常）仍以正确 uuid 更新状态为 error。

## Test plan

新增 `tests/unit/trading/test_broker_manager_start_broker_errors.py`（2 个 TDD 行为测试，经 RED→GREEN）：

- `test_no_unbound_local_noise_when_broker_lookup_raises`：CRUD 查询抛异常 → 断言返回 False，且诊断日志**不含** UnboundLocalError 噪音（跨 Python 版本鲁棒：3.13+ 消息为 "cannot access local variable 'broker'..."，旧版 "local variable 'broker' referenced before assignment"，共同锚点 "local variable" + "broker"）。
- `test_updates_status_when_broker_found_but_later_step_raises`：**回归锁**（守卫对称面）——broker 已绑定但后续步骤抛异常时，状态更新仍以正确 uuid 触发，防止守卫被误写成 `if broker is None`。

本地三层冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1：`py_compile` src/api 全量通过
- ✅ Layer 2：启动路径点名（user_crud_mock / containers / user_cli）29 passed
- ✅ Layer 3：新测试 + `test_broker_manager_existing.py` → 2 新测试 PASS，14 passed
  - ⚠️ `test_create_broker_success` 失败为 **pre-existing**（已用 `git checkout origin/master -- broker_manager.py` 还原验证同样失败）：失败点 `broker_manager.py:117` create_broker 的 "已绑定" 检查，与本 PR 改动的 start_broker 无关

Closes #5552
