### PR TITLE
fix: deploy info 按 deployment_id 查询, 对齐主键语义 (#5939)

### DIFF
--- a/api/api/deployment.py
+++ b/api/api/deployment.py
@@ -54,11 +54,11 @@ async def deploy(req: DeployRequest):
     return ok(data=deploy_data, message="部署成功")
 
 
-@router.get("/{portfolio_id}")
-async def get_deployment_info(portfolio_id: str):
-    """查询指定 Portfolio 的部署信息"""
+@router.get("/{deployment_id}")
+async def get_deployment_info(deployment_id: str):
+    """查询指定部署记录(deployment_id)的部署信息 #5939"""
     service = _get_deployment_service()
-    result = service.get_deployment_info(portfolio_id)
+    result = service.get_deployment_info(deployment_id)
 
     if not result.success:
         raise HTTPException(status_code=404, detail=result.error)

--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -65,14 +65,14 @@ def deploy(
 
 @app.command("info")
 def info(
-    portfolio_id: Annotated[str, typer.Argument(help="部署后的Portfolio ID")],
+    deployment_id: Annotated[str, typer.Argument(help="部署记录ID (deploy 返回的 Deployment ID)")],
 ):
-    """查看部署详情"""
+    """查看部署详情(按 deployment_id 查询) #5939"""
     try:
         from ginkgo.trading.containers import trading_container
 
         svc = trading_container.deployment_service()
-        result = svc.get_deployment_info(portfolio_id)
+        result = svc.get_deployment_info(deployment_id)
 
         if result.success:
             data = result.data

--- a/src/ginkgo/data/crud/deployment_crud.py
+++ b/src/ginkgo/data/crud/deployment_crud.py
@@ -25,3 +25,7 @@ class DeploymentCRUD(BaseCRUD):
     def get_by_source_portfolio(self, portfolio_id: str):
         """根据源Portfolio ID查询部署记录"""
         return self.find(filters={"source_portfolio_id": portfolio_id})
+
+    def get_by_uuid(self, deployment_id: str):
+        """根据部署记录 uuid(主键) 查询 #5939"""
+        return self.find(filters={"uuid": deployment_id})

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -244,15 +244,16 @@ class DeploymentService(BaseService):
         }
         return result
 
-    def get_deployment_info(self, portfolio_id: str) -> ServiceResult:
-        """获取部署信息"""
-        records = self._deployment_crud.get_by_target_portfolio(portfolio_id)
+    def get_deployment_info(self, deployment_id: str) -> ServiceResult:
+        """获取部署信息(按 deployment_id 主键查) #5939"""
+        records = self._deployment_crud.get_by_uuid(deployment_id)
         if not records:
             return ServiceResult(success=False, error="未找到部署记录")
 
         deployment = records[0]
         result = ServiceResult(success=True)
         result.data = {
+            "deployment_id": deployment.uuid,
             "source_task_id": deployment.source_task_id,
             "target_portfolio_id": deployment.target_portfolio_id,
             "source_portfolio_id": deployment.source_portfolio_id,

--- a/tests/unit/client/test_deploy_cli.py
+++ b/tests/unit/client/test_deploy_cli.py
@@ -1,0 +1,71 @@
+# Related: #5939
+# deploy info <deployment_id> 透传 service.get_deployment_info(deployment_id)
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ginkgo.client import deploy_cli
+from ginkgo.data.services.base_service import ServiceResult
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestDeployInfo:
+    """#5939: deploy info 按 deployment_id 查, 非 portfolio_id。
+
+    根因: info 命令参数按 portfolio_id 查(get_by_target_portfolio), 但 deploy 返回的主标识是
+    deployment_id(部署记录 uuid)。用户传 deployment_id 查不到。修复: info 改按 deployment_id 查。
+    """
+
+    def _info_data(self, deployment_id="d1"):
+        return {
+            "deployment_id": deployment_id,
+            "source_task_id": None,
+            "target_portfolio_id": "tgt-1",
+            "source_portfolio_id": "src-1",
+            "mode": 1,
+            "account_id": None,
+            "status": 2,
+            "create_at": None,
+        }
+
+    def test_info_routes_deployment_id_to_service(self, cli_runner):
+        """info <deployment_id> 透传到 service.get_deployment_info(deployment_id)。"""
+        svc = MagicMock()
+        svc.get_deployment_info.return_value = ServiceResult(
+            success=True, data=self._info_data("d-abc"))
+        with patch("ginkgo.trading.containers.trading_container") as mc:
+            mc.deployment_service.return_value = svc
+            r = cli_runner.invoke(deploy_cli.app, ["info", "d-abc"])
+
+        assert r.exit_code == 0, r.output
+        svc.get_deployment_info.assert_called_once_with("d-abc")
+
+    def test_info_not_found_exits_nonzero(self, cli_runner):
+        """deployment_id 查不到 → 非零退出 + 错误提示。"""
+        svc = MagicMock()
+        svc.get_deployment_info.return_value = ServiceResult(
+            success=False, error="未找到部署记录")
+        with patch("ginkgo.trading.containers.trading_container") as mc:
+            mc.deployment_service.return_value = svc
+            r = cli_runner.invoke(deploy_cli.app, ["info", "nope"])
+
+        assert r.exit_code != 0
+        assert "未找到" in r.output
+
+    def test_info_help_says_deployment_id(self, cli_runner):
+        """info --help 参数说明应明示 deployment_id(非 portfolio_id)。"""
+        r = cli_runner.invoke(deploy_cli.app, ["info", "--help"])
+        assert r.exit_code == 0
+        # 参数语义对齐 deployment_id
+        assert "deployment" in r.output.lower() or "部署记录" in r.output

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -128,3 +128,45 @@ class TestDeploymentServiceErrorMessages:
         assert not result.success
         # service error 不应有 "部署失败:" 前缀（CLI 层加）
         assert not result.error.startswith("部署失败:")
+
+
+class TestGetDeploymentInfo:
+    """#5939: get_deployment_info 按 deployment_id(uuid 主键) 查, 非 target_portfolio_id。
+
+    根因: deploy 返回的 Deployment ID 是部署记录 uuid, 但 info 命令按 target_portfolio_id
+    查询, 致 deploy info <deployment_id> 报"未找到"。查询键须对齐主键(arch_backtest_id_boundary)。
+    """
+
+    def _make_deployment(self, uuid="d1"):
+        d = MagicMock()
+        d.uuid = uuid
+        d.source_task_id = None
+        d.target_portfolio_id = "tgt-1"
+        d.source_portfolio_id = "src-1"
+        d.mode = 1
+        d.account_id = None
+        d.status = 2
+        d.create_at = None
+        return d
+
+    def test_get_info_by_deployment_id_uuid(self):
+        """get_deployment_info(deployment_id) 按 uuid 查到正确记录。"""
+        svc = _make_svc()
+        dep = self._make_deployment(uuid="d-abc")
+        svc._deployment_crud.get_by_uuid.return_value = [dep]
+
+        result = svc.get_deployment_info("d-abc")
+
+        assert result.success, result.error
+        svc._deployment_crud.get_by_uuid.assert_called_once_with("d-abc")
+        assert result.data["target_portfolio_id"] == "tgt-1"
+
+    def test_get_info_not_found_returns_error(self):
+        """deployment_id 查不到 → success=False + 未找到提示。"""
+        svc = _make_svc()
+        svc._deployment_crud.get_by_uuid.return_value = []
+
+        result = svc.get_deployment_info("nonexistent-id")
+
+        assert not result.success
+        assert "未找到" in result.error


### PR DESCRIPTION
## Summary
修复 #5939。`deploy deploy` 返回 Deployment ID（部署记录 uuid），但 `deploy info <该ID>` 报"未找到"，反用 portfolio_id 能查到。根因：info 命令（CLI + API）按 `target_portfolio_id` 查询，查询键与命令语义脱节。

## 调用链分析
```
deploy info <arg> → get_deployment_info(arg) → crud.get_by_target_portfolio(arg)  # 按 target_portfolio_id 查
```
用户传的 `deployment_id`（deploy 返回主标识 = uuid）≠ target_portfolio_id → 查不到。

## 变更（查询键对齐主键 uuid，记忆 arch_backtest_id_boundary）
- **deployment_crud**：新增 `get_by_uuid`（按主键查，同 find(filters={"uuid":...}) 模式）
- **deployment_service.get_deployment_info**：签名 `portfolio_id → deployment_id`，改用 `get_by_uuid`；data 补 `deployment_id` 字段
- **deploy_cli info**：参数 `portfolio_id → deployment_id`，help 改"部署记录ID (deploy 返回的 Deployment ID)"
- **api GET /{deployment_id}**：路径参数 `portfolio_id → deployment_id`，CLI/API 统一查询语义

## 调用方同步
`get_deployment_info` 两调用方（deploy_cli + api/deployment.py）均已同步签名变更。
`get_by_target_portfolio` 仍由 `find_by_target_portfolio` 使用，未删（零破坏）。

## Test plan
- [x] 新增 `TestGetDeploymentInfo`（service 层 2 测：按 uuid 查正/反）
- [x] 新增 `tests/unit/client/test_deploy_cli.py`（CLI 3 测：透传 deployment_id、未找到退出、help 语义）
- [x] 既有 service/crud/api 测试回归不破（18 + 2 passed）
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）

Closes #5939
