### PR TITLE
feat(#5783): 加 GET /portfolios/{uuid}/positions 端点（验收2）

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -588,6 +588,38 @@ async def get_portfolio_analytics(uuid: str):
         raise BusinessError(f"Error getting analytics: {e}")
 
 
+@router.get("/{uuid}/positions")
+async def get_portfolio_positions(
+    uuid: str,
+    active_only: bool = Query(False, description="仅返回 volume>0 的活跃持仓"),
+):
+    """获取 Portfolio 当前持仓快照（#5783 验收2）
+
+    数据层 PositionCRUD 早已支持按 portfolio 查询，本端点在 portfolio router
+    暴露持仓查询能力（对齐 backtest /{uuid}/positions，序列化形状与
+    load_persisted_state 一致）。
+    """
+    try:
+        portfolio_service = get_portfolio_service()
+        result = portfolio_service.get_positions(uuid, active_only=active_only)
+
+        if not result.is_success():
+            return ok(data=[], message=result.error or "Failed to retrieve positions")
+
+        items = result.data
+        meta = pagination_meta(
+            page=1,
+            total=len(items),
+            page_size=max(len(items), 1),
+        )
+        return ok(data=items, message="Positions retrieved successfully", meta=meta)
+    except NotFoundError:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting positions for portfolio {uuid}: {e}")
+        raise BusinessError(f"Error getting positions: {e}")
+
+
 @router.get("/{uuid}/events")
 async def get_portfolio_events(
     uuid: str,

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -456,6 +456,51 @@ class PortfolioService(BaseService):
             GLOG.ERROR(f"Failed to load persisted portfolio state: {e}")
             return ServiceResult.error(f"Database operation failed: {str(e)}")
 
+    def get_positions(self, portfolio_id: str, active_only: bool = False) -> ServiceResult:
+        """
+        获取 Portfolio 的当前持仓快照（#5783 验收2）。
+
+        数据层 PositionCRUD.find_by_portfolio / get_active_positions 早已存在，
+        本方法在 service 层接线并按 load_persisted_state 既有形状序列化，
+        供 GET /portfolios/{uuid}/positions 端点使用。
+
+        Args:
+            portfolio_id: 投资组合UUID
+            active_only: True 仅返回 volume>0 的活跃持仓
+
+        Returns:
+            ServiceResult: data 为持仓 dict 列表（字段对齐 load_persisted_state:425-440）
+        """
+        try:
+            position_crud = self._get_position_crud()
+            if active_only:
+                m_positions = position_crud.get_active_positions(portfolio_id)
+            else:
+                m_positions = position_crud.find_by_portfolio(portfolio_id)
+
+            positions_data = []
+            for m_pos in m_positions:
+                positions_data.append({
+                    "portfolio_id": m_pos.portfolio_id,
+                    "engine_id": m_pos.engine_id,
+                    "task_id": m_pos.task_id,
+                    "code": m_pos.code,
+                    "cost": str(m_pos.cost),
+                    "volume": m_pos.volume,
+                    "frozen_volume": m_pos.frozen_volume,
+                    "settlement_frozen_volume": m_pos.settlement_frozen_volume,
+                    "settlement_days": m_pos.settlement_days,
+                    "settlement_queue_json": m_pos.settlement_queue_json,
+                    "frozen_money": str(m_pos.frozen_money),
+                    "price": str(m_pos.price),
+                    "fee": str(m_pos.fee),
+                    "uuid": m_pos.uuid,
+                })
+            return ServiceResult.success(positions_data)
+        except Exception as e:
+            GLOG.ERROR(f"Failed to get positions for portfolio {(portfolio_id or '')[:8]}: {e}")
+            return ServiceResult.error(f"Database operation failed: {str(e)}")
+
     def _get_position_crud(self):
         """获取 PositionCRUD 实例（延迟导入避免循环依赖）"""
         from ginkgo import services

--- a/tests/unit/data/services/test_portfolio_service_positions.py
+++ b/tests/unit/data/services/test_portfolio_service_positions.py
@@ -1,0 +1,107 @@
+"""
+#5783: PortfolioService.get_positions 持仓查询（验收2）
+
+背景：数据层 PositionCRUD.find_by_portfolio 早已存在，但 portfolio_service
+从未接线持仓查询，portfolio 层无 /positions 端点（验收2 未达标）。
+本测试覆盖新增公开方法 get_positions 的行为，序列化字段对齐既有
+load_persisted_state（portfolio_service.py:420-440），不引入新数据形状。
+"""
+
+import os
+import sys
+from decimal import Decimal
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.portfolio_service import PortfolioService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_position(code="000001.SZ", volume=100):
+    """构造 mock MPosition（字段对齐 load_persisted_state 序列化）。"""
+    m = MagicMock()
+    m.portfolio_id = "p1"
+    m.engine_id = "e1"
+    m.task_id = "t1"
+    m.code = code
+    m.cost = Decimal("10.5")
+    m.volume = volume
+    m.frozen_volume = 0
+    m.settlement_frozen_volume = 0
+    m.settlement_days = 0
+    m.settlement_queue_json = None
+    m.frozen_money = Decimal("0")
+    m.price = Decimal("11.0")
+    m.fee = Decimal("5")
+    m.uuid = "u-" + code
+    return m
+
+
+@pytest.fixture
+def service_with_positions():
+    """PortfolioService + mock position crud（含 1 活跃 + 1 零仓位）。"""
+    active = _make_position("000001.SZ", 100)
+    closed = _make_position("600000.SH", 0)
+    mock_crud = MagicMock()
+    mock_crud.find_by_portfolio.return_value = [active, closed]
+    mock_crud.get_active_positions.return_value = [active]
+    with patch("ginkgo.libs.GLOG"):
+        svc = PortfolioService(
+            crud_repo=MagicMock(),
+            portfolio_file_mapping_crud=MagicMock(),
+        )
+    svc._get_position_crud = lambda: mock_crud
+    return svc, mock_crud
+
+
+@pytest.mark.unit
+class TestPortfolioServiceGetPositions:
+    """#5783: get_positions 持仓查询行为。"""
+
+    def test_get_positions_returns_all_serialized(self, service_with_positions):
+        """get_positions 返回 portfolio 全部持仓，字段序列化对齐 load_persisted_state。"""
+        svc, mock_crud = service_with_positions
+        result = svc.get_positions("p1")
+
+        assert result.is_success()
+        assert len(result.data) == 2
+        first = result.data[0]
+        assert first["code"] == "000001.SZ"
+        assert first["volume"] == 100
+        # Decimal 经 str() 序列化（对齐 load_persisted_state:430）
+        assert first["cost"] == "10.5"
+        assert first["price"] == "11.0"
+        mock_crud.find_by_portfolio.assert_called_once_with("p1")
+
+    def test_get_positions_active_only_filters_zero_volume(self, service_with_positions):
+        """active_only=True 只返回 volume>0 持仓（走 get_active_positions）。"""
+        svc, mock_crud = service_with_positions
+        result = svc.get_positions("p1", active_only=True)
+
+        assert result.is_success()
+        assert len(result.data) == 1
+        assert result.data[0]["code"] == "000001.SZ"
+        assert result.data[0]["volume"] == 100
+        mock_crud.get_active_positions.assert_called_once_with("p1")
+        mock_crud.find_by_portfolio.assert_not_called()
+
+    def test_get_positions_empty_portfolio_returns_empty_list(self):
+        """无持仓的 portfolio 返回空列表（非错误，不抛异常）。"""
+        mock_crud = MagicMock()
+        mock_crud.find_by_portfolio.return_value = []
+        with patch("ginkgo.libs.GLOG"):
+            svc = PortfolioService(
+                crud_repo=MagicMock(),
+                portfolio_file_mapping_crud=MagicMock(),
+            )
+        svc._get_position_crud = lambda: mock_crud
+
+        result = svc.get_positions("empty-portfolio")
+
+        assert result.is_success()
+        assert result.data == []


### PR DESCRIPTION
## Summary

修复 #5783 验收2：加 `GET /portfolios/{uuid}/positions` 端点，portfolio 层暴露持仓查询能力。

**根因**：数据层 `PositionCRUD.find_by_portfolio` / `get_active_positions` / `get_portfolio_value`（position_crud.py:191/218/224）早已存在，`MPosition.portfolio_id` 字段完备，但 **portfolio_service 从未接线持仓查询**，portfolio router 也无 `/positions` 端点——能力具备、入口缺失。owner 复核（2026-06-20）确认验收1（`/analytics` 返回 metrics+net_value_series）已满足，验收2（`/positions`）未达标，持仓只能经回测任务路径取。

**修复**（深度模块复用，零新数据形状）：
1. **`PortfolioService.get_positions(portfolio_id, active_only=False)`**（portfolio_service.py）：service 层接线既有 `_get_position_crud()`，序列化形状**逐字段复用** `load_persisted_state:425-440`（Decimal 经 `str()`，与持仓快照持久化路径一致）。`active_only=True` 走 `get_active_positions`（volume>0），默认走 `find_by_portfolio` 返回全部。
2. **`GET /portfolios/{uuid}/positions`**（portfolio.py）：薄转发端点，对齐同模块 `get_portfolio_events` 的 `ok + pagination_meta` 模式，语义对齐 `backtest /{uuid}/positions`。支持 `?active_only=true`。

**控制流不变**：纯增量（新方法 + 新端点），未修改既有 PositionCRUD / load_persisted_state / 任何 Base 类。验收3 的"净值曲线/风险指标/收益分析"由既有 `/analytics`（metrics+net_value_series）覆盖。

## Test plan

新增 `tests/unit/data/services/test_portfolio_service_positions.py`（3 个 TDD 行为测试，经 RED→GREEN，mock 依赖隔离）：
- `get_positions` 返回全部持仓，字段序列化对齐 load_persisted_state（Decimal→str）
- `active_only=True` 只返回 volume>0（走 get_active_positions，不调 find_by_portfolio）
- 无持仓 portfolio 返回空列表（非错误）

本地三层冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1：`py_compile` src/api 全量通过
- ✅ Layer 2：启动路径点名 smoke（user_crud_mock / containers / user_cli / portfolio_service_mock）75 passed
- ✅ Layer 3：新测试 3 + 既有 portfolio_service_mock（40 方法回归）共 49 passed，零回归

端点为薄转发（对齐既有 get_portfolio_analytics 生产模式），核心逻辑在 service 层 TDD 覆盖；端点可达性由 Layer 2 启动路径 smoke 覆盖。未加独立 api 层单测（SECRET_KEY 环境依赖 + api/unit namespace 污染陷阱，单跑正常但混跑报错，ROI 低）。

Closes #5783
