### PR TITLE
refactor: 6 枚举加 CANCELLED 双L别名桥接 brokers 拼写 (#6061)

### DIFF
--- a/src/ginkgo/enums.py
+++ b/src/ginkgo/enums.py
@@ -189,6 +189,7 @@ class ORDERSTATUS_TYPES(EnumBase):
     PARTIALLY_FILLED = 3  # 别名，兼容不同命名风格
     FILLED = 4
     CANCELED = 5
+    CANCELLED = 5  # 双L别名，兼容 brokers 层拼写 (#6061)
     REJECTED = 6
 
 
@@ -199,6 +200,7 @@ class TRANSFERSTATUS_TYPES(EnumBase):
     SUBMITTED = 2
     FILLED = 3
     CANCELED = 4
+    CANCELLED = 4  # 双L别名 (#6061)
     PENDING = 5
 
 
@@ -255,6 +257,7 @@ class RECORDSTAGE_TYPES(EnumBase):
     ORDERSEND = 3
     ORDERFILLED = 4
     ORDERCANCELED = 5
+    ORDERCANCELLED = 5  # 双L别名 (#6061)
     ENDDAY = 6
     # T5/T6: 扩展订单生命周期阶段
     ORDERACK = 7
@@ -357,6 +360,7 @@ class ENGINE_TYPES(EnumBase):
     COMPLETED = 5
     ERROR = 6
     CANCELED = 7
+    CANCELLED = 7  # 双L别名 (#6061)
 
 
 class ENGINE_ARCHITECTURE(EnumBase):
@@ -425,6 +429,7 @@ class EXECUTION_STATUS(EnumBase):
     REJECTED = 2                # 被拒绝
     TIMEOUT = 3                 # 超时
     CANCELED = 4                # 已取消
+    CANCELLED = 4                # 双L别名 (#6061)
     FILLED = 5                  # 已成交
     PARTIAL_FILLED = 6          # 部分成交
     ERROR = 7                   # 执行错误
@@ -439,6 +444,7 @@ class TRACKINGSTATUS_TYPES(EnumBase):
     EXECUTED = 2                # 已执行
     TIMEOUT = 3                 # 超时
     CANCELED = 4                # 已取消
+    CANCELLED = 4                # 双L别名 (#6061)
 
 
 class ACCOUNT_TYPE(EnumBase):

--- a/tests/unit/test_enums_cancelled_alias.py
+++ b/tests/unit/test_enums_cancelled_alias.py
@@ -1,0 +1,46 @@
+"""#6061: CANCELED/CANCELLED 双L别名向后兼容测试。
+
+6 个枚举历史用单 L ``CANCELED``，而 brokers 层用双 L ``CANCELLED``。
+为枚举加双 L 别名桥接两套拼写；别名与原成员同一对象、同值，单 L 引用不受影响。
+
+先例：``ORDERSTATUS_TYPES`` 已有 ``PARTIALLY_FILLED`` 别名（enums.py L189）。
+"""
+from ginkgo.enums import (
+    ORDERSTATUS_TYPES,
+    TRANSFERSTATUS_TYPES,
+    RECORDSTAGE_TYPES,
+    ENGINE_TYPES,
+    EXECUTION_STATUS,
+    TRACKINGSTATUS_TYPES,
+)
+
+
+def test_orderstatus_cancelled_alias():
+    assert ORDERSTATUS_TYPES.CANCELLED is ORDERSTATUS_TYPES.CANCELED
+    assert ORDERSTATUS_TYPES.CANCELLED.value == 5
+
+
+def test_transferstatus_cancelled_alias():
+    assert TRANSFERSTATUS_TYPES.CANCELLED is TRANSFERSTATUS_TYPES.CANCELED
+    assert TRANSFERSTATUS_TYPES.CANCELLED.value == 4
+
+
+def test_recordstage_ordercancelled_alias():
+    # RECORDSTAGE 取消成员是带 ORDER 前缀的 ORDERCANCELED
+    assert RECORDSTAGE_TYPES.ORDERCANCELLED is RECORDSTAGE_TYPES.ORDERCANCELED
+    assert RECORDSTAGE_TYPES.ORDERCANCELLED.value == 5
+
+
+def test_engine_cancelled_alias():
+    assert ENGINE_TYPES.CANCELLED is ENGINE_TYPES.CANCELED
+    assert ENGINE_TYPES.CANCELLED.value == 7
+
+
+def test_execution_status_cancelled_alias():
+    assert EXECUTION_STATUS.CANCELLED is EXECUTION_STATUS.CANCELED
+    assert EXECUTION_STATUS.CANCELLED.value == 4
+
+
+def test_trackingstatus_cancelled_alias():
+    assert TRACKINGSTATUS_TYPES.CANCELLED is TRACKINGSTATUS_TYPES.CANCELED
+    assert TRACKINGSTATUS_TYPES.CANCELLED.value == 4


### PR DESCRIPTION
## Summary
修复 #6061。`enums.py` 6 个枚举历史用单 L `CANCELED`，而 brokers 层（`base_broker.py`/`interfaces.py`）用双 L `CANCELLED`，两套拼写并存致跨模块 `.CANCELED`/`.CANCELLED` 易错。本 PR 为 6 枚举各加双 L 别名，桥接两套拼写，单 L 引用向后兼容。

## issue 描述偏差（逐字符核对，以实际代码为准）
issue brief 中枚举名有误，实际修改的 6 枚举：
- `ORDERSTATUS_TYPES.CANCELED=5` → +`CANCELLED=5`
- `TRANSFERSTATUS_TYPES.CANCELED=4` → +`CANCELLED=4`
- `RECORDSTAGE_TYPES.ORDERCANCELED=5` → +`ORDERCANCELLED=5`（成员名带 ORDER 前缀）
- `ENGINE_TYPES.CANCELED=7`（issue 误称 `BACKTEST_MODE_TYPES`，该名不存在）→ +`CANCELLED=7`
- `EXECUTION_STATUS.CANCELED=4`（issue 误称 `MANUALEXECUTIONSTATUS_TYPES`，该名不存在）→ +`CANCELLED=4`
- `TRACKINGSTATUS_TYPES.CANCELED=4` → +`CANCELLED=4`

issue 称 `ExecutionStatus`/`OrderStatus` 已双 L 无需改——实际 `EXECUTION_STATUS`/`ORDERSTATUS_TYPES` 均为单 L，本 PR 已加别名。

## 机制
Python `Enum` 别名：同值后定义的成员成为先定义成员的别名（`Cls.CANCELLED is Cls.CANCELED` 为 True）。先例：`ORDERSTATUS_TYPES.PARTIALLY_FILLED=3`（enums.py L189）已是此模式。纯增量，零删除，58 处现有 `.CANCELED` 引用不受影响。

## Test plan
- [x] 新增 `tests/unit/test_enums_cancelled_alias.py`（6 测试，每枚举断言 `CANCELLED is CANCELED` + 值正确）
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）
- [x] L3 变更相关（`test_enum_conversion.py` 回归 6 passed + 新别名 6 passed）
- [x] 向后兼容：单 L `.CANCELED` 引用继续解析（别名 `is` 同一对象）

Closes #6061
