### PR TITLE
fix: config get 补 log_path/working_path 分支 (#5356)

### DIFF
--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -80,6 +80,12 @@ def get(
                 console.print(f":white_check_mark: quiet: {GCONF.QUIET}")
             elif key.lower() == 'cpu_ratio':
                 console.print(f":white_check_mark: cpu_ratio: {GCONF.CPURATIO*100:.1f}%")
+            elif key.lower() == 'log_path':
+                # #5356: list 列出 log_path 但 get 缺分支，落 else 报 not found。
+                console.print(f":white_check_mark: log_path: {GCONF.LOGGING_PATH}")
+            elif key.lower() == 'working_path':
+                # #5356: 同根因——list 列出 working_path 但 get 缺分支。
+                console.print(f":white_check_mark: working_path: {GCONF.WORKING_PATH}")
             else:
                 console.print(f":x: Configuration key '{key}' not found")
         else:

--- a/tests/unit/client/test_config_cli.py
+++ b/tests/unit/client/test_config_cli.py
@@ -128,6 +128,24 @@ class TestConfigGet:
         assert "cpu_ratio" in result.output
         assert "80" in result.output
 
+    def test_get_log_path_shows_value(self, cli_runner, mock_gconf):
+        """#5356: get log_path 返回日志路径（list 列出但 get 缺分支→not found）"""
+        mock_gconf.LOGGING_PATH = "/tmp/ginkgo/logs"
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(config_cli.app, ["get", "log_path"])
+        assert result.exit_code == 0
+        assert "not found" not in result.output
+        assert "/tmp/ginkgo/logs" in result.output
+
+    def test_get_working_path_shows_value(self, cli_runner, mock_gconf):
+        """#5356: get working_path 返回工作目录（同 list↔get 不一致根因的另一受害者）"""
+        mock_gconf.WORKING_PATH = "/home/kaoru/Ginkgo"
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(config_cli.app, ["get", "working_path"])
+        assert result.exit_code == 0
+        assert "not found" not in result.output
+        assert "/home/kaoru/Ginkgo" in result.output
+
     def test_get_unknown_key_shows_not_found(self, cli_runner, mock_gconf):
         """get 未知 key 显示 not found"""
         with patch("ginkgo.libs.GCONF", mock_gconf):


### PR DESCRIPTION
## Summary

修复 #5356：`config get log_path` 报 `Configuration key 'log_path' not found`，但 `config list` 明确列出 log_path。

**根因**：`config get` 的特定 key 查找（`config_cli.py:77-84` if/elif 链）只认 `debug/quiet/cpu_ratio` 3 个，但 `config list`(:204-208) 与 get 无参分支(:94-98) 都列 5 个（含 `log_path`/`working_path`）。get 缺 log_path 与 working_path 分支 → 落 `:84 else` 报 not found。

**调用链**：

```
ginkgo config get log_path
  → get(key="log_path")
    → if debug? elif quiet? elif cpu_ratio? 都不匹配
    → else → "Configuration key 'log_path' not found"  ❌
ginkgo config list  → table 列 log_path/working_path  ✓（但 get 取不到）
```

**根因比 issue 报的更深**：issue 只提 log_path，但 `working_path` 同样缺失（同一 else 分支受害者，list 也列出）。修应覆盖全部 list key（验收3）。

**修复**：get 加 log_path + working_path 两个 elif 分支，与 list key 集合对齐：

```python
elif key.lower() == 'log_path':
    console.print(f":white_check_mark: log_path: {GCONF.LOGGING_PATH}")
elif key.lower() == 'working_path':
    console.print(f":white_check_mark: working_path: {GCONF.WORKING_PATH}")
```

## scope

- ✅ `config get log_path` 返回日志路径（验收1）
- ✅ `config get working_path` 返回工作目录（同根因另一受害者）
- ✅ list 列出的 5 个 key 都能 get（验收3）
- ⏭️ 未抽取 key→handler 映射表（YAGNI，5 个 elif 仍可读；list/get 两处硬编码是既有技术债，超本 issue 范围）

## Test plan

- [x] TDD RED：`test_get_log_path_shows_value` + `test_get_working_path_shows_value` 修复前 output 含 "not found"、无路径值 → fail
- [x] TDD GREEN：修复后返回路径值、不含 "not found"
- [x] `tests/unit/client/test_config_cli.py` 全 46 测通过（44 旧 + 2 新），无回归
- [x] py_compile 通过

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_config_cli.py -o addopts= -q
# 46 passed
```

Closes #5356
