### PR TITLE
fix: EventEngine start-stop-start 重建 Thread (#5499)

### DIFF
--- a/src/ginkgo/trading/engines/event_engine.py
+++ b/src/ginkgo/trading/engines/event_engine.py
@@ -287,9 +287,16 @@ class EventEngine(BaseEngine):
         except Exception as e:
             GLOG.WARN(f"Failed to log engine start event: {e}")
 
-        # 启动已存在的线程对象（每个线程只能启动一次）
+        # 启动主线程对象
         GLOG.INFO(f"🔍 Before thread start: _main_thread_started={self._main_thread_started}, is_alive={self._main_thread.is_alive()}")
         if not self._main_thread_started and not self._main_thread.is_alive():
+            # #5499: Python Thread 只能 start 一次；stop 后复用同一 Thread 对象会抛
+            # RuntimeError: threads can only be started once。检测到该对象已启动过
+            # （_started=True）时，必须重建实例。
+            if getattr(self._main_thread, '_started', False):
+                GLOG.INFO(f"🔄 Rebuilding ended _main_thread before restart.")
+                self._main_thread = Thread(target=self.main_loop, args=(self._main_flag,))
+                self._main_thread.daemon = True
             GLOG.INFO(f"🔄 Clearing main_flag before thread start: {not self._main_flag.is_set()}")
             self._main_flag.clear()  # 确保清除标志
             GLOG.INFO(f"🚀 Starting main thread...")
@@ -306,6 +313,11 @@ class EventEngine(BaseEngine):
 
         # 根据开关状态决定是否启动定时器线程
         if self._enable_timer and not self._timer_thread_started and not self._timer_thread.is_alive():
+            # #5499: 同 _main_thread，stop 后须重建已 ended 的 Thread 对象
+            if getattr(self._timer_thread, '_started', False):
+                GLOG.INFO(f"🔄 Rebuilding ended _timer_thread before restart.")
+                self._timer_thread = Thread(target=self.timer_loop, args=(self._timer_flag,))
+                self._timer_thread.daemon = True
             self._timer_flag.clear()
             self._timer_thread.start()
             self._timer_thread_started = True

--- a/tests/integration/backtest/test_event_engine.py
+++ b/tests/integration/backtest/test_event_engine.py
@@ -290,6 +290,29 @@ class TestThreading:
         # Stop engine
         event_engine_with_time.stop()
 
+    def test_start_stop_start_does_not_raise(self, event_engine_with_time):
+        """#5499: EventEngine start-stop-start 不应抛 RuntimeError。
+
+        Python Thread 只能 start 一次；stop 后再次 start 必须重建 Thread 对象，
+        否则 ``self._main_thread.start()`` 抛
+        ``RuntimeError: threads can only be started once``。
+        """
+        engine = event_engine_with_time
+        engine.start()
+        time.sleep(0.1)
+        engine.stop()
+
+        # 记录 stop 后的 Thread 对象，用于后续验证是否重建
+        thread_before_restart = engine._main_thread
+
+        # 修复前：此处抛 RuntimeError: threads can only be started once
+        restart_ok = engine.start()
+        assert restart_ok is True
+
+        # #5499: 重启后应使用新的 Thread 对象（而非复用已 ended 的旧实例）
+        assert engine._main_thread is not thread_before_restart
+        assert engine._main_thread.is_alive()
+
 
 # ========== Attribute Tests ==========
 


### PR DESCRIPTION
## Summary

修复 #5499：`EventEngine` 执行 `start() → stop() → start()` 时第二次 `start()` 抛 `RuntimeError: threads can only be started once`。

**根因**：CPython 的 `threading.Thread` 只能 `start()` 一次（内部 `_started` 标志不可重置）。`EventEngine` 在 `__init__` 创建 `_main_thread` / `_timer_thread` 各一次，`stop()` 仅重置业务标志 `_main_thread_started=False`（**不重建 Thread 对象**）。再次 `start()` 进入 "未启动且不 alive" 分支，对已 ended 的同一 Thread 实例调 `.start()` → `RuntimeError`。

**调用链**：
```
__init__   self._main_thread = Thread(...)          # 创建一次（:70）
start()    self._main_thread.start()                 # 首次 OK（:296）
stop()     join + _main_thread_started = False       # 不重建 Thread（:358-364）
start()    self._main_thread.start()                 # 同一 ended 实例 → ❌ RuntimeError
```

**修复**（`event_engine.py` `start()`）：
- `_main_thread` 与 `_timer_thread` 在 `.start()` 前检测：若 Thread 对象 `_started=True`（曾被启动过），**重建实例**（`Thread(target=..., args=...)` + `daemon=True`，与 `__init__` 一致）
- 首次 `start()` 不受影响（`_started=False`，不重建），**向后兼容**

## scope

- ✅ `start()` 内 `_main_thread` 按需重建（`_started=True` 时）
- ✅ `_timer_thread` 同构修复（即便 `_enable_timer=False` 默认不触发，仍补全对称性）
- ✅ 首次 `start()` 行为不变（`_started=False` 不进重建分支）
- ⏭️ 未改 `stop()`（在 `start()` 按需重建更内聚：stop 不依赖"是否还会 start"）
- ⏭️ 未加独立 `restart()` 方法（验收"或文档说明单次用"——现 `start()` 自身支持重启，语义更直观）

## Test plan

- [x] TDD RED→GREEN：`start() → stop() → start()` 不抛 `RuntimeError`，返回 `True`，且重启后 `_main_thread` 是**新对象**（`is not` 旧引用）且 `is_alive()`
- [x] 守护：`test_thread_lifecycle`（start→stop 单次）仍通过
- [x] 回归：`test_event_engine.py` 全 **26 测**通过；`test_base_engine.py`（父类 restart）**27 测**通过
- [x] 冒烟：`py_compile` OK；`inspect.getsource(EventEngine.start)` 含重建逻辑；`__file__` 指向 worktree

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/integration/backtest/test_event_engine.py::TestThreading -o addopts= -q
# 3 passed（含新增 start-stop-start）
```

Closes #5499
