### PR TITLE
fix(#6181): risk 报告方法 Decimal 算术混算修复（liquidity/volatility）

### DIFF
--- a/src/ginkgo/trading/risk_management/liquidity_risk.py
+++ b/src/ginkgo/trading/risk_management/liquidity_risk.py
@@ -364,8 +364,11 @@ class LiquidityRisk(BaseRiskManagement):
             Dict: 流动性分析报告
         """
         positions = portfolio_info.get("positions", {})
-        portfolio_liquidity_score = 0.0
-        total_value = 0.0
+        # #6181: market_value 为 Decimal（ADR-010，自 1803ce39），float 累加器与之
+        # 算术混算会抛 TypeError（float + Decimal）。累加器用 Decimal(0)，
+        # 对齐 #6180 ConcentrationRisk 修法。
+        portfolio_liquidity_score = Decimal(0)
+        total_value = Decimal(0)
         low_liquidity_positions = []
 
         for code, position in positions.items():
@@ -374,8 +377,8 @@ class LiquidityRisk(BaseRiskManagement):
                 position_weight = position.market_value
                 total_value += position_weight
 
-                # 计算加权流动性评分
-                portfolio_liquidity_score += liquidity_score * position_weight
+                # 计算加权流动性评分（liquidity_score 为 float，转 Decimal 避免与 Decimal 混算）
+                portfolio_liquidity_score += Decimal(str(liquidity_score)) * position_weight
 
                 # 识别低流动性持仓
                 if liquidity_score < 30:

--- a/src/ginkgo/trading/risk_management/volatility_risk.py
+++ b/src/ginkgo/trading/risk_management/volatility_risk.py
@@ -253,7 +253,11 @@ class VolatilityRisk(BaseRiskManagement):
         weighted_volatility = 0.0
         for code, position in positions.items():
             if position and position.market_value > 0:
-                weight = position.market_value / total_value
+                # #6181: market_value/total_value 均为 Decimal（ADR-010，自 1803ce39），
+                # weight 是 Decimal；stock_volatility 为 float。Decimal × float 抛
+                # TypeError。weight 转 float（权重为无量纲比值，float 无失真风险），
+                # 对齐方法签名 -> float。对齐 #6180 / #6181 修法。
+                weight = float(position.market_value / total_value)
                 stock_volatility = self._get_stock_volatility(code)
                 weighted_volatility += weight * stock_volatility
 

--- a/tests/unit/trading/strategy/risk_managements/test_risk_decimal_arithmetic.py
+++ b/tests/unit/trading/strategy/risk_managements/test_risk_decimal_arithmetic.py
@@ -1,0 +1,65 @@
+"""
+#6181: LiquidityRisk / VolatilityRisk 报告方法 V5(ADR-010) Decimal 算术混算
+
+Position.market_value 自 1803ce39 起为 Decimal（见 position.py:630）。
+报告方法的 float 累加器（0.0）累加 Decimal market_value 会抛
+TypeError: unsupported operand type(s) for +: 'float' and 'Decimal'.
+
+注意区分：Decimal > float（比较）在 Py3.2+ 合法不抛，算术（+ * /）才抛。
+故 #6180 ConcentrationRisk 的比较没崩，本处累加崩了。
+
+对齐 #6180 修法：累加器改 Decimal(0) / float 量转换。
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.trading.risk_management.liquidity_risk import LiquidityRisk
+from ginkgo.trading.risk_management.volatility_risk import VolatilityRisk
+
+
+def _make_position(market_value):
+    """market_value 取 Decimal 以模拟 ADR-010 后的真实 Position 类型。"""
+    pos = MagicMock()
+    pos.market_value = market_value
+    return pos
+
+
+def _make_portfolio_info(positions):
+    return {"worth": 100000, "positions": positions, "uuid": "p1", "now": datetime.now()}
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
+class TestRiskDecimalArithmetic:
+    """#6181: 报告方法在 Decimal market_value 下不得抛 TypeError"""
+
+    def test_get_liquidity_report_decimal_market_value_no_typeerror(self):
+        """get_liquidity_report: Decimal market_value 累加不抛 TypeError（#6181）。"""
+        r = LiquidityRisk()
+        info = _make_portfolio_info({
+            "000001.SZ": _make_position(Decimal("10000")),
+            "600000.SH": _make_position(Decimal("8000")),
+        })
+        # 隔离外部数据依赖，聚焦报告方法的算术路径
+        r.get_liquidity_score = MagicMock(return_value=80.0)
+        report = r.get_liquidity_report(info)
+        assert "portfolio_liquidity_score" in report
+        assert report["total_positions"] == 2
+
+    def test_get_portfolio_volatility_decimal_market_value_no_typeerror(self):
+        """get_portfolio_volatility: Decimal market_value 加权不抛 TypeError（#6181）。"""
+        r = VolatilityRisk()
+        info = _make_portfolio_info({
+            "000001.SZ": _make_position(Decimal("10000")),
+            "600000.SH": _make_position(Decimal("8000")),
+        })
+        # 隔离外部数据依赖，聚焦加权算术路径
+        r._get_stock_volatility = MagicMock(return_value=0.25)
+        result = r.get_portfolio_volatility(info)
+        # 签名声明 -> float；只要不抛 TypeError、返回非负数值即通过
+        assert result >= 0


### PR DESCRIPTION
## Summary

修复 #6181：`LiquidityRisk.get_liquidity_report` / `VolatilityRisk.get_portfolio_volatility` 在 `Position.market_value` 为 `Decimal`（ADR-010，自 1803ce39）时，float 累加器与之算术混算抛 `TypeError: unsupported operand type(s) for +/-*: 'float' and 'decimal.Decimal'`。

**根因**：`Position.market_value` 自 1803ce39 起为 Decimal（position.py:630）。两个报告方法的加权累加用 `0.0`（float）作初值/累加器，与 Decimal market_value 做 `+` `*` 算术 → TypeError。注意 `Decimal > float`（比较）在 Py3.2+ 合法不抛，故 #6180 ConcentrationRisk 的比较路径未崩，而本两处的**算术**路径崩了。

**修复**（对齐 #6180 修法）：
1. **LiquidityRisk.get_liquidity_report**：累加器 `portfolio_liquidity_score` / `total_value` 改 `Decimal(0)`；`liquidity_score`（float）经 `Decimal(str())` 转换避免 `Decimal(float)` 精度噪声。出口 dict 仍携带 Decimal 值（对齐 #6180 concentration 出口，下游已兼容）。
2. **VolatilityRisk.get_portfolio_volatility**：`weight = position.market_value / total_value`（Decimal/Decimal=Decimal）转 `float(weight)`——权重为无量纲比值，float 无失真风险；保持方法签名 `-> float`。

**控制流不变**：两方法的分支结构、返回结构、阈值比较逻辑均未改动，仅修正累加器/操作数类型。

## Test plan

新增 `tests/unit/trading/strategy/risk_managements/test_risk_decimal_arithmetic.py`（2 个 TDD 行为测试，经 RED→GREEN）：
- `test_get_liquidity_report_decimal_market_value_no_typeerror`：Decimal market_value 下 `get_liquidity_report` 不抛 TypeError
- `test_get_portfolio_volatility_decimal_market_value_no_typeerror`：Decimal market_value 下 `get_portfolio_volatility` 不抛 TypeError

本地三层冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1：`py_compile` src/api 全量通过
- ✅ Layer 2：启动路径点名（user_crud_mock / containers / user_cli）29 passed
- ✅ Layer 3：新测试 2 + 现有 `test_liquidity_risk` + `test_volatility_risk` 共 65 passed, 1 skipped，无回归

Closes #6181
