### PR TITLE
fix: config SECRET_KEY DEBUG 模式降级 warning 不阻塞启动 (#6064)

### DIFF
--- a/api/core/config.py
+++ b/api/core/config.py
@@ -47,13 +47,28 @@ class Settings(BaseSettings):
 
     @model_validator(mode="after")
     def _validate_secret_key(self) -> "Settings":
-        """#5464: 拒绝不安全的默认 SECRET_KEY"""
+        """#5464/#6064: 拒绝不安全的默认 SECRET_KEY
+
+        生产模式（DEBUG=False）硬拒绝启动；开发模式（DEBUG=True）降级为
+        warning，避免未配 SECRET_KEY 的环境因模块级 ``settings = Settings()``
+        在 import 期崩溃（#6064）。
+        """
         if self.SECRET_KEY == _INSECURE_DEFAULT_KEY:
-            raise ValueError(
+            message = (
                 "SECRET_KEY must be set via environment variable and cannot use "
                 f"the default value '{_INSECURE_DEFAULT_KEY}'. "
                 "Generate a secure key with: python -c \"import secrets; print(secrets.token_urlsafe(32))\""
             )
+            if self.DEBUG:
+                import warnings
+                warnings.warn(
+                    "SECRET_KEY using unsafe default — set env var before production. "
+                    f"({message})",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                raise ValueError(message)
         return self
 
     class Config:

--- a/tests/api/test_jwt_security.py
+++ b/tests/api/test_jwt_security.py
@@ -226,6 +226,14 @@ class TestSecretKeyConfig:
         with pytest.raises(ValueError, match="SECRET_KEY"):
             Settings(SECRET_KEY="your-secret-key-change-in-production")
 
+    def test_debug_mode_allows_default_secret_key_with_warning(self):
+        """#6064: DEBUG 模式用默认 SECRET_KEY 应仅 warn，不阻塞启动"""
+        from core.config import Settings
+        with pytest.warns(UserWarning, match="SECRET_KEY"):
+            s = Settings(SECRET_KEY="your-secret-key-change-in-production", DEBUG=True)
+        assert s.DEBUG is True
+        assert s.SECRET_KEY == "your-secret-key-change-in-production"
+
 
 # ============================================================
 # PR #6057 review: delete_user 后旧 token 应被撤销


### PR DESCRIPTION
## Summary

修复 #6064：未配置 `SECRET_KEY` 的环境启动崩溃（`ginkgo serve api` / `serve all` / 任何 `from api.core.config import settings`）。

**根因**：PR #6057 新增的 `_validate_secret_key` model_validator **无条件 `raise ValueError`**，但 `settings = Settings()` 是模块级代码（导入即执行）。未配 `SECRET_KEY` 的开发/部署环境在 import 期就崩。

**调用链**：
```
ginkgo serve api  (或任何 import)
  → from api.core.config import settings
    → settings = Settings()                        # 模块级，import 即执行
      → _validate_secret_key (model_validator after)
        → SECRET_KEY == 默认值 → raise ValueError   # 无条件，不分 DEBUG  ❌
        → ValidationError 冒泡 → 启动崩溃
```

**修复**（`api/core/config.py:48-74`）：按 `DEBUG` 分级降级
- **DEBUG=True（开发）**：`warnings.warn(...)` + 允许使用默认值启动
- **DEBUG=False（生产）**：保持 `raise ValueError`（#5464 的安全要求不变）

```python
if self.SECRET_KEY == _INSECURE_DEFAULT_KEY:
    if self.DEBUG:
        import warnings
        warnings.warn("SECRET_KEY using unsafe default — ...", UserWarning)
    else:
        raise ValueError(message)
```

## scope

- ✅ DEBUG 模式用默认 SECRET_KEY 仅 warn，不阻塞启动（验收 #1）
- ✅ 生产模式（DEBUG=False）保持 raise（验收 #2，#5464 安全不变）
- ✅ 既有 `test_config_refuses_default_secret_key` 仍通过（DEBUG 未设 = False → raise）
- ⏭️ 未改 `settings = Settings()` 的模块级位置（降级在 validator 内处理，更内聚）
- ⏭️ 未改默认 key 值 / 其他字段

## Test plan

- [x] TDD RED→GREEN：`Settings(SECRET_KEY=默认, DEBUG=True)` → `pytest.warns(UserWarning)` 且构造成功（修复前 fail：ValidationError）
- [x] 守护：`Settings(SECRET_KEY=默认)`（DEBUG=False）→ 仍 `pytest.raises(ValueError)`（既有测试，未破）
- [x] 冒烟1：`env -u SECRET_KEY DEBUG=True python -c "from core.config import settings"` → `OK import`（修复前崩）
- [x] 冒烟2：`env -u SECRET_KEY DEBUG=False python -c "..."` → 仍报 ValidationError（生产保留）
- [x] `test_jwt_security.py` 全 **21 测**通过，无回归
- [x] py_compile 通过；inspect 确认新代码落地 + `__file__` 指向 worktree

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src:$PWD/api python -m pytest tests/api/test_jwt_security.py -o addopts= -q
# 21 passed
```

Closes #6064
