### PR TITLE
fix: stockinfo limit 参数被忽略，?limit=1000 返回 50 (#5872)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -238,10 +238,18 @@ async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: in
 async def get_stockinfo(
     search: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=50, ge=1, le=500)
+    page_size: int = Query(default=50, ge=1, le=500),
+    limit: Optional[int] = None
 ):
-    """获取股票信息列表（分页，搜索下推到DB层）"""
+    """获取股票信息列表（分页，搜索下推到DB层）
+
+    #5872: limit 参数显式约束返回条数（limit=1000 → 至多 1000 条），
+    未传时沿用 page_size（默认 50），向后兼容。与 #5621（ticks，PR#6335）同模式。
+    """
     try:
+        # #5872: limit 提供且 > 0 时作为实际 page_size（截断返回条数），
+        # 避免 ?limit=1000 被 FastAPI 静默丢弃致默认 50 截断
+        effective_page_size = limit if (limit is not None and limit > 0) else page_size
         stockinfo_service = get_stockinfo_service()
 
         if search:
@@ -249,10 +257,10 @@ async def get_stockinfo(
             result = stockinfo_service.search(
                 keyword=search,
                 page=page - 1,
-                page_size=page_size,
+                page_size=effective_page_size,
             )
             if not result.is_success() or not result.data:
-                return paginated(items=[], total=0, page=page, page_size=page_size)
+                return paginated(items=[], total=0, page=page, page_size=effective_page_size)
 
             result_data = result.data
             total_count = result_data.get("total", 0) if isinstance(result_data, dict) else 0
@@ -263,13 +271,13 @@ async def get_stockinfo(
             total_count = count_result.data if count_result.is_success() else 0
 
             result = stockinfo_service.get(
-                limit=page_size,
-                offset=(page - 1) * page_size,
+                limit=effective_page_size,
+                offset=(page - 1) * effective_page_size,
                 order_by="code"
             )
 
             if not result.is_success() or not result.data:
-                return paginated(items=[], total=total_count, page=page, page_size=page_size)
+                return paginated(items=[], total=total_count, page=page, page_size=effective_page_size)
 
             items = result.data
 
@@ -297,7 +305,7 @@ async def get_stockinfo(
                 "updated_at": update_at.isoformat() if update_at else None
             })
 
-        return paginated(items=stock_summaries, total=total_count, page=page, page_size=page_size)
+        return paginated(items=stock_summaries, total=total_count, page=page, page_size=effective_page_size)
 
     except Exception as e:
         logger.error(f"Error getting stockinfo: {e}")

--- a/tests/api/test_data_pagination.py
+++ b/tests/api/test_data_pagination.py
@@ -91,3 +91,72 @@ class TestAdjustFactorsPagination:
         # service.get 应接收到分页参数
         call_kwargs = mock_service.get.call_args.kwargs
         assert call_kwargs.get("page") is not None or call_kwargs.get("limit") is not None
+
+
+class TestStockinfoLimitParam:
+    """#5872: stockinfo limit 参数应映射到 service.get 的截断条数
+
+    根因：get_stockinfo 签名只有 page_size（默认 50），无 limit 参数。
+    FastAPI 对未知 query 参数（?limit=1000）静默丢弃 → 用默认 50 → DB 有 7651 但只返回 50。
+    与 #5621（ticks，PR#6335 open）同模式：加 limit 别名，提供时覆盖 page_size。
+    """
+
+    def _make_mock_stock(self, code="000001.SZ"):
+        s = MagicMock()
+        s.uuid = f"{code}-uuid"
+        s.code = code
+        s.code_name = "测试"
+        s.market = 1
+        s.is_del = False
+        s.industry = None
+        s.update_at = None
+        return s
+
+    def test_limit_param_truncates_page_size(self):
+        """limit=1000 时 service.get 收到 limit=1000（非默认 50）"""
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[self._make_mock_stock()])
+        mock_service.count.return_value = make_mock_result(data=7651)
+
+        from api.data import get_stockinfo
+
+        with patch("api.data.get_stockinfo_service", return_value=mock_service):
+            run_async(get_stockinfo(limit=1000))
+
+        call_kwargs = mock_service.get.call_args.kwargs
+        assert call_kwargs.get("limit") == 1000, (
+            f"limit=1000 应直接传给 service.get，实际 {call_kwargs.get('limit')}")
+
+    def test_limit_none_keeps_default_page_size(self):
+        """未传 limit 时保持默认 page_size=50（向后兼容）"""
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[self._make_mock_stock()])
+        mock_service.count.return_value = make_mock_result(data=7651)
+
+        from api.data import get_stockinfo
+
+        with patch("api.data.get_stockinfo_service", return_value=mock_service):
+            run_async(get_stockinfo())
+
+        call_kwargs = mock_service.get.call_args.kwargs
+        assert call_kwargs.get("limit") == 50, (
+            f"未传 limit 应保持默认 50，实际 {call_kwargs.get('limit')}")
+
+    def test_limit_propagates_to_response_page_size(self):
+        """limit=N 时响应体 page_size 字段也为 N（前端分页元数据一致）"""
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[self._make_mock_stock()])
+        mock_service.count.return_value = make_mock_result(data=7651)
+
+        from api.data import get_stockinfo
+
+        with patch("api.data.get_stockinfo_service", return_value=mock_service):
+            result = run_async(get_stockinfo(limit=200))
+
+        # paginated() 返回 {meta: {page_size: N}}，元数据应反映 limit（非默认 50）
+        meta = result.get("meta", {})
+        assert meta.get("page_size") == 200, (
+            f"响应 meta.page_size 应=200，实际 {meta.get('page_size')}")


### PR DESCRIPTION
## Summary

修复 #5872：`GET /api/v1/data/stockinfo?limit=1000` 始终返回 50 条（DB 有 7651 只股票）。

**根因**：`get_stockinfo`（api/api/data.py:242）签名参数是 `page_size`（默认 50），**无 `limit` 参数**。FastAPI 对未知 query 参数（`?limit=1000`）静默丢弃 → 用默认 `page_size=50` → `service.get(limit=50)` → 只返回 50 条。HTTP 200 无错误，行为与预期不符，极难被静态检查发现。

**调用链**：
```
GET /data/stockinfo?limit=1000
  → get_stockinfo(page_size=50)           # limit 被 FastAPI 丢弃（未知参数）
    → effective_page_size = limit if limit>0 else page_size   # 修复后
    → service.get(limit=effective_page_size)                  # 修复后 limit=1000
  → 修复前：limit=50（默认截断）  ❌
  → 修复后：limit=1000           ✅
```

**修复**（与 #5621 ticks limit 完全同模式）：
- 签名加 `limit: Optional[int] = None`
- 计算 `effective_page_size = limit if (limit is not None and limit > 0) else page_size`
- 函数体内 7 处 `page_size` 引用替换为 `effective_page_size`（search 分支 + 无 search 分支 + 3 处 `paginated()` 元数据）
- 覆盖 search 分支（ticks 无 search，stockinfo 独有）：search 时 `limit` 同样生效

**与 #5621 的关系**：#5621（ticks limit，PR#6335）同根因同模式，**PR#6335 当前 OPEN 未合并**。本 PR 独立修 stockinfo 端点，不依赖 PR#6335 合并。若 PR#6335 后续合并，两处端点风格一致。

## scope

- ✅ `get_stockinfo` 签名加 `limit: Optional[int] = None`
- ✅ `effective_page_size` 计算 + 7 处引用替换
- ✅ 向后兼容：未传 `limit` 时行为不变（page_size 默认 50）
- ✅ search 分支同样支持 `limit`（stockinfo 独有，ticks 无 search）
- ⏭️ 未改 service 层（`StockinfoService.get` 已正确接收 `limit` 参数，bug 在端点层签名）
- ⏭️ 未改 `page_size` 参数（保留向后兼容，`limit` 作为别名新增）

## Test plan

- [x] TDD RED→GREEN：`limit=1000` → `service.get(limit=1000)`；未传 limit → 默认 50；响应 `meta.page_size` 反映 limit
- [x] 回归：`test_data_pagination.py` 全 **6 测**通过（3 新 stockinfo + 3 ticks/adjustfactors 回归）
- [x] 冒烟：`py_compile` OK；7 处 `page_size` 引用全替换为 `effective_page_size`

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/api/test_data_pagination.py -o addopts= -q
# 6 passed
```

Closes #5872
