### PR TITLE
fix: user-groups count_all_members 字段错配 group_id→group_uuid (#5675)

### DIFF
--- a/src/ginkgo/data/services/user_group_service.py
+++ b/src/ginkgo/data/services/user_group_service.py
@@ -135,10 +135,12 @@ class UserGroupService:
             model = self.mapping_crud.model_class
             conn = self.mapping_crud._get_connection()
             with conn.get_session() as s:
+                # #5675: MUserGroupMapping 字段是 group_uuid（非 group_id），
+                # 用错字段名会 AttributeError 被 except 吞成 {} → member_count 永远 0
                 rows = s.query(
-                    model.group_id,
+                    model.group_uuid,
                     func.count(model.uuid),
-                ).group_by(model.group_id).all()
+                ).group_by(model.group_uuid).all()
                 return {str(row[0]): row[1] for row in rows}
         except Exception as e:
             GLOG.ERROR(f"Failed to count all members: {e}")

--- a/tests/unit/test_user_group_count_all_members.py
+++ b/tests/unit/test_user_group_count_all_members.py
@@ -1,0 +1,49 @@
+"""
+#5675: ``UserGroupService.count_all_members()`` 字段错配测试。
+
+根因：``count_all_members`` 用 ``model.group_id``（user_group_service.py:139,141），
+但 ``MUserGroupMapping`` 模型字段实为 ``group_uuid``（model_user_group_mapping.py:34）。
+``AttributeError`` 被 service 的 ``try/except`` 吞掉 → 返回 ``{}`` → 端点 ``member_count`` 永远 0。
+
+漏测原因：端点测试 ``test_settings_user_groups.py:53`` 用
+``mock_service.count_all_members.return_value = {"g-1": 3}`` mock 掉了 service 层，
+掩盖了此 bug。本测试直连 Test DB 验证 service 真实行为（不 mock）。
+"""
+import pytest
+
+from ginkgo.data.services.user_group_service import UserGroupService
+
+
+@pytest.mark.integration
+class TestCountAllMembersFieldMapping:
+    """count_all_members 字段名错配回归（#5675）"""
+
+    def test_returns_non_empty_dict_when_mappings_exist(self):
+        """Test DB 存在 mappings 时，count_all_members 必须返回非空 dict。
+
+        修复前：``model.group_id`` 不存在 → AttributeError 被吞 → 返回 ``{}``。
+        """
+        svc = UserGroupService()
+        counts = svc.count_all_members()
+
+        assert isinstance(counts, dict)
+        assert len(counts) > 0, (
+            "count_all_members 返回空——端点 member_count 将永远 0。"
+            "检查 group_by 字段名是否与 MUserGroupMapping 一致（group_uuid 非 group_id）"
+        )
+
+    def test_keys_are_actual_group_uuids(self):
+        """返回的键必须是真实 group_uuid，能与 list_groups 的 group 对上。
+
+        修复前即使返回非空，键也来自不存在的 group_id，无法匹配。
+        """
+        svc = UserGroupService()
+        counts = svc.count_all_members()
+        groups = svc.group_crud.find(filters={"is_del": False})
+        group_uuids = {g.uuid for g in groups}
+
+        # 至少有一个 count 键能匹配到真实 group_uuid
+        matched = [k for k in counts.keys() if k in group_uuids]
+        assert len(matched) > 0, (
+            f"count_all_members 的键 {list(counts.keys())[:3]} 不匹配任何真实 group_uuid"
+        )


### PR DESCRIPTION
## Summary

修复 #5675：`GET /api/v1/settings/user-groups` 的 `member_count` 永远 0（原报 500）。

**根因**：`UserGroupService.count_all_members()`（user_group_service.py:139,141）用 `model.group_id`，但 `MUserGroupMapping` 模型字段实为 `group_uuid`（model_user_group_mapping.py:34）。`AttributeError` 被 service 的 `try/except` 吞掉 → 返回 `{}` → 端点 `member_counts.get(group_uuid, 0)` 永远取默认 0。

**500 现象已被掩盖**：issue 报告的 500 在当前代码已被 `count_all_members` 内部 `except` 吞成返回 `{}`（端点不再 500，但 `member_count` 全 0）。真实 bug 是字段名错配致统计失效，非崩溃。

**调用链**：
```
GET /settings/user-groups
  → list_user_groups()
    → group_service.count_all_members()
      → s.query(model.group_id, ...)         # group_id 不存在（实为 group_uuid）
        → AttributeError 被 except 吞
      → return {}                             # 空 dict
    → member_counts.get(group_uuid, 0)        # 永远 0  ❌
```

**漏测原因**：端点测试 `test_settings_user_groups.py:53` 用 `mock_service.count_all_members.return_value = {"g-1": 3}` mock 掉了 service 层，掩盖了此 bug。新增 service 层集成测试（不 mock）直连 Test DB 验证真实行为。

## scope

- ✅ `count_all_members` 字段名 `group_id` → `group_uuid`（与 `MUserGroupMapping` 模型一致，docstring 原本就写 `{group_uuid: count}`）
- ✅ 返回真实 `{group_uuid: count}` dict（验证 Test DB 25 组 mappings，count 1/3/3...）
- ✅ 端点 `member_count` 正确（非 0）
- ⏭️ 未改端点（`list_user_groups` 逻辑正确，bug 在 service 层）
- ⏭️ 未改端点测试的 mock 模式（端点测试职责是端点契约，service 实现由新测试覆盖）

## Test plan

- [x] TDD RED→GREEN：`count_all_members()` 返回非空 dict + 键匹配真实 group_uuid（修复前返 `{}`）
- [x] 回归：`test_settings_user_groups.py` 9 测全通过（分跑，避开 unit×api namespace 污染）
- [x] 冒烟：`py_compile` OK；实调 `count_all_members()` 返回 25 组真实数据

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/test_user_group_count_all_members.py -o addopts= -q
# 2 passed
```

注：unit 与 api 测试须分两次 pytest 进程跑（namespace pollution 既知，非本 PR 引入）。

Closes #5675
