### PR TITLE
fix(#5760): bars 缺 code 参数返回 422 校验错误（子问题3）

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -310,7 +310,7 @@ async def get_stockinfo(
 
 @router.get("/bars")
 async def get_bars(
-    code: Optional[str] = None,
+    code: str,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,

--- a/tests/api/test_bars_code_required.py
+++ b/tests/api/test_bars_code_required.py
@@ -1,0 +1,27 @@
+"""#5760(3): bars 缺 code 参数应返回 422 校验错误（防静默空响应）。
+
+范围: 仅子问题(3)。
+- (1) bars code 模糊匹配/后缀补全: 触及 A股代码归一边界，划出
+- (2) stockinfo 分页格式统一: breaking change，划出
+"""
+import os
+
+os.environ.setdefault("GINKGO_SKIP_DEBUG_CHECK", "1")
+
+import inspect
+
+
+def test_bars_code_is_required_query_param(api_modules):
+    """#5760(3): bars 端点 code 应为必填 query 参数，缺则 FastAPI 自动 422。
+
+    FastAPI 声明式校验: 函数参数无默认值 = 必填，缺则 422。
+    用 inspect 签名验证(default is empty)，避开 app 启动/根 main.py 遮蔽
+    (arch_api_test_root_main_shadow)。
+    """
+    from api.data import get_bars
+
+    sig = inspect.signature(get_bars)
+    code_param = sig.parameters["code"]
+    assert code_param.default is inspect.Parameter.empty, (
+        f"code 必须是必填参数(无默认值)以触发 422，当前 default={code_param.default!r}"
+    )


### PR DESCRIPTION
## Summary

`GET /api/v1/data/bars` 缺 `code` 参数时原静默返回空分页（`paginated items=[] total=0`），用户无任何提示。本 PR 将 `code` 改为必填 query 参数，缺则 FastAPI 自动 422 校验错误。

## 范围划界（三合一 issue #5760，本 PR 仅修子问题 3）

| 子问题 | 状态 | 原因 |
|---|---|---|
| (3) bars 缺 code 返回 422 | **本 PR 修** | 单点参数校验 |
| (1) bars code 模糊匹配/后缀补全 | 划出 | 触及 A股代码归一边界（`arch_ashare_code_market_prefix_gap`，项目无统一 helper，各硬编码漂移，mootdx 是裁判），需独立设计 |
| (2) stockinfo 分页格式统一 | 划出 | breaking change（前端依赖当前 `{data:[...]}` 格式），需前端协调 |

issue 保持 open 等待 (1)(2) follow-up。

## 修复

`api/api/data.py` get_bars 端点：`code: Optional[str] = None` → `code: str`。FastAPI 声明式校验，缺参自动 422，无需手写校验逻辑。

## Test plan

- [x] `test_bars_code_is_required_query_param`：inspect 签名验证 `code` 必填（`default is empty`），避开 app 启动/根 main.py 遮蔽（`arch_api_test_root_main_shadow`）
- [x] 三层冒烟：L1 py_compile ✅ / L2 启动路径三名点 29 passed ✅ / L3 新测试 1 passed ✅
- [ ] 人工：`GET /api/v1/data/bars?page_size=5`（无 code）应返回 422；`GET /api/v1/data/bars?code=000001.SZ` 正常

**注**：本 PR 不含 `Closes #5760`（三合一部分修复，issue 须保持 open 等全部子问题修复）。
