### PR TITLE
fix: 回测 positions/orders 数值字段返回 JSON number (#5864)

### DIFF
--- a/src/ginkgo/data/services/backtest_task_schemas.py
+++ b/src/ginkgo/data/services/backtest_task_schemas.py
@@ -92,10 +92,11 @@ class BacktestOrderItem(BaseModel):
     order_type: Optional[str] = None
     status: Optional[str] = None
     volume: int = 0
-    limit_price: Optional[str] = None  # #5787: 市价单无价哨兵 None, 非 "0"
-    transaction_price: str = "0"
+    # #5864: 数值字段返回 JSON number；#5787: 市价单无价→None 哨兵（默认 None 兼容）
+    limit_price: Optional[float] = None
+    transaction_price: float = 0.0
     transaction_volume: int = 0
-    fee: str = "0"
+    fee: float = 0.0
     timestamp: Optional[str] = None
 
 
@@ -106,11 +107,12 @@ class BacktestPositionItem(BaseModel):
     engine_id: str = ""
     task_id: str = ""
     code: str = ""
-    cost: str = "0"
+    # #5864: 数值字段返回 JSON number 非 str
+    cost: float = 0.0
     volume: int = 0
     frozen_volume: int = 0
-    price: str = "0"
-    fee: str = "0"
+    price: float = 0.0
+    fee: float = 0.0
 
 
 class BacktestAnalyzerGroup(BaseModel):

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -19,9 +19,9 @@ import pandas as pd
 from datetime import datetime
 
 from ginkgo.libs import cache_with_expiration, retry, GLOG
+from ginkgo.libs.data.number import convert_to_float
 from ginkgo.data.crud.model_conversion import ModelList
 from ginkgo.data.services.base_service import BaseService, ServiceResult
-from ginkgo.data.mappers.order_mapper import OrderMapper
 from ginkgo.interfaces.kafka_topics import KafkaTopics
 
 
@@ -1103,10 +1103,10 @@ class BacktestTaskService(BaseService):
                     order_type=str(getattr(o, "order_type", "")) if getattr(o, "order_type", None) is not None else None,
                     status=str(getattr(o, "status", "")) if getattr(o, "status", None) is not None else None,
                     volume=int(getattr(o, "volume", 0) or 0),
-                    limit_price=OrderMapper._price_to_dto(getattr(o, "limit_price", 0)),
-                    transaction_price=str(getattr(o, "transaction_price", 0)),
+                    limit_price=convert_to_float(getattr(o, "limit_price", 0)) or None,
+                    transaction_price=convert_to_float(getattr(o, "transaction_price", 0)),
                     transaction_volume=int(getattr(o, "transaction_volume", 0) or 0),
-                    fee=str(getattr(o, "fee", 0)),
+                    fee=convert_to_float(getattr(o, "fee", 0)),
                     timestamp=self._format_dt(getattr(o, "timestamp", None)),
                 ))
 
@@ -1221,10 +1221,10 @@ class BacktestTaskService(BaseService):
                     order_type=str(getattr(o, "order_type", "")) if getattr(o, "order_type", None) is not None else None,
                     status=str(getattr(o, "status", "")) if getattr(o, "status", None) is not None else None,
                     volume=int(getattr(o, "volume", 0) or 0),
-                    limit_price=OrderMapper._price_to_dto(getattr(o, "limit_price", 0)),
-                    transaction_price=str(getattr(o, "transaction_price", 0)),
+                    limit_price=convert_to_float(getattr(o, "limit_price", 0)) or None,
+                    transaction_price=convert_to_float(getattr(o, "transaction_price", 0)),
                     transaction_volume=int(getattr(o, "transaction_volume", 0) or 0),
-                    fee=str(getattr(o, "fee", 0)),
+                    fee=convert_to_float(getattr(o, "fee", 0)),
                     timestamp=self._format_dt(getattr(o, "timestamp", None)),
                 ))
 
@@ -1261,11 +1261,11 @@ class BacktestTaskService(BaseService):
                     engine_id=getattr(p, "engine_id", ""),
                     task_id=getattr(p, "task_id", ""),
                     code=getattr(p, "code", ""),
-                    cost=str(getattr(p, "cost", 0)),
+                    cost=convert_to_float(getattr(p, "cost", 0)),
                     volume=int(getattr(p, "volume", 0) or 0),
                     frozen_volume=int(getattr(p, "frozen_volume", 0) or 0),
-                    price=str(getattr(p, "price", 0)),
-                    fee=str(getattr(p, "fee", 0)),
+                    price=convert_to_float(getattr(p, "price", 0)),
+                    fee=convert_to_float(getattr(p, "fee", 0)),
                 ))
 
             sr = ServiceResult.success(data=items, message="Positions retrieved")

--- a/src/ginkgo/libs/data/number.py
+++ b/src/ginkgo/libs/data/number.py
@@ -34,6 +34,10 @@ def convert_to_float(value, default: float = 0.0) -> float:
         return value
     if isinstance(value, int):
         return float(value)
+    if isinstance(value, Decimal):
+        # ClickHouse DECIMAL 列读出为 Decimal（非 int/float 子类），须显式转换，
+        # 否则落入末尾 return default 静默返 0.0（#5864 数据丢失）。
+        return float(value)
     if isinstance(value, str):
         try:
             return float(value)

--- a/tests/unit/libs/data/test_number.py
+++ b/tests/unit/libs/data/test_number.py
@@ -16,7 +16,7 @@ _path = str(Path(__file__).parent.parent.parent)
 if _path not in sys.path:
     sys.path.insert(0, _path)
 
-from ginkgo.libs.data.number import Number, to_decimal
+from ginkgo.libs.data.number import Number, convert_to_float, to_decimal
 
 
 # ---------------------------------------------------------------------------
@@ -116,3 +116,21 @@ class TestNumberTypeAlias:
     def test_number_rejects_none(self):
         """None 不符合 Number 类型"""
         assert not isinstance(None, Number)
+
+
+# ---------------------------------------------------------------------------
+# convert_to_float
+# ---------------------------------------------------------------------------
+@pytest.mark.unit
+class TestConvertToFloat:
+    """convert_to_float 类型转换测试
+
+    #5864: ClickHouse DECIMAL 列读出为 Decimal 实例（非 int/float 子类），
+    convert_to_float 必须正确处理，否则静默返 default=0.0（数据丢失）。
+    """
+
+    def test_decimal_to_float(self):
+        """Decimal 输入应转 float 而非静默返 default 0.0（#5864 回归核心）"""
+        result = convert_to_float(Decimal("19.81"))
+        assert isinstance(result, float)
+        assert result == pytest.approx(19.81)

--- a/tests/unit/services/test_backtest_task_service_limit_price.py
+++ b/tests/unit/services/test_backtest_task_service_limit_price.py
@@ -1,7 +1,7 @@
-"""#5787: 回测订单 limit_price 序列化市价单→None 而非 '0'。
+"""回测订单 limit_price 序列化：#5864 返回 JSON number(float)，#5787 市价单→None 哨兵。
 
-list_orders / list_order_records 两入口应复用 OrderMapper._price_to_dto 的
-0→None 市价单哨兵语义, 而非直接 str() 化 (旧实现 str(0)→'0')。
+list_orders / list_order_records 两入口经 convert_to_float(...) or None：
+非 0 价 → float；0/None → None（市价单无价哨兵，替代旧 str(0)→'0'）。
 """
 import datetime
 from types import SimpleNamespace
@@ -39,7 +39,7 @@ def _svc_with_orders(orders):
 
 
 class TestListOrdersLimitPriceSerialization:
-    """#5787: limit_price 市价单→None, 限价单→str(价格)。"""
+    """limit_price 市价单→None, 限价单→float(#5864 JSON number)。"""
 
     @pytest.mark.unit
     def test_market_order_limit_price_is_null_not_zero(self):
@@ -50,24 +50,24 @@ class TestListOrdersLimitPriceSerialization:
              patch("ginkgo.data.containers.container", container):
             result = svc.list_orders("any-uuid")
         assert result.is_success()
-        # #5787: 旧实现 str(0)→'0'; 修复后应 None
+        # #5787: 旧实现 str(0)→'0'; convert_to_float(0) or None → None
         assert result.data[0].limit_price is None, \
             f"市价单 limit_price 应为 None, 实际 {result.data[0].limit_price!r}"
 
     @pytest.mark.unit
-    def test_limit_order_limit_price_is_str(self):
-        """限价单(limit_price=19.81)序列化为 '19.81'。"""
+    def test_limit_order_limit_price_is_number(self):
+        """限价单(limit_price=19.81)序列化为 float 19.81(#5864 JSON number)。"""
         svc, container = _svc_with_orders([_make_order(limit_price=19.81, order_type=2)])
         with patch.object(svc, "_resolve_task_id",
                           return_value=("task-1", "port-1", None)), \
              patch("ginkgo.data.containers.container", container):
             result = svc.list_orders("any-uuid")
         assert result.is_success()
-        assert result.data[0].limit_price == "19.81"
+        assert result.data[0].limit_price == 19.81
 
 
 class TestListOrderRecordsLimitPriceSerialization:
-    """#5787: list_order_records 路径同样复用 _price_to_dto。"""
+    """list_order_records 路径同样：市价单→None, 限价单→float。"""
 
     @pytest.mark.unit
     def test_market_order_limit_price_is_null_not_zero(self):

--- a/tests/unit/test_backtest_numeric_fields.py
+++ b/tests/unit/test_backtest_numeric_fields.py
@@ -4,6 +4,7 @@
 service.list_positions/list_orders 填充时用 str() 包装 Decimal/float。
 双层修复：schema str→float + service 去掉 str()。
 """
+from decimal import Decimal
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -73,6 +74,23 @@ class TestPositionNumericFields:
             result = svc.list_positions("x")
         assert isinstance(result.data[0].fee, float)
         assert result.data[0].fee == pytest.approx(5.0)
+
+    def test_decimal_input_from_clickhouse(self):
+        """#5864 回归：ClickHouse DECIMAL 列返回 Decimal（非 float 子类），
+        convert_to_float 须正确转换，否则静默返 0.0（PR #6344 review 打回根因）。"""
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_positions.return_value = MagicMock(
+            is_success=lambda: True,
+            data={"data": [_make_position(cost=Decimal("19.81"), price=Decimal("20.5"), fee=Decimal("5"))], "total": 1},
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_positions("x")
+        item = result.data[0]
+        assert isinstance(item.cost, float)
+        assert item.cost == pytest.approx(19.81)
+        assert item.price == pytest.approx(20.5)
+        assert item.fee == pytest.approx(5.0)
 
 
 class TestOrderNumericFields:

--- a/tests/unit/test_backtest_numeric_fields.py
+++ b/tests/unit/test_backtest_numeric_fields.py
@@ -1,0 +1,126 @@
+"""#5864: 回测 Positions/Orders 数值字段应返回 JSON number 类型。
+
+根因：BacktestPositionItem/BacktestOrderItem schema 数值字段声明为 str，
+service.list_positions/list_orders 填充时用 str() 包装 Decimal/float。
+双层修复：schema str→float + service 去掉 str()。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+
+
+def _make_service():
+    """绕过 __init__（需 crud_repo 依赖），直接构造实例 + stub _resolve_task_id。"""
+    svc = object.__new__(BacktestTaskService)
+    svc._resolve_task_id = lambda uuid: ("task-1", "pf-1", None)
+    return svc
+
+
+def _make_position(cost=19.81, volume=50, price=19.81, fee=5):
+    p = MagicMock()
+    p.uuid = "p1"; p.portfolio_id = "pf"; p.engine_id = "e"; p.task_id = "t"
+    p.code = "000001.SZ"; p.cost = cost; p.volume = volume
+    p.frozen_volume = 0; p.price = price; p.fee = fee
+    return p
+
+
+def _make_order(limit_price=0, transaction_price=19.81, fee=5):
+    o = MagicMock()
+    o.uuid = "o1"; o.portfolio_id = "pf"; o.engine_id = "e"; o.task_id = "t"
+    o.code = "000001.SZ"; o.direction = 1; o.order_type = 1; o.status = 2
+    o.volume = 50; o.limit_price = limit_price
+    o.transaction_price = transaction_price; o.transaction_volume = 50
+    o.fee = fee; o.timestamp = None
+    return o
+
+
+class TestPositionNumericFields:
+    """#5864: positions cost/price/fee 应为 float 非 str。"""
+
+    def test_cost_is_float_not_string(self):
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_positions.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_position()], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_positions("x")
+        item = result.data[0]
+        assert isinstance(item.cost, float)
+        assert not isinstance(item.cost, str)
+        assert item.cost == pytest.approx(19.81)
+
+    def test_price_is_float_not_string(self):
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_positions.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_position(price=20.5)], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_positions("x")
+        assert isinstance(result.data[0].price, float)
+        assert result.data[0].price == pytest.approx(20.5)
+
+    def test_fee_is_float_not_string(self):
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_positions.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_position(fee=5)], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_positions("x")
+        assert isinstance(result.data[0].fee, float)
+        assert result.data[0].fee == pytest.approx(5.0)
+
+
+class TestOrderNumericFields:
+    """#5864: orders transaction_price/fee 应为 float；limit_price=0（市价单）应返 None。"""
+
+    def test_transaction_price_is_float_not_string(self):
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_orders.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_order()], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_orders("x")
+        item = result.data[0]
+        assert isinstance(item.transaction_price, float)
+        assert not isinstance(item.transaction_price, str)
+        assert item.transaction_price == pytest.approx(19.81)
+
+    def test_fee_is_float_not_string(self):
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_orders.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_order(fee=5)], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_orders("x")
+        assert isinstance(result.data[0].fee, float)
+        assert result.data[0].fee == pytest.approx(5.0)
+
+    def test_limit_price_zero_returns_none(self):
+        """#5864 验收：limit_price=0（市价单无限制价格）应返 None 非 "0"。"""
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_orders.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_order(limit_price=0)], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_orders("x")
+        assert result.data[0].limit_price is None
+
+    def test_limit_price_nonzero_is_float(self):
+        """限价单 limit_price 非 0 时应返 float。"""
+        svc = _make_service()
+        mock_rs = MagicMock()
+        mock_rs.get_orders.return_value = MagicMock(
+            is_success=lambda: True, data={"data": [_make_order(limit_price=20.5)], "total": 1}
+        )
+        with patch("ginkgo.data.containers.container.result_service", return_value=mock_rs):
+            result = svc.list_orders("x")
+        assert isinstance(result.data[0].limit_price, float)
+        assert result.data[0].limit_price == pytest.approx(20.5)


### PR DESCRIPTION
## Summary

修复 #5864：回测 Positions/Orders API 数值字段（cost/price/fee/limit_price/transaction_price）返回字符串 `"19.81"` 而非 JSON number `19.81`。

**根因（双层）**：
1. **schema 层**：`BacktestOrderItem`/`BacktestPositionItem`（backtest_task_schemas.py）数值字段声明为 `str`（`limit_price: str = "0"`、`cost: str = "0"` 等）
2. **service 层**：`list_orders`/`list_positions` 填充 schema 时用 `str()` 包装 Decimal/float（配合 schema 的 str 类型）

`str()` 把 `Decimal('19.81')` → `"19.81"`，pydantic schema 字段是 str 接收并存为 str，端点 `[o.dict() for o in items]` 序列化时输出字符串。

**调用链**：
```
GET /backtests/{uuid}/positions
  → task_service.list_positions()
    → BacktestPositionItem(cost=str(getattr(p,"cost",0)))   # str() 包装 ❌
      → schema cost: str 字段接收 "19.81"
  → 端点 [p.dict() for p in items]
  → JSON: {"cost": "19.81"}  ❌ 字符串

修复后：
    → BacktestPositionItem(cost=convert_to_float(...))      # float 转换 ✅
      → schema cost: float 字段接收 19.81
  → JSON: {"cost": 19.81}  ✅ number
```

**修复（双层，避开 Base 禁区）**：
- schema：`cost/price/fee: str` → `float`；`limit_price: str` → `Optional[float]`（市价单 0 应返 None）
- service：3 方法（list_orders / list_order_records / list_positions）`str(getattr(...))` → `convert_to_float(getattr(...))`；`limit_price` 加 `or None`（0→None 语义）
- `convert_to_float`（libs/data/number.py）安全转换 None/Decimal/str → float，防 `float(None)` 崩

**跨方法根因合并**：`list_order_records`（订单流水，issue 未提）有完全相同的 `str()` 包装，同根因同模式，一并修复，避免留半个 bug。

## scope

- ✅ `BacktestOrderItem`：`limit_price: Optional[float]=None`、`transaction_price/fee: float`
- ✅ `BacktestPositionItem`：`cost/price/fee: float`
- ✅ `list_orders` / `list_order_records` / `list_positions`：`str()` → `convert_to_float()`；limit_price=0 → None
- ⏭️ 未改端点（`[o.dict() for o in items]` 逻辑正确，bug 在 service+schema 层）
- ⏭️ 未改 entity Position/Order（禁区 Base，且字段内部 Decimal 存储正确，问题在序列化层）

## Test plan

- [x] TDD RED→GREEN：7 测覆盖（Position cost/price/fee float；Order transaction_price/fee float；limit_price=0→None；limit_price≠0→float）
- [x] 回归：`tests/unit/data/services/` 全跑，9 失败均为**预存**（param/portfolio service，stash 基线对照 master 同样失败），非本 PR 引入
- [x] 冒烟：`py_compile` OK；残留 `str(getattr(...cost/price/fee))` 全清零

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/test_backtest_numeric_fields.py -o addopts= -q
# 7 passed
```

Closes #5864
