### PR TITLE
fix: validate 支持组件名称/UUID 解析（文件路径向后兼容）

### DIFF
--- a/src/ginkgo/client/validation_cli.py
+++ b/src/ginkgo/client/validation_cli.py
@@ -200,14 +200,54 @@ def validate(
 
     else:  # component_file
         file_path = Path(component_file)
-        if not file_path.exists():
-            console.print(f":x: [red]File not found: {component_file}[/red]")
+        if file_path.exists():
+            # Backward compat: real file path
+            source_info = f"Local file: {file_path.name}"
+            _validate_single_strategy(
+                file_path, component_type, report_format, output, verbose,
+                show_trace, code, events, source_info, console
+            )
+            return
+
+        # #5357: 非文件路径 → 尝试按组件名/UUID 从 DB 解析
+        from ginkgo.data.containers import container
+        from ginkgo.trading.evaluation.utils.database_loader import DatabaseStrategyLoader
+
+        # 先按名称查；命中则取其 file_id (uuid)
+        resolved_file_id = None
+        try:
+            name_result = container.file_service().get_by_name(component_file)
+            if name_result.is_success() and name_result.data and name_result.data.get("count", 0) > 0:
+                resolved_file_id = name_result.data["files"][0].uuid
+        except Exception as e:
+            if verbose:
+                console.print(f":warning: 名称查询异常，改按 UUID 尝试: {e}")
+
+        # 名称未命中 → 当作 UUID 直接交给 loader（内部按 uuid 查，查不到抛 FileNotFoundError）
+        if resolved_file_id is None:
+            resolved_file_id = component_file
+
+        loader = DatabaseStrategyLoader()
+        try:
+            with loader.load_by_file_id(resolved_file_id) as temp_path:
+                temp_file_path = temp_path
+                source_info = f"Database (resolved '{component_file}' → file_id: {resolved_file_id[:8]}...)"
+                if verbose:
+                    console.print(f":link: 已将 '{component_file}' 解析为 file_id {resolved_file_id[:8]}...")
+                _validate_single_strategy(
+                    temp_path, component_type, report_format, output, verbose,
+                    show_trace, code, events, source_info, console
+                )
+        except FileNotFoundError:
+            console.print(f":x: [red]未找到组件 '{component_file}'，请使用文件路径或组件名称/UUID[/red]")
+            console.print("  提示: 运行 `ginkgo validate --list` 查看可用组件")
             raise typer.Exit(2)
-        source_info = f"Local file: {file_path.name}"
-        _validate_single_strategy(
-            file_path, component_type, report_format, output, verbose,
-            show_trace, code, events, source_info, console
-        )
+        except Exception as e:
+            console.print(f":x: [red]Error loading from database: {e}[/red]")
+            if verbose:
+                import traceback
+                console.print(traceback.format_exc())
+            raise typer.Exit(5)
 
 def _validate_single_strategy(
     file_path: Path,

--- a/tests/unit/client/test_validation_cli.py
+++ b/tests/unit/client/test_validation_cli.py
@@ -25,6 +25,7 @@ import pytest
 from typer.testing import CliRunner
 
 from ginkgo.client import validation_cli
+from ginkgo.data.services.base_service import ServiceResult
 
 
 @pytest.fixture
@@ -102,11 +103,17 @@ class TestValidateErrors:
         assert "Invalid format" in result.output
 
     def test_file_not_found(self, cli_runner):
-        result = cli_runner.invoke(validation_cli.app, [
-            "nonexistent_file.py"
-        ])
+        """#5357: 名称/UUID 均未命中时给清晰中文提示，不再误报 'File not found'。"""
+        mock_container = _mock_file_container_for_name("nonexistent_file.py", [])
+        with patch("ginkgo.data.containers.container", mock_container), \
+             patch("ginkgo.trading.evaluation.utils.database_loader.DatabaseStrategyLoader") as MockLoader:
+            MockLoader.return_value.load_by_file_id.side_effect = FileNotFoundError("not in db")
+            result = cli_runner.invoke(validation_cli.app, [
+                "nonexistent_file.py"
+            ])
         assert result.exit_code == 2
-        assert "File not found" in result.output
+        assert "未找到组件" in result.output
+        assert "File not found" not in result.output
 
     def test_multiple_sources_mutually_exclusive(self, cli_runner):
         """Cannot specify both file and --file-id."""
@@ -199,3 +206,73 @@ class TestHelperFunctions:
 
     def test_get_format_extension_unknown(self):
         assert validation_cli._get_format_extension("unknown") == "txt"
+
+
+# ============================================================================
+# 6. Component name / UUID resolution (#5357)
+# ============================================================================
+
+
+def _mock_file_container_for_name(name, files):
+    """Build a mock container whose file_service().get_by_name(name) returns
+    a real ServiceResult wrapping the given ORM-like file objects."""
+    mock_container = MagicMock()
+    mock_file_service = MagicMock()
+    mock_file_service.get_by_name.return_value = ServiceResult.success(
+        data={"files": files, "count": len(files)},
+        message=f"Found {len(files)} files with name '{name}'",
+    )
+    mock_container.file_service.return_value = mock_file_service
+    return mock_container
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestComponentNameUuidResolution:
+    """#5357: validate <name> / <uuid> should resolve from DB, not just file paths."""
+
+    def test_validate_by_component_name_resolves_from_db(self, cli_runner):
+        """validate momentum (momentum in DB) → resolves to file_id, loads, validates.
+        Must NOT print 'File not found'."""
+        mock_file = MagicMock()
+        mock_file.uuid = "abc123def4567890abcdef1234567890"
+        mock_container = _mock_file_container_for_name("momentum", [mock_file])
+
+        with patch("ginkgo.data.containers.container", mock_container), \
+             patch("ginkgo.trading.evaluation.utils.database_loader.DatabaseStrategyLoader") as MockLoader, \
+             patch.object(validation_cli, "_validate_single_strategy") as mock_validate:
+            mock_loader = MockLoader.return_value
+            mock_cm = MagicMock()
+            mock_cm.__enter__.return_value = Path("/tmp/resolved_momentum.py")
+            mock_cm.__exit__.return_value = False
+            mock_loader.load_by_file_id.return_value = mock_cm
+
+            result = cli_runner.invoke(validation_cli.app, ["momentum", "--type", "strategy"])
+
+        assert result.exit_code == 0, result.output
+        assert "File not found" not in result.output, f"误报 File not found:\n{result.output}"
+        # 名称命中 → 用 get_by_name 返回的 uuid 加载
+        mock_loader.load_by_file_id.assert_called_once_with("abc123def4567890abcdef1234567890")
+        mock_validate.assert_called_once()
+
+    def test_validate_by_uuid_falls_back_when_name_misses(self, cli_runner):
+        """validate <uuid> (uuid 不在 name 表但有效) → name 未命中后按 uuid 加载。"""
+        # 名称查不到（count=0）
+        mock_container = _mock_file_container_for_name("deadbeefdeadbeefdeadbeefdeadbeef", [])
+        with patch("ginkgo.data.containers.container", mock_container), \
+             patch("ginkgo.trading.evaluation.utils.database_loader.DatabaseStrategyLoader") as MockLoader, \
+             patch.object(validation_cli, "_validate_single_strategy") as mock_validate:
+            mock_loader = MockLoader.return_value
+            mock_cm = MagicMock()
+            mock_cm.__enter__.return_value = Path("/tmp/resolved_uuid.py")
+            mock_cm.__exit__.return_value = False
+            mock_loader.load_by_file_id.return_value = mock_cm
+
+            result = cli_runner.invoke(
+                validation_cli.app, ["deadbeefdeadbeefdeadbeefdeadbeef", "--type", "strategy"]
+            )
+
+        assert result.exit_code == 0, result.output
+        # name 未命中 → 用原始 uuid 输入加载
+        mock_loader.load_by_file_id.assert_called_once_with("deadbeefdeadbeefdeadbeefdeadbeef")
+        mock_validate.assert_called_once()


### PR DESCRIPTION
## Summary

修复 #5357：`ginkgo validate <name|uuid>` 报 `File not found`，仅文件路径可用。

**根因**：`validation_cli.validate` 的位置参数 `component_file` 仅当文件路径处理——`Path(component_file).exists()` 为假即打印 `File not found` 并退出，从不尝试按组件名/UUID 从 DB 解析，与 `component show` 等支持名称/UUID 的命令行为不一致。

**调用链**：
```
ginkgo validate momentum          # momentum 是 DB 中的组件名
  → validation_cli.validate(component_file="momentum", ...)
    → file_id 为 None, all_db 为 False → else 分支
      → Path("momentum").exists() == False
      → console.print("File not found: momentum"); raise typer.Exit(2)   ❌
```

**修复**（`validation_cli.py` else 分支）：
1. `Path.exists()` 命中 → 真实文件路径（**向后兼容**，现有 happy path 不变）
2. 不命中 → `file_service.get_by_name(component_file)`，命中取 `files[0].uuid`
3. 名称未命中 → 把输入当 UUID 交给 `DatabaseStrategyLoader.load_by_file_id`（内部按 uuid 查，查不到抛 `FileNotFoundError`）
4. 两者都失败 → 清晰中文提示「未找到组件 '...'，请使用文件路径或组件名称/UUID」+ `--list` 提示

## scope

- ✅ `validate <component_name>` 按名称查找并验证（验收 #1）
- ✅ `validate <uuid>` 按 UUID 查找并验证（验收 #2）
- ✅ 向后兼容文件路径方式（验收 #3，现有 `test_validate_strategy_file` 不变）
- ✅ 找不到时清晰提示「未找到组件」（验收 #4）
- ⏭️ 未改 `file_id` / `--all-db` 分支（它们本就走 DB，无此问题）
- ⏭️ 未改 service 层（在 CLI 适配，复用已有 `file_service.get_by_name` + `DatabaseStrategyLoader`）

## Test plan

- [x] TDD RED→GREEN slice 1：`validate momentum`（DB 有 name=momentum）→ 解析为 file_id 加载，**不**报 `File not found`，`load_by_file_id` 用 `get_by_name` 返回的 uuid
- [x] TDD slice 2：`validate <不存在的名>` → 名称/UUID 均未命中 → 「未找到组件」，exit 2，**不再**误报 `File not found`（更新既有 `test_file_not_found`）
- [x] TDD slice 3：`validate <uuid>`（name 未命中但 uuid 有效）→ name 未命中后按原始 uuid 加载
- [x] `test_validation_cli.py` 全 **17 测**通过（15 既有 + 2 新；`test_file_not_found` 原地更新），无回归
- [x] py_compile 通过
- [x] 冒烟：`sys.path.insert(0,wt)` 强制导入 worktree 修复版，inspect 确认 `resolved_file_id` / `未找到组件` / `get_by_name` 代码落地 + `__file__` 指向 worktree

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest tests/unit/client/test_validation_cli.py -o addopts= -q
# 17 passed
```

Closes #5357
