### PR TITLE
fix: PaperTradingWorker 用枚举替换 deploy mode 魔术数字 (#6029)

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -99,7 +99,8 @@ def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
         deployment_svc = _get_deployment_service()
         related = []
 
-        if mode_int == 0:  # BACKTEST: find deployed PAPER/LIVE
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+        if mode_int == PORTFOLIO_MODE_TYPES.BACKTEST.value:  # BACKTEST: find deployed PAPER/LIVE
             dep_result = deployment_svc.find_by_source_portfolio(source_portfolio_id=portfolio_id)
             deployments = dep_result.data if dep_result.is_success() else []
             if deployments:
@@ -108,7 +109,7 @@ def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
                     target_list = portfolio_svc.get(portfolio_id=dep.target_portfolio_id)
                     if target_list and target_list.data:
                         t = target_list.data[0]
-                        mode_str = "PAPER" if t.mode == 1 else "LIVE"
+                        mode_str = "PAPER" if t.mode == PORTFOLIO_MODE_TYPES.PAPER.value else "LIVE"
                         metrics = {
                             "annual_return": float(getattr(t, "annual_return", 0) or 0),
                             "max_drawdown": float(getattr(t, "max_drawdown", 0) or 0),
@@ -147,7 +148,7 @@ def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
                             related.append({
                                 "uuid": o.uuid,
                                 "name": o.name,
-                                "mode": "PAPER" if o.mode == 1 else "LIVE",
+                                "mode": "PAPER" if o.mode == PORTFOLIO_MODE_TYPES.PAPER.value else "LIVE",
                                 "state": _map_state(o.state),
                                 "annual_return": float(getattr(o, "annual_return", 0) or 0),
                                 "max_drawdown": float(getattr(o, "max_drawdown", 0) or 0),
@@ -358,7 +359,7 @@ async def get_portfolio(uuid: str):
         data = {
             "uuid": uuid,
             "name": portfolio_model.name,
-            "mode": "BACKTEST" if portfolio_model.mode == 0 else ("PAPER" if portfolio_model.mode == 1 else "LIVE"),
+            "mode": _map_mode(portfolio_model.mode),
             "state": _map_state(portfolio_model.state),
             "config_locked": portfolio_service.is_portfolio_frozen(uuid),
             "net_value": 1.0,

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -876,7 +876,7 @@ class PaperTradingWorker:
 
             # Mode 校验：只接受 PAPER 或 LIVE
             portfolio_mode = getattr(db_portfolio, 'mode', -1)
-            if portfolio_mode == 0:  # BACKTEST
+            if portfolio_mode == PORTFOLIO_MODE_TYPES.BACKTEST.value:
                 GLOG.ERROR(
                     f"[PAPER-WORKER] Cannot deploy BACKTEST portfolio {portfolio_id}. "
                     "Deploy first via DeploymentService.deploy()."

--- a/tests/api/test_portfolio_mode_mapping.py
+++ b/tests/api/test_portfolio_mode_mapping.py
@@ -1,0 +1,29 @@
+"""
+portfolio mode 字符串映射锚定测试。
+
+背景（#6029 AC2）：api/api/portfolio.py 的 mode→字符串映射原先用魔法数字内联展开，
+重构后 get-portfolio 端点（L362）复用 `_map_mode`，与 list 端点（L233）一致。
+`_map_mode` 此前无直接测试——本文件锚定其三分支契约，防止未来改动静默改变映射语义。
+"""
+import pytest
+
+
+class TestMapMode:
+    """`_map_mode(mode_value)` 把 PORTFOLIO_MODE_TYPES 数值映射为对外字符串。"""
+
+    def test_backtest(self, api_modules):
+        from api.portfolio import _map_mode
+
+        assert _map_mode(0) == "BACKTEST"
+
+    def test_paper(self, api_modules):
+        from api.portfolio import _map_mode
+
+        assert _map_mode(1) == "PAPER"
+
+    def test_live(self, api_modules):
+        from api.portfolio import _map_mode
+
+        # LIVE(2) 走 else 分支；任意非 BACKTEST/PAPER 值同样兜底为 LIVE
+        assert _map_mode(2) == "LIVE"
+        assert _map_mode(99) == "LIVE"

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -560,6 +560,36 @@ class TestDeploy:
         result = worker._handle_deploy({"portfolio_id": "p-001"})
         assert result is False
 
+    def test_deploy_rejects_backtest_mode_portfolio(self):
+        """#6029: BACKTEST mode portfolio 不应被 paper worker deploy。
+
+        _handle_deploy 的 mode 校验只接受 PAPER/LIVE，BACKTEST 必须拒绝。
+        characterization test：锁定当前拒绝行为，后续用枚举替换魔术数字 0 时此测保持绿。
+        """
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        worker = PaperTradingWorker(worker_id="test-1")
+        mock_engine = MagicMock()
+        worker._engine = mock_engine
+
+        mock_db_portfolio = MagicMock()
+        mock_db_portfolio.uuid = "p-bt-001"
+        mock_db_portfolio.mode = PORTFOLIO_MODE_TYPES.BACKTEST.value  # == 0
+
+        # 对齐真实代码路径 services.data.cruds.portfolio().find()
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = [mock_db_portfolio]
+        mock_data = MagicMock()
+        mock_data.cruds.portfolio.return_value = mock_crud
+
+        with patch("ginkgo.services", create=True) as mock_services:
+            mock_services.data = mock_data
+            result = worker._handle_deploy({"portfolio_id": "p-bt-001"})
+
+        assert result is False
+        mock_engine.add_portfolio.assert_not_called()
+
 
 class TestUnload:
     """unload 命令处理测试"""


### PR DESCRIPTION
## Summary

`PaperTradingWorker._handle_deploy` 的 BACKTEST mode 校验用魔术数字 `0` 判断，与 `# BACKTEST` 注释脱耦，有枚举重排风险。替换为 `PORTFOLIO_MODE_TYPES.BACKTEST.value`（行为保持，`value == 0`），对齐同文件 L117 已有枚举 pattern。

## 根因

L879 `if portfolio_mode == 0:  # BACKTEST` —— 魔术数字与注释解耦：若枚举重排（BACKTEST 不再是 0），代码静默错误，注释无强制力。同文件 L117 已用 `PORTFOLIO_MODE_TYPES.PAPER.value`、L23 已 import，pattern 已确立，仅 L879 落单。

## 修复

- `paper_trading_worker.py` L879：`== 0` → `== PORTFOLIO_MODE_TYPES.BACKTEST.value`，删冗余注释（枚举自描述）
- 新增 `test_deploy_rejects_backtest_mode_portfolio`（characterization test）：锁定 BACKTEST 拒绝行为，重构护栏；mock 路径对齐真实代码 `services.data.cruds.portfolio().find()`

## Test plan

- [x] L1 py_compile（src+api 全量）✅
- [x] L2 启动路径 smoke（user_crud_mock + containers + user_cli，29 passed）✅
- [x] L3 TestDeploy 3 测试（含新 characterization）全绿 ✅
- [x] stash 验证：3 个既有失败（TestDailyCycle/TestGetBaseline/TestGetDeviationConfig，Redis mock + 时间控制）在 origin/master 纯净基线**同样失败** → 既有问题，非本 PR 引入，建议单独 follow-up
- [ ] CI 验证

Closes #6029
