### PR TITLE
fix: result 子命令统一 --task-id 命名 (兼容旧 --run-id) (#5998)

### DIFF
--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -627,18 +627,27 @@ def list(
 
 @result_app.command()
 def get(
-    task_id: str = typer.Argument(..., help=":mag: 回测任务ID (uuid 或 task_id)"),
+    task_id: Optional[str] = typer.Argument(None, help=":mag: 回测任务ID (uuid 或 task_id, 与 --task-id 二选一)"),
+    task_id_opt: Optional[str] = typer.Option(None, "--task-id", help=":mag: 同位置参数, 统一参数名"),
     details: bool = typer.Option(False, "--details", "-d", help=":information_source: 显示完整回测记录详情"),
     trades: bool = typer.Option(False, "--trades", "-t", help=":repeat: 显示成交订单(按 order_id 去重后的最终态)"),
 ):
     """
-    :mag: 获取回测结果详情。参数为 task_id。
+    :mag: 获取回测结果详情。参数为 task_id (位置参数或 --task-id)。
 
     Examples:
         ginkgo result get <task_id>
+        ginkgo result get --task-id <task_id>
         ginkgo result get <task_id> --details
         ginkgo result get <task_id> --trades
     """
+    # #5998: 位置参数与 --task-id 二选一, 统一参数命名
+    tid = task_id or task_id_opt
+    if not tid:
+        console.print(":x: [red]错误: 需提供 task_id (位置参数或 --task-id)[/red]")
+        raise typer.Exit(1)
+    task_id = tid
+
     from ginkgo.data.containers import container
 
     console.print(f":mag: 获取回测结果: {task_id}")
@@ -696,7 +705,9 @@ def get(
 
 @result_app.command("show")
 def show(
-    task_id: Optional[str] = typer.Option(None, "--run-id", "-r", help=":abc: Run session ID"),
+    task_id: Optional[str] = typer.Option(None, "--task-id", "-t", help=":abc: 回测任务ID (统一参数名)"),
+    run_id: Optional[str] = typer.Option(
+        None, "--run-id", "-r", help="⚠ 已弃用, 请改用 --task-id", hidden=True),
     portfolio_id: Optional[str] = typer.Option(None, "--portfolio", "-p", help=":bank: Portfolio ID"),
     analyzer: Optional[str] = typer.Option(None, "--analyzer", "-a", help=":bar_chart: Analyzer name"),
     mode: str = typer.Option("table", "--mode", "-m", help=":display: Display mode (table/terminal/plot)"),
@@ -707,9 +718,16 @@ def show(
 
     Examples:
         ginkgo result show                    # List available runs
-        ginkgo result show --run-id a3b5c7d9e2f1a4b6c8d0e2f4a6b8c0d2
-        ginkgo result show --run-id xxx --portfolio yyy --analyzer net_value --mode terminal
+        ginkgo result show --task-id a3b5c7d9e2f1a4b6c8d0e2f4a6b8c0d2
+        ginkgo result show --task-id xxx --portfolio yyy --analyzer net_value --mode terminal
+        ginkgo result show --run-id xxx       # 旧名, 已弃用 (deprecation warning)
     """
+    # #5998: 向后兼容旧 --run-id, 提示弃用
+    if run_id is not None:
+        console.print(":warning: [yellow]--run-id 已弃用, 请改用 --task-id[/yellow]")
+        if task_id is None:
+            task_id = run_id
+
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import (
         display_dataframe,
@@ -750,8 +768,8 @@ def show(
             title=":chart_with_upwards_trend: [bold]可用的运行会话[/bold]",
             console=console
         )
-        console.print("\n[yellow]使用 --run-id 参数查看详细结果[/yellow]")
-        console.print("[dim]示例: ginkgo result show --run-id <task_id>[/dim]")
+        console.print("\n[yellow]使用 --task-id 参数查看详细结果[/yellow]")
+        console.print("[dim]示例: ginkgo result show --task-id <task_id>[/dim]")
         raise typer.Exit(0)
 
     # 获取运行摘要

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -354,3 +354,101 @@ class TestResultGetRealData:
         task_svc.get_by_id.assert_called_once_with("task-9")
         assert "not yet implemented" not in result.output
         assert "15.2%" not in result.output
+
+
+# ============================================================================
+# #5998: result 子命令参数命名统一为 --task-id（兼容旧 --run-id + deprecation）
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestResultShowTaskIdUnify:
+    """#5998: result show 主 flag 统一为 --task-id，保留 --run-id 别名 + 弃用提示。"""
+
+    def _wire_show(self, task_id_value):
+        """装配 show 完整路径 mock，返回 (mock_result_svc, mock_container_ctx)。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        import pandas as pd
+
+        summary = {"task_id": task_id_value, "engine_id": "e1", "total_records": 1,
+                   "portfolio_count": 1, "portfolios": ["p1"]}
+        mock_result_svc = MagicMock()
+        mock_result_svc.get_run_summary.return_value = ServiceResult.success(data=summary)
+        mock_result_svc.get_portfolio_analyzers.return_value = ServiceResult.success(data=["net_value"])
+        mock_result_svc.get_analyzer_values_df.return_value = ServiceResult.success(
+            data=pd.DataFrame([{"timestamp": "2025-01-01", "value": 1.05}]))
+        return mock_result_svc
+
+    def test_show_help_exposes_task_id(self, cli_runner):
+        """show --help 含 --task-id（统一参数名）。"""
+        result = cli_runner.invoke(flat_cli.result_app, ["show", "--help"])
+        assert result.exit_code == 0
+        assert "--task-id" in result.output
+
+    def test_show_help_keeps_run_id_alias(self, cli_runner):
+        """show --help 仍含 --run-id（向后兼容）。"""
+        result = cli_runner.invoke(flat_cli.result_app, ["show", "--help"])
+        assert result.exit_code == 0
+        assert "--run-id" in result.output
+
+    def test_show_task_id_routes_to_summary(self, cli_runner):
+        """--task-id <id> 透传到 result_service.get_run_summary(task_id)。"""
+        svc = self._wire_show("t1")
+        with patch("ginkgo.data.containers.container") as mc:
+            mc.result_service.return_value = svc
+            r = cli_runner.invoke(flat_cli.result_app, ["show", "--task-id", "t1"])
+        assert r.exit_code == 0, r.output
+        svc.get_run_summary.assert_called_once_with("t1")
+
+    def test_show_run_id_still_works_and_warns(self, cli_runner):
+        """旧 --run-id 仍工作 + 透传 task_id + 输出弃用提示。"""
+        svc = self._wire_show("r1")
+        with patch("ginkgo.data.containers.container") as mc:
+            mc.result_service.return_value = svc
+            r = cli_runner.invoke(flat_cli.result_app, ["show", "--run-id", "r1"])
+        assert r.exit_code == 0, r.output
+        svc.get_run_summary.assert_called_once_with("r1")
+        assert "弃用" in r.output or "deprecated" in r.output.lower()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestResultGetTaskIdOption:
+    """#5998: result get 新增 --task-id Option（位置参数二选一），统一命名。"""
+
+    def _task_svc(self, record=None):
+        from ginkgo.data.services.base_service import ServiceResult
+        svc = MagicMock()
+        svc.get_by_id.return_value = ServiceResult(success=True, data=record)
+        return svc
+
+    def test_get_with_task_id_option(self, cli_runner):
+        """get --task-id <id> 透传到 backtest_task_service.get_by_id。"""
+        record = MagicMock(name="bt")
+        record.name = "opt-bt"
+        svc = self._task_svc(record=record)
+        with patch("ginkgo.data.containers.container") as mc:
+            mc.backtest_task_service.return_value = svc
+            r = cli_runner.invoke(flat_cli.result_app, ["get", "--task-id", "opt-1"])
+        assert r.exit_code == 0, r.output
+        svc.get_by_id.assert_called_once_with("opt-1")
+
+    def test_get_positional_still_works(self, cli_runner):
+        """位置参数回归不破：get <id> 仍透传。"""
+        record = MagicMock(name="bt")
+        record.name = "pos-bt"
+        svc = self._task_svc(record=record)
+        with patch("ginkgo.data.containers.container") as mc:
+            mc.backtest_task_service.return_value = svc
+            r = cli_runner.invoke(flat_cli.result_app, ["get", "pos-1"])
+        assert r.exit_code == 0, r.output
+        svc.get_by_id.assert_called_once_with("pos-1")
+
+    def test_get_without_any_id_errors(self, cli_runner):
+        """get 无位置参数且无 --task-id时报错（必填校验）。"""
+        with patch("ginkgo.data.containers.container") as mc:
+            mc.backtest_task_service.return_value = self._task_svc()
+            r = cli_runner.invoke(flat_cli.result_app, ["get"])
+        assert r.exit_code != 0, r.output
+        assert "task" in r.output.lower()


### PR DESCRIPTION
## Summary
修复 #5998。`result` 子命令参数命名不一致：`show` 暴露 `--run-id`、`get` 用位置参数、`segment-stability` 已是 `--task-id`。统一为 `--task-id`，保留旧名兼容。

## 变更（逐字符核对源码）
- **result show**：主 flag 改 `--task-id/-t`；`--run-id/-r` 降级为 hidden 别名，使用时打印弃用提示并透传 `task_id`。内部变量本就名 `task_id`（脱节点在 flag 暴露名）。
- **result get**：新增 `--task-id` Option（与位置参数二选一，互斥取 `task_id or task_id_opt`，两者皆空则报错退出）。位置参数向后兼容。`-t` 已被 `--trades` 占用，故 `--task-id` 不配短标志。
- **result segment-stability**：已是 `--task-id/-t`（L851），作为基准不动。

## 机制
- Typer 参数顺序：Argument 在 Option 前；`task_id` 改 `Optional + None` 默认值后才能在后续加 `--task-id` Option。
- 旧 `--run-id` / 位置参数引用全保留，零破坏（show 走别名+提示，get 走二选一）。
- 对齐 ADR `arch_backtest_id_boundary`：`task_id` 为回测主查询键（≡uuid）。

## Test plan
- [x] 新增 `TestResultShowTaskIdUnify`（4 测：help 含 --task-id/--run-id、--task-id 路由 summary、--run-id 兼容+弃用提示）
- [x] 新增 `TestResultGetTaskIdOption`（3 测：--task-id Option 路由、位置参数回归、无 id 报错）
- [x] 既有 `TestResultGetRealData` 位置参数回归不破
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）
- [x] L3 flat_cli 变更相关（29 passed；TestComponentCreate 2 失败为 master 预存，与 #5998 无关）

Closes #5998
