### PR TITLE
fix: 回测订单 limit_price 市价单输出 None 而非 "0" (#5787)

### DIFF
--- a/src/ginkgo/data/services/backtest_task_schemas.py
+++ b/src/ginkgo/data/services/backtest_task_schemas.py
@@ -92,7 +92,7 @@ class BacktestOrderItem(BaseModel):
     order_type: Optional[str] = None
     status: Optional[str] = None
     volume: int = 0
-    limit_price: str = "0"
+    limit_price: Optional[str] = None  # #5787: 市价单无价哨兵 None, 非 "0"
     transaction_price: str = "0"
     transaction_volume: int = 0
     fee: str = "0"

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -21,6 +21,7 @@ from datetime import datetime
 from ginkgo.libs import cache_with_expiration, retry, GLOG
 from ginkgo.data.crud.model_conversion import ModelList
 from ginkgo.data.services.base_service import BaseService, ServiceResult
+from ginkgo.data.mappers.order_mapper import OrderMapper
 from ginkgo.interfaces.kafka_topics import KafkaTopics
 
 
@@ -1066,7 +1067,7 @@ class BacktestTaskService(BaseService):
                     order_type=str(getattr(o, "order_type", "")) if getattr(o, "order_type", None) is not None else None,
                     status=str(getattr(o, "status", "")) if getattr(o, "status", None) is not None else None,
                     volume=int(getattr(o, "volume", 0) or 0),
-                    limit_price=str(getattr(o, "limit_price", 0)),
+                    limit_price=OrderMapper._price_to_dto(getattr(o, "limit_price", 0)),
                     transaction_price=str(getattr(o, "transaction_price", 0)),
                     transaction_volume=int(getattr(o, "transaction_volume", 0) or 0),
                     fee=str(getattr(o, "fee", 0)),
@@ -1114,7 +1115,7 @@ class BacktestTaskService(BaseService):
                     order_type=str(getattr(o, "order_type", "")) if getattr(o, "order_type", None) is not None else None,
                     status=str(getattr(o, "status", "")) if getattr(o, "status", None) is not None else None,
                     volume=int(getattr(o, "volume", 0) or 0),
-                    limit_price=str(getattr(o, "limit_price", 0)),
+                    limit_price=OrderMapper._price_to_dto(getattr(o, "limit_price", 0)),
                     transaction_price=str(getattr(o, "transaction_price", 0)),
                     transaction_volume=int(getattr(o, "transaction_volume", 0) or 0),
                     fee=str(getattr(o, "fee", 0)),

--- a/tests/unit/services/test_backtest_task_service_limit_price.py
+++ b/tests/unit/services/test_backtest_task_service_limit_price.py
@@ -1,0 +1,82 @@
+"""#5787: 回测订单 limit_price 序列化市价单→None 而非 '0'。
+
+list_orders / list_order_records 两入口应复用 OrderMapper._price_to_dto 的
+0→None 市价单哨兵语义, 而非直接 str() 化 (旧实现 str(0)→'0')。
+"""
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_order(limit_price=0.0, order_type=1, status=4):
+    """构造回测订单快照。order_type=1 市价单, limit_price=0 表无价哨兵。"""
+    return SimpleNamespace(
+        uuid="u-1", order_id="ord-1",
+        portfolio_id="port-1", engine_id="eng-1", task_id="task-1",
+        code="000001.SZ", direction=1, order_type=order_type, status=status,
+        volume=100, limit_price=limit_price, transaction_price=10.0,
+        transaction_volume=100, fee=5.0,
+        timestamp=datetime.datetime(2025, 6, 3, 9, 30),
+    )
+
+
+def _svc_with_orders(orders):
+    """装配 BacktestTaskService, mock result_service.get_orders 返回给定订单。"""
+    svc = BacktestTaskService(MagicMock())
+    result_svc = MagicMock()
+    result_svc.get_orders.return_value = ServiceResult(
+        success=True, data={"data": orders, "total": len(orders)})
+    result_svc.get_order_records.return_value = ServiceResult(
+        success=True, data={"data": orders, "total": len(orders)})
+    container = MagicMock()
+    container.result_service.return_value = result_svc
+    return svc, container
+
+
+class TestListOrdersLimitPriceSerialization:
+    """#5787: limit_price 市价单→None, 限价单→str(价格)。"""
+
+    @pytest.mark.unit
+    def test_market_order_limit_price_is_null_not_zero(self):
+        """市价单(limit_price=0)序列化为 None, 非字符串 '0'。"""
+        svc, container = _svc_with_orders([_make_order(limit_price=0, order_type=1)])
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            result = svc.list_orders("any-uuid")
+        assert result.is_success()
+        # #5787: 旧实现 str(0)→'0'; 修复后应 None
+        assert result.data[0].limit_price is None, \
+            f"市价单 limit_price 应为 None, 实际 {result.data[0].limit_price!r}"
+
+    @pytest.mark.unit
+    def test_limit_order_limit_price_is_str(self):
+        """限价单(limit_price=19.81)序列化为 '19.81'。"""
+        svc, container = _svc_with_orders([_make_order(limit_price=19.81, order_type=2)])
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            result = svc.list_orders("any-uuid")
+        assert result.is_success()
+        assert result.data[0].limit_price == "19.81"
+
+
+class TestListOrderRecordsLimitPriceSerialization:
+    """#5787: list_order_records 路径同样复用 _price_to_dto。"""
+
+    @pytest.mark.unit
+    def test_market_order_limit_price_is_null_not_zero(self):
+        """市价单 limit_price=0 序列化为 None, 非字符串 '0'。"""
+        svc, container = _svc_with_orders([_make_order(limit_price=0, order_type=1)])
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            result = svc.list_order_records("any-uuid")
+        assert result.is_success()
+        assert result.data[0].limit_price is None, \
+            f"市价单 limit_price 应为 None, 实际 {result.data[0].limit_price!r}"


### PR DESCRIPTION
## Summary
修复 #5787。`GET /api/v1/backtests/{id}/orders` 返回订单 `limit_price:"0"`，但 `transaction_price` 正常（如 "19.81"）。

## 根因
`list_orders`（backtest_task_service.py:1069）和 `list_order_records`（:1117）两处 `limit_price=str(getattr(o,'limit_price',0))` 直接 `str()` 化，市价单（默认 0）输出 `"0"`。

项目已有 `OrderMapper._price_to_dto`（order_mapper.py:24）的 **0/None→None 市价单无价哨兵** 语义，`to_dto`/`model_to_dto` 已用，唯独回测订单列表序列化绕过了它。

## 修复
- service 两处 `str()` → `OrderMapper._price_to_dto`（复用既有市价单哨兵，单一事实来源）
- schema `limit_price: str = "0"` → `Optional[str] = None`（接 None）

两处对称改动，零删除，限价单（非 0）行为不变（回归守卫测试保护）。

## 验收对照
- [x] 市价单（limit_price=0）→ `None`（非 `"0"`）
- [x] 限价单（limit_price=19.81）→ `"19.81"`
- [x] `list_orders` + `list_order_records` 两路径均覆盖

## Test plan
- [x] 新增 `tests/unit/services/test_backtest_task_service_limit_price.py`（3 测试）
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）
- [x] L3 变更相关：order_mapper 回归 7 passed + #5842 list_orders/order_records 分流回归 8 passed

Closes #5787
