### PR TITLE
fix(#5517): data migrate 路径便携化（__file__ 相对解析 + --path 覆盖）

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -739,6 +739,10 @@ def migrate(
     autogenerate: bool = typer.Option(False, "--autogenerate", "-a", help="Auto-generate migration from model changes"),
     revision: Optional[str] = typer.Option(None, "--revision", "-r", help="Specific revision to upgrade/downgrade"),
     action: str = typer.Option("upgrade", "--action", help="Action: upgrade/downgrade/heads/history/current"),
+    path: Optional[str] = typer.Option(
+        None, "--path", "-p",
+        help="Override migrations directory (absolute or relative to cwd). Default: <source-tree>/migrations/<database>",
+    ),
 ):
     """
     :page_facing_up: Database migration management.
@@ -755,7 +759,15 @@ def migrate(
             import subprocess
             import os
 
-            migrations_dir = "/home/kaoru/Ginkgo/migrations/mysql"
+            if path:
+                migrations_dir = os.path.abspath(path)
+            else:
+                # 相对源码树根解析（#5517）：src/ginkgo/client/data_cli.py 上溯 4 级
+                # (client -> ginkgo -> src -> 仓库根)，使迁移目录随安装位置走，
+                # 而非硬编码 /home/kaoru/Ginkgo/migrations/mysql。
+                _client_dir = os.path.dirname(os.path.abspath(__file__))
+                _source_root = os.path.dirname(os.path.dirname(os.path.dirname(_client_dir)))
+                migrations_dir = os.path.join(_source_root, "migrations", database)
             alembic_ini = os.path.join(migrations_dir, "alembic.ini")
 
             if autogenerate:

--- a/tests/unit/client/test_data_cli_migrate_path.py
+++ b/tests/unit/client/test_data_cli_migrate_path.py
@@ -1,0 +1,74 @@
+"""
+#5517: data migrate 路径便携性 + --path 覆盖
+
+默认 migrations_dir 不再硬编码 /home/kaoru/Ginkgo/migrations/mysql，
+而是相对 data_cli.__file__ 上溯到源码树根解析；新增 --path 覆盖参数。
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from ginkgo.client import data_cli
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+def _expected_default_migrations_dir():
+    """相对 data_cli.__file__ 上溯 4 级到源码树根，拼 migrations/mysql。"""
+    src_ginkgo_client = os.path.dirname(os.path.abspath(data_cli.__file__))
+    src_ginkgo = os.path.dirname(src_ginkgo_client)
+    src_dir = os.path.dirname(src_ginkgo)
+    source_root = os.path.dirname(src_dir)
+    return os.path.join(source_root, "migrations", "mysql")
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestMigratePath:
+    """#5517: data migrate 路径便携性"""
+
+    def test_migrate_help_exposes_path_option(self, cli_runner):
+        """--path 选项暴露在 migrate help（#5517 覆盖参数）。"""
+        result = cli_runner.invoke(data_cli.app, ["migrate", "--help"])
+        assert result.exit_code == 0
+        assert "--path" in result.output
+
+    @patch("subprocess.run")
+    def test_migrate_path_override_sets_cwd(self, mock_run, cli_runner, tmp_path):
+        """--path 覆盖时，alembic 在用户指定目录执行（cwd = 该目录绝对路径）。"""
+        mock_run.return_value = MagicMock(returncode=0)
+        result = cli_runner.invoke(data_cli.app, ["migrate", "--action", "upgrade", "--path", str(tmp_path)])
+        assert result.exit_code == 0
+        # 所有 subprocess.run 调用的 cwd 都应是 --path 指定的绝对路径
+        for call in mock_run.call_args_list:
+            assert call.kwargs["cwd"] == str(tmp_path)
+
+    @patch("subprocess.run")
+    def test_migrate_default_cwd_tracks_source_tree(self, mock_run, cli_runner):
+        """默认（无 --path）时 migrations_dir 相对 data_cli.__file__ 解析，便携。
+
+        #5517：不再硬编码 /home/kaoru/Ginkgo/migrations/mysql。换机/换安装目录后，
+        默认路径应跟随源码树真实位置，alembic.ini 仍可触达。
+        """
+        mock_run.return_value = MagicMock(returncode=0)
+        result = cli_runner.invoke(data_cli.app, ["migrate", "--action", "upgrade"])
+        assert result.exit_code == 0
+        for call in mock_run.call_args_list:
+            cwd = call.kwargs["cwd"]
+            # 便携性锚点 1：等于 __file__ 上溯到源码树根 + migrations/mysql
+            assert cwd == _expected_default_migrations_dir()
+            # 便携性锚点 2：解析出的目录真实存在（alembic.ini 可触达）
+            assert os.path.exists(os.path.join(cwd, "alembic.ini"))
+        # 便携性锚点 3：源码不再把硬编码绝对路径赋给 migrations_dir
+        # （注释里解释旧值是允许的；禁止的是重新把它写进赋值）
+        src = open(data_cli.__file__, encoding="utf-8").read()
+        assert 'migrations_dir = "/home/kaoru' not in src


### PR DESCRIPTION
## Summary

修复 #5517：`ginkgo data migrate` 硬编码 `migrations_dir = "/home/kaoru/Ginkgo/migrations/mysql"`，换机/换安装目录后 alembic 在不存在的 cwd 执行而失败。

**根因**：`data_cli.py` migrate 命令把 migrations 目录写成字面量绝对路径，用于 `alembic_ini` 拼接 + 7 处 `subprocess.run(..., cwd=migrations_dir)`。migrations 实际位于仓库根（包**外**），不随安装位置走。

**修复**（对齐验收标准）：
1. **默认路径便携化**：相对 `data_cli.__file__` 上溯 4 级（`client → ginkgo → src → 仓库根`）定位源码树根，再拼 `migrations/<database>`。editable 安装下 `__file__` 指向源码树，解析正确；不再依赖 `/home/kaoru/Ginkgo`。
2. **新增 `--path`/`-p` 覆盖参数**：非源码安装（如 wheel）或自定义迁移目录时，用户可显式指定（绝对或相对 cwd，内部 `os.path.abspath` 归一）。
3. **泛化**：默认路径用 `database` 参量替代硬编码 `"mysql"`，为将来 clickhouse/mongodb 的 alembic 化预留。

**控制流不变**：alembic 子命令、autogenerate/upgrade/downgrade/heads/history/current 各分支、clickhouse/mongodb 手动说明、unknown database 报错均未改动。

## Test plan

新增 `tests/unit/client/test_data_cli_migrate_path.py`（3 个 TDD 行为测试，经 RED→GREEN）：

- `test_migrate_help_exposes_path_option`：`--path` 暴露在 help
- `test_migrate_path_override_sets_cwd`：`--path <dir>` 时所有 subprocess.run 的 cwd == 该目录绝对路径
- `test_migrate_default_cwd_tracks_source_tree`：默认（无 `--path`）时 cwd == `__file__` 上溯解析的路径 + alembic.ini 真实可触达 + 源码不再把硬编码绝对路径赋给 `migrations_dir`（便携性回归锁）

本地三层冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1：`py_compile` src/api 全量通过
- ✅ Layer 2：启动路径点名（user_crud_mock / containers / user_cli）29 passed
- ✅ Layer 3：新测试 3 passed + 现有 `test_data_cli.py`（含 TestMigrate 全部）44 passed，无回归

Closes #5517
