### PR TITLE
fix: scheduler 系列命令输出字面 \n 改为真换行 (#6001)

### DIFF
--- a/src/ginkgo/client/scheduler_cli.py
+++ b/src/ginkgo/client/scheduler_cli.py
@@ -49,21 +49,21 @@ def start(
 
         # Display Scheduler info
         console.print(Panel.fit(
-            f"[bold cyan]:calendar: Scheduler[/bold cyan]\\n"
-            f"[dim]Configuration:[/dim]\\n"
-            f"  • Schedule Interval: {interval}s\\n"
-            f"  • Debug Mode: {'On' if debug else 'Off'}\\n"
-            f"[dim]Features:[/dim]\\n"
-            f"  • Heartbeat monitoring (TTL=30s)\\n"
-            f"  • Load balancing algorithm\\n"
-            f"  • Automatic failover\\n"
-            f"  • Portfolio migration\\n",
+            f"[bold cyan]:calendar: Scheduler[/bold cyan]\n"
+            f"[dim]Configuration:[/dim]\n"
+            f"  • Schedule Interval: {interval}s\n"
+            f"  • Debug Mode: {'On' if debug else 'Off'}\n"
+            f"[dim]Features:[/dim]\n"
+            f"  • Heartbeat monitoring (TTL=30s)\n"
+            f"  • Load balancing algorithm\n"
+            f"  • Automatic failover\n"
+            f"  • Portfolio migration\n",
             title="[bold]Portfolio Dynamic Scheduler[/bold]",
             border_style="cyan"
         ))
 
         if debug:
-            console.print("\\n[yellow]:bug: Debug mode enabled - verbose logging active[/yellow]\\n")
+            console.print("\n[yellow]:bug: Debug mode enabled - verbose logging active[/yellow]\n")
 
         # Get Redis client
         console.print(f":hourglass: Connecting to Redis...")
@@ -80,7 +80,7 @@ def start(
         console.print(":white_check_mark: Kafka connected")
 
         # Create Scheduler instance
-        console.print(f"\\n:rocket: [bold green]Creating Scheduler...[/bold green]")
+        console.print(f"\n:rocket: [bold green]Creating Scheduler...[/bold green]")
         scheduler = Scheduler(
             redis_client=redis_client,
             kafka_producer=kafka_producer,
@@ -90,7 +90,7 @@ def start(
 
         # Start Scheduler
         console.print(f":rocket: [bold green]Starting Scheduler...[/bold green]")
-        console.print(":information: Press Ctrl+C to stop\\n")
+        console.print(":information: Press Ctrl+C to stop\n")
 
         scheduler.start()
 
@@ -104,15 +104,15 @@ def start(
             import time
 
             def signal_handler(signum, frame):
-                console.print("\\n\\n:stop_button: [yellow]Stopping Scheduler...[/yellow]")
+                console.print("\n\n:stop_button: [yellow]Stopping Scheduler...[/yellow]")
                 scheduler.stop()
 
                 # Show statistics
                 healthy_nodes = scheduler._get_healthy_nodes()
                 console.print(Panel.fit(
-                    f"[bold green]:white_check_mark: Scheduler stopped[/bold green]\\n"
-                    f"[dim]Runtime Statistics:[/dim]\\n"
-                    f"  • Healthy Nodes: {len(healthy_nodes)}\\n"
+                    f"[bold green]:white_check_mark: Scheduler stopped[/bold green]\n"
+                    f"[dim]Runtime Statistics:[/dim]\n"
+                    f"  • Healthy Nodes: {len(healthy_nodes)}\n"
                     f"  • Schedule Interval: {scheduler.schedule_interval}s",
                     title="[bold]Shutdown Complete[/bold]"
                 ))
@@ -125,7 +125,7 @@ def start(
 
             # Keep running until interrupted
             console.print(":gear: [dim]Scheduler is running...[/dim]")
-            console.print(":information: [dim]Monitoring ExecutionNode heartbeats[/dim]\\n")
+            console.print(":information: [dim]Monitoring ExecutionNode heartbeats[/dim]\n")
 
             while scheduler.is_running:
                 time.sleep(1)
@@ -141,7 +141,7 @@ def start(
         except SystemExit:
             raise
         except Exception as e:
-            console.print(f"\\n[red]:x: Scheduler error: {e}[/red]")
+            console.print(f"\n[red]:x: Scheduler error: {e}[/red]")
             scheduler.stop()
             raise typer.Exit(1)
 
@@ -248,7 +248,7 @@ def plan():
             table.add_row(portfolio_short, node_short)
 
         console.print(table)
-        console.print(f"\\n:information: Total portfolios scheduled: [bold]{len(plan_data)}[/bold]")
+        console.print(f"\n:information: Total portfolios scheduled: [bold]{len(plan_data)}[/bold]")
 
     except Exception as e:
         console.print(f"[red]:x: Error getting schedule plan: {e}[/red]")
@@ -315,7 +315,7 @@ def nodes():
             table.add_row(node_short, portfolio_count, queue_size, f"{cpu_usage}%", heartbeat_time)
 
         console.print(table)
-        console.print(f"\\n:information: Total healthy nodes: [bold]{len(heartbeat_keys)}[/bold]")
+        console.print(f"\n:information: Total healthy nodes: [bold]{len(heartbeat_keys)}[/bold]")
 
     except Exception as e:
         console.print(f"[red]:x: Error listing ExecutionNodes: {e}[/red]")
@@ -360,21 +360,21 @@ def migrate(
         )
 
         # Show migration plan
-        console.print(f"\\n:clipboard: Migration Plan:")
+        console.print(f"\n:clipboard: Migration Plan:")
         console.print(f"  • Portfolio: [cyan]{portfolio_id}[/cyan]")
         console.print(f"  • Target Node: [green]{target_node}[/green]")
         console.print(f"  • Timestamp: {migration_dto.timestamp}")
 
         # Confirm unless force
         if not force:
-            console.print("\\n[yellow]:warning: This will migrate the portfolio to a different node[/yellow]")
+            console.print("\n[yellow]:warning: This will migrate the portfolio to a different node[/yellow]")
             confirm = typer.confirm("Are you sure you want to proceed?", default=False)
             if not confirm:
                 console.print("[red]:x: Migration cancelled[/red]")
                 raise typer.Exit(0)
 
         # Send migration command to Kafka
-        console.print(f"\\n:satellite: Sending migration command to Kafka...")
+        console.print(f"\n:satellite: Sending migration command to Kafka...")
         producer = GinkgoProducer()
         success = producer.send(KafkaTopics.SCHEDULE_UPDATES, migration_dto.model_dump())
 
@@ -419,14 +419,14 @@ def reload(
         )
 
         # Show reload plan
-        console.print(f"\\n:clipboard: Reload Plan:")
+        console.print(f"\n:clipboard: Reload Plan:")
         console.print(f"  • Portfolio: [cyan]{portfolio_id}[/cyan]")
         console.print(f"  • Action: Reload from database")
         console.print(f"  • Timestamp: {reload_dto.timestamp}")
 
         # Confirm unless force
         if not force:
-            console.print("\\n[yellow]:warning: This will reload the portfolio configuration[/yellow]")
+            console.print("\n[yellow]:warning: This will reload the portfolio configuration[/yellow]")
             console.print("[yellow]:warning: The portfolio will be temporarily stopped[/yellow]")
             confirm = typer.confirm("Are you sure you want to proceed?", default=False)
             if not confirm:
@@ -434,7 +434,7 @@ def reload(
                 raise typer.Exit(0)
 
         # Send reload command to Kafka
-        console.print(f"\\n:satellite: Sending reload command to Kafka...")
+        console.print(f"\n:satellite: Sending reload command to Kafka...")
         producer = GinkgoProducer()
         success = producer.send(KafkaTopics.SCHEDULE_UPDATES, reload_dto.model_dump())
 

--- a/tests/unit/client/test_scheduler_cli.py
+++ b/tests/unit/client/test_scheduler_cli.py
@@ -162,3 +162,65 @@ class TestSchedulePlanRead:
             if c.args and c.args[0] == "schedule:plan"
         ]
         assert get_calls == [], "schedule:plan 是 hash，用 get() 会触发 WRONGTYPE"
+
+
+# ===========================================================================
+# 输出转义（#6001）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSchedulerOutputEscape:
+    """#6001: scheduler 系列命令输出不应含字面 ``\\n``（反斜杠+n 两字符）。
+
+    根因：scheduler_cli.py 源码字符串字面量写成 ``\\\\n``（双反斜杠），
+    Python 解析为字面「反斜杠+n」，rich console.print 原样输出；
+    应为 ``\\n``（单反斜杠）→ 解析为真换行 LF。验收：输出无字面 \\n。
+    """
+
+    def test_nodes_no_literal_backslash_n(self, cli_runner):
+        """#6001 tracer: nodes 输出 'Total healthy nodes' 行不含字面 \\n，应为真换行。"""
+        mock_redis = MagicMock()
+        mock_redis.keys.return_value = [b"heartbeat:node:node-1"]
+        mock_redis.ttl.return_value = 30
+        mock_redis.hgetall.return_value = {
+            b'portfolio_count': b'1', b'queue_size': b'0', b'cpu_usage': b'5.0',
+        }
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = mock_redis
+            result = cli_runner.invoke(scheduler_cli.app, ["nodes"])
+
+        assert result.exit_code == 0
+        assert "Total healthy nodes" in result.output
+        # 字面 \n（反斜杠+n）= 源码 \\n 双反斜杠误用所致，修复后必须消失
+        assert "\\n" not in result.output, (
+            f"nodes 输出含字面 \\n（应为真换行）: {repr(result.output[-120:])}"
+        )
+
+    def test_plan_no_literal_backslash_n(self, cli_runner):
+        """#6001: plan 输出 'Total portfolios scheduled' 行不含字面 \\n。"""
+        mock_redis = MagicMock()
+        mock_redis.hgetall.return_value = {b"port-uuid-1": b"node-1"}
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = mock_redis
+            result = cli_runner.invoke(scheduler_cli.app, ["plan"])
+
+        assert result.exit_code == 0
+        assert "Total portfolios scheduled" in result.output
+        assert "\\n" not in result.output, (
+            f"plan 输出含字面 \\n: {repr(result.output[-120:])}"
+        )
+
+    def test_reload_no_literal_backslash_n(self, cli_runner):
+        """#6001: reload --force 输出 'Reload Plan' 不含字面 \\n。"""
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as MockProducer:
+            MockProducer.return_value.send.return_value = True
+            result = cli_runner.invoke(
+                scheduler_cli.app, ["reload", "port-uuid-1", "--force"]
+            )
+
+        assert result.exit_code == 0
+        assert "Reload Plan" in result.output
+        assert "\\n" not in result.output, (
+            f"reload 输出含字面 \\n: {repr(result.output[-120:])}"
+        )


### PR DESCRIPTION
## Summary

修复 #6001：`ginkgo scheduler nodes/plan/reload` 输出含字面 `\n`（反斜杠+n 两字符）而非真换行。

**根因**：`scheduler_cli.py` 源码字符串字面量误写双反斜杠 `\\n`（Python 解析为字面「反斜杠+n」），rich `console.print` 原样输出；应为单反斜杠 `\n`（解析为换行符 LF）。

**调用链**：

```
ginkgo scheduler nodes
  → scheduler_cli.nodes()
    → console.print(f"...\\n:information: Total healthy nodes: ...")   # 源码 \\n（双反斜杠）
    → rich 把字面「反斜杠+n」原样输出                                    # 用户看到 \n 文本  ❌
```

**修复**：全文 28 处 `\\n`（源码双反斜杠）→ `\n`（单反斜杠）。

Python 字符串字面量规则：源码 `"\\n"` = 2 字符（反斜杠+n），源码 `"\n"` = 1 字符换行符 LF。rich `console.print` 不解释转义序列，只渲染字符串里的真换行符——所以问题纯粹是源码多写了一个反斜杠。

**影响范围**：nodes / plan / reload / migrate / start 等 scheduler 系列命令的输出渲染。纯字符串字面量修正，无逻辑变更，无回归。

## scope

- ✅ scheduler_cli.py 全文 28 处 `\\n` → `\n`
- ✅ 修复前 nodes 输出 `'\\n' is contained here`（字面反斜杠+n），修复后无字面 `\n`
- ⏭️ 未改任何命令逻辑（纯字符串字面量修正）

## Test plan

- [x] TDD RED：`test_nodes_no_literal_backslash_n` 修复前 fail（`'\\n' is contained here`）
- [x] TDD GREEN：修复后通过
- [x] 扩展覆盖：`test_plan_no_literal_backslash_n` / `test_reload_no_literal_backslash_n`
- [x] `test_scheduler_cli.py` 全 **8 测**通过（5 旧 status/schedule/recalculate + 3 新），无回归
- [x] py_compile 通过
- [x] 冒烟：`import ginkgo.client.scheduler_cli` 启动路径 OK

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_scheduler_cli.py -o addopts= -q
# 8 passed
```

Closes #6001
