### PR TITLE
fix: data get calendar 加友好 stub 不再 Unknown (#5350)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -414,6 +414,11 @@ def get(
             console.print(table)
             console.print(f":information: {len(configured_sources)} data source(s) configured")
 
+        elif data_type == "calendar":
+            # #5350: calendar 列在 help 的 [planned] 类型中，但查询未实现。
+            # 与 sources 等 stub 一致给出友好提示，而非落 else 报 Unknown（与 help planned 标记对齐）。
+            console.print(":information: Calendar data query is planned but not yet implemented.")
+
         else:
             console.print(f":x: Unknown data type: {data_type}")
             raise typer.Exit(1)

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -260,6 +260,14 @@ class TestGetOtherTypes:
         # 容器注入了 tushare/tdx（containers.py），应被列出
         assert "tushare" in result.output.lower()
 
+    def test_get_calendar_returns_friendly_not_unknown(self, cli_runner):
+        """calendar 数据类型返回友好 planned 提示，不再 Unknown"""
+        result = cli_runner.invoke(data_cli.app, ["get", "calendar"])
+        assert result.exit_code == 0
+        assert "Unknown" not in result.output
+        out_lower = result.output.lower()
+        assert "calendar" in out_lower
+
 
 # ============================================================================
 # 4. status 测试


### PR DESCRIPTION
## Summary

修复 #5350：`ginkgo data get calendar` 报 `Unknown data type: calendar`，改为友好 planned 提示。

**根因**：`data_cli.py` 的 `get` 命令 type dispatcher（if/elif 链）注册了 `stockinfo/day/tick/adjustfactor/sources`，但漏 `calendar` → 落 `:417 else` 报 `Unknown data type: calendar` + `Exit(1)`。

而 help（`:25`）已通过 PR#6230 用 `\[planned: calendar]` 转义标记 calendar 为「计划中未实现」——dispatcher 与 help 不一致：help 暗示 calendar 合法，输入却撞 Unknown。

**调用链**：

```
ginkgo data get calendar
  → get(data_type="calendar")
    → dispatcher: stockinfo? day? tick? adjustfactor? sources? 都不匹配
    → else → "Unknown data type: calendar" + Exit(1)  ❌
```

**修复**：dispatcher 加 `calendar` elif 分支，友好 stub（与 `sources`/`status` stub 风格一致），与 help 的 `[planned]` 标记对齐：

```python
elif data_type == "calendar":
    # calendar 列在 help 的 [planned] 类型中，但查询未实现。
    console.print(":information: Calendar data query is planned but not yet implemented.")
```

## scope

- ✅ 主验收：`data get calendar` 返回友好 planned 提示，不再 Unknown（exit_code=0）
- ✅ dispatcher 与 help `[planned: calendar]` 标记一致
- ⏭️ 未实现真实 calendar 查询（planned 状态，与 sources 等其他 stub 一致；真实实现待交易日历数据源接入）

## Test plan

- [x] TDD RED：`test_get_calendar_returns_friendly_not_unknown` 修复前 `exit_code=1`（落 else Unknown）→ fail
- [x] TDD GREEN：修复后 `exit_code=0`、不含 `Unknown`、output 含 `calendar`
- [x] `tests/unit/client/test_data_cli.py` 全 45 测通过（44 旧 + 1 新），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_data_cli.py -o addopts= -q
# 45 passed
```

Closes #5350
