### PR TITLE
fix: data sync 无效 type 错误提示列出有效值 (#5390)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -603,6 +603,12 @@ def _record_sync_result(service, record_uuid: str, result, started_at: float):
         service.record_complete(uuid=record_uuid, status="partial", duration_ms=duration_ms)
 
 
+# #5390: sync_data 支持的 type 白名单——新增 type 时须同步此常量与下方
+# if/elif 分支（stockinfo/bars/ticks/adjustfactor）。错误提示从此常量
+# 生成，避免有效值列表与分支漂移。
+_SUPPORTED_DATA_SYNC_TYPES = ("stockinfo", "bars", "ticks", "adjustfactor")
+
+
 @router.post("/sync")
 async def sync_data(request: DataUpdateRequest):
     """触发数据同步"""
@@ -715,7 +721,10 @@ async def sync_data(request: DataUpdateRequest):
             )
 
         else:
-            raise HTTPException(status_code=400, detail=f"Unsupported data type: {request.type}")
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported data type: {request.type}. Supported types: {', '.join(_SUPPORTED_DATA_SYNC_TYPES)}",
+            )
 
     except HTTPException:
         raise

--- a/tests/api/test_data_sync_type_error.py
+++ b/tests/api/test_data_sync_type_error.py
@@ -1,0 +1,56 @@
+# Upstream: api.api.data.sync_data (POST /api/v1/data/sync)
+# Role: 验证无效 type 错误提示列出所有有效值 (#5390)
+"""
+sync_data 无效 type 错误提示测试
+
+#5390: type=bar 等无效值返回 'Unsupported data type: bar'，
+未告诉用户合法值（stockinfo/bars/ticks/adjustfactor）。
+本测试锁定：错误提示应列出全部有效 type。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi import HTTPException
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_sync_record_mock():
+    """构造 DataSyncRecordService + record_start 返回值的替身"""
+    svc = MagicMock()
+    rec = MagicMock()
+    rec.is_success.return_value = True
+    rec.data = {"uuid": "rec-uuid-1"}
+    svc.record_start.return_value = rec
+    return svc
+
+
+@pytest.mark.unit
+class TestSyncDataUnsupportedType:
+    """#5390: 无效 type 错误提示列出有效值"""
+
+    def test_unsupported_type_lists_all_valid_values(self):
+        """type=bar 无效时，400 错误提示含全部有效 type
+
+        RED: 当前 detail='Unsupported data type: bar' 未列有效值。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        request = DataUpdateRequest(type="bar", codes=["000001.SZ"])
+
+        with patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            with pytest.raises(HTTPException) as exc:
+                run_async(sync_data(request))
+
+        assert exc.value.status_code == 400
+        detail = str(exc.value.detail)
+        assert "Unsupported data type: bar" in detail
+        # 列出全部有效值
+        assert "stockinfo" in detail
+        assert "bars" in detail
+        assert "ticks" in detail
+        assert "adjustfactor" in detail


### PR DESCRIPTION
## Summary

修复 #5390：`POST /api/v1/data/sync` 无效 `type` 错误提示未列出有效值，补 `Supported types` 列表。

**根因**：`api/api/data.py` 的 `sync_data` 端点用 if/elif 链分发 `type`（stockinfo/bars/ticks/adjustfactor），无效值落 `:717 else` 抛 `Unsupported data type: {type}`——只说「什么错了」，未告诉用户合法值是什么，须翻文档或源码才能纠正。

**调用链**：

```
POST /api/v1/data/sync  {"type":"bar","codes":["000001.SZ"]}
  → sync_data(request)
    → if stockinfo? elif bars? elif ticks? elif adjustfactor? 都不匹配
    → else → HTTPException(400, "Unsupported data type: bar")  ❌ 无有效值
```

**修复**：提取模块级常量 `_SUPPORTED_DATA_SYNC_TYPES = ("stockinfo", "bars", "ticks", "adjustfactor")` 作为有效值单一事实源，else 消息用 `', '.join(...)` 生成列表：

```python
raise HTTPException(
    status_code=400,
    detail=f"Unsupported data type: {request.type}. Supported types: {', '.join(_SUPPORTED_DATA_SYNC_TYPES)}",
)
```

常量防漂移：未来 if/elif 新增 type 时，更新此常量即可让错误消息自动同步（注释已标注同步要求）。

## scope

- ✅ 主验收：无效 type 返回 400 + detail 含全部有效值（stockinfo/bars/ticks/adjustfactor）
- ✅ 提取 `_SUPPORTED_DATA_SYNC_TYPES` 常量（单一事实源，防有效值列表与分支漂移）
- ⏭️ 未改 `type` 字段为 `Literal[...]`（issue 提的「更好方案」，但改 schema 会改变 422 验证错误格式，属 breaking change，超范围；当前错误消息方案已满足验收且零 breaking）

## Test plan

- [x] TDD RED：`test_unsupported_type_lists_all_valid_values` mock `get_sync_record_service` + `type=bar` → 修复前 detail 无 `stockinfo` 等 → fail
- [x] TDD GREEN：修复后 detail 含 `Unsupported data type: bar` + 全部 4 个有效值
- [x] 新建 `tests/api/test_data_sync_type_error.py`（1 测），直调 `sync_data` + `pytest.raises(HTTPException)`，避开 TestClient/app 启动（符合 `arch_api_test_root_main_shadow`）
- [x] tests/api data sync 相关全回归（codes_field/adjustfactor/status + 新测 = 18 passed）
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest \
  tests/api/test_data_sync_type_error.py tests/api/test_data_sync_codes_field.py \
  tests/api/test_data_sync_adjustfactor.py tests/api/test_data_sync_status.py -o addopts= -q
# 18 passed
```

Closes #5390
