### PR TITLE
fix: data bars 端点 order 参数映射 desc_order (#5652)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -313,7 +313,8 @@ async def get_bars(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=100, ge=1, le=500)
+    page_size: int = Query(default=100, ge=1, le=500),
+    order: Optional[str] = None,  # #5652: asc|desc，默认降序（最新在前）
 ):
     """获取K线数据列表（分页）"""
     try:
@@ -329,6 +330,11 @@ async def get_bars(
             end_dt = datetime.utcnow()
             start_dt = end_dt - timedelta(days=365)
 
+        # #5652: order 参数映射为 desc_order。
+        # 原签名无 order，FastAPI 静默丢弃 ?order=desc → 用户无法控制排序方向。
+        # asc → 升序（最旧在前）；desc / None / 无效值 → 降序（最新在前，符合验收默认）。
+        desc_order = (order or "").lower() != "asc"
+
         # 使用BarService.get方法，支持分页
         result = bar_service.get(
             code=code,
@@ -339,7 +345,7 @@ async def get_bars(
             page=page - 1,  # Service层page是0-based
             page_size=page_size,
             order_by="timestamp",
-            desc_order=True
+            desc_order=desc_order
         )
 
         if not result.is_success() or not result.data:

--- a/tests/api/test_data_bars_order.py
+++ b/tests/api/test_data_bars_order.py
@@ -1,0 +1,67 @@
+# #5652 — data/bars order 参数被忽略
+"""
+验证 GET /api/v1/data/bars?order=asc|desc 映射到 bar_service.get(desc_order)。
+
+端点原签名 (api/api/data.py get_bars) 无 order/sort 参数，
+FastAPI 静默丢弃未知 query 参数 → ?order=desc 无效，用户无法控制排序方向。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _mock_empty_result():
+    """构造 is_success=False 的 mock result，让端点走空结果早退，
+    只为捕获 service.get 的调用参数（desc_order）。"""
+    mock_result = MagicMock()
+    mock_result.is_success.return_value = False
+    mock_result.data = None
+    return mock_result
+
+
+class TestGetBarsOrderParam:
+    """get_bars 应把 order 参数映射到 service.get(desc_order=...)"""
+
+    @pytest.mark.asyncio
+    @patch("api.data.get_bar_service")
+    async def test_order_asc_maps_to_desc_order_false(self, mock_get_svc):
+        """order=asc → service.get(desc_order=False)（升序）"""
+        from api.data import get_bars
+
+        mock_svc = MagicMock()
+        mock_svc.get.return_value = _mock_empty_result()
+        mock_get_svc.return_value = mock_svc
+
+        await get_bars(code="000001.SZ", order="asc")
+
+        _, kwargs = mock_svc.get.call_args
+        assert kwargs.get("desc_order") is False, "order=asc 应映射为 desc_order=False"
+
+    @pytest.mark.asyncio
+    @patch("api.data.get_bar_service")
+    async def test_order_desc_maps_to_desc_order_true(self, mock_get_svc):
+        """order=desc → service.get(desc_order=True)（降序，最新在前）"""
+        from api.data import get_bars
+
+        mock_svc = MagicMock()
+        mock_svc.get.return_value = _mock_empty_result()
+        mock_get_svc.return_value = mock_svc
+
+        await get_bars(code="000001.SZ", order="desc")
+
+        _, kwargs = mock_svc.get.call_args
+        assert kwargs.get("desc_order") is True, "order=desc 应映射为 desc_order=True"
+
+    @pytest.mark.asyncio
+    @patch("api.data.get_bar_service")
+    async def test_no_order_defaults_to_desc(self, mock_get_svc):
+        """不传 order → 默认降序（最新在前），符合 #5652 验收点2"""
+        from api.data import get_bars
+
+        mock_svc = MagicMock()
+        mock_svc.get.return_value = _mock_empty_result()
+        mock_get_svc.return_value = mock_svc
+
+        await get_bars(code="000001.SZ")
+
+        _, kwargs = mock_svc.get.call_args
+        assert kwargs.get("desc_order") is True, "默认应降序（desc_order=True）"


### PR DESCRIPTION
## Summary

修复 #5652：`GET /api/v1/data/bars?order=asc|desc` 参数被忽略，用户无法控制排序方向。

**根因**：`api/api/data.py` 的 `get_bars` 端点签名**无 `order` 参数**。FastAPI 对未声明的 query 参数**静默丢弃**（不报 422）→ `?order=desc` 被丢弃，端点硬编码 `desc_order=True`。

**调用链**：
```
GET /api/v1/data/bars?order=asc
  → get_bars(code, start, end, page, page_size)   ❌ 签名无 order
    → FastAPI 静默丢弃 ?order=asc（未声明 ≠ 报错）
      → 硬编码 desc_order=True
        → bar_service.get(desc_order=True)
          → base_crud.find(desc_order=True)   ✅ 逻辑正确（base_crud.py:697）
```
根因在**端点层**（缺参数声明），CRUD 层 `desc_order` 逻辑正确。

**修复**：`get_bars` 加 `order: Optional[str] = None`，映射 `desc_order`：
- `asc` → `desc_order=False`（升序，最旧在前）
- `desc` / 不传 / 无效值 → `desc_order=True`（降序，最新在前，符合验收默认）

## scope

- ✅ `api/api/data.py` get_bars：加 `order` 参数 + `desc_order` 映射
- ✅ `tests/api/test_data_bars_order.py`：3 TDD 切片（asc / desc / 默认）
- ⏭️ 不改 CRUD 层（base_crud 逻辑正确，且 BaseCRUD 是禁区）

## Test plan

- [x] TDD RED→GREEN：3 切片
  - `order=asc` → `service.get(desc_order=False)`
  - `order=desc` → `service.get(desc_order=True)`
  - 不传 `order` → `desc_order=True`（默认降序，验收点 2）
- [x] 回归：`test_data_bars_500_fix` + `test_data_pagination` **6 passed**（签名加可选参数，旧调用走默认，向后兼容）
- [x] py_compile OK；变更覆盖率 `data.py` → `test_data_bars_order.py` ✓

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/api/test_data_bars_order.py -o addopts= -q
# 3 passed in 0.50s
```

Closes #5652
