### PR TITLE
fix: bar_adjustment 显式排序防降序复权方向反 (#5501)

### DIFF
--- a/src/ginkgo/data/services/bar_adjustment.py
+++ b/src/ginkgo/data/services/bar_adjustment.py
@@ -159,7 +159,12 @@ def get_precomputed_adjustment_factors(
             return df_factors[['timestamp', factor_column]].copy()
         else:
             # 基于adjustfactor计算临时因子（仅用于测试）
-            if 'adjustfactor' in df_factors.columns and not df_factors.empty():
+            if 'adjustfactor' in df_factors.columns and not df_factors.empty:
+                # #5501: 上游 adjustfactor_service.get 不保证排序顺序（crud 无 order_by），
+                # 显式按 timestamp 升序后再取 latest(iloc[-1])/earliest(iloc[0])，
+                # 否则降序输入下 fore/back 复权方向反转。
+                # 另：原 df_factors.empty() 把 @property 当方法调用致 TypeError，已修正。
+                df_factors = df_factors.sort_values('timestamp').reset_index(drop=True)
                 latest_factor = df_factors['adjustfactor'].iloc[-1]
                 if adjustment_type == ADJUSTMENT_TYPES.FORE:
                     # 前复权系数 = 最新因子 / 历史因子

--- a/tests/unit/services/test_bar_adjustment_sort_order.py
+++ b/tests/unit/services/test_bar_adjustment_sort_order.py
@@ -1,0 +1,110 @@
+"""TDD for bar_adjustment sort order -- #5501
+
+get_precomputed_adjustment_factors 临时因子分支用 iloc[-1]/iloc[0] 取因子，
+假设 DataFrame 升序；上游 adjustfactor_service.get 不保证排序（crud 无 order_by），
+降序输入时 FORE/BACK 方向反。#5501 修复：显式 sort_values('timestamp')。
+
+注：仅「临时因子」测试分支受影响；生产核心 calculate_adjusted_prices /
+apply_matrix_adjustment 用 merge(on="timestamp") 顺序无关，不受影响。
+"""
+import pytest
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from ginkgo.data.services import bar_adjustment
+from ginkgo.enums import ADJUSTMENT_TYPES
+
+
+def _make_descending_factors() -> pd.DataFrame:
+    """降序（newest first）adjustfactor DataFrame，无预计算列 → 走临时因子分支。
+
+    最新日期 2025-01-03 因子 1.2 最大（正常：时间越近复权因子越大）。
+    """
+    return pd.DataFrame({
+        "timestamp": ["2025-01-03", "2025-01-02", "2025-01-01"],  # 降序
+        "adjustfactor": [1.2, 1.1, 1.0],
+    })
+
+
+def _make_mock_service(df: pd.DataFrame) -> MagicMock:
+    """构造 adjustfactor_service mock，data 支持 len() + to_dataframe()。
+
+    MagicMock 默认 __len__ 返回 0 会触发 L146 空分支，须显式配非 0。
+    """
+    mock_svc = MagicMock()
+    mock_result = MagicMock()
+    mock_result.success = True
+    mock_data = MagicMock()
+    mock_data.__len__ = MagicMock(return_value=len(df))
+    mock_data.to_dataframe.return_value = df
+    mock_result.data = mock_data
+    mock_svc.get.return_value = mock_result
+    return mock_svc
+
+
+class TestPrecomputedFactorsSortOrder:
+    """#5501: 降序输入时复权方向须正确（显式排序，不依赖上游顺序契约）。"""
+
+    def test_fore_descending_input_latest_factor_is_base(self):
+        """FORE 复权：降序输入时最新日期系数应=1.0（latest/自身）。
+
+        bug: iloc[-1] 在降序下取到最早因子(1.0)，最新日期系数=1.0/1.2≈0.833≠1。
+        修复后: 显式升序排序，iloc[-1]=1.2（最新），最新日期系数=1.2/1.2=1.0。
+        """
+        df_desc = _make_descending_factors()
+        mock_svc = _make_mock_service(df_desc)
+
+        result = bar_adjustment.get_precomputed_adjustment_factors(
+            code="000001.SZ",
+            dates=["2025-01-01", "2025-01-02", "2025-01-03"],
+            adjustment_type=ADJUSTMENT_TYPES.FORE,
+            adjustfactor_service=mock_svc,
+        )
+
+        row_latest = result[result["timestamp"] == "2025-01-03"].iloc[0]
+        assert row_latest["foreadjustfactor"] == pytest.approx(1.0), (
+            "FORE 最新日期系数应为 1.0（最新因子/自身）；降序输入下 iloc[-1] 取到最早因子致方向反"
+        )
+
+    def test_back_descending_input_earliest_factor_is_base(self):
+        """BACK 复权：降序输入时最早日期系数应=1.0（earliest/自身）。
+
+        bug: iloc[0] 在降序下取到最新因子(1.2)，最早日期系数=1.0/1.2≈0.833≠1。
+        修复后: 显式升序，iloc[0]=1.0（最早 2025-01-01），最早日期系数=1.0/1.0=1.0。
+        """
+        df_desc = _make_descending_factors()
+        mock_svc = _make_mock_service(df_desc)
+
+        result = bar_adjustment.get_precomputed_adjustment_factors(
+            code="000001.SZ",
+            dates=["2025-01-01", "2025-01-02", "2025-01-03"],
+            adjustment_type=ADJUSTMENT_TYPES.BACK,
+            adjustfactor_service=mock_svc,
+        )
+
+        row_earliest = result[result["timestamp"] == "2025-01-01"].iloc[0]
+        assert row_earliest["backadjustfactor"] == pytest.approx(1.0), (
+            "BACK 最早日期系数应为 1.0（最早因子/自身）；降序输入下 iloc[0] 取到最新因子致方向反"
+        )
+
+    def test_fore_factor_values_correct_after_sort(self):
+        """FORE 复权系数值正确性：升序排序后 latest=1.2，各日期系数=1.2/历史因子。
+
+        2025-01-01: 1.2/1.0=1.2, 2025-01-02: 1.2/1.1≈1.0909, 2025-01-03: 1.2/1.2=1.0。
+        断言全部三个值，锁死方向（非仅端点）。
+        """
+        df_desc = _make_descending_factors()
+        mock_svc = _make_mock_service(df_desc)
+
+        result = bar_adjustment.get_precomputed_adjustment_factors(
+            code="000001.SZ",
+            dates=["2025-01-01", "2025-01-02", "2025-01-03"],
+            adjustment_type=ADJUSTMENT_TYPES.FORE,
+            adjustfactor_service=mock_svc,
+        )
+        result = result.set_index("timestamp")
+
+        assert result.loc["2025-01-01", "foreadjustfactor"] == pytest.approx(1.2)
+        assert result.loc["2025-01-02", "foreadjustfactor"] == pytest.approx(1.2 / 1.1)
+        assert result.loc["2025-01-03", "foreadjustfactor"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

修复 #5501：`get_precomputed_adjustment_factors` 临时因子分支用 `iloc[-1]`/`iloc[0]` 取 latest/earliest 因子，假设 DataFrame 升序；上游 `adjustfactor_service.get` 不保证排序顺序（crud 无 `order_by`），降序输入下 FORE/BACK 复权方向反转。

**调用链**：
```
get_precomputed_adjustment_factors(code, dates, type, svc)
  → adjustfactor_service.get(...)            # 无 order_by，顺序未定义
    → result.data.to_dataframe() = df_factors
      → else 分支（无预计算列）:
        iloc[-1] = latest_factor   ❌ 假设升序（降序取到最早）
        iloc[0]  = earliest_factor ❌ 假设升序（降序取到最新）
```

**修复**：else 分支内显式 `df_factors.sort_values('timestamp').reset_index(drop=True)` 后再取位置索引。

## TDD 暴露的额外预存 bug

L162 `df_factors.empty()` 把 pandas `DataFrame.empty`（**@property 属性**，返回 bool）当方法调用 → `TypeError: 'bool' object is not callable`，被 L176 `except Exception` 吞掉返回空 DataFrame。

**后果**：else 分支**从未执行到 L163**——#5501 报的「降序方向反」表象实际不会出现（直接返回空因子）。本次一并修正 `empty()`→`empty`，让 else 分支真正可运行，排序修复才有意义。

## 影响范围（实测，issue 描述有夸大）

- ✅ **本次修**：`get_precomputed_adjustment_factors` 临时因子分支（注释「仅用于测试」）
- ⏭️ **生产核心不受影响**：`calculate_adjusted_prices`（L211 `pd.merge(on="timestamp")`）+ `apply_matrix_adjustment`（L256 merge）按 timestamp 对齐，**位置无关**，降序也能正确合并。issue 称「affecting all downstream backtests」夸大——核心复权计算用 merge 不依赖行顺序。

## scope

- ✅ `bar_adjustment.py`：else 分支加 `sort_values` + 修正 `empty()`→`empty` + 注释说明
- ✅ `tests/unit/services/test_bar_adjustment_sort_order.py`：3 TDD 切片
- ⏭️ 不动生产核心 `calculate_adjusted_prices`/`apply_matrix_adjustment`（merge 顺序无关，无需改）

## Test plan

- [x] TDD RED→GREEN：3 切片
  - FORE 降序：最新日期系数 = 1.0（latest/自身）
  - BACK 降序：最早日期系数 = 1.0（earliest/自身）
  - FORE 全值正确性：3 个日期系数锁死方向
- [x] 回归：`test_bar_adjustment_smoke.py` + 新测试 **8 passed**
- [x] py_compile OK

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/services/smoke/test_bar_adjustment_smoke.py \
    tests/unit/services/test_bar_adjustment_sort_order.py -o addopts= -q
# 8 passed in 0.09s
```

Closes #5501
