### PR TITLE
fix: system status version 改 importlib.metadata 自动读 pyproject (#5406)

### DIFF
--- a/src/ginkgo/core/services/system_service.py
+++ b/src/ginkgo/core/services/system_service.py
@@ -10,9 +10,24 @@ System Service - 系统状态和基础设施管理服务
 
 from typing import Dict, Any, List
 from time import time
+from importlib.metadata import version as _installed_version, PackageNotFoundError
 
 from ginkgo.libs.core.config import GCONF
 from ginkgo.libs import GLOG
+
+
+def _read_installed_version() -> str:
+    """从已安装包 metadata 读取版本（pyproject.toml version 字段）。
+
+    #5406 验收点2: 版本应在部署时自动注入，而非硬编码常量——此前 VERSION="0.11.0"
+    与 pyproject.toml version="0.8.2" 漂移。importlib.metadata 读 pip 安装的
+    dist metadata（editable install 同步 pyproject），部署即自动取 pyproject 版本。
+    包未安装（如裸源码运行）时 fallback "unknown"。
+    """
+    try:
+        return _installed_version("ginkgo")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 class SystemService:
@@ -26,7 +41,7 @@ class SystemService:
     - 获取所有Worker/组件状态
     """
 
-    VERSION = "0.11.0"
+    VERSION = _read_installed_version()
     _start_time = time()
 
     def __init__(self):

--- a/tests/unit/core/services/test_system_service.py
+++ b/tests/unit/core/services/test_system_service.py
@@ -29,6 +29,23 @@ class TestSystemServiceConstruction:
         assert hasattr(SystemService, "VERSION")
         assert isinstance(SystemService.VERSION, str)
 
+    def test_version_read_from_package_metadata(self):
+        """#5406 验收点2: VERSION 从已安装包 metadata (pyproject.toml) 自动读取，
+        非硬编码常量——防版本漂移（曾硬编码 0.11.0 与 pyproject 0.8.2 不一致）。"""
+        from importlib.metadata import version as installed_version
+        assert SystemService.VERSION == installed_version("ginkgo"), (
+            "VERSION 应等于 pyproject.toml 声明版本（部署自动注入），非硬编码"
+        )
+
+    def test_read_version_fallback_unknown_when_not_installed(self):
+        """#5406: 包未安装时 _read_installed_version fallback "unknown"
+        （裸源码运行无 dist metadata 的兜底，不抛异常）。"""
+        from importlib.metadata import PackageNotFoundError
+        from ginkgo.core.services import system_service
+        with patch.object(system_service, "_installed_version",
+                          side_effect=PackageNotFoundError):
+            assert system_service._read_installed_version() == "unknown"
+
     def test_start_time_attribute(self):
         """启动时间属性"""
         assert hasattr(SystemService, "_start_time")


### PR DESCRIPTION
## Summary

修复 #5406：`GET /api/v1/system/status` 的 version 字段此前硬编码为类常量，与 pyproject.toml 漂移。

**验证（修复前）**：实测端点返回 `version="0.11.0"`（**非 "unknown"**——clock.py #5383 修复后，端点成功路径正常返回 `SystemService.VERSION`）。issue 描述的 "unknown" 是 clock.py SyntaxError 走端点 except 兜底的副作用，**已随 #5383 消失**。

**残留缺口（本次修）**：`SystemService.VERSION = "0.11.0"` 是**硬编码类常量**，与 `pyproject.toml version = "0.8.2"` 漂移。部署版本确认不可靠，且每次发版需手动同步两处。

**调用链**：
```
GET /api/v1/system/status
  → system.py:24 svc.get_system_status()
    → SystemService.get_system_status() L48 "version": SystemService.VERSION
      → SystemService.VERSION = "0.11.0"   ❌ 硬编码常量（与 pyproject 0.8.2 漂移）
```

**修复**：`VERSION` 改为 `importlib.metadata.version("ginkgo")` 动态读 pip 安装的 dist metadata（editable install 同步 pyproject.toml），包未安装时 fallback `"unknown"`。部署即自动取 pyproject 版本，无需手动同步。

## scope

- ✅ `system_service.py`：加 `_read_installed_version()` + `VERSION = _read_installed_version()`
- ✅ `test_system_service.py`：+2 TDD 切片
- ⏭️ 不动端点层（`system.py` except 兜底 "unknown" 保留——service 异常时的合理降级）
- ⏭️ 不动 base 禁区

## 验收对照

- [x] version 非 "unknown"：随 #5383 已满足（成功路径返 pyproject 版本 "0.8.2"）
- [x] 部署自动注入：`importlib.metadata` 读 pyproject（本次）
- [ ] `ginkgo version` CLI 与 API 一致：全仓**未找到 `ginkgo version` 命令**（pyproject 无 console_scripts，client 无 version command；CLI 入口为 `flat_cli.py` 的 get/set/list/create app）。验收点3 的 CLI 不存在——若后续新增 `ginkgo version`，复用 `SystemService.VERSION`（现已自动注入）即天然一致。此点超出本 issue 的端点修复范围。

## Test plan

- [x] TDD RED→GREEN：2 切片
  - `SystemService.VERSION == importlib.metadata.version("ginkgo")`（自动注入，修漂移）
  - `_read_installed_version()` 包未装时 fallback `"unknown"`（mock `PackageNotFoundError`）
- [x] 回归：`test_system_service.py` 全 **26 passed**（VERSION 改动不影响 `get_system_status` 现有断言）

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/core/services/test_system_service.py -o addopts= -q
# 26 passed in 0.87s
```

Closes #5406
