### PR TITLE
fix: data get calendar 友好提示 planned 非 Unknown data type (#5919)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -414,6 +414,16 @@ def get(
             console.print(table)
             console.print(f":information: {len(configured_sources)} data source(s) configured")
 
+        elif data_type == "calendar":
+            # #5919: help 标 [planned: calendar]，dispatch 给友好提示而非 "Unknown data type"。
+            # 仿 sources 分支：print 后 fall-through 正常结束 try，不走 else。
+            # ⚠️ 勿用 raise typer.Exit —— click.Exit 是 Exception 子类（非 SystemExit），
+            # 会被外层 except Exception 捕获并转成 Exit(1) + "Error getting data" 污染输出。
+            console.print(
+                ":information: calendar is planned but not yet implemented. "
+                "See `ginkgo data get --help`."
+            )
+
         else:
             console.print(f":x: Unknown data type: {data_type}")
             raise typer.Exit(1)

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -75,7 +75,7 @@ class TestDataCLIHelp:
         """data get help 区分"可用"与 [planned] 未实现的 data_type（#4900/#5242）。
 
         adjustfactor/sources 已实现（PR #6234：接 service / 列数据源），列入可用；
-        calendar 仍不可用（报 Unknown data type，#5242 not_planned），标 [planned]。
+        calendar 仍未实现（dispatch 友好提示 planned 而非 Unknown data type，#5919），help 标 [planned]。
         help 必须与实际一致，否则误导用户——#6230 旧的 [planned: calendar/adjustfactor/sources]
         在 #6234 实现两者后已过时。
         """
@@ -251,6 +251,15 @@ class TestGetOtherTypes:
         result = cli_runner.invoke(data_cli.app, ["get", "nonexistent"])
         assert result.exit_code == 1
         assert "Unknown" in result.output or "unknown" in result.output
+
+    def test_get_calendar_shows_planned_not_unknown(self, cli_runner):
+        """#5919: calendar 在 help 标 [planned]，dispatch 应提示 planned/未实现，
+        不应报通用 'Unknown data type'（help 已声明该类型，只是未实现）。
+        区别于 test_get_unknown_data_type（nonexistent 真未知 → Unknown）。"""
+        result = cli_runner.invoke(data_cli.app, ["get", "calendar"])
+        out = result.output.lower()
+        assert "planned" in out or "not yet implemented" in out
+        assert "unknown data type" not in out
 
     def test_get_sources_lists_configured_sources(self, cli_runner):
         """sources 数据类型列出已配置的数据源（不再显示 not yet implemented 桩）"""


### PR DESCRIPTION
## Summary

修复 #5919：`data get calendar` 报 "Unknown data type"，但 `data get --help` 已标 `[planned: calendar]`。

**根因**：commit 5a53c997 对齐了 help（日历标 `\[planned: calendar]`），但 dispatch 漏加日历分支 → `data get calendar` 落入通用 else（"Unknown data type"）。help 声明的类型不应报 Unknown（用户已知该类型存在，只是未实现），区别于真未知命令（如 `data get nonexistent`）。

**调用链**：
```
ginkgo data get calendar
  → data_cli.py get() dispatch
    → if stockinfo / elif day / elif tick / elif adjustfactor / elif sources 均不匹配
    → else: console.print("Unknown data type: calendar")  ❌  (help 却标 [planned: calendar])

修复后：
    → elif data_type == "calendar": 友好提示 planned / not yet implemented  ✅
```

**修复**：dispatch 加 `calendar` elif，仿 `sources` 分支 `console.print` 后 fall-through 正常结束 try。

⚠️ **关键坑（架构发现）**：calendar 分支**不能用 `raise typer.Exit`**。`click.Exit`（typer.Exit 的基类）继承自 `Exception`（**不是** `SystemExit`），会被 `get()` 外层 `try/except Exception`（L421）捕获，转成 `Exit(1)` + `"Error getting data"` 污染输出 —— RED 测试输出正好暴露了 else 分支 `Exit(1)` 被二次处理的痕迹（两行：`Unknown data type` + `Error getting data: 1`）。故 calendar 分支仿 sources 用 fall-through，干净 exit 0。

**边界（不做跨方法合并的理由）**：`data sync --help` **未** 列 calendar，`data sync calendar` 对用户而言是真未知命令，L737 报 Unknown 是正确行为，保留。

## scope

- ✅ `data_cli.py` get dispatch：加 `elif data_type == "calendar"` 友好提示分支（fall-through）
- ✅ `test_data_cli.py`：新增 `test_get_calendar_shows_planned_not_unknown`；更新 `test_get_help_marks` L78 过时注释（旧行为"报 Unknown"→ 新行为"提示 planned"）
- ⏭️ 不改 help（L25 `[planned: calendar]` 保留——`test_get_help_marks` L88 断言约束）
- ⏭️ 不改 sync（help 未列 calendar，L737 Unknown 正确）

## Test plan

- [x] TDD RED→GREEN：`data get calendar` → 输出含 "planned"/"not yet implemented"，不含 "unknown data type"
- [x] 回归：`test_data_cli.py` 全 **45 passed**（help / unknown / sources 测试不破；`test_get_unknown_data_type` 用 `"nonexistent"` 非日历，不受影响）
- [x] 冒烟：`py_compile` OK；变更覆盖率 `data_cli.py` → `test_data_cli.py` ✓

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/client/test_data_cli.py -o addopts= -q
# 45 passed
```

Closes #5919
