### PR TITLE
fix: Component search 参数下推作 keyword 过滤 (#5444)

### DIFF
--- a/api/api/components.py
+++ b/api/api/components.py
@@ -94,6 +94,7 @@ async def list_components(
     component_type: Optional[str] = None,
     is_active: Optional[bool] = None,
     keyword: Optional[str] = None,
+    search: Optional[str] = None,
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
 ):
@@ -113,9 +114,11 @@ async def list_components(
             types_to_check = list(COMPONENT_FILE_TYPE_MAP.values())
 
         # 调用 service 层分页查询
+        # #5444: search 与 keyword 同义——前端用 keyword，API 调用者/手测惯用 search。
+        # 任一非空即下推过滤，避免 search 被当未声明 query 静默忽略致返回首页。
         result = file_service.list_components(
             file_types=types_to_check,
-            keyword=keyword,
+            keyword=keyword or search,
             is_del=False if is_active else (not is_active if is_active is not None else False),
             page=page - 1,
             page_size=page_size,

--- a/tests/api/test_components_pagination.py
+++ b/tests/api/test_components_pagination.py
@@ -108,3 +108,36 @@ class TestComponentsPagination:
         assert item["name"] == "MyStrategy"
         assert item["component_type"] == "strategy"
         assert item["is_active"] is True
+
+    def test_search_param_filters_as_keyword(self):
+        """#5444: search 参数应下推到 service 作 keyword 过滤（与 keyword 等价）"""
+        mock_service = MagicMock()
+        mock_service.list_components.return_value = make_mock_result(
+            data={"data": [], "total": 0}
+        )
+
+        from api.components import list_components
+
+        with patch("api.components.get_file_service", return_value=mock_service):
+            run_async(list_components(search="moving_average", page=1, page_size=20))
+
+        call_kwargs = mock_service.list_components.call_args.kwargs
+        assert call_kwargs.get("keyword") == "moving_average"
+
+    def test_search_no_match_returns_empty(self):
+        """#5444 验收3: search 无匹配时返回空列表，非首页默认结果"""
+        mock_service = MagicMock()
+        mock_service.list_components.return_value = make_mock_result(
+            data={"data": [], "total": 0}
+        )
+
+        from api.components import list_components
+
+        with patch("api.components.get_file_service", return_value=mock_service):
+            result = run_async(list_components(search="不存在的组件", page=1, page_size=20))
+
+        # search 值下推到 service（非被当未声明 query 忽略）
+        assert mock_service.list_components.call_args.kwargs.get("keyword") == "不存在的组件"
+        # 无匹配返回空，非首页默认结果
+        assert result["data"] == []
+        assert result["meta"]["total"] == 0


### PR DESCRIPTION
## Summary

修复 #5444：`GET /api/v1/components/?search=moving_average` 始终返回首页，search 参数被忽略。

**根因**：`list_components` 端点参数名是 `keyword` 非 `search`（`api/api/components.py:96`）。FastAPI 对未声明的 query 参数静默忽略（不报错），于是 `?search=xxx` 被丢弃 → 无 keyword 传入 → 无 `name__like` 过滤 → 返回全量首页。

**调用链验证**（修复前已全通，非过滤逻辑坏）：

```
GET /api/v1/components/?keyword=moving_average   # 正确参数名 → 生效
  → list_components(keyword="moving_average")     # API :96
  → file_service.list_components(keyword=...)     # :118
  → filters["name__like"] = keyword               # file_service.py:588
  → crud.find + crud.count                         # :590-594
```

前端已正确用 `keyword`（`web-ui/src/views/portfolio/PortfolioFormEditor.vue:764`）；issue 报告者/API 调用者用 `search`（REST 惯例）被忽略。

**修复**：端点加 `search: Optional[str]` 参数，`keyword or search` 合并下推 service：

```python
search: Optional[str] = None,   # 新增，与 keyword 同义
...
keyword=keyword or search,      # 任一非空即下推 name__like 过滤
```

向后兼容现有 `keyword` 调用（前端不破坏）+ 满足 `search` 验收。

## scope

- ✅ 主验收：`?search=moving_average` 过滤结果（下推 `name__like`），不再返回首页
- ✅ search 无匹配返回空列表（验收3）
- ✅ 向后兼容：`?keyword=` 仍工作（现有 `test_passes_filters_and_pagination` 覆盖）
- ⏭️ 未把 `keyword` 改名为 `search`（breaking change，破坏前端契约）；用同义参数兼容

## Test plan

- [x] TDD RED：`test_search_param_filters_as_keyword` 修复前 `TypeError: unexpected keyword argument 'search'` → fail
- [x] TDD GREEN：修复后 search 值下推 service 作 keyword
- [x] `test_search_no_match_returns_empty`：search 无匹配返回空（验收3）
- [x] `tests/api/test_components_pagination.py` 全 6 测通过（4 旧 + 2 新），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/api/test_components_pagination.py -o addopts= -q
# 6 passed
```

Closes #5444
