### PR TITLE
fix: NodeGraphCreate schema 补 portfolio_uuid 字段 (#5387)

### DIFF
--- a/api/schemas/node_graph.py
+++ b/api/schemas/node_graph.py
@@ -88,6 +88,9 @@ class NodeGraphCreate(BaseModel):
     graph_data: GraphData
     is_template: bool = False
     is_public: bool = False
+    # #5387: 创建路由 node_graph.py:145 读 data.portfolio_uuid 关联 portfolio，
+    # 缺此字段致 AttributeError。默认 None 时路由兜底 str(uuid.uuid4())，向后兼容。
+    portfolio_uuid: Optional[str] = None
 
 
 class NodeGraphUpdate(BaseModel):

--- a/tests/api/test_node_graph_create_schema.py
+++ b/tests/api/test_node_graph_create_schema.py
@@ -1,0 +1,48 @@
+# Issue: NodeGraphCreate schema 缺 portfolio_uuid 字段
+# Upstream: api.schemas.node_graph.NodeGraphCreate
+# Downstream: api.api.node_graph.create_node_graph (:145 读 data.portfolio_uuid)
+# Role: 验证创建节点图 schema 接受 portfolio_uuid，使路由能关联到 portfolio
+
+"""
+NodeGraphCreate schema 字段测试
+
+验证 NodeGraphCreate 包含可选 portfolio_uuid 字段——创建路由
+(api.api.node_graph:145) 读 data.portfolio_uuid 关联 portfolio，
+schema 缺该字段会 AttributeError 致创建失败。
+"""
+
+import sys
+from pathlib import Path
+
+# api 是 namespace package（无 __init__.py），pytest 下 sys.path 干扰致
+# `from api.schemas.node_graph` 解析失败（No module named 'api.schemas'）。
+# 直插 schemas 目录 + 按模块名导入（node_graph.py 无 api 内部依赖，独立可加载）。
+# 仿 test_node_graph_file_type.py 模式，避开 namespace 包解析陷阱。
+_schemas_dir = str(Path(__file__).resolve().parents[2] / "api" / "schemas")
+if _schemas_dir not in sys.path:
+    sys.path.insert(0, _schemas_dir)
+
+from node_graph import NodeGraphCreate
+
+
+def _graph_data():
+    """最小合法 graph_data（空 nodes/edges）"""
+    return {"nodes": [], "edges": []}
+
+
+class TestNodeGraphCreatePortfolioUuid:
+    """#5387: NodeGraphCreate schema 的 portfolio_uuid 字段"""
+
+    def test_accepts_portfolio_uuid(self):
+        """schema 接受 portfolio_uuid 字段并保留值"""
+        schema = NodeGraphCreate(
+            name="test",
+            graph_data=_graph_data(),
+            portfolio_uuid="portfolio-abc-123",
+        )
+        assert schema.portfolio_uuid == "portfolio-abc-123"
+
+    def test_portfolio_uuid_defaults_none(self):
+        """不传 portfolio_uuid 时默认 None（向后兼容，路由兜底生成 uuid）"""
+        schema = NodeGraphCreate(name="test", graph_data=_graph_data())
+        assert schema.portfolio_uuid is None


### PR DESCRIPTION
## Summary

修复 #5387：`POST /api/v1/node-graphs/` 创建节点图报 `'NodeGraphCreate' object has no attribute 'portfolio_uuid'`。

**根因**：创建路由 `api/api/node_graph.py:145` 读 `data.portfolio_uuid or str(uuid.uuid4())` 关联 portfolio，但 `NodeGraphCreate` schema（`api/schemas/node_graph.py:84-90`）只有 name/description/graph_data/is_template/is_public，**缺 portfolio_uuid 字段** → Pydantic 模型无该属性 → AttributeError。

**调用链**：

```
POST /api/v1/node-graphs/ {"name":"test","portfolio_uuid":"<uuid>","graph_data":{...}}
  → create_node_graph(data: NodeGraphCreate)
    → portfolio_uuid = data.portfolio_uuid or str(uuid.uuid4())  # node_graph.py:145
    → AttributeError: 'NodeGraphCreate' object has no attribute 'portfolio_uuid'  ❌
```

**修复**：schema 加 `portfolio_uuid: Optional[str] = None`：

```python
class NodeGraphCreate(BaseModel):
    ...
    portfolio_uuid: Optional[str] = None  # #5387
```

默认 None 时路由 `data.portfolio_uuid or str(uuid.uuid4())` 兜底生成 uuid，**向后兼容**（不传 portfolio_uuid 的旧调用仍工作）。

## scope

- ✅ NodeGraphCreate schema 接受 portfolio_uuid 字段
- ✅ 默认 None（向后兼容，路由兜底生成 uuid）
- ⏭️ 未改路由逻辑（:145 已正确用 `data.portfolio_uuid or str(uuid.uuid4())`，只缺 schema 字段声明）

## Test plan

- [x] TDD RED：`test_accepts_portfolio_uuid` + `test_portfolio_uuid_defaults_none` 修复前 AttributeError → fail
- [x] TDD GREEN：修复后 schema.portfolio_uuid 可读 + 默认 None
- [x] 新建 `tests/api/test_node_graph_create_schema.py`（2 测）。注：`api/` 是 namespace package（无 `__init__.py`），pytest 下 `from api.schemas.node_graph` 解析失败（`No module named 'api.schemas'`），故用 sys.path 直插 schemas 目录 + 按模块名导入（仿 `test_node_graph_file_type.py`）
- [x] file_type 回归 12 测通过，无回归
- [x] py_compile 通过

```
python -m pytest tests/api/test_node_graph_create_schema.py tests/api/test_node_graph_file_type.py -o addopts= -q
# 14 passed
```

Closes #5387
