### PR TITLE
fix(#6285): deploy info 状态显示枚举名 + 记录源回测任务

### DIFF
--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -18,6 +18,7 @@ def deploy(
     mode: Annotated[str, typer.Option("--mode", "-m", help="部署模式: paper 或 live")] = "paper",
     account: Annotated[Optional[str], typer.Option("--account", "-a", help="实盘账号ID (live模式必填)")] = None,
     name: Annotated[Optional[str], typer.Option("--name", "-n", help="新Portfolio名称")] = None,
+    source_task: Annotated[Optional[str], typer.Option("--source-task", help="源回测任务ID (可选, 记录回测→部署链路)")] = None,
 ):
     """一键部署：Portfolio → 纸上交易/实盘"""
     try:
@@ -46,6 +47,7 @@ def deploy(
             mode=mode_map[mode],
             account_id=account,
             name=name,
+            source_task_id=source_task,
         )
 
         if result.success:
@@ -85,7 +87,7 @@ def info(
             mode_str = "纸上交易" if data.get("mode") == 1 else "实盘"
             table.add_row("模式", mode_str)
             table.add_row("实盘账号", data.get("account_id", "N/A"))
-            table.add_row("状态", str(data.get("status", "")))
+            table.add_row("状态", data.get("status_name") or str(data.get("status", "")))
             table.add_row("创建时间", data.get("create_at", ""))
             console.print(table)
         else:

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -9,6 +9,18 @@ from ginkgo.enums import PORTFOLIO_MODE_TYPES, FILE_TYPES
 from ginkgo.data.models import MDeployment
 from ginkgo.enums import DEPLOYMENT_STATUS
 
+# #6285: int→枚举名映射，供 info/list 输出人类可读部署状态。
+# 动态收集 DEPLOYMENT_STATUS 类属性，新增成员自动覆盖，无需手维护 dict。
+_DEPLOYMENT_STATUS_NAMES = {
+    v: k for k, v in vars(DEPLOYMENT_STATUS).items()
+    if not k.startswith("_") and isinstance(v, int)
+}
+
+
+def _status_name(status: int) -> str:
+    """裸 int → 枚举名（未知值降级为字符串形式，不抛错）。"""
+    return _DEPLOYMENT_STATUS_NAMES.get(status, str(status))
+
 
 class DeploymentService(BaseService):
     """部署编排服务"""
@@ -39,6 +51,7 @@ class DeploymentService(BaseService):
         mode: PORTFOLIO_MODE_TYPES,
         account_id: Optional[str] = None,
         name: Optional[str] = None,
+        source_task_id: Optional[str] = None,
     ) -> ServiceResult:
         """
         一键部署：从组合部署到模拟盘/实盘
@@ -48,6 +61,7 @@ class DeploymentService(BaseService):
             mode: PAPER 或 LIVE
             account_id: MLiveAccount.uuid (live模式必填)
             name: 新Portfolio名称 (可选，自动生成)
+            source_task_id: 源回测任务 id (可选, #6285 记录回测→部署链路便于追溯)
 
         Returns:
             ServiceResult with data: {"portfolio_id": str, "deployment_id": str}
@@ -78,7 +92,7 @@ class DeploymentService(BaseService):
 
         # 3b. 创建 PENDING deployment 记录
         deployment = MDeployment(
-            source_task_id=None,
+            source_task_id=source_task_id,
             target_portfolio_id="",
             source_portfolio_id=portfolio_id,
             mode=mode.value,
@@ -263,6 +277,7 @@ class DeploymentService(BaseService):
             "mode": deployment.mode,
             "account_id": deployment.account_id,
             "status": deployment.status,
+            "status_name": _status_name(deployment.status),  # #6285
             "create_at": str(deployment.create_at) if deployment.create_at else None,
         }
         return result
@@ -277,6 +292,7 @@ class DeploymentService(BaseService):
             "mode": r.mode,
             "account_id": r.account_id,
             "status": r.status,
+            "status_name": _status_name(r.status),  # #6285
             "create_at": str(r.create_at) if r.create_at else None,
         }
 

--- a/tests/unit/client/test_deploy_cli.py
+++ b/tests/unit/client/test_deploy_cli.py
@@ -1,0 +1,79 @@
+"""
+#6285 deploy CLI 输出断言测试
+- info: 状态显示枚举名 status_name（非裸 int）
+- deploy: --source-task 透传到 svc.deploy
+"""
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from ginkgo.client import deploy_cli
+from ginkgo.data.services.base_service import ServiceResult
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+def _mock_svc():
+    svc = MagicMock()
+    svc.get_deployment_info.return_value = ServiceResult(
+        success=True,
+        data={
+            "source_task_id": "bt_task_123",
+            "source_portfolio_id": "src_pid",
+            "target_portfolio_id": "tgt_pid",
+            "mode": 1,
+            "account_id": None,
+            "status": 1,
+            "status_name": "DEPLOYED",
+            "create_at": "2026-06-22 10:00:00",
+        },
+    )
+    svc.deploy.return_value = ServiceResult(
+        success=True, data={"portfolio_id": "tgt_pid", "deployment_id": "d1"}
+    )
+    return svc
+
+
+class TestDeployInfoStatusDisplay:
+    """#6285: info 状态显示枚举名"""
+
+    def test_info_shows_status_name_not_raw_int(self, cli_runner):
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=_mock_svc(),
+        ):
+            result = cli_runner.invoke(deploy_cli.app, ["info", "tgt_pid"])
+
+        assert result.exit_code == 0, result.output
+        # 枚举名出现，裸 int "1" 不作为状态值独立出现
+        assert "DEPLOYED" in result.output
+        # 源回测任务回显
+        assert "bt_task_123" in result.output
+
+
+class TestDeploySourceTaskPassthrough:
+    """#6285: deploy --source-task 透传到 svc.deploy"""
+
+    def test_deploy_passes_source_task_id(self, cli_runner):
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=_mock_svc(),
+        ) as factory:
+            result = cli_runner.invoke(
+                deploy_cli.app,
+                ["deploy", "src_pid", "--mode", "paper", "--source-task", "bt_task_456"],
+            )
+
+        assert result.exit_code == 0, result.output
+        svc = factory.return_value
+        svc.deploy.assert_called_once()
+        _, kwargs = svc.deploy.call_args
+        assert kwargs.get("source_task_id") == "bt_task_456"

--- a/tests/unit/trading/services/test_deployment_service_info_status.py
+++ b/tests/unit/trading/services/test_deployment_service_info_status.py
@@ -1,0 +1,88 @@
+# Related: #6285
+# deploy info 输出打磨：status 返回枚举名、source_task_id deploy 记录后回显。
+import sys
+from pathlib import Path
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from unittest.mock import MagicMock
+from ginkgo.enums import PORTFOLIO_MODE_TYPES
+from ginkgo.trading.services.deployment_service import DeploymentService
+
+
+def _make_svc(**overrides):
+    svc = DeploymentService.__new__(DeploymentService)
+    svc._portfolio_service = overrides.get("portfolio_service", MagicMock())
+    svc._mapping_service = overrides.get("mapping_service", MagicMock())
+    svc._file_service = overrides.get("file_service", MagicMock())
+    svc._deployment_crud = overrides.get("deployment_crud", MagicMock())
+    svc._broker_instance_crud = overrides.get("broker_instance_crud", MagicMock())
+    svc._live_account_service = overrides.get("live_account_service", MagicMock())
+    svc._mongo_driver = overrides.get("mongo_driver", None)
+    svc._param_crud = overrides.get("param_crud", MagicMock())
+    return svc
+
+
+def _mock_deployment(status=1, source_task_id=None):
+    d = MagicMock()
+    d.source_task_id = source_task_id
+    d.target_portfolio_id = "t1"
+    d.source_portfolio_id = "s1"
+    d.mode = 1
+    d.account_id = None
+    d.status = status
+    d.create_at = None
+    return d
+
+
+def _mock_portfolio_found():
+    mp = MagicMock()
+    mp.name = "Src"
+    return MagicMock(success=True, data=[mp])
+
+
+class TestDeploymentInfoStatusName:
+    """#6285: get_deployment_info / list_deployments 返回 status_name 枚举名"""
+
+    def test_info_returns_status_name_deployed(self):
+        svc = _make_svc()
+        svc._deployment_crud.get_by_target_portfolio.return_value = [_mock_deployment(status=1)]
+
+        result = svc.get_deployment_info("t1")
+        assert result.success
+        assert result.data["status"] == 1  # 原始 int 仍保留（向后兼容）
+        assert result.data["status_name"] == "DEPLOYED"
+
+    def test_list_returns_status_name(self):
+        svc = _make_svc()
+        svc._deployment_crud.find.return_value = [_mock_deployment(status=0), _mock_deployment(status=3)]
+
+        result = svc.list_deployments()
+        assert result.success
+        assert result.data[0]["status_name"] == "PENDING"
+        assert result.data[1]["status_name"] == "STOPPED"
+
+
+class TestDeploymentRecordsSourceTask:
+    """#6285: deploy 记录 source_task_id，info/list 回显"""
+
+    def test_deploy_records_source_task_id(self):
+        """deploy(--source-task) 传入的 task id 应写入 MDeployment.source_task_id"""
+        svc = _make_svc()
+        svc._portfolio_service.get.return_value = _mock_portfolio_found()
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        svc._deploy_core = MagicMock(return_value=MagicMock(success=True, data={"portfolio_id": "p_new", "deployment_id": "d1"}))
+
+        result = svc.deploy(
+            portfolio_id="p1",
+            mode=PORTFOLIO_MODE_TYPES.PAPER,
+            source_task_id="backtest_task_abc",
+        )
+        assert result.success, f"deploy 应成功: {result.error}"
+
+        svc._deployment_crud.add.assert_called_once()
+        created = svc._deployment_crud.add.call_args.args[0]
+        assert created.source_task_id == "backtest_task_abc"
+


### PR DESCRIPTION
## Summary
修复 #6285。`ginkgo deploy info` 输出两处缺陷：`状态` 显示裸 int（如 `1`），`源回测任务` 恒空。

## 根因
1. **状态裸 int**：`get_deployment_info`/`list_deployments`（deployment_service.py）返回原始 `status` int，CLI info 用 `str()` 显示。`DEPLOYMENT_STATUS` 枚举名（PENDING/DEPLOYED/FAILED/STOPPED）存在但未用于显示。
2. **源回测任务恒空**：`deploy()` 创建 MDeployment 时硬编码 `source_task_id=None`（:81），deploy 命令也不接收 task_id 参数。

## 修复
- **service**：`_status_name()` 从 `DEPLOYMENT_STATUS` 类属性动态收集 int→名映射（新增成员自动覆盖）；`get_deployment_info`/`list_deployments` 返回 `status_name`（原始 `status` int 保留向后兼容）
- **service**：`deploy()` 加 `source_task_id` 参数，替代硬编码 None
- **cli**：deploy 命令加 `--source-task` 透传；info 状态行显示 `status_name`（缺省降级裸 int）

## 验收对照
- [x] `状态` 显示可读枚举名（非裸 int）
- [x] `源回测任务` 在 deploy 记录后回显（`--source-task` 记录，info/list 回显）
- [x] 新增 deploy info 输出断言测试

## Test plan
- [x] 新增 `tests/unit/trading/services/test_deployment_service_info_status.py`（3 测试：info/list status_name + deploy 记录 source_task_id）
- [x] 新增 `tests/unit/client/test_deploy_cli.py`（2 测试：info 显示 status_name + deploy --source-task 透传）
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）
- [x] L3 变更相关（info_status 3 + 现有 deployment_service/find 回归 + deploy_cli 2，16 passed）

Closes #6285
