### PR TITLE
fix(#5941): data migrate 用 sys.executable -m alembic 替代裸二进制

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -754,26 +754,31 @@ def migrate(
         if database == "mysql":
             import subprocess
             import os
+            import sys
 
             migrations_dir = "/home/kaoru/Ginkgo/migrations/mysql"
             alembic_ini = os.path.join(migrations_dir, "alembic.ini")
+
+            # #5941: 用 [sys.executable, "-m", "alembic"] 绑定当前解释器，
+            # 避免裸 `alembic` 在 venv/uv 下 PATH 不可见触发 FileNotFoundError。
+            alembic_cmd = [sys.executable, "-m", "alembic"]
 
             if autogenerate:
                 # Auto-generate migration
                 console.print(f":memo: Generating migration for MySQL database...")
                 if message:
-                    cmd = ["alembic", "revision", "--autogenerate", "-m", message]
+                    cmd = alembic_cmd + ["revision", "--autogenerate", "-m", message]
                 else:
-                    cmd = ["alembic", "revision", "--autogenerate"]
+                    cmd = alembic_cmd + ["revision", "--autogenerate"]
                 subprocess.run(cmd, cwd=migrations_dir, check=True)
                 console.print(f":white_check_mark: Migration generated successfully")
 
             elif action == "upgrade":
                 console.print(f":arrow_up: Upgrading MySQL database to latest version...")
                 if revision:
-                    subprocess.run(["alembic", "upgrade", revision], cwd=migrations_dir, check=True)
+                    subprocess.run(alembic_cmd + ["upgrade", revision], cwd=migrations_dir, check=True)
                 else:
-                    subprocess.run(["alembic", "upgrade", "head"], cwd=migrations_dir, check=True)
+                    subprocess.run(alembic_cmd + ["upgrade", "head"], cwd=migrations_dir, check=True)
                 console.print(f":white_check_mark: Database upgraded successfully")
 
             elif action == "downgrade":
@@ -781,15 +786,15 @@ def migrate(
                     console.print(":x: --revision is required for downgrade")
                     raise typer.Exit(1)
                 console.print(f":arrow_down: Downgrading MySQL database to {revision}...")
-                subprocess.run(["alembic", "downgrade", revision], cwd=migrations_dir, check=True)
+                subprocess.run(alembic_cmd + ["downgrade", revision], cwd=migrations_dir, check=True)
                 console.print(f":white_check_mark: Database downgraded successfully")
 
             elif action == "heads":
-                subprocess.run(["alembic", "heads"], cwd=migrations_dir)
+                subprocess.run(alembic_cmd + ["heads"], cwd=migrations_dir)
             elif action == "history":
-                subprocess.run(["alembic", "history"], cwd=migrations_dir)
+                subprocess.run(alembic_cmd + ["history"], cwd=migrations_dir)
             elif action == "current":
-                subprocess.run(["alembic", "current"], cwd=migrations_dir)
+                subprocess.run(alembic_cmd + ["current"], cwd=migrations_dir)
             else:
                 # Show current status
                 console.print(f":information: MySQL Database Migration Status")

--- a/tests/unit/client/test_data_cli_migrate.py
+++ b/tests/unit/client/test_data_cli_migrate.py
@@ -1,0 +1,66 @@
+"""
+#5941 data migrate alembic 调用可移植性测试
+裸 `alembic` 二进制在 venv/uv 下 PATH 不可见 → FileNotFoundError。
+应使用 [sys.executable, "-m", "alembic"] 绑定当前解释器。
+"""
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import sys
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from ginkgo.client import data_cli
+from ginkgo.client.data_cli import app
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+class TestDataMigrateAlembicPortable:
+    """#5941: migrate 用 sys.executable -m alembic，不依赖 PATH 中的裸 alembic"""
+
+    def test_current_action_uses_sys_executable_m_alembic(self, cli_runner):
+        """--action current 应经 sys.executable -m alembic 调用，非裸 alembic"""
+        with patch("subprocess.run") as mock_run:
+            result = cli_runner.invoke(app, ["migrate", "--database", "mysql", "--action", "current"])
+
+        assert result.exit_code == 0, result.output
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        cmd = args[0] if args else kwargs.get("args")
+        # 前缀须为 [sys.executable, "-m", "alembic"]，非裸 "alembic"
+        assert cmd[0] == sys.executable, f"应用 sys.executable, 实际 cmd[0]={cmd[0]!r}"
+        assert cmd[1:3] == ["-m", "alembic"], f"应用 -m alembic, 实际={cmd[1:3]!r}"
+        assert "current" in cmd
+
+    @pytest.mark.parametrize(
+        "action,expected_sub",
+        [
+            ("heads", ["heads"]),
+            ("history", ["history"]),
+            ("current", ["current"]),
+        ],
+    )
+    def test_status_actions_use_portable_prefix(self, cli_runner, action, expected_sub):
+        """heads/history/current 均走便携前缀"""
+        with patch("subprocess.run") as mock_run:
+            result = cli_runner.invoke(app, ["migrate", "--database", "mysql", "--action", action])
+        assert result.exit_code == 0, result.output
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == [sys.executable, "-m", "alembic"]
+        assert cmd[3:] == expected_sub
+
+    def test_upgrade_head_uses_portable_prefix(self, cli_runner):
+        """--action upgrade（无 revision）走便携前缀 + upgrade head"""
+        with patch("subprocess.run") as mock_run:
+            result = cli_runner.invoke(app, ["migrate", "--database", "mysql", "--action", "upgrade"])
+        assert result.exit_code == 0, result.output
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:3] == [sys.executable, "-m", "alembic"]
+        assert cmd[3:] == ["upgrade", "head"]


### PR DESCRIPTION
## Summary
修复 #5941。`ginkgo data migrate` 在 venv/uv 环境 PATH 无 `alembic` 二进制时报 `FileNotFoundError: [Errno 2] No such file or directory: 'alembic'`。

## 根因
`data_cli.py` migrate 命令 8 处 `subprocess.run(["alembic", ...])` 裸调 `alembic` 二进制，依赖 PATH。venv/uv 环境只装 Python 包（`pip install alembic`），不在 PATH 注入 `alembic` 入口脚本 → `FileNotFoundError`。

## 修复
- 加 `import sys` + 模块常量 `alembic_cmd = [sys.executable, "-m", "alembic"]`（单一事实来源）
- 8 处调用（revision/upgrade/downgrade/heads/history/current）统一改为 `alembic_cmd + [...]`
- 绑定当前解释器，venv/uv/CI 一致，不依赖 PATH

## 验收对照
- [x] `data migrate --action current/heads/history` 经 `sys.executable -m alembic` 调用
- [x] 用 `[sys.executable, "-m", "alembic"]` 替代 subprocess 裸 `alembic`
- [x] 真实验证：`python -m alembic -c migrations/mysql/alembic.ini current` 成功连 MySQL 读 revision（末尾 migration 链断裂属 #5529 独立 issue，非本 scope）

## Test plan
- [x] 新增 `tests/unit/client/test_data_cli_migrate.py`（5 测试：current/heads/history/upgrade-head 均断言 `[sys.executable, "-m", "alembic"]` 前缀）
- [x] L1 py_compile 全绿
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）
- [x] L3 变更相关（migrate 新测 5 + data_cli 既有回归，49 passed）

## 说明
migrations_dir 硬编码绝对路径 `/home/kaoru/Ginkgo/migrations/mysql` 是另一问题（跨机不可移植），不在本 issue scope（#5941 仅 alembic 找不到），未动。

Closes #5941
