### PR TITLE
fix: 日志级别 set-level 持久化跨进程 (#5932)

### DIFF
--- a/src/ginkgo/services/logging/level_service.py
+++ b/src/ginkgo/services/logging/level_service.py
@@ -3,7 +3,9 @@
 # Role: LevelService 动态日志级别管理服务 - 运行时调整日志级别，无需重启服务
 
 from typing import Dict, List, Optional
+import json
 import logging
+from pathlib import Path
 
 from ginkgo.data.services.base_service import BaseService, ServiceResult
 from ginkgo.libs import GLOG, GCONF
@@ -24,6 +26,10 @@ class LevelService(BaseService):
         _whitelist: 模块白名单
     """
 
+    # 持久化文件: 跨进程保留自定义级别（CLI 每次是独立进程）#5932
+    # 测试可 monkeypatch 此类变量注入 tmp_path
+    _LEVELS_FILE = Path.home() / ".ginkgo" / "logging_levels.json"
+
     # 有效的日志级别
     VALID_LEVELS = {
         "DEBUG": logging.DEBUG,
@@ -43,7 +49,8 @@ class LevelService(BaseService):
         super().__init__(glog=glog)
 
         self._glog = glog if glog else GLOG
-        self._custom_levels: Dict[str, str] = {}
+        # 内存是持久化文件的缓存; CLI 跨进程通过文件传递状态 #5932
+        self._custom_levels: Dict[str, str] = self._load_persisted_levels()
         self._whitelist: List[str] = self._load_whitelist()
 
     def _load_whitelist(self) -> List[str]:
@@ -55,6 +62,48 @@ class LevelService(BaseService):
         """
         whitelist = getattr(GCONF, 'LOGGING_LEVEL_WHITELIST', ["backtest", "trading", "data", "analysis"])
         return whitelist if isinstance(whitelist, list) else []
+
+    def _load_persisted_levels(self) -> Dict[str, str]:
+        """
+        从持久化文件加载自定义级别 #5932
+
+        CLI 每次调用是独立进程, 内存 _custom_levels 跨进程隔离。
+        文件缺失/损坏/格式错 → 返回空 dict（降级为旧行为）。
+
+        Returns:
+            Dict[str, str]: {module: level_upper}，仅保留白名单校验通过的条目
+        """
+        try:
+            f = self._LEVELS_FILE
+            if f.exists():
+                data = json.loads(f.read_text(encoding="utf-8"))
+                if isinstance(data, dict):
+                    return {
+                        str(k): str(v).upper()
+                        for k, v in data.items()
+                        if str(v).upper() in self.VALID_LEVELS
+                    }
+        except Exception as e:
+            self._logger.WARNING(f"加载持久化日志级别失败: {e}")
+        return {}
+
+    def _persist_levels(self) -> None:
+        """
+        原子写入 _custom_levels 到持久化文件 #5932
+
+        tmp + replace 防半写; 失败仅警告不中断主流程。
+        """
+        try:
+            f = self._LEVELS_FILE
+            f.parent.mkdir(parents=True, exist_ok=True)
+            tmp = f.with_suffix(f.suffix + ".tmp")
+            tmp.write_text(
+                json.dumps(self._custom_levels, ensure_ascii=False),
+                encoding="utf-8"
+            )
+            tmp.replace(f)
+        except Exception as e:
+            self._logger.WARNING(f"持久化日志级别失败: {e}")
 
     def set_level(self, module_name: str, level: str) -> ServiceResult:
         """
@@ -85,6 +134,7 @@ class LevelService(BaseService):
 
         # 设置自定义级别
         self._custom_levels[module_name] = level_upper
+        self._persist_levels()  # 持久化供新进程读取 #5932
 
         # 应用到 GLOG（如果有 set_level 方法）
         if hasattr(self._glog, 'set_level'):
@@ -136,6 +186,7 @@ class LevelService(BaseService):
         """
         cleared_count = len(self._custom_levels)
         self._custom_levels.clear()
+        self._persist_levels()  # 同步清空持久化文件 #5932
 
         self._logger.INFO(f"已重置 {cleared_count} 个模块的日志级别为默认值")
 

--- a/tests/unit/services/test_level_service_persist.py
+++ b/tests/unit/services/test_level_service_persist.py
@@ -1,0 +1,49 @@
+"""#5932: set-level 跨进程持久化。
+
+CLI 每次调用是独立进程, 内存 _custom_levels 跨进程隔离。
+set_level 必须持久化到文件, 新实例(__init__ 模拟新进程)能读到。
+旧实现纯内存 → set 进程退出丢失, get 新进程读空 → INFO。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.services.logging.level_service import LevelService
+
+
+def _patched_env(levels_file):
+    """patch GCONF 白名单 + LevelService 持久化路径 → levels_file。"""
+    gconf_patch = patch("ginkgo.services.logging.level_service.GCONF")
+    file_patch = patch.object(LevelService, "_LEVELS_FILE", levels_file)
+    return gconf_patch, file_patch
+
+
+class TestSetLevelPersistsAcrossInstances:
+    """#5932: set_level 后新实例(新进程)能读到持久化级别。"""
+
+    @pytest.mark.unit
+    def test_set_then_new_instance_reads_level(self, tmp_path):
+        f = tmp_path / "levels.json"
+        gconf_patch, file_patch = _patched_env(f)
+        with gconf_patch as mock_gconf, file_patch:
+            mock_gconf.LOGGING_LEVEL_WHITELIST = ["backtest", "trading", "data"]
+            svc1 = LevelService(glog=MagicMock())
+            r = svc1.set_level("backtest", "DEBUG")
+            assert r.is_success()
+            # 新实例 = 模拟新进程, 应从持久化源读到 DEBUG
+            svc2 = LevelService(glog=MagicMock())
+        assert svc2.get_level("backtest") == "DEBUG", \
+            f"新进程应读到持久化 DEBUG, 实际 {svc2.get_level('backtest')!r}"
+
+    @pytest.mark.unit
+    def test_reset_then_new_instance_back_to_default(self, tmp_path):
+        f = tmp_path / "levels.json"
+        gconf_patch, file_patch = _patched_env(f)
+        with gconf_patch as mock_gconf, file_patch:
+            mock_gconf.LOGGING_LEVEL_WHITELIST = ["backtest", "trading", "data"]
+            svc = LevelService(glog=MagicMock())
+            svc.set_level("backtest", "DEBUG")
+            svc.reset_levels()
+            # 新实例: 重置应已清空持久化源
+            svc2 = LevelService(glog=MagicMock())
+        assert svc2.get_level("backtest") == "INFO", \
+            f"重置后新进程应回默认 INFO, 实际 {svc2.get_level('backtest')!r}"


### PR DESCRIPTION
## Summary
修复 #5932。`ginkgo logging set-level` 后, 新进程（下次 CLI 调用）读不到自定义级别, `get-level` 总返回 INFO, `reset` 报 cleared_count=0。

## 根因
`LevelService.set_level`（level_service.py）只写内存 `self._custom_levels` + 当前进程 GLOG。**CLI 每次调用是独立进程, 进程间内存隔离** → set 进程退出 dict 丢失, 新进程 `__init__` 重建空 dict → get 永远 INFO, reset cleared_count=0。

issue 自述"写 ClickHouse"有误（origin/master 实际零 DB/CH 写入, 纯内存）。

## 修复
加 JSON 文件持久化 `~/.ginkgo/logging_levels.json`（轻量运行时配置, 零依赖, 避开 DB schema/Redis）:
- 类变量 `_LEVELS_FILE`（可 monkeypatch 注入 tmp_path 测试）
- `_load_persisted_levels`: `__init__` 加载, `.upper()` 归一 + `VALID_LEVELS` 过滤防手改注入非法级别
- `_persist_levels`: tmp+replace 原子写, 失败仅 WARNING 不中断主流程
- `set_level`/`reset_levels` 写回; 新进程 `__init__` 继承

零删除; `get_level`/`reset_levels` 签名不变。

## 验收对照
- [x] set 后新进程（新实例）读到持久化级别
- [x] reset 后新进程回默认 INFO
- [x] 文件损坏/格式错降级为空（不崩溃）
- [x] 文件被手改注入非法级别被过滤

## Test plan
- [x] 新增 `tests/unit/services/test_level_service_persist.py`（2 跨进程持久化测试）
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli, 29 passed）
- [x] L3 变更相关（persist + level_service_smoke + logging_containers_smoke + logging_cli, 32 passed）

Closes #5932
