### PR TITLE
fix(#5393): segment-stability n_segments 接受 int 并归一化为 [int]

### DIFF
--- a/api/api/validation.py
+++ b/api/api/validation.py
@@ -5,8 +5,8 @@
 """
 
 from fastapi import APIRouter, Query
-from typing import List, Optional
-from pydantic import BaseModel, Field
+from typing import List, Optional, Union
+from pydantic import BaseModel, Field, field_validator
 
 from core.logging import logger
 from core.response import ok, paginated
@@ -19,8 +19,24 @@ router = APIRouter()
 class SegmentStabilityRequest(BaseModel):
     task_id: str = Field(..., description="回测任务 UUID")
     portfolio_id: str = Field(..., description="组合 UUID")
-    n_segments: Optional[List[int]] = Field(default=[2, 4, 8], description="分段数列表")
+    # #5393: 字段名 n_segments 暗示单数，但服务层按「多分段数列表」循环。
+    # 接受 int 或 list[int]，int 自动归一化为 [int]，list 与默认 [2,4,8] 保留。
+    n_segments: Optional[Union[int, List[int]]] = Field(
+        default=[2, 4, 8],
+        description="分段数：单个整数或列表（如 4 或 [2,4,8]，int 自动归一化为 [int]）",
+    )
     metrics: Optional[List[str]] = Field(default=None, description="分析器名称列表")
+
+    @field_validator("n_segments", mode="before")
+    @classmethod
+    def _coerce_n_segments(cls, v):
+        """#5393: int → [int] 归一化；list 与 None 原样透传（None 由 service 兜底为默认）。"""
+        # bool 是 int 子类，JSON true 不应归一化为 [1]
+        if isinstance(v, bool):
+            return v
+        if isinstance(v, int):
+            return [v]
+        return v
 
 
 class AvailableMetricsRequest(BaseModel):

--- a/tests/api/test_validation_segment_stability_nsegments.py
+++ b/tests/api/test_validation_segment_stability_nsegments.py
@@ -1,0 +1,46 @@
+"""
+#5393 SegmentStabilityRequest n_segments 接受 int（归一化为 [int]）
+
+字段名 n_segments 暗示单个整数，但类型声明为 list[int] → 传 int 报 422
+"Input should be a valid list"。服务层 segment_stability(n_segments_list)
+循环 for n in n_segments_list 证实设计意图是「多分段数列表」，故不能简单改 int。
+修复：Union[int, list[int]] + field_validator(mode="before") 归一化 int→[int]，
+默认 [2,4,8] 保留，list 输入不变。
+
+纯模型测试（避开 api/main.py 遮蔽陷阱，走 api_modules fixture 延迟导入）。
+"""
+import pytest
+
+
+def _make_request(api_modules):
+    from api.validation import SegmentStabilityRequest
+    return SegmentStabilityRequest
+
+
+class TestSegmentStabilityNAcceptsInt:
+    """#5393: n_segments 接受 int 并归一化为单元素 list"""
+
+    def test_int_normalized_to_singleton_list(self, api_modules):
+        """传 n_segments=4（int）应归一化为 [4]，不报 422"""
+        SegmentStabilityRequest = _make_request(api_modules)
+        req = SegmentStabilityRequest(task_id="t", portfolio_id="p", n_segments=4)
+        assert req.n_segments == [4]
+
+    def test_list_input_preserved(self, api_modules):
+        """list 输入原样保留（不破坏多分段分析能力）"""
+        SegmentStabilityRequest = _make_request(api_modules)
+        req = SegmentStabilityRequest(task_id="t", portfolio_id="p", n_segments=[2, 4, 8])
+        assert req.n_segments == [2, 4, 8]
+
+    def test_default_remains_multi_segment(self, api_modules):
+        """缺省仍为 [2,4,8]（多分段默认）"""
+        SegmentStabilityRequest = _make_request(api_modules)
+        req = SegmentStabilityRequest(task_id="t", portfolio_id="p")
+        assert req.n_segments == [2, 4, 8]
+
+    def test_invalid_string_still_rejected(self, api_modules):
+        """非法类型（字符串）仍被拒，证明归一化是选择性的（非放开一切）"""
+        from pydantic import ValidationError
+        SegmentStabilityRequest = _make_request(api_modules)
+        with pytest.raises(ValidationError):
+            SegmentStabilityRequest(task_id="t", portfolio_id="p", n_segments="four")


### PR DESCRIPTION
## Summary
修复 #5393。`POST /api/v1/validation/segment-stability` 传 `n_segments: 4`（int）报 422 `Input should be a valid list`。

## 根因
`SegmentStabilityRequest.n_segments` 声明为 `Optional[List[int]]`，但字段名 `n_segments`（分段数）暗示单个整数。调用链：
- `POST /segment-stability` → `req.n_segments`(List[int]) → `ValidationService.segment_stability(n_segments_list=req.n_segments)` → `for n in n_segments_list: _split_returns(returns, n_segments=n)`

服务层循环证实设计意图是「多分段数列表」（一次请求算多种分段下的稳定性），**不能简单改 int**（会丢多分段能力）。根因在请求模型层类型与字段名语义错配。

## 修复
`api/api/validation.py`：
- 类型 `Optional[List[int]]` → `Optional[Union[int, List[int]]]`
- 加 `field_validator("n_segments", mode="before")` 归一化 int → `[int]`
- bool 单独排除（bool 是 int 子类，JSON `true` 不应归一化为 `[1]`）
- 更新 description 说明接受 int 或 list

行为：
| 输入 | 结果 |
|---|---|
| `n_segments=4`（int） | 归一化为 `[4]` → 单分段分析 ✅（原先 422） |
| `n_segments=[2,4,8]` | 原样保留 → 多分段分析 ✅ |
| 缺省 | `[2,4,8]` 保留 ✅ |
| `n_segments="four"` | 仍 ValidationError ✅（归一化选择性，非放开一切） |

## 验收对照
- [x] `n_segments` 接受 int（传 4 不再 422，归一化为 [4]）
- [x] list 输入不变（多分段能力保留）
- [x] OpenAPI schema description 与实际用途一致（"单个整数或列表"）

## Test plan
- [x] 新增 `tests/api/test_validation_segment_stability_nsegments.py`（4 测：int 归一化 / list 保留 / 默认保留 / 非法字符串仍拒），全绿
- [x] L1 py_compile（validation.py + 新测）✅
- [x] L2 启动路径 smoke（user_crud + containers + user_cli，29 passed）✅
- [x] L3 unit `test_validation_service.py` 10 passed ✅
- 纯模型测试，避开 api/main.py 遮蔽陷阱（走 `api_modules` fixture 延迟导入）

## 说明
`tests/api/test_validation_pagination.py` 2 个失败为 **master 预存**（stash 我的改动后仍败，`'NoneType' object has no attribute 'kwargs'` mock 问题），与本改动无因果，非回归。属另一 issue 范围。

Closes #5393
