### PR TITLE
fix: engine create Engine ID 显示纯 UUID 替代 dict repr

### DIFF
--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -181,7 +181,18 @@ def create(
         result = engine_service.add(name=name, is_live=is_live, description=description or "")
 
         if result.success:
-            engine_uuid = result.data.uuid if hasattr(result.data, 'uuid') else result.data
+            # #5988: service.add 返回 data={"engine_info": {...}}（dict），
+            # 旧 hasattr(result.data,'uuid') 对 dict 必然 False，会把整个 dict
+            # repr 当 Engine ID 打印。按实际契约逐层提取，并兼容扁平 dict / Model 对象。
+            data = result.data
+            if isinstance(data, dict) and "engine_info" in data:
+                engine_uuid = data["engine_info"].get("uuid", "")
+            elif isinstance(data, dict) and "uuid" in data:
+                engine_uuid = data["uuid"]
+            elif hasattr(data, "uuid"):
+                engine_uuid = data.uuid
+            else:
+                engine_uuid = data
             console.print(f":white_check_mark: Engine '{name}' created successfully")
             console.print(f"  • Engine ID: {engine_uuid}")
             console.print(f"  • Type: {engine_type}")

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -710,3 +710,42 @@ class TestResolveEngineIdFuzzy:
 
         # fuzzy 命中第一条的 UUID 应被返回，而非因 NameError 返回 None
         assert resolved == engine.uuid
+
+
+# ---------------------------------------------------------------------------
+# #5988: engine create 输出 Engine ID 应为纯 UUID，非 dict repr
+# ---------------------------------------------------------------------------
+
+class TestEngineCreate:
+    """#5988: ``engine create`` 成功后 ``Engine ID`` 行应只含纯 UUID 字符串。
+
+    Service 层 ``engine_service.add`` 返回 ``data={"engine_info": {...}}``（dict），
+    而非带 ``.uuid`` 属性的 Model 对象。旧代码用 ``hasattr(result.data, 'uuid')``
+    探测 dict 必然 False，回退分支把整个 dict ``repr`` 当成 Engine ID 打印。
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_create_shows_pure_uuid_not_dict_repr(self, cli_runner):
+        engine_info = {
+            "uuid": "abc123def4567890abcdef1234567890",
+            "name": "test_engine",
+            "is_live": False,
+            "status": "IDLE",
+            "desc": "回测引擎: test_engine",
+        }
+        svc = _mock_engine_service(
+            add=ServiceResult.success(data={"engine_info": engine_info})
+        )
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(
+                engine_cli.app, ["create", "-n", "test_engine", "-t", "backtest"]
+            )
+
+        assert result.exit_code == 0, result.output
+        engine_id_lines = [l for l in result.output.splitlines() if "Engine ID" in l]
+        assert engine_id_lines, f"未找到 Engine ID 行:\n{result.output}"
+        engine_id_line = engine_id_lines[0]
+        # dict repr 含 '{' / '}' —— 纯 UUID 行不应含这些
+        assert "{" not in engine_id_line, f"Engine ID 行含 dict repr:\n{engine_id_line}"
+        assert "abc123def4567890abcdef1234567890" in engine_id_line


### PR DESCRIPTION
## Summary

修复 #5988：`ginkgo engine create` 成功后 `Engine ID` 行打印整个 dict repr（`{'engine_info': {'uuid': '...'}}`）而非纯 UUID。

**根因**：`engine_cli.py:184` 用 `hasattr(result.data, 'uuid')` 探测返回值——但 `engine_service.add` 返回 `data={"engine_info": {...}}`（dict），dict 无 `.uuid` 属性，`hasattr` 必然 False，走 else 把整个 dict 当 Engine ID 打印。

**调用链**：
```
ginkgo engine create -n test -t backtest
  → engine_cli.create()
    → engine_service.add() → ServiceResult.success(data={"engine_info": {...}})
    → engine_uuid = result.data.uuid if hasattr(result.data,'uuid') else result.data
                                                    # dict 无 .uuid → False → 走 else
    → console.print(f"  • Engine ID: {engine_uuid}")  # engine_uuid=整个 dict  ❌
```

**修复**：按 service 实际契约逐层提取，兼容嵌套 dict / 扁平 dict / Model 对象三种形态：
```python
data = result.data
if isinstance(data, dict) and "engine_info" in data:
    engine_uuid = data["engine_info"].get("uuid", "")
elif isinstance(data, dict) and "uuid" in data:
    engine_uuid = data["uuid"]
elif hasattr(data, "uuid"):
    engine_uuid = data.uuid
else:
    engine_uuid = data
```

## scope

- ✅ `engine create` 成功后 Engine ID 显示纯 UUID（验收）
- ✅ 多分支兼容 service 未来可能的返回格式变更（嵌套/扁平/Model 对象）
- ⏭️ 未改 service 层返回契约（在 CLI 适配，service 的 `{"engine_info": {...}}` 包装保留供其他消费方）

## Test plan

- [x] TDD RED：`test_create_shows_pure_uuid_not_dict_repr` 修复前 fail（`Engine ID: {'engine_info': {'uuid': ...}`）
- [x] TDD GREEN：修复后 Engine ID 行只含纯 UUID，无 `{` dict repr
- [x] `test_engine_cli.py` 全 **42 测**通过（41 旧 + 1 新），无回归
- [x] py_compile 通过
- [x] 冒烟：`sys.path.insert(0,wt)` 强制导入 worktree 修复版，inspect 确认新代码 + `__file__` 指向 worktree

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_engine_cli.py -o addopts= -q
# 42 passed
```

Closes #5988
