### PR TITLE
fix(#5920): data get day -c 前缀形式归一化（SH600000→600000.SH）

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -20,6 +20,26 @@ app = typer.Typer(help=":page_facing_up: Data management", rich_markup_mode="ric
 console = Console(emoji=True, legacy_windows=False)
 
 
+def _normalize_stock_code(code: str) -> str:
+    """#5920: 归一化 A 股代码到**后缀形式** ``NNNNNN.SH``/``NNNNNN.SZ``（DB stockinfo 存后缀）。
+
+    项目内并存两种记法（见 [[arch_ashare_code_market_prefix_gap]]）：
+    - 后缀 ``600000.SH``（stockinfo 表、data get stockinfo -c）
+    - 前缀 ``SH600000``（策略/回测组件、position/adjustfactor/tick mapper）
+
+    get（读取侧）应兼容两种，故前缀 → 后缀归一化后查询。已是后缀或无法识别的原样返回
+    （读取侧不因格式惩罚用户；无效格式交由下游 ``No bar data`` 提示）。纯字符串变换，
+    不依赖 mootdx 首位推断（前缀已带市场标记）。
+    """
+    import re
+    if not code:
+        return code
+    m = re.fullmatch(r"(SH|SZ)(\d{6})", code)
+    if m:
+        return f"{m.group(2)}.{m.group(1)}"
+    return code
+
+
 @app.command()
 def get(
     data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick/adjustfactor/sources) \\[planned: calendar]"),
@@ -251,6 +271,9 @@ def get(
             if not code:
                 console.print(":x: Stock code required for bar data")
                 raise typer.Exit(1)
+
+            # #5920: 前缀 SH600000 → 后缀 600000.SH（DB 存后缀），与策略/回测组件格式对齐
+            code = _normalize_stock_code(code)
 
             from datetime import datetime, timedelta
             if not end:

--- a/tests/unit/client/test_data_cli_get_code_normalize.py
+++ b/tests/unit/client/test_data_cli_get_code_normalize.py
@@ -1,0 +1,96 @@
+"""#5920: data get day -c SH600000 返回无数据（DB 存后缀 600000.SH）。
+
+读取侧加前缀→后缀归一化（与 #5962 写入侧校验门对偶），让前缀/后缀两种
+项目既有记法（见 arch_ashare_code_market_prefix_gap）在 get 查询时返回相同数据。
+
+验收：-c SH600000 与 -c 600000.SH 返回相同数据（归一化后查同一 DB key）。
+"""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+import pandas as pd
+
+from ginkgo.client.data_cli import app, _normalize_stock_code
+
+runner = CliRunner()
+
+
+class TestNormalizeStockCode:
+    """#5920: 前缀→后缀归一化（DB stockinfo 存后缀为事实源）"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "prefix,suffix",
+        [("SH600000", "600000.SH"), ("SZ000001", "000001.SZ"),
+         ("SH510300", "510300.SH"), ("SZ159915", "159915.SZ")],
+    )
+    def test_prefix_to_suffix(self, prefix, suffix):
+        """SHNNNNNN/SZNNNNNN → NNNNNN.SH/NNNNNN.SZ"""
+        assert _normalize_stock_code(prefix) == suffix
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("code", ["600000.SH", "000001.SZ", "510300.SH", "000001.SH"])
+    def test_suffix_unchanged(self, code):
+        """已是后缀形式 → 原样返回（幂等）"""
+        assert _normalize_stock_code(code) == code
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("code", ["INVALIDCODE", "000001", "000001.sz", "HK0001", "", None])
+    def test_unrecognized_passthrough(self, code):
+        """无法识别的格式 → 原样返回（交由下游/DB 判定，读取侧不报错）"""
+        assert _normalize_stock_code(code) == code
+
+
+class TestGetDayCodeNormalization:
+    """#5920: data get day -c 归一化后传 bar_service"""
+
+    @pytest.mark.unit
+    def test_prefix_code_normalized_before_query(self):
+        """-c SH600000 → bar_service.get_bars_df 收到 code='600000.SH'"""
+        df = pd.DataFrame({"code": ["600000.SH"], "timestamp": ["2025-01-02"],
+                           "open": [10.0], "high": [11.0], "low": [9.0],
+                           "close": [10.5], "volume": [1000], "amount": [10500.0]})
+        mock_bar = MagicMock()
+        ok = MagicMock()
+        ok.success = True
+        ok.data = df
+        mock_bar.get_bars_df.return_value = ok
+
+        with patch("ginkgo.data.containers.container.bar_service", return_value=mock_bar):
+            result = runner.invoke(app, ["get", "day", "-c", "SH600000",
+                                         "-s", "20250102", "-e", "20250110"])
+
+        assert result.exit_code == 0, \
+            f"前缀 code 应正常查询（exit={result.exit_code}）output={result.output}\nexc={result.exception}"
+        mock_bar.get_bars_df.assert_called_once()
+        called_code = mock_bar.get_bars_df.call_args.kwargs.get("code")
+        assert called_code == "600000.SH", \
+            f"SH600000 应归一化为 600000.SH 再查，实得 {called_code!r}"
+
+    @pytest.mark.unit
+    def test_suffix_code_query_unchanged(self):
+        """-c 600000.SH → bar_service.get_bars_df 收到 code='600000.SH'（回归）"""
+        df = pd.DataFrame({"code": ["600000.SH"], "timestamp": ["2025-01-02"],
+                           "open": [10.0], "high": [11.0], "low": [9.0],
+                           "close": [10.5], "volume": [1000], "amount": [10500.0]})
+        mock_bar = MagicMock()
+        ok = MagicMock()
+        ok.success = True
+        ok.data = df
+        mock_bar.get_bars_df.return_value = ok
+
+        with patch("ginkgo.data.containers.container.bar_service", return_value=mock_bar):
+            result = runner.invoke(app, ["get", "day", "-c", "600000.SH",
+                                         "-s", "20250102", "-e", "20250110"])
+
+        assert result.exit_code == 0, f"后缀 code 应正常: {result.output}"
+        called_code = mock_bar.get_bars_df.call_args.kwargs.get("code")
+        assert called_code == "600000.SH", f"后缀应原样，实得 {called_code!r}"


### PR DESCRIPTION
## Summary

修复 #5920：`data get day -c SH600000` 返回 "No bar data found"，但 `600000.SH` 正常。

**根因**：get day 分支 `code` 原样传 `bar_service.get_bars_df`，DB stockinfo 表存**后缀** `600000.SH`，前缀 `SH600000` 查不到。

**调用链**：
```
ginkgo data get day -c SH600000
  → data_cli.get() L250 day 分支
    → L263 bar_service.get_bars_df(code="SH600000")   ❌ 无归一化
      → CRUD 查 code="SH600000"
        → DB 存 "600000.SH" → 0 条 → df.empty → "No bar data"
```

**修复**：get day 分支查询前 `_normalize_stock_code(code)` 把前缀 `SH600000` → 后缀 `600000.SH`。

## 与 #5962 的对偶关系

| | #5962（sync/写入侧） | #5920（get/读取侧） |
|---|---|---|
| 问题 | 接受无效代码报成功 | 拒绝合法前缀记法 |
| 解法 | **校验门**（拒绝无效） | **归一化**（兼容双形式） |
| 方向 | 写入侧惩罚错误输入 | 读取侧兼容历史格式 |

两侧面对同一前缀/后缀双记法（见 [[arch_ashare_code_market_prefix_gap]]），但读不该惩罚用户的历史格式习惯——故 get 用归一化而非校验。归一化方向锁定前缀→后缀（DB 存后缀为事实源）。

## scope

- ✅ `data_cli.py`：`_normalize_stock_code` helper（前缀→后缀，后缀/未识别幂等）+ get day 分支接入
- ✅ `test_data_cli_get_code_normalize.py`：helper 参数化单元 + 2 行为切片（CliRunner）
- ⏭️ tick/adjustfactor get 分支同根因（也接 `--code`），但 #5920 只提 day；helper 模块级，后续同模式接入零成本
- ⏭️ 全局格式统一（建议点2「统一一种格式」）属破坏性重构，超出本 issue 范围

## Test plan

- [x] TDD RED→GREEN：helper 14 参数化（前缀→后缀 4 + 后缀幂等 4 + 未识别透传 6）+ 2 行为切片
  - `-c SH600000` → `get_bars_df` 收到 `code="600000.SH"`（归一化）
  - `-c 600000.SH` → `get_bars_df` 收到 `code="600000.SH"`（回归，幂等）
- [x] 回归：`test_data_cli.py` + `test_data_cli_adjustfactor.py` + 新测试 **64 passed**
- [x] py_compile OK

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/client/test_data_cli_get_code_normalize.py \
    tests/unit/client/test_data_cli.py \
    tests/unit/client/test_data_cli_adjustfactor.py -o addopts= -q
# 64 passed in 0.75s
```

Closes #5920
