### PR TITLE
perf(#3869): event_engine 热路径日志降级 INFO→DEBUG

### DIFF
--- a/src/ginkgo/trading/engines/event_engine.py
+++ b/src/ginkgo/trading/engines/event_engine.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
 import uuid
 import datetime
+import logging
 import time
 import threading
 from threading import Thread
@@ -212,9 +213,11 @@ class EventEngine(BaseEngine):
                 event = self._event_queue.get(timeout=1.0)  # 1秒超时
                 event_id = id(event)
                 order_uuid = event.order.uuid[:8] if hasattr(event, 'order') and event.order else 'NO_ORDER'
-                GLOG.DEBUG(f"🔍 [EVENT ENGINE MAIN LOOP] Got event from queue: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+                if GLOG.logger.isEnabledFor(logging.DEBUG):
+                    GLOG.DEBUG(f"🔍 [EVENT ENGINE MAIN LOOP] Got event from queue: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
                 self._process(event)
-                GLOG.DEBUG(f"🔍 [EVENT ENGINE MAIN LOOP] Event processing completed: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+                if GLOG.logger.isEnabledFor(logging.DEBUG):
+                    GLOG.DEBUG(f"🔍 [EVENT ENGINE MAIN LOOP] Event processing completed: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
             except Empty:
                 # 队列为空，继续循环
                 continue
@@ -428,31 +431,40 @@ class EventEngine(BaseEngine):
         with self._queue_lock:
             event_id = id(enhanced_event)
             order_uuid = enhanced_event.order.uuid[:8] if hasattr(enhanced_event, 'order') and enhanced_event.order else 'NO_ORDER'
-            GLOG.DEBUG(f"🔍 [EVENT ENGINE TRACKING] Putting event into queue: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+            if GLOG.logger.isEnabledFor(logging.DEBUG):
+                GLOG.DEBUG(f"🔍 [EVENT ENGINE TRACKING] Putting event into queue: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
             self._event_queue.put(enhanced_event)
-            GLOG.DEBUG(f"🔍 [EVENT ENGINE TRACKING] Event put into queue successfully: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+            if GLOG.logger.isEnabledFor(logging.DEBUG):
+                GLOG.DEBUG(f"🔍 [EVENT ENGINE TRACKING] Event put into queue successfully: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
 
-        GLOG.DEBUG(f"Event queued: {enhanced_event.event_type} seq={enhanced_event.sequence_number}")
+        if GLOG.logger.isEnabledFor(logging.DEBUG):
+            GLOG.DEBUG(f"Event queued: {enhanced_event.event_type} seq={enhanced_event.sequence_number}")
 
     def _process(self, event: "EventBase") -> None:
         """安全事件处理 - 默认启用统计"""
         event_id = id(event)
         order_uuid = event.order.uuid[:8] if hasattr(event, 'order') and event.order else 'NO_ORDER'
-        GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Processing event: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
-        GLOG.DEBUG(f"Process {event.event_type}")
+        if GLOG.logger.isEnabledFor(logging.DEBUG):
+            GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Processing event: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+        if GLOG.logger.isEnabledFor(logging.DEBUG):
+            GLOG.DEBUG(f"Process {event.event_type}")
 
         try:
             # 具体事件处理器
             if event.event_type in self._handlers:
                 handlers_count = len(self._handlers[event.event_type])
-                GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Found {handlers_count} handlers for {event.event_type}")
+                if GLOG.logger.isEnabledFor(logging.DEBUG):
+                    GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Found {handlers_count} handlers for {event.event_type}")
                 for i, handler in enumerate(self._handlers[event.event_type]):
                     handler_id = id(handler)
                     handler_name = getattr(handler, '__name__', 'unknown')
-                    GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Calling handler {i+1}/{handlers_count}: {handler_name}, handler_id={handler_id}")
+                    if GLOG.logger.isEnabledFor(logging.DEBUG):
+                        GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Calling handler {i+1}/{handlers_count}: {handler_name}, handler_id={handler_id}")
                     result = handler(event)
-                    GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Handler {i+1} completed: result={type(result)}")
-                GLOG.DEBUG(f"{self.name} Deal with {event.event_type}.")
+                    if GLOG.logger.isEnabledFor(logging.DEBUG):
+                        GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Handler {i+1} completed: result={type(result)}")
+                if GLOG.logger.isEnabledFor(logging.DEBUG):
+                    GLOG.DEBUG(f"{self.name} Deal with {event.event_type}.")
             else:
                 GLOG.WARN(f"There is no handler for {event.event_type}")
 
@@ -637,7 +649,8 @@ class EventEngine(BaseEngine):
             # 分配序列号
             event.sequence_number = self._get_next_sequence_number()
 
-            GLOG.DEBUG(f"Event enhanced: {event.event_type} seq={event.sequence_number}")
+            if GLOG.logger.isEnabledFor(logging.DEBUG):
+                GLOG.DEBUG(f"Event enhanced: {event.event_type} seq={event.sequence_number}")
             return event
 
         except Exception as e:

--- a/src/ginkgo/trading/engines/event_engine.py
+++ b/src/ginkgo/trading/engines/event_engine.py
@@ -212,9 +212,9 @@ class EventEngine(BaseEngine):
                 event = self._event_queue.get(timeout=1.0)  # 1秒超时
                 event_id = id(event)
                 order_uuid = event.order.uuid[:8] if hasattr(event, 'order') and event.order else 'NO_ORDER'
-                GLOG.INFO(f"🔍 [EVENT ENGINE MAIN LOOP] Got event from queue: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+                GLOG.DEBUG(f"🔍 [EVENT ENGINE MAIN LOOP] Got event from queue: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
                 self._process(event)
-                GLOG.INFO(f"🔍 [EVENT ENGINE MAIN LOOP] Event processing completed: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+                GLOG.DEBUG(f"🔍 [EVENT ENGINE MAIN LOOP] Event processing completed: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
             except Empty:
                 # 队列为空，继续循环
                 continue
@@ -428,9 +428,9 @@ class EventEngine(BaseEngine):
         with self._queue_lock:
             event_id = id(enhanced_event)
             order_uuid = enhanced_event.order.uuid[:8] if hasattr(enhanced_event, 'order') and enhanced_event.order else 'NO_ORDER'
-            GLOG.INFO(f"🔍 [EVENT ENGINE TRACKING] Putting event into queue: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+            GLOG.DEBUG(f"🔍 [EVENT ENGINE TRACKING] Putting event into queue: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
             self._event_queue.put(enhanced_event)
-            GLOG.INFO(f"🔍 [EVENT ENGINE TRACKING] Event put into queue successfully: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+            GLOG.DEBUG(f"🔍 [EVENT ENGINE TRACKING] Event put into queue successfully: event_type={enhanced_event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
 
         GLOG.DEBUG(f"Event queued: {enhanced_event.event_type} seq={enhanced_event.sequence_number}")
 
@@ -438,20 +438,20 @@ class EventEngine(BaseEngine):
         """安全事件处理 - 默认启用统计"""
         event_id = id(event)
         order_uuid = event.order.uuid[:8] if hasattr(event, 'order') and event.order else 'NO_ORDER'
-        GLOG.INFO(f"🔍 [EVENT ENGINE PROCESSING] Processing event: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
+        GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Processing event: event_type={event.event_type}, order_uuid={order_uuid}, event_id={event_id}")
         GLOG.DEBUG(f"Process {event.event_type}")
 
         try:
             # 具体事件处理器
             if event.event_type in self._handlers:
                 handlers_count = len(self._handlers[event.event_type])
-                GLOG.INFO(f"🔍 [EVENT ENGINE PROCESSING] Found {handlers_count} handlers for {event.event_type}")
+                GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Found {handlers_count} handlers for {event.event_type}")
                 for i, handler in enumerate(self._handlers[event.event_type]):
                     handler_id = id(handler)
                     handler_name = getattr(handler, '__name__', 'unknown')
-                    GLOG.INFO(f"🔍 [EVENT ENGINE PROCESSING] Calling handler {i+1}/{handlers_count}: {handler_name}, handler_id={handler_id}")
+                    GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Calling handler {i+1}/{handlers_count}: {handler_name}, handler_id={handler_id}")
                     result = handler(event)
-                    GLOG.INFO(f"🔍 [EVENT ENGINE PROCESSING] Handler {i+1} completed: result={type(result)}")
+                    GLOG.DEBUG(f"🔍 [EVENT ENGINE PROCESSING] Handler {i+1} completed: result={type(result)}")
                 GLOG.DEBUG(f"{self.name} Deal with {event.event_type}.")
             else:
                 GLOG.WARN(f"There is no handler for {event.event_type}")

--- a/tests/unit/trading/test_event_engine_hot_path_logging.py
+++ b/tests/unit/trading/test_event_engine_hot_path_logging.py
@@ -8,12 +8,14 @@
 - put / _process 热路径不再产生 INFO 级噪音日志（降级为 DEBUG）
 - 功能不变：事件正确入队、统计计数正确更新
 """
+import logging
 import threading
 from queue import Queue
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, PropertyMock
 
 import pytest
 
+from ginkgo.libs import GLOG
 from ginkgo.trading.engines.event_engine import EventEngine
 
 
@@ -95,7 +97,11 @@ class TestHotPathLoggingSilenced:
         assert engine._processed_events_count == 1
 
     def test_put_still_logs_debug_for_diagnostics(self, monkeypatch):
-        """回归锁：降级后 DEBUG 诊断日志仍在（put 成功入队仍可追踪，仅级别下调）。"""
+        """回归锁：降级后 DEBUG 诊断日志仍在（put 成功入队仍可追踪，仅级别下调）。
+
+        注：守卫语义下 DEBUG 仅在 DEBUG 启用时输出，故此处须显式 enable
+        才符合「诊断仍可追踪」本意（与 TestHotPathDebugFStringLaziness 对齐）。
+        """
         engine = _make_lightweight_engine()
         event = _make_event()
         debug_calls = []
@@ -103,9 +109,87 @@ class TestHotPathLoggingSilenced:
             "ginkgo.trading.engines.event_engine.GLOG.DEBUG",
             lambda msg: debug_calls.append(msg),
         )
+        monkeypatch.setattr(GLOG.logger, "isEnabledFor", lambda lvl: True)
 
         engine.put(event)
 
         # put 成功后应有一条 DEBUG（Event queued ... seq=...）
         assert any("queued" in m for m in debug_calls), \
             f"put 应保留 DEBUG 诊断日志，实际 DEBUG: {debug_calls}"
+
+
+# review #6317 打回点：INFO→DEBUG 降级缺 isEnabledFor 守卫。
+# GLOG.DEBUG(msg: str) 接收预构造 str（logger.py:747），f-string 在调用处传参时已求值；
+# DEBUG 内部 isEnabledFor 守卫（logger.py:749）只跳过 _emit I/O，不省格式化（arch_glog_debug_fstring_eager）。
+# #3869 AC1 要求「GLOG.DEBUG + if GLOG.isEnabledFor(DEBUG) guard」——本组测试钉死该契约。
+def _make_counting_event():
+    """event_type 用 PropertyMock 计数——验证 DEBUG f-string 是否被守卫跳过。
+
+    put 路径 event_type 仅出现在日志 f-string（无业务读），故访问次数==0 等价于
+    「f-string 未 eager 求值」。order=None 走 'NO_ORDER' 分支避开 MagicMock 切片。
+    """
+    event = MagicMock()
+    event.order = None
+    event.sequence_number = 0
+    counter = {"n": 0}
+
+    def _count_event_type():
+        counter["n"] += 1
+        return "COUNTED"
+
+    type(event).event_type = PropertyMock(side_effect=_count_event_type)
+    return event, counter
+
+
+class TestHotPathDebugFStringLaziness:
+    """#3869 AC1：默认 INFO 级，热路径 DEBUG f-string 不得 eager 求值。"""
+
+    def test_put_does_not_eagerly_format_debug_fstring_when_debug_disabled(self, monkeypatch):
+        """put() 入队路径 4 处 DEBUG f-string（_enhance_event L628 + put L419/421/423）在
+        DEBUG 禁用时不得 eager 求值——event_type 访问次数==0。"""
+        engine = _make_lightweight_engine()
+        event, counter = _make_counting_event()
+        # 默认 INFO 级：DEBUG 关闭（模拟生产回测常态）
+        monkeypatch.setattr(GLOG.logger, "isEnabledFor", lambda lvl: lvl >= logging.INFO)
+
+        engine.put(event)
+
+        assert counter["n"] == 0, (
+            f"put() DEBUG f-string 仍 eager 求值 event_type {counter['n']} 次"
+            "（缺 isEnabledFor 守卫，arch_glog_debug_fstring_eager）"
+        )
+
+    def test_process_skips_debug_calls_when_debug_disabled(self, monkeypatch):
+        """_process() 业务逻辑（L434 event_type in handlers）必须执行，无法断 event_type==0；
+        改断 GLOG.DEBUG 调用次数==0 验证守卫跳过诊断日志（L429/430 等）。"""
+        engine = _make_lightweight_engine()
+        event = _make_event()  # _handlers={} → 走 else 分支
+        debug_calls = []
+        monkeypatch.setattr(
+            "ginkgo.trading.engines.event_engine.GLOG.DEBUG",
+            lambda msg: debug_calls.append(msg),
+        )
+        monkeypatch.setattr(GLOG.logger, "isEnabledFor", lambda lvl: lvl >= logging.INFO)
+
+        engine._process(event)
+
+        assert debug_calls == [], (
+            f"DEBUG 禁用时 _process 仍调 GLOG.DEBUG {len(debug_calls)} 次: {debug_calls}"
+        )
+
+    def test_put_still_emits_debug_when_enabled(self, monkeypatch):
+        """回归锁：守卫不破坏 DEBUG 启用时的诊断日志（put 仍记录 'Event queued'）。"""
+        engine = _make_lightweight_engine()
+        event = _make_event()
+        debug_calls = []
+        monkeypatch.setattr(
+            "ginkgo.trading.engines.event_engine.GLOG.DEBUG",
+            lambda msg: debug_calls.append(msg),
+        )
+        monkeypatch.setattr(GLOG.logger, "isEnabledFor", lambda lvl: True)  # DEBUG 启用
+
+        engine.put(event)
+
+        assert any("queued" in m for m in debug_calls), (
+            f"DEBUG 启用时 put 应记录诊断日志，实际: {debug_calls}"
+        )

--- a/tests/unit/trading/test_event_engine_hot_path_logging.py
+++ b/tests/unit/trading/test_event_engine_hot_path_logging.py
@@ -1,0 +1,111 @@
+"""#3869 回测热路径日志降级行为测试。
+
+热路径（put / _process / main loop）每事件产生 6-8 条 INFO 日志 + f-string
+格式化，回测数百万事件 → 数千万次日志开销。owner 复核（2026-06-20）确认
+仍存在。
+
+行为契约（修复后）：
+- put / _process 热路径不再产生 INFO 级噪音日志（降级为 DEBUG）
+- 功能不变：事件正确入队、统计计数正确更新
+"""
+import threading
+from queue import Queue
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.trading.engines.event_engine import EventEngine
+
+
+def _make_lightweight_engine() -> EventEngine:
+    """轻量装配 EventEngine（避开 BaseEngine 的 entities 延迟导入重依赖）。
+
+    保留 _enhance_event / _get_next_sequence_number 等方法绑定，仅设 put() /
+    _process() 依赖的数据属性。
+    """
+    engine = object.__new__(EventEngine)
+    engine._engine_id = "test-engine-id"
+    engine._task_id = "test-task-id"
+    engine._sequence_number = 0
+    engine._sequence_lock = threading.Lock()
+    engine._event_queue = Queue(maxsize=100)
+    engine._queue_lock = threading.Lock()
+    engine._stats_lock = threading.Lock()
+    engine._event_stats = {
+        "total_events": 0,
+        "completed_events": 0,
+        "failed_events": 0,
+        "processing_start_time": None,
+    }
+    engine._processed_events_count = 0
+    engine._processing_start_time = None
+    engine._handlers = {}
+    engine._general_handlers = []
+    engine.name = "test-engine"
+    # now 是 EventEngine @property（返回 datetime.now()），无需装配
+    return engine
+
+
+def _make_event() -> MagicMock:
+    """构造测试事件（event.order=None 使日志走 'NO_ORDER' 分支，无 MagicMock 切片）。"""
+    event = MagicMock()
+    event.event_type = "TEST_EVENT"
+    event.order = None
+    event.sequence_number = 0
+    return event
+
+
+class TestHotPathLoggingSilenced:
+    """热路径 INFO 日志应降级为 DEBUG（默认 INFO 级别下静默）。"""
+
+    def test_put_does_not_emit_info_on_hot_path(self, monkeypatch):
+        """put() 入队路径不再产生 🔍 INFO 噪音，且事件正确入队。"""
+        engine = _make_lightweight_engine()
+        event = _make_event()
+        info_calls = []
+        monkeypatch.setattr(
+            "ginkgo.trading.engines.event_engine.GLOG.INFO",
+            lambda msg: info_calls.append(msg),
+        )
+
+        engine.put(event)
+
+        hot_path_info = [m for m in info_calls if "EVENT ENGINE" in m]
+        assert hot_path_info == [], f"put 热路径仍泄露 INFO: {hot_path_info}"
+        # 功能不变：事件已入队
+        assert not engine._event_queue.empty()
+        assert engine._event_queue.qsize() == 1
+
+    def test_process_does_not_emit_info_on_hot_path(self, monkeypatch):
+        """_process() 处理路径不再产生 🔍 INFO 噪音，且 completed 统计正确。"""
+        engine = _make_lightweight_engine()
+        event = _make_event()
+        info_calls = []
+        monkeypatch.setattr(
+            "ginkgo.trading.engines.event_engine.GLOG.INFO",
+            lambda msg: info_calls.append(msg),
+        )
+
+        engine._process(event)
+
+        hot_path_info = [m for m in info_calls if "EVENT ENGINE" in m]
+        assert hot_path_info == [], f"_process 热路径仍泄露 INFO: {hot_path_info}"
+        # 功能不变：completed 统计 +1
+        assert engine._event_stats["completed_events"] == 1
+        assert engine._processed_events_count == 1
+
+    def test_put_still_logs_debug_for_diagnostics(self, monkeypatch):
+        """回归锁：降级后 DEBUG 诊断日志仍在（put 成功入队仍可追踪，仅级别下调）。"""
+        engine = _make_lightweight_engine()
+        event = _make_event()
+        debug_calls = []
+        monkeypatch.setattr(
+            "ginkgo.trading.engines.event_engine.GLOG.DEBUG",
+            lambda msg: debug_calls.append(msg),
+        )
+
+        engine.put(event)
+
+        # put 成功后应有一条 DEBUG（Event queued ... seq=...）
+        assert any("queued" in m for m in debug_calls), \
+            f"put 应保留 DEBUG 诊断日志，实际 DEBUG: {debug_calls}"


### PR DESCRIPTION
## Summary

修复 #3869 子问题①：`event_engine` 回测热路径日志过量（owner 2026-06-20 复核确认仍存在）。

**根因**：`put()`(L400-423) / `_process()`(L425-462) / main loop(L212-217) 每事件产生 6-8 条 `GLOG.INFO` + f-string 格式化。回测热路径（10年日线×100股 ≈ 数百万事件，PriceUpdate→Signal→Portfolio→Order→Fill 链路）累计数千万次日志 I/O + 格式化开销。

**修复**：降级 8 条 `🔍 [EVENT ENGINE ...]` 调试日志 INFO→DEBUG（默认 INFO 级别下静默）：
- main loop L215/217（出队/完成）
- put L419/421（入队/成功）
- _process L429/436/440/442（Processing / Found handlers / Calling handler / Handler completed）

**功能不变**：事件入队、统计计数、handler 分发逻辑均未改动。生命周期 INFO（Engine started / Main loop END / Queue resize completed 等）保留。

## 子问题②③④处理说明

**② 移除 `_queue_lock`（issue 建议）→ 不做（经验证为误判）**

逐点验证（`feedback_no_blind_dead_code_deletion`）发现 `_queue_lock` 非冗余。它 4 处使用——put(L416) + resize 路径(L827/887/900)——保护的是 **`self._event_queue` 引用的原子切换**（队列 resize 时替换整个 Queue 对象），而非 `Queue.put()` 调用本身。`Queue.put` 线程安全仅针对单个 Queue 内部，但 resize 会替换 Queue 对象：put 与 resize 之间的引用一致性必须靠 `_queue_lock` 保证，移除会导致 resize 期间 put 的事件进入旧队列（丢失）。issue"_queue_lock 多余"只看了 put 一处，忽略 resize 路径的 3 处使用。

**③ 延迟导入移顶部（time_controlled_engine.py 7 处）→ 留后续**

需逐个验证循环依赖，范围独立，不在本 PR。

**④ uuid4 → 递增整数（base_event.py:52）→ 留后续 / HITL**

位于 `BaseEvent.__init__` 核心基类，且需区分回测/实盘 ID 生成策略（实盘需全局唯一，回测可轻量递增），属架构决策，需 HITL。

## Test plan

新增 `tests/unit/trading/test_event_engine_hot_path_logging.py`（3 个 TDD 行为测试，经 RED→GREEN）：

- `test_put_does_not_emit_info_on_hot_path`：put 后断言热路径无 INFO 泄露 + 事件正确入队（qsize=1）
- `test_process_does_not_emit_info_on_hot_path`：_process 后断言无 INFO 泄露 + completed 统计正确（+1）
- `test_put_still_logs_debug_for_diagnostics`：回归锁——降级后 DEBUG 诊断日志仍在（"Event queued"）

本地三层冒烟（对齐 `.github/workflows/ci.yml`）：

- ✅ Layer 1：`py_compile` src/api 全量通过
- ✅ Layer 2：启动路径点名（user_crud_mock / containers / user_cli）
- ✅ Layer 3：新测试 + EventEngine 邻居（test_public_query_interfaces / test_engine_interface）→ 115 passed

Refs #3869
