### PR TITLE
fix(#6281): deploy live 非法 account 加存在性预检，不再抛裸 SQL

### DIFF
--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -70,6 +70,15 @@ class DeploymentService(BaseService):
         if mode == PORTFOLIO_MODE_TYPES.LIVE and not account_id:
             return ServiceResult(success=False, error="实盘部署需要提供 account_id")
 
+        # 3a. #6281: account 存在性预检
+        # 非法 account 不应直冲下游查询，否则环境层 DB 列漂移时抛裸 1054 (见 arch_create_all_no_alter_drift)。
+        if mode == PORTFOLIO_MODE_TYPES.LIVE and account_id:
+            account_res = self._live_account_service.get_account_by_uuid(account_id)
+            if not account_res or not account_res.get("success"):
+                return ServiceResult(
+                    success=False, error=f"实盘账户不存在: {account_id}"
+                )
+
         # 3c. 检查 live_account 是否已被其他 Portfolio 绑定
         if mode == PORTFOLIO_MODE_TYPES.LIVE and account_id:
             existing_brokers = self._broker_instance_crud.get_broker_by_live_account(account_id)

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -67,6 +67,57 @@ class TestDeploymentServiceDeploy:
         assert not result.success
         assert "account_id" in result.error
 
+    def test_deploy_rejects_live_with_nonexistent_account(self):
+        """#6281: 实盘模式 account 不存在时应返回业务错误，不直冲下游查询。
+
+        根因: LIVE 分支在 get_broker_by_live_account(查"已绑定")前缺 account 存在性预检，
+        非法 account 直冲下游；环境层 DB 漂移(portfolio.live_account_id 列缺失)时抛裸 1054。
+        修复: 加 get_account_by_uuid 预检，account 不存在优雅返回"实盘账户不存在"。
+        """
+        svc = _make_svc()
+        svc._portfolio_service.get.return_value = _mock_portfolio_found()
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        # account 不存在: get_account_by_uuid 返回 success=False
+        svc._live_account_service.get_account_by_uuid.return_value = {
+            "success": False,
+            "error": "Account not found: fake_nonexistent",
+        }
+
+        result = svc.deploy(
+            portfolio_id="p1",
+            mode=PORTFOLIO_MODE_TYPES.LIVE,
+            account_id="fake_nonexistent",
+        )
+
+        assert not result.success
+        assert "实盘账户不存在" in result.error
+        # 行为断言: 预检须在查"已绑定"之前拦截，非法 account 不应走到下游查询
+        svc._broker_instance_crud.get_broker_by_live_account.assert_not_called()
+
+    def test_deploy_proceeds_when_live_account_exists(self):
+        """#6281 回归: account 存在时预检放行，继续走"已绑定"检查（不误伤正常路径）。"""
+        svc = _make_svc()
+        svc._portfolio_service.get.return_value = _mock_portfolio_found()
+        svc._portfolio_service.is_portfolio_frozen.return_value = False
+        # account 存在: 预检应放行
+        svc._live_account_service.get_account_by_uuid.return_value = {
+            "success": True,
+            "data": {"uuid": "valid_account"},
+        }
+        # 已被绑定 → 证明预检放行后走到了 get_broker_by_live_account
+        svc._broker_instance_crud.get_broker_by_live_account.return_value = [MagicMock()]
+
+        result = svc.deploy(
+            portfolio_id="p1",
+            mode=PORTFOLIO_MODE_TYPES.LIVE,
+            account_id="valid_account",
+        )
+
+        # 预检放行 → get_broker_by_live_account 被调用，已绑定逻辑生效
+        svc._broker_instance_crud.get_broker_by_live_account.assert_called_once_with("valid_account")
+        assert not result.success
+        assert "已被其他组合绑定" in result.error
+
     def test_deploy_propagates_source_initial_capital(self):
         """#6200 部署时目标组合应继承源组合 initial_capital(非 service 默认 1000000)。
 


### PR DESCRIPTION
## Summary

`ginkgo deploy --mode live --account <不存在>` 当前把底层 ORM 异常直接抛给用户（`pymysql.err.OperationalError (1054, Unknown column ...)`）。本 PR 在代码层加 account 存在性预检，非法 account 优雅返回业务错误。

## 根因（双层）

- **代码层**：`deployment_service.deploy` LIVE 分支在 `get_broker_by_live_account`（查"已绑定"）之前缺 account 存在性预检，非法 account 直冲下游查询。
- **环境层**：issue 报的 `1054 Unknown column 'portfolio.live_account_id'` 是 DB 漂移——模型已有该列（`model_portfolio.py:43`），旧 DB 表缺失（见 `arch_create_all_no_alter_drift`），须重建 DB，代码不可修。

## 修复

`deployment_service.deploy` LIVE+account_id 分支加 `get_account_by_uuid` 存在性预检，account 不存在优雅返回 `实盘账户不存在: <id>`，不暴露 SQL/ORM 堆栈。

**范围划界**：仅修代码层预检。环境层 DB 漂移不在代码层 try/except 兜底（吞 ORM 异常会掩盖真实问题），在 issue/文档中指引重建 DB。

## Test plan

- [x] `test_deploy_rejects_live_with_nonexistent_account`：非法 account 返回"实盘账户不存在"，且 `get_broker_by_live_account` 未被调用（预检前置拦截）
- [x] `test_deploy_proceeds_when_live_account_exists`：account 存在时预检放行，继续走"已绑定"检查（不误伤正常路径）
- [x] 三层冒烟：L1 py_compile ✅ / L2 启动路径三名点 29 passed ✅ / L3 deployment_service 8 passed ✅
- [ ] 人工：`ginkgo deploy <pid> --mode live --account <不存在>` 应输出"实盘账户不存在: ..."（非裸 SQL）

Closes #6281
