### PR TITLE
fix(#5962): data sync day --code 加格式校验门（拒绝无效代码非零退出）

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -433,6 +433,24 @@ def status():
     console.print(":information: Data status check not yet implemented")
 
 
+def _is_valid_stock_code(code: str) -> bool:
+    """#5962: 校验 A 股代码格式。接受项目内**两种既有记法**：
+
+    - 后缀: ``NNNNNN.SH``/``NNNNNN.SZ``（如 ``000001.SZ``，``data get stockinfo -c`` 用此）
+    - 前缀: ``SHNNNNNN``/``SZNNNNNN``（如 ``SH600000``，position/adjustfactor/tick mapper 用此）
+
+    仅做**格式**校验，不做 DB 存在性校验（后者属 service 层职责）。
+    目的：拒绝 ``INVALIDCODE`` / 裸 ``000001``（无市场标记）等明显无效输入，避免穿透到
+    service 层后以 "no data" + exit 0 的形式误报成功（见 [[arch_ashare_code_market_prefix_gap]]）。
+    """
+    import re
+    if not code:
+        return False
+    suffix = r"\d{6}\.(SH|SZ)"
+    prefix = r"(SH|SZ)\d{6}"
+    return bool(re.fullmatch(suffix, code) or re.fullmatch(prefix, code))
+
+
 @app.command()
 def sync(
     data_type: str = typer.Argument(..., help="Data type to sync (stockinfo/day/tick/adjustfactor)"),
@@ -447,6 +465,18 @@ def sync(
     """
     :repeat: Sync data from external sources.
     """
+    # #5962: --code 格式校验门。须在 try 块外，否则 typer.Exit 被外层 except(Exception) 吞
+    # 并多印 "Error updating data: 1" 噪音（见 arch_typer_exit_caught_by_except）。
+    # day/tick/adjustfactor 接受 --code；无效格式直接非零退出，避免穿透到 service 层
+    # 后以 "no data available" warning + exit 0 的形式误报成功。
+    if code is not None and data_type in ("day", "tick", "adjustfactor"):
+        if not _is_valid_stock_code(code):
+            console.print(
+                f":x: Invalid stock code '{code}'. "
+                "Expected format: NNNNNN.SH or NNNNNN.SZ (e.g. 000001.SZ, 600000.SH)."
+            )
+            raise typer.Exit(1)
+
     try:
         # 如果是daemon模式，发送Kafka消息并退出
         if daemon:

--- a/tests/unit/client/test_data_cli_sync_code_validation.py
+++ b/tests/unit/client/test_data_cli_sync_code_validation.py
@@ -1,0 +1,108 @@
+"""#5962: ginkgo data sync day --code 缺格式校验，接受 INVALIDCODE 并报告成功。
+
+验收（本 PR 聚焦格式校验，P1+P2）：
+- INVALIDCODE / 000001（缺后缀）→ 报错非零退出，不触达 bar_service
+- 000001.SZ（合法格式）→ 放行，调 bar_service.sync_smart
+
+DB 存在性校验（"code not found"）属 service 层，本 PR 不做（见 PR body scope）。
+"""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client.data_cli import app, _is_valid_stock_code
+
+runner = CliRunner()
+
+
+class TestIsValidStockCode:
+    """#5962: 格式契约 NNNNNN.SH/NNNNNN.SZ（6 位数字 + 大写交易所后缀）"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "code",
+        [
+            # 后缀记法（data get stockinfo -c 风格）
+            "000001.SZ", "600000.SH", "510300.SH", "000001.SH", "159915.SZ", "200002.SZ", "900901.SH",
+            # 前缀记法（position/adjustfactor/tick mapper 风格）
+            "SH600000", "SZ000001", "SH510300", "SZ159915",
+        ],
+    )
+    def test_accepts_valid_formats(self, code):
+        """后缀 NNNNNN.SH/NNNNNN.SZ + 前缀 SHNNNNNN/SZNNNNNN 两种项目既有记法"""
+        assert _is_valid_stock_code(code) is True, f"{code} 应合法"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "code",
+        ["INVALIDCODE", "000001", "000001.sz", "000001.sh", "00001.SZ", "0000001.SZ", "000001.HK", " 000001.SZ", "", None],
+    )
+    def test_rejects_invalid_formats(self, code):
+        """非数字/缺后缀/小写后缀/位数错/他交易所/空白/空"""
+        assert _is_valid_stock_code(code) is False, f"{repr(code)} 应非法"
+
+
+def _ok_result():
+    r = MagicMock()
+    r.is_success.return_value = True
+    r.message = "ok"
+    raw = MagicMock()
+    raw.records_added = 0
+    r.data = raw
+    return r
+
+
+class TestSyncDayCodeValidation:
+    """#5962: --code 格式校验门（try 块外，干净非零退出）"""
+
+    @pytest.mark.unit
+    def test_invalid_code_rejected_before_service(self):
+        """INVALIDCODE → 非零退出 + 不触达 bar_service（校验门先于 try）"""
+        mock_bar = MagicMock()
+        mock_bar.sync_smart.return_value = _ok_result()
+
+        with patch("ginkgo.data.containers.container.bar_service", return_value=mock_bar), \
+             patch("ginkgo.data.containers.container.stockinfo_service", return_value=MagicMock()):
+            result = runner.invoke(app, ["sync", "day", "--code", "INVALIDCODE"])
+
+        assert result.exit_code != 0, \
+            f"INVALIDCODE 应非零退出（exit={result.exit_code}）output={result.output}"
+        assert "INVALIDCODE" in result.output or "nvalid" in result.output.lower(), \
+            f"错误提示应含代码或 invalid 字样: {result.output}"
+        mock_bar.sync_smart.assert_not_called()
+
+    @pytest.mark.unit
+    def test_missing_suffix_rejected(self):
+        """000001（缺 .SH/.SZ 后缀）→ 格式错误非零退出"""
+        mock_bar = MagicMock()
+
+        with patch("ginkgo.data.containers.container.bar_service", return_value=mock_bar), \
+             patch("ginkgo.data.containers.container.stockinfo_service", return_value=MagicMock()):
+            result = runner.invoke(app, ["sync", "day", "--code", "000001"])
+
+        assert result.exit_code != 0, f"缺后缀应非零退出: {result.output}"
+        mock_bar.sync_smart.assert_not_called()
+
+    @pytest.mark.unit
+    def test_valid_code_proceeds_to_sync(self):
+        """000001.SZ（合法格式）→ 放行，bar_service.sync_smart 被调"""
+        mock_bar = MagicMock()
+        mock_bar.sync_smart.return_value = _ok_result()
+
+        with patch("ginkgo.data.containers.container.bar_service", return_value=mock_bar), \
+             patch("ginkgo.data.containers.container.stockinfo_service", return_value=MagicMock()):
+            result = runner.invoke(app, ["sync", "day", "--code", "000001.SZ"])
+
+        assert result.exit_code == 0, \
+            f"合法 code 应放行（exit={result.exit_code}）output={result.output}\nexc={result.exception}"
+        mock_bar.sync_smart.assert_called_once()
+        assert mock_bar.sync_smart.call_args.kwargs.get("code") == "000001.SZ" or \
+               mock_bar.sync_smart.call_args.args[0] == "000001.SZ"


### PR DESCRIPTION
## Summary

修复 #5962：`ginkgo data sync day --code INVALIDCODE` 接受任意字符串并报告成功（exit 0）。

**根因**：`data_cli.sync` 的 `--code` 参数零校验，原样透传到 service 层。

**调用链**：
```
ginkgo data sync day --code INVALIDCODE
  → data_cli.sync() L437
    → L512  codes = [code]   ❌ 无格式校验，原样入列
      → bar_service.sync_smart("INVALIDCODE")
        → 返回 0 记录 success → "no data available" warning
          → "Day sync completed. Success: 0, Errors: 0" + exit 0  ← 脚本无法判失败
```

**修复**：try 块外（L450 前）加格式校验门，无效格式直接 `raise typer.Exit(1)`。

**为什么在 try 外**：sync 的外层 `except Exception`（L730）会捕 `typer.Exit`（继承 Exception 非 SystemExit，见 arch_typer_exit_caught_by_except），内层 raise 会被吞并多印 `Error updating data: 1` 噪音。校验门在 try 外，干净非零退出。

## 回归暴露的格式契约（TDD 价值）

首版正则仅接受后缀 `NNNNNN.SH`（#5962 验收口径）。回归跑 `test_data_cli.py::test_sync_day_no_data_available` 红——该测试用 **前缀形式 `SH600000`**。grep 确认前缀 `SHNNNNNN`/`SZNNNNNN` 是全仓既有规范记法（position/adjustfactor/tick mapper 均用此，见 [[arch_ashare_code_market_prefix_gap]]）。

→ helper 改为**双形式兼容**（后缀 + 前缀），既满足 #5962 后缀口径，又不破坏既有前缀用法。RED-via-regression 暴露了单看 issue body 会漏掉的格式契约。

## scope

- ✅ `data_cli.py`：`_is_valid_stock_code` helper（双形式）+ try 外校验门（day/tick/adjustfactor 共用）
- ✅ `test_data_cli_sync_code_validation.py`：3 行为切片（CliRunner）+ 17 helper 参数化单元
- ⏭️ **P3 延后**：验收「`999999.SH`（不存在）报 code not found」需 DB 存在性校验（查 stock_info 表），属 service 层职责，超出本 PR 的 CLI 格式校验范围。`bar_service.sync_smart` 对不存在代码已返回 0 记录 → per-code "no data" warning（非 success）。
- ⏭️ **P4 已基本满足**：`records_added > 0` 守卫（L548-559）已防 per-code 误报 success；本 PR 的格式门进一步把无效格式挡在 service 外。

## Test plan

- [x] TDD RED→GREEN：3 行为切片
  - `INVALIDCODE` → exit≠0 + bar_service 不触达
  - `000001`（缺后缀）→ exit≠0
  - `000001.SZ`（合法）→ 放行，sync_smart 被调
- [x] helper 单元：7 合法（后缀 ETF/指数/B 股 + 前缀）× 9 非法（INVALIDCODE/裸数字/小写/位数错/他交易所/空/None）
- [x] 回归：`test_data_cli.py` + `test_data_cli_adjustfactor.py` + 新测试 **72 passed**（含前缀形式 `SH600000` 既有用例）
- [x] py_compile OK

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/client/test_data_cli_sync_code_validation.py \
    tests/unit/client/test_data_cli_adjustfactor.py \
    tests/unit/client/test_data_cli.py -o addopts= -q
# 72 passed in 0.76s
```

Closes #5962
