### PR TITLE
fix: config workers/containers 补 list action 分发 (#5991)

### DIFF
--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -289,6 +289,21 @@ def workers(
             console.print(":bulb: Consider using: ginkgo config containers restart")
             console.print(":white_check_mark: Workers restarted")
 
+        elif action == "list":
+            # #5991: 列出已配置 worker（复用 status 的 GTM 数据源），无则友好提示。
+            # list 原落 else 报 "Unknown action: list"，应返回有意义结果。
+            console.print(":construction_worker: Workers:")
+            try:
+                workers_status = GTM.get_workers_status()
+                if workers_status:
+                    for worker_id in workers_status:
+                        console.print(f"  - {worker_id}")
+                else:
+                    console.print("  :clipboard: No workers configured")
+            except Exception as e:
+                GLOG.ERROR(f"Failed to list workers: {e}")
+                console.print("  :clipboard: Worker list not available")
+
         else:
             console.print(f":x: Unknown action: {action}")
 
@@ -404,6 +419,30 @@ def containers(
                     console.print(":x: Docker is not installed")
             else:
                 console.print(":x: docker-compose.yml not found")
+
+        elif action == "list":
+            # #5991: 列出容器名（复用 status 的 docker ps 数据源），无 docker 时友好提示。
+            # list 原落 else 报 "Unknown action: list"，应返回有意义结果。
+            console.print(":whale: Containers:")
+            import subprocess
+            try:
+                result = subprocess.run(
+                    ["docker", "ps", "-a", "--format", "{{.Names}}\t{{.Image}}"],
+                    capture_output=True, text=True, timeout=10,
+                )
+                lines = [l for l in result.stdout.splitlines() if l.strip()]
+                if lines:
+                    for line in lines:
+                        parts = line.split("\t")
+                        name = parts[0]
+                        image = parts[1] if len(parts) > 1 else "-"
+                        console.print(f"  - {name} ({image})")
+                else:
+                    console.print("  :clipboard: No containers")
+            except subprocess.TimeoutExpired:
+                console.print("  :clipboard: Docker 查询超时")
+            except FileNotFoundError:
+                console.print("  :clipboard: 未安装 Docker 或不在 PATH 中")
 
         else:
             console.print(f":x: Unknown action: {action}")

--- a/tests/unit/client/test_config_cli.py
+++ b/tests/unit/client/test_config_cli.py
@@ -368,6 +368,30 @@ class TestConfigWorkers:
         assert result.exit_code == 0
         assert "restarted" in result.output.lower()
 
+    def test_workers_list_shows_worker_ids(self, cli_runner, mock_gtm):
+        """#5991: workers list 列出 worker id（复用 status 的 GTM 数据源），不报 Unknown action"""
+        mock_gtm.get_workers_status.return_value = {
+            "worker-1": {"running": True},
+            "worker-2": {"running": False},
+        }
+        with patch("ginkgo.libs.GTM", mock_gtm), \
+             patch("ginkgo.data.containers.container", MagicMock()):
+            result = cli_runner.invoke(config_cli.app, ["workers", "list"])
+        assert result.exit_code == 0
+        assert "Unknown action" not in result.output
+        assert "worker-1" in result.output
+        assert "worker-2" in result.output
+
+    def test_workers_list_no_workers(self, cli_runner, mock_gtm):
+        """#5991: workers list 无活跃 worker 时友好提示，不报 Unknown action"""
+        mock_gtm.get_workers_status.return_value = {}
+        with patch("ginkgo.libs.GTM", mock_gtm), \
+             patch("ginkgo.data.containers.container", MagicMock()):
+            result = cli_runner.invoke(config_cli.app, ["workers", "list"])
+        assert result.exit_code == 0
+        assert "Unknown action" not in result.output
+        assert "No" in result.output or "无" in result.output
+
     def test_workers_unknown_action(self, cli_runner, mock_gtm):
         """workers 未知 action 显示错误"""
         with patch("ginkgo.libs.GTM", mock_gtm), \
@@ -481,6 +505,26 @@ class TestConfigContainers:
         result = cli_runner.invoke(config_cli.app, ["containers", "deploy"])
         assert result.exit_code == 0
         assert "Deployment" in result.output or "deploy" in result.output.lower()
+
+    def test_containers_list_shows_names(self, cli_runner):
+        """#5991: containers list 列出容器名（复用 status 的 docker ps 数据源），不报 Unknown action"""
+        fake = MagicMock(
+            stdout="my-real-container\tUp 1 hour\tmyimg:v1\nsecond-box\tExited\timg2\n",
+            stderr="", returncode=0,
+        )
+        with patch("subprocess.run", return_value=fake):
+            result = cli_runner.invoke(config_cli.app, ["containers", "list"])
+        assert result.exit_code == 0
+        assert "Unknown action" not in result.output
+        assert "my-real-container" in result.output
+        assert "second-box" in result.output
+
+    def test_containers_list_no_docker(self, cli_runner):
+        """#5991: containers list 无 docker 时友好提示，不报 Unknown action"""
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            result = cli_runner.invoke(config_cli.app, ["containers", "list"])
+        assert result.exit_code == 0
+        assert "Unknown action" not in result.output
 
     def test_containers_unknown_action(self, cli_runner):
         """containers 未知 action 显示错误"""


### PR DESCRIPTION
## Summary

修复 #5991：`config workers list` / `config containers list` 报 `❌ Unknown action: list`。

**根因**：`workers`/`containers` 子命令的 action dispatcher 注册了 status/start/stop/restart（containers 还有 scale/deploy），**唯独缺 `list` 分支** → 落 `else` 报 `Unknown action: list`。

**调用链**：

```
ginkgo config workers list
  → config_cli.workers(action="list")
    → if status / elif start / elif stop / elif restart 都不匹配
    → else → "❌ Unknown action: list"  ❌
```

**修复**：各加 `elif action == "list"`，**复用 status 已有数据源**（不引入新依赖）：

- `workers list` → `GTM.get_workers_status()` 列 worker_id（同 status 数据源）
- `containers list` → `docker ps -a --format "{{.Names}}\t{{.Image}}"` 列容器名+镜像（同 status 数据源，精简不查 CPU/Mem）

无数据时友好提示（`No workers configured` / `No containers`），无 docker 时降级提示（沿用 status 的 FileNotFoundError/TimeoutExpired 处理）。

## scope

- ✅ `workers list` 列 worker id（验收1）
- ✅ `containers list` 列容器名（验收2）
- ✅ 不再显示 "Unknown action"（验收3）
- ⏭️ 未实现 list 的过滤/分页（YAGNI，status 也无；list 是 status 的精简视图）

## Test plan

- [x] TDD RED：4 测修复前 fail（输出含 `"Unknown action: list"`）
- [x] TDD GREEN：修复后 list 列条目，输出不含 `Unknown action`
- [x] `test_workers_list_shows_worker_ids` / `test_workers_list_no_workers`
- [x] `test_containers_list_shows_names` / `test_containers_list_no_docker`
- [x] `test_config_cli.py` 全 **48 测**通过（44 旧 + 4 新），`test_workers_unknown_action`/`test_containers_unknown_action` 回归仍通过（list 不影响真 unknown 的报错）
- [x] py_compile 通过
- [x] 手测 `workers list`（mock GTM）输出 `👷 Workers: - w-backtest`

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_config_cli.py -o addopts= -q
# 48 passed
```

Closes #5991
