### PR TITLE
fix: portfolio delete 支持 名称/部分UUID fuzzy 解析 (#5995)

### DIFF
--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -433,24 +433,73 @@ def status(
         raise typer.Exit(1)
 
 
+def _resolve_portfolio_identifier(portfolio_service, identifier: str):
+    """#5995: 将 名称/部分UUID/完整UUID 解析为具体 UUID。
+
+    解析链：精确 UUID → 精确名称 → fuzzy（uuid/name 片段）。
+    与同文件 ``get``/``status`` 的 UUID→name 回退模式对齐，新增部分 UUID fuzzy 兜底。
+
+    注：本模块存在 ``def list(...)`` 命令函数遮蔽 builtin ``list``，故此处避免 ``list()``，
+    改用 ``len()`` + 直接索引（data 为 list/ModelList，支持 ``__len__``/``__getitem__``）。
+
+    Returns:
+        (uuid, None) 命中唯一；(None, error_msg) 未命中或歧义。
+    """
+    def _has_match(r) -> bool:
+        return r is not None and getattr(r, 'success', False) and bool(getattr(r, 'data', None))
+
+    def _first_uuid(data):
+        if not data:
+            return None
+        return data[0].uuid
+
+    # 1. 精确 UUID
+    r = portfolio_service.get(portfolio_id=identifier)
+    if _has_match(r):
+        return _first_uuid(r.data), None
+
+    # 2. 精确名称
+    r = portfolio_service.get(name=identifier)
+    if _has_match(r):
+        return _first_uuid(r.data), None
+
+    # 3. fuzzy: uuid/name 片段
+    r = portfolio_service.fuzzy_search(identifier)
+    if _has_match(r):
+        count = len(r.data)
+        if count == 1:
+            return r.data[0].uuid, None
+        return None, f"Multiple portfolios match '{identifier}' ({count} found), use full UUID"
+
+    return None, f"投资组合不存在: {identifier}"
+
+
 @app.command()
 def delete(
-    portfolio_id: str = typer.Argument(..., help="Portfolio UUID"),
+    portfolio_id: str = typer.Argument(..., help="Portfolio UUID, name, or partial UUID (fuzzy)"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
 ):
     """
-    :wastebasket: Delete portfolio.
+    :wastebasket: Delete portfolio. Accepts full UUID, name, or partial UUID (fuzzy match).
     """
     if not confirm:
         console.print(":x: Please use --confirm to delete portfolio")
         raise typer.Exit(1)
 
-    console.print(f":wastebasket: Deleting portfolio: {portfolio_id}")
-
     try:
         from ginkgo.data.containers import container
         portfolio_service = container.portfolio_service()
-        result = portfolio_service.delete(portfolio_id)
+
+        # #5995: 名称/部分UUID 解析（精确 UUID → 名称 → fuzzy）
+        resolved_uuid, error = _resolve_portfolio_identifier(portfolio_service, portfolio_id)
+        if resolved_uuid is None:
+            console.print(f":x: {error}")
+            raise typer.Exit(1)
+
+        if resolved_uuid != portfolio_id:
+            console.print(f":wastebasket: Resolved '{portfolio_id}' -> {resolved_uuid}")
+        console.print(f":wastebasket: Deleting portfolio: {resolved_uuid}")
+        result = portfolio_service.delete(resolved_uuid)
 
         if result.success:
             console.print(":white_check_mark: Portfolio deleted successfully")
@@ -458,6 +507,8 @@ def delete(
             console.print(f":x: Failed to delete portfolio: {result.error}")
             raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: Error: {e}")
         raise typer.Exit(1)

--- a/src/ginkgo/data/crud/portfolio_crud.py
+++ b/src/ginkgo/data/crud/portfolio_crud.py
@@ -140,6 +140,53 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
         return items
 
     # Business Helper Methods
+    def fuzzy_search(
+        self,
+        query: str,
+        fields: Optional[List[str]] = None,
+    ) -> List[MPortfolio]:
+        """#5995: 模糊搜索投资组合，支持 UUID 片段 / 名称部分匹配（去重）。
+
+        Args:
+            query: 搜索字符串（UUID 片段或名称片段）
+            fields: 搜索字段列表。默认: ['uuid', 'name']
+
+        Returns:
+            去重后的匹配列表
+        """
+        if not query or not query.strip():
+            return []
+
+        query_lower = query.lower().strip()
+
+        if fields is None:
+            fields = ['uuid', 'name']
+
+        all_results: List[MPortfolio] = []
+        seen_uuids = set()
+
+        if 'uuid' in fields:
+            try:
+                for item in self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False}):
+                    uuid_val = getattr(item, 'uuid', None)
+                    if uuid_val and uuid_val not in seen_uuids:
+                        all_results.append(item)
+                        seen_uuids.add(uuid_val)
+            except Exception as e:
+                GLOG.WARN(f"Portfolio UUID fuzzy search failed: {e}")
+
+        if 'name' in fields:
+            try:
+                for item in self.find(filters={"name__like": f"%{query_lower}%", "is_del": False}):
+                    uuid_val = getattr(item, 'uuid', None)
+                    if uuid_val and uuid_val not in seen_uuids:
+                        all_results.append(item)
+                        seen_uuids.add(uuid_val)
+            except Exception as e:
+                GLOG.WARN(f"Portfolio name fuzzy search failed: {e}")
+
+        return all_results
+
     def find_by_uuid(self, uuid: str) -> List[MPortfolio]:
         """Find portfolio by UUID."""
         return self.find(filters={"uuid": uuid}, page_size=1)

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -919,6 +919,28 @@ class PortfolioService(BaseService):
             GLOG.ERROR(f"获取投资组合失败: {str(e)}")
             return ServiceResult.error(f"获取投资组合失败: {str(e)}")
 
+    def fuzzy_search(
+        self,
+        query: str,
+        fields: Optional[List[str]] = None,
+    ) -> ServiceResult:
+        """#5995: 模糊搜索投资组合，支持 UUID 片段 / 名称部分匹配。
+
+        Args:
+            query: 搜索字符串
+            fields: 搜索字段列表。默认: ['uuid', 'name']
+
+        Returns:
+            ServiceResult: data 为匹配的投资组合列表
+        """
+        try:
+            if not query or not query.strip():
+                return ServiceResult.success([])
+            results = self._crud_repo.fuzzy_search(query, fields)
+            return ServiceResult.success(results)
+        except Exception as e:
+            return ServiceResult.error(f"Portfolio fuzzy search failed: {str(e)}")
+
     # ===== ADR-010 Phase 4 R1a：类型即契约多出口（DF 出口，纯增量） =====
 
     def _build_portfolio_filters(self, portfolio_id: str = None, name: str = None,

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -431,9 +431,10 @@ class TestPortfolioDelete:
     """portfolio delete 命令"""
 
     @patch("ginkgo.data.containers.container")
-    def test_delete_with_confirm(self, mock_container, cli_runner):
-        """使用 --confirm 成功删除"""
+    def test_delete_with_confirm(self, mock_container, cli_runner, mock_portfolio):
+        """使用 --confirm + 完整 UUID 成功删除"""
         mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
         mock_service.delete.return_value = ServiceResult.success(data=None)
         mock_container.portfolio_service.return_value = mock_service
 
@@ -442,6 +443,7 @@ class TestPortfolioDelete:
         ])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
+        mock_service.delete.assert_called_once_with("portfolio-uuid-001")
 
     def test_delete_missing_confirm(self, cli_runner):
         """缺少 --confirm 时拒绝删除"""
@@ -452,14 +454,86 @@ class TestPortfolioDelete:
         assert "--confirm" in result.output
 
     @patch("ginkgo.data.containers.container")
-    def test_delete_service_error(self, mock_container, cli_runner):
-        """服务返回错误时删除失败"""
+    def test_delete_by_name_resolves_uuid(self, mock_container, cli_runner):
+        """#5995: 按名称删除——精确 UUID 查空后回退 name 查找，解析出 uuid 再删"""
         mock_service = MagicMock()
+        named = MagicMock()
+        named.uuid = "resolved-uuid-999"
+        mock_service.get.side_effect = [
+            ServiceResult.success(data=[]),              # get(portfolio_id=name) 空
+            ServiceResult.success(data=[named]),         # get(name=name) 命中
+        ]
+        mock_service.delete.return_value = ServiceResult.success(data=None)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "delete", "deploy_test", "--confirm"
+        ])
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.output
+        mock_service.delete.assert_called_once_with("resolved-uuid-999")
+
+    @patch("ginkgo.data.containers.container")
+    def test_delete_by_partial_uuid_fuzzy(self, mock_container, cli_runner):
+        """#5995: 按 partial UUID 模糊匹配——精确 UUID/name 均空后 fuzzy 命中唯一"""
+        mock_service = MagicMock()
+        fuzzy_hit = MagicMock()
+        fuzzy_hit.uuid = "deadbeefdeadbeefdeadbeefdeadbeef"
+        mock_service.get.return_value = ServiceResult.success(data=[])
+        mock_service.fuzzy_search.return_value = ServiceResult.success(data=[fuzzy_hit])
+        mock_service.delete.return_value = ServiceResult.success(data=None)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "delete", "deadbeef", "--confirm"
+        ])
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.output
+        mock_service.fuzzy_search.assert_called_once_with("deadbeef")
+        mock_service.delete.assert_called_once_with("deadbeefdeadbeefdeadbeefdeadbeef")
+
+    @patch("ginkgo.data.containers.container")
+    def test_delete_ambiguous_fuzzy_rejected(self, mock_container, cli_runner):
+        """#5995: fuzzy 多匹配时不删除，提示用完整 UUID"""
+        mock_service = MagicMock()
+        a, b = MagicMock(), MagicMock()
+        a.uuid, b.uuid = "uuid-aaa", "uuid-bbb"
+        mock_service.get.return_value = ServiceResult.success(data=[])
+        mock_service.fuzzy_search.return_value = ServiceResult.success(data=[a, b])
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "delete", "uuid", "--confirm"
+        ])
+        assert result.exit_code == 1
+        assert "Multiple" in result.output or "多个" in result.output
+        mock_service.delete.assert_not_called()
+
+    @patch("ginkgo.data.containers.container")
+    def test_delete_not_found_clear_error(self, mock_container, cli_runner):
+        """#5995: 名称/UUID/fuzzy 均未命中时给明确错误，不报裸异常"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=[])
+        mock_service.fuzzy_search.return_value = ServiceResult.success(data=[])
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "delete", "nonexistent", "--confirm"
+        ])
+        assert result.exit_code == 1
+        assert "投资组合不存在" in result.output
+        mock_service.delete.assert_not_called()
+
+    @patch("ginkgo.data.containers.container")
+    def test_delete_service_error(self, mock_container, cli_runner, mock_portfolio):
+        """解析成功但 service.delete 返回错误时删除失败"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
         mock_service.delete.return_value = ServiceResult.error(error="Portfolio not found")
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "bad-uuid", "--confirm"
+            "delete", "portfolio-uuid-001", "--confirm"
         ])
         assert result.exit_code == 1
         assert "Failed to delete portfolio" in result.output

--- a/tests/unit/data/services/test_portfolio_service_mock.py
+++ b/tests/unit/data/services/test_portfolio_service_mock.py
@@ -686,3 +686,40 @@ class TestPersistState:
 
         assert result.is_success()
         assert result.data.get("engine_current_time") is None
+
+
+# ============================================================
+# 模糊搜索测试（#5995）
+# ============================================================
+
+
+class TestFuzzySearch:
+    """#5995: portfolio fuzzy_search 委托 CRUD 的薄包装测试"""
+
+    @pytest.mark.unit
+    def test_fuzzy_search_results(self, service, mock_deps):
+        """搜索返回匹配结果（委托 crud_repo.fuzzy_search）"""
+        mock_result = [_make_portfolio(name="p1", uuid="u1")]
+        mock_deps["crud_repo"].fuzzy_search.return_value = mock_result
+
+        result = service.fuzzy_search(query="p1")
+        assert result.success is True
+        assert result.data is mock_result
+        mock_deps["crud_repo"].fuzzy_search.assert_called_once_with("p1", None)
+
+    @pytest.mark.unit
+    def test_fuzzy_search_empty_query(self, service, mock_deps):
+        """空查询字符串返回空结果，不触 CRUD"""
+        result = service.fuzzy_search(query="")
+        assert result.success is True
+        assert result.data == []
+        mock_deps["crud_repo"].fuzzy_search.assert_not_called()
+
+    @pytest.mark.unit
+    def test_fuzzy_search_exception(self, service, mock_deps):
+        """搜索异常时返回 error（success=False）"""
+        mock_deps["crud_repo"].fuzzy_search.side_effect = Exception("search err")
+
+        result = service.fuzzy_search(query="p1")
+        assert result.success is False
+        assert "search err" in result.error


### PR DESCRIPTION
## Summary

修复 #5995：`ginkgo portfolio delete <name|partial-uuid>` 报"投资组合不存在"，仅完整 UUID 可用。同文件 `get`/`status` 已有 UUID→name 回退，`delete` 是唯一例外。

## 调用链

```
ginkgo portfolio delete deploy_test --confirm     # deploy_test 是名称
  → portfolio_cli.delete(portfolio_id="deploy_test")
    → portfolio_service.delete("deploy_test")        # 按精确 UUID 查
      → CRUD find(uuid="deploy_test") → 空
      → ServiceResult.error / 删除失败                ❌
```

## 修复

新增"精确 UUID → 精确名称 → fuzzy（uuid/name 片段）"解析链：

1. **`PortfolioCRUD.fuzzy_search`**（`crud/portfolio_crud.py`）：uuid/name 片段去重匹配，镜像 `backtest_task_crud.fuzzy_search`
2. **`PortfolioService.fuzzy_search`**（`services/portfolio_service.py`）：委托 CRUD 的薄包装
3. **`portfolio_cli.delete`**（`client/portfolio_cli.py`）：解析后取唯一 uuid 再删；歧义（多匹配）提示用完整 UUID，未命中给明确中文错误

### 踩坑：`list` shadowing

`portfolio_cli` 模块级有 `@app.command() def list(...)` 命令函数，**遮蔽了 builtin `list`**。resolver 初版用 `list(data)` 调用的是 list **命令函数**（触发真实 DB 全量查询并打印），返回 None。改为 `len()` + 直接索引规避。

## scope

- ✅ `delete <name>` 名称解析后删除（验收 #1）
- ✅ `delete <partial-uuid>` fuzzy 命中唯一时删除（验收 #2）
- ✅ 歧义（多匹配）拒绝删除，提示完整 UUID
- ✅ 未命中给明确错误（不再裸异常）
- ✅ 完整 UUID 向后兼容（既有 happy path 不变）
- ⏭️ 未改 `get`/`status`（已有回退，YAGNI）
- ⏭️ CRUD 层 fuzzy_search 是 SQL 委托薄包装，镜像 backtest 既有约定未单测（service 层端到端覆盖）

## Test plan

- [x] TDD `TestPortfolioDelete` 7 测（RED→GREEN）：名称/部分UUID/歧义/未命中/完整UUID/service错误/缺--confirm
- [x] TDD `TestFuzzySearch` 3 测（service 层）：results/empty/exception（镜像 engine_service 先例）
- [x] `test_portfolio_cli.py` 36 passed（1 预存失败 `test_extracts_task_id_from_paginated_result`，与本改动无关，单跑亦失败）
- [x] py_compile 通过；import 链正常（应用启动路径覆盖）

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src python -m pytest \
  tests/unit/client/test_portfolio_cli.py::TestPortfolioDelete \
  tests/unit/data/services/test_portfolio_service_mock.py::TestFuzzySearch -o addopts= -q
# 10 passed
```

Closes #5995
