### PR TITLE
fix(#6021): pytest-timeout 声明 dev 依赖 + required_plugins 自洽校验

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",
+    "pytest-timeout>=2.0.0",
     "ruff>=0.8.0",
     "pre-commit>=4.0.0",
     "typer[testing]>=0.9.0",
@@ -288,7 +289,7 @@ timeout = 300
 console_output_style = "progress"
 
 # 所需插件
-required_plugins = ["pytest-cov"]
+required_plugins = ["pytest-cov", "pytest-timeout"]
 
 [tool.coverage.run]
 source = ["src/ginkgo"]

--- a/tests/unit/core/test_pytest_config_consistency.py
+++ b/tests/unit/core/test_pytest_config_consistency.py
@@ -1,0 +1,69 @@
+"""#6021: pyproject.toml pytest 配置自洽测试。
+
+addopts/timeout 引用 pytest-timeout 时，dev 依赖与 required_plugins 必须声明它，
+否则未装包的环境跑 `pytest` 报 `unrecognized arguments: --timeout=60`（须手动
+`-o addopts=` 绕过）。本测试静态校验配置自洽，防回归。
+"""
+import tomllib
+from pathlib import Path
+
+
+def _load_pyproject() -> tuple[Path, dict]:
+    """从本测试文件向上定位仓库根的 pyproject.toml。"""
+    here = Path(__file__).resolve()
+    for parent in [here.parent, *here.parents]:
+        cand = parent / "pyproject.toml"
+        if cand.exists():
+            return cand, tomllib.loads(cand.read_text(encoding="utf-8"))
+    raise FileNotFoundError("pyproject.toml not found from test location")
+
+
+def _uses_timeout(ini: dict) -> bool:
+    addopts = ini.get("addopts", [])
+    if any("--timeout" in str(a) for a in addopts):
+        return True
+    return "timeout" in ini  # 全局 timeout = N 同样需 pytest-timeout
+
+
+def test_pytest_timeout_declared_in_dev_deps_when_used():
+    """#6021: addopts/ini 引用 --timeout → dev 依赖必须声明 pytest-timeout。
+
+    未声明时未装包环境跑 pytest 报 unrecognized arguments(--timeout=60)。
+    """
+    _, data = _load_pyproject()
+    ini = data["tool"]["pytest"]["ini_options"]
+    if not _uses_timeout(ini):
+        return
+    dev_deps = data["project"]["optional-dependencies"].get("dev", [])
+    assert any("pytest-timeout" in d for d in dev_deps), (
+        "addopts/ini 引用 --timeout，但 dev 依赖未声明 pytest-timeout → "
+        "pytest 报 unrecognized arguments: --timeout=60 (#6021)"
+    )
+
+
+def test_pytest_timeout_in_required_plugins_when_used():
+    """#6021: addopts/ini 引用 --timeout → required_plugins 必须含 pytest-timeout。
+
+    required_plugins 在 pytest 启动期强校验插件齐全，缺则明确报 'missing
+    required plugin'，而非 addopts 的 unrecognized arguments 困惑报错；
+    并防止配置与依赖再次解耦（回归护栏）。
+    """
+    _, data = _load_pyproject()
+    ini = data["tool"]["pytest"]["ini_options"]
+    if not _uses_timeout(ini):
+        return
+    required = ini.get("required_plugins", [])
+    assert "pytest-timeout" in required, (
+        "required_plugins 缺 pytest-timeout → 启动期无强校验，配置与依赖可再次解耦 (#6021 回归)"
+    )
+
+
+def test_pytest_timeout_plugin_is_installed():
+    """#6021 端到端验收: pytest-timeout 已安装可 import（dev 环境装了 .[dev]）。
+
+    配置自洽(前两测)是必要条件，本测验证充分条件——包确实装了。
+    CI/开发者 `pip install -e .[dev]` 后此测绿；裸环境红提示装包。
+    """
+    import importlib
+
+    importlib.import_module("pytest_timeout")

--- a/uv.lock
+++ b/uv.lock
@@ -1216,6 +1216,7 @@ dependencies = [
     { name = "dependency-injector" },
     { name = "fastapi" },
     { name = "gunicorn" },
+    { name = "h2" },
     { name = "hiredis" },
     { name = "httptools" },
     { name = "huggingface-hub" },
@@ -1284,6 +1285,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "typer" },
 ]
@@ -1327,6 +1329,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.116.0" },
     { name = "graphifyy", marker = "extra == 'dev'", specifier = ">=0.2.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
+    { name = "h2", specifier = ">=4.0.0" },
     { name = "hiredis", specifier = ">=2.4.0" },
     { name = "httptools", specifier = ">=0.6.0" },
     { name = "huggingface-hub", specifier = ">=0.34.0" },
@@ -1363,6 +1366,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.5.0" },
@@ -1503,6 +1507,19 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -1605,6 +1622,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
@@ -1696,6 +1722,15 @@ dependencies = [
 sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/f7/e0/308849e8ff9590505815f4a300cb8941a21c5889fb94c955d992539b5bef/huggingface_hub-1.0.1.tar.gz", hash = "sha256:87b506d5b45f0d1af58df7cf8bab993ded25d6077c2e959af58444df8b9589f3", size = 419291, upload-time = "2025-10-28T12:48:43.526Z" }
 wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/db/fb/d71f914bc69e6357cbde04db62ef15497cd27926d95f03b4930997c4c390/huggingface_hub-1.0.1-py3-none-any.whl", hash = "sha256:7e255cd9b3432287a34a86933057abb1b341d20b97fb01c40cbd4e053764ae13", size = 503841, upload-time = "2025-10-28T12:48:41.821Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -3401,6 +3436,18 @@ dependencies = [
 sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.tuna.tsinghua.edu.cn/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://pypi.tuna.tsinghua.edu.cn/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://pypi.tuna.tsinghua.edu.cn/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pytest` 直接运行报 `unrecognized arguments: --timeout=60`，须手动 `-o "addopts="` 绕过。本 PR 将 pytest-timeout 声明为 dev 依赖并加入 required_plugins，配置自洽。

## 根因

`pyproject.toml` addopts 配 `--timeout=60` (line 232) + `timeout=300` (line 287)，但 dev 依赖（line 124-134）未声明 pytest-timeout → 未装包环境跑 pytest 报 unrecognized arguments。**配置与依赖解耦，无机制强制声明**。

## 修复

1. `[project.optional-dependencies] dev` 加 `pytest-timeout>=2.0.0`
2. `required_plugins` 加 `pytest-timeout`：pytest 启动期强校验插件齐全，缺则明确报 `Missing required plugins: pytest-timeout`（而非 addopts 的 unrecognized 困惑报错）；防止配置与依赖再次解耦（回归护栏）

## uv.lock 同步（CI 用 `uv sync --frozen` 严格按 lock）

- ✅ pytest-timeout 2.4.0（本 issue）
- ⚠️ h2/hpack/hyperframe：`typer[testing]>=0.9.0` 的既有传递依赖。typer 0.20 移除 `testing` extra，resolver 回退解析出 httpx→h2 链。属 lock 全量同步的副产物（**非本 issue 引入**），是 typer[testing] 独立潜伏问题，建议单独 follow-up。

## Test plan

- [x] `test_pytest_timeout_declared_in_dev_deps_when_used`：addopts 用 --timeout → dev deps 必声明
- [x] `test_pytest_timeout_in_required_plugins_when_used`：required_plugins 必含 pytest-timeout（回归护栏）
- [x] `test_pytest_timeout_plugin_is_installed`：端到端 import 验收
- [x] 三层冒烟：L1 py_compile ✅ / L2 启动路径 29 passed ✅ / L3 新测 3 passed ✅（端到端，**不绕过 addopts**）
- [ ] CI 验证：`uv sync --frozen` 装 pytest-timeout 后 pytest 不再报 unrecognized

Closes #6021
