### PR TITLE
fix: data/ticks limit 参数生效 (#5621)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -403,9 +403,14 @@ async def get_ticks(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=100, ge=1, le=500)
+    page_size: int = Query(default=100, ge=1, le=500),
+    limit: Optional[int] = None  # #5621: 显式约束返回条数，未传沿用 page_size
 ):
-    """获取Tick数据列表（分页）"""
+    """获取Tick数据列表（分页）
+
+    #5621: limit 参数显式约束返回条数（limit=3 → 至多 3 条），
+    未传时沿用 page_size，向后兼容。
+    """
     try:
         tick_service = get_tick_service()
 
@@ -420,6 +425,9 @@ async def get_ticks(
         start_dt = datetime.fromisoformat(start_date) if start_date else None
         end_dt = datetime.fromisoformat(end_date) if end_date else None
 
+        # #5621: limit 提供且 > 0 时作为实际 page_size（截断返回条数）
+        effective_page_size = limit if (limit is not None and limit > 0) else page_size
+
         # 使用TickService.get方法（支持分页）
         result = tick_service.get(
             code=code,
@@ -427,11 +435,11 @@ async def get_ticks(
             end_date=end_dt,
             adjustment_type=ADJUSTMENT_TYPES.NONE,
             page=page - 1,
-            page_size=page_size,
+            page_size=effective_page_size,
         )
 
         if not result.is_success() or not result.data:
-            return paginated(items=[], total=0, page=page, page_size=page_size)
+            return paginated(items=[], total=0, page=page, page_size=effective_page_size)
 
         # 处理返回的数据（已是分页后的结果）
         result_data = result.data
@@ -470,7 +478,7 @@ async def get_ticks(
             items=tick_summaries,
             total=total_count,
             page=page,
-            page_size=page_size
+            page_size=effective_page_size
         )
 
     except HTTPException:

--- a/tests/api/test_data_pagination.py
+++ b/tests/api/test_data_pagination.py
@@ -67,6 +67,42 @@ class TestTicksPagination:
         # 不应因空结果报错
         assert "data" in result or "items" in result
 
+    def test_limit_param_sets_page_size(self):
+        """#5621: limit 参数应映射到 service.get 的 page_size（limit=3 → page_size=3）"""
+
+        mock_tick = MagicMock()
+        mock_tick.uuid = "tick-1"
+        mock_tick.timestamp = datetime(2025, 1, 1)
+        mock_tick.price = 10.0
+        mock_tick.volume = 100
+        mock_tick.direction = 0
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[mock_tick])
+
+        from api.data import get_ticks
+
+        with patch("api.data.get_tick_service", return_value=mock_service):
+            run_async(get_ticks(code="000001.SZ", limit=3))
+
+        # limit=3 应直接作为 page_size 传给 service（截断返回数）
+        call_kwargs = mock_service.get.call_args.kwargs
+        assert call_kwargs.get("page_size") == 3
+
+    def test_limit_none_keeps_default_page_size(self):
+        """#5621: 未传 limit 时 page_size 保持默认（向后兼容）"""
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[])
+
+        from api.data import get_ticks
+
+        with patch("api.data.get_tick_service", return_value=mock_service):
+            run_async(get_ticks(code="000001.SZ", page=1, page_size=100))
+
+        call_kwargs = mock_service.get.call_args.kwargs
+        assert call_kwargs.get("page_size") == 100
+
 
 class TestAdjustFactorsPagination:
     """adjustfactors 分页测试"""


### PR DESCRIPTION
## Summary

修复 #5621：`GET /api/v1/data/ticks?code=...&limit=3` 忽略 `limit`，返回 100 条。

**根因**：`api/api/data.py` 的 `get_ticks` 签名只有 `page`/`page_size`，**没有 `limit` 参数**。FastAPI 对端点签名未声明的 query param **静默丢弃**（不报错），`limit=3` 被忽略，用默认 `page_size=100` 查询返回 100 条。

**调用链**：
```
GET /ticks?limit=3
  → get_ticks(code, page, page_size)          # 签名无 limit → FastAPI 丢弃
    → tick_service.get(page_size=100)          # 默认 page_size
      → 返回 100 条                            ❌ 与 limit=3 不符
```

**修复**（`api/api/data.py` `get_ticks`）：
- 签名新增 `limit: Optional[int] = None`
- `limit` 提供且 `> 0` 时作为 `effective_page_size`（截断返回条数）
- 未传 `limit` 时沿用 `page_size`（向后兼容）
- `paginated()` 返回元信息同步用 `effective_page_size`

## scope

- ✅ `limit` 参数生效（`limit=3` → `service.get(page_size=3)`）
- ✅ 未传 `limit` 时 `page_size` 默认不变（向后兼容）
- ✅ 空结果 / 成功两处 `paginated` 元信息一致
- ⏭️ **未改 `get_bars`**：`get_bars` 至今也无 `limit` 参数，#5613 无关联 PR/commit/comment 直接关闭（"关闭未修"）。本 PR 只修 ticks（#5621 范围）；如需 bars 同步加 `limit`，建议另开 issue。

## Test plan

- [x] TDD RED→GREEN：`get_ticks(limit=3)` → `service.get` 收到 `page_size=3`（修复前 `TypeError: unexpected keyword argument 'limit'`）
- [x] 守护：未传 `limit` → `page_size` 保持默认 100（向后兼容）
- [x] 回归：`test_data_pagination.py` + `test_data_bars_500_fix.py` + `test_data_sync_status.py` 共 **19 测**通过
- [x] 冒烟：`py_compile` OK；`inspect.signature(get_ticks)` 含 `limit`（默认 `None`）；`__file__` 指向 worktree 版本

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src:$PWD/api \
  python -m pytest tests/api/test_data_pagination.py -o addopts= -q
# 5 passed（2 新增 limit + 3 原有）
```

Closes #5621
