### PR TITLE
fix: node-graphs files 端点空 file_id 校验防静默成功 (#5645)

### DIFF
--- a/api/api/_file_type.py
+++ b/api/api/_file_type.py
@@ -39,3 +39,14 @@ def _resolve_file_type(raw):
     if result is None:
         raise ValueError(f"Unknown file_type: {s}")
     return result
+
+
+def _validate_file_id(file_id):
+    """校验 file_id 非空 (#5645)。
+
+    空值（None / 空串 / 纯空白）raise ValueError；合法值返回 strip 后的字符串。
+    用于 add_file_to_portfolio 端点防止空 file_id 静默成功（创建无效映射）。
+    """
+    if file_id is None or str(file_id).strip() == "":
+        raise ValueError("file_id must not be empty")
+    return str(file_id).strip()

--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -36,7 +36,7 @@ def get_portfolio_mapping_service():
     return container.portfolio_mapping_service()
 
 
-from ._file_type import _resolve_file_type  # noqa: F401 — 无副作用，可安全导入
+from ._file_type import _resolve_file_type, _validate_file_id  # noqa: F401 — 无副作用，可安全导入
 
 
 def get_file_service():
@@ -436,6 +436,9 @@ async def add_file_to_portfolio(
     try:
         from ginkgo.enums import FILE_TYPES
 
+        # #5645: 空 file_id 校验（空串/None/纯空白）防止静默成功创建无效映射
+        file_id = _validate_file_id(file_id)
+
         service = get_portfolio_mapping_service()
 
         # 解析 file_type：支持整数、数字字符串、枚举名、别名（#5774）
@@ -460,6 +463,12 @@ async def add_file_to_portfolio(
         }, message="File added successfully")
     except HTTPException:
         raise
+    except ValueError as e:
+        # #5645: 入参校验失败（空 file_id / 无效 file_type）→ 400 而非 500
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e)
+        )
     except Exception as e:
         logger.error(f"Error adding file to portfolio {portfolio_uuid}: {str(e)}")
         raise HTTPException(

--- a/tests/api/test_node_graph_file_id.py
+++ b/tests/api/test_node_graph_file_id.py
@@ -1,0 +1,47 @@
+"""
+#5645: node-graphs files 端点 file_id 校验测试
+
+验证 _validate_file_id 能拒绝空值（空串 / None / 纯空白），
+避免 add_file_to_portfolio 对空 file_id 静默返回成功。
+
+直接导入 api/api/_file_type.py（无模块级副作用）进行测试，与 #5578 同模式。
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# _file_type.py 无 FastAPI/core 依赖，安全加入 sys.path
+_api_api_dir = str(Path(__file__).parent.parent.parent / "api" / "api")
+if _api_api_dir not in sys.path:
+    sys.path.insert(0, _api_api_dir)
+
+from _file_type import _validate_file_id  # noqa: E402
+
+
+class TestFileIdValidation:
+    """file_id 非空校验 — #5645"""
+
+    @pytest.mark.unit
+    def test_empty_string_rejected(self):
+        """#5645: 空字符串 file_id 应 raise ValueError（不应静默成功）"""
+        with pytest.raises(ValueError, match="file_id"):
+            _validate_file_id("")
+
+    @pytest.mark.unit
+    def test_none_rejected(self):
+        """#5645: None file_id 应 raise ValueError"""
+        with pytest.raises(ValueError, match="file_id"):
+            _validate_file_id(None)
+
+    @pytest.mark.unit
+    def test_whitespace_only_rejected(self):
+        """#5645: 纯空白 file_id 应 raise ValueError（等价于空）"""
+        with pytest.raises(ValueError, match="file_id"):
+            _validate_file_id("   ")
+
+    @pytest.mark.unit
+    def test_valid_id_returned(self):
+        """#5645: 合法 file_id 原样返回（向后兼容）"""
+        assert _validate_file_id("abc-123") == "abc-123"


### PR DESCRIPTION
## Summary

修复 #5645：`POST /api/v1/node-graphs/{portfolio_uuid}/files?file_id=&file_type=riskmanager` 返回 `code=0 "File added successfully"` 假成功，但 `file_id=""` 未被校验，实际创建无效映射（`GET /node-graphs/{pid}` 显示 `nodes: 0`）。

**根因**：`add_file_to_portfolio` 端点参数 `file_id: str` 是 FastAPI 必填 query 参数，但 FastAPI 区分"缺省"（→ 422）和"空字符串"（接受为合法 str 值）。`file_id=` 传空串通过参数检查，端点无非空校验，直传 `service.add_file(file_id="")` 创建空映射，`is_success()=True` → 假成功。

**调用链**：
```
POST /files?file_id=&file_type=riskmanager
  → add_file_to_portfolio(file_id="")              # 签名 str 必填，空串通过
    → 无非空校验
    → service.add_file(file_id="", ...)            # 创建无效映射
      → is_success()=True
    → return ok({"file_id": ""}, "File added successfully")  ❌ 假成功
```

**修复**（`api/api/_file_type.py` + `api/api/node_graph.py`）：
- 抽 `_validate_file_id(file_id)` 纯函数（对齐 `_resolve_file_type` 无依赖模式，#5578 同模式可裸导入测）：空值（None/空串/纯空白）raise `ValueError`，合法值返回 strip 后字符串
- 端点 `add_file_to_portfolio` try 块首行调 `_validate_file_id`
- except 链新增 `except ValueError → 400`（file_id 与 file_type 入参校验失败统一 400，而非落入 `Exception → 500`）

## scope

- ✅ 空 file_id（空串/None/纯空白）→ 400（修复前假成功 code=0）
- ✅ 合法 file_id 不变（向后兼容）
- ✅ 副作用改进：无效 file_type（`_resolve_file_type` raise ValueError）原先被 `except Exception` 吞成 500，现统一 400（入参校验失败本应 400）
- ⏭️ 未改 service 层：`PortfolioMappingService.add_file` 是否也应校验 file_id 非空是设计选择，端点层校验是 API 契约责任（最小修复）

## Test plan

- [x] TDD RED→GREEN：`_validate_file_id("")/None/"  "` raise ValueError；`_validate_file_id("abc-123")` 返回 `"abc-123"`
- [x] 回归：`test_node_graph_file_type.py` 12 测全通过（_resolve_file_type 未破坏）
- [x] 冒烟：`py_compile` OK；纯函数 4 单测 + 回归共 **16 passed**
- [x] 代码审查：端点接线 3 处（import / 校验调用 / except ValueError）+ FastAPI 标准异常模式

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/api/test_node_graph_file_id.py tests/api/test_node_graph_file_type.py -o addopts= -q
# 16 passed
```

注：端点 HTTP 行为无法用 TestClient 干净冒烟（`api/` 无 `__init__.py` 为 namespace package + node_graph 相对 import `from ._file_type`），与 #5578 同限制；端点 400 行为由 `_validate_file_id` 纯函数确定性 raise ValueError + `except ValueError → HTTPException(400)` 标准模式共同保证。

Closes #5645
