### PR TITLE
fix(#5316): check_commands 补 is_connected 守卫防 Kafka 断连 AttributeError

### DIFF
--- a/src/ginkgo/livecore/scheduler/command_handler.py
+++ b/src/ginkgo/livecore/scheduler/command_handler.py
@@ -60,7 +60,13 @@ class CommandHandler:
         Args:
             command_consumer: GinkgoConsumer 命令消费者实例
         """
-        if not command_consumer:
+        # #5316: GinkgoConsumer 连接失败时把内部 self.consumer 置 None
+        # （ginkgo_kafka.py:202/237/242），包装对象本身仍存在。原 `if not
+        # command_consumer` 只查包装非 None，放行后 consumer.poll() 抛
+        # AttributeError 被 except 吞成每 ~5s 一条 error log。补 is_connected
+        # 守卫（对齐 notification_worker/backtest_worker/data_worker 既有模式），
+        # getattr 防属性缺失。
+        if not command_consumer or not getattr(command_consumer, "is_connected", False):
             return
 
         try:

--- a/tests/unit/livecore/test_command_handler_consumer_guard.py
+++ b/tests/unit/livecore/test_command_handler_consumer_guard.py
@@ -1,0 +1,81 @@
+# Upstream: Scheduler（持有 CommandHandler 实例，每 ~5s 调 check_commands）
+# Downstream: Kafka 断连时 command_consumer.consumer 为 None，poll 抛 AttributeError
+# Role: #5316 守护 check_commands 的连接守卫，断连不刷 error log、不碰 poll
+
+"""
+CommandHandler.check_commands 连接守卫测试（#5316）。
+
+背景：GinkgoConsumer 在 Kafka 连接失败时把内部 self.consumer 置 None
+（ginkgo_kafka.py:202/237/242），但包装对象本身仍存在。check_commands 原守卫
+`if not command_consumer` 只查包装非 None，放行后 `consumer.poll()` 抛
+AttributeError，被 except 吞成每 ~5s 一条 error log，命令永不消费。
+
+修复：守卫补 `is_connected` 检查（对齐 notification_worker:155 /
+backtest_worker/node.py:385 / data/worker/worker.py:349 既有模式），
+用 getattr 防属性缺失。
+"""
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+project_root = Path(__file__).parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+
+from ginkgo.livecore.scheduler.command_handler import CommandHandler
+import ginkgo.livecore.scheduler.command_handler as _cmd_mod
+
+
+def _make_handler() -> CommandHandler:
+    """构造 CommandHandler，8 个依赖全 MagicMock（check_commands 不触达它们）。"""
+    return CommandHandler(*[MagicMock() for _ in range(8)])
+
+
+@pytest.mark.unit
+class TestCheckCommandsConsumerGuard:
+    """#5316：Kafka 断连（内部 consumer=None）时不刷 error log、不碰 poll。"""
+
+    def test_disconnected_consumer_no_error_log(self):
+        """内部 consumer=None + is_connected=False → 守卫拦住，无 error log（#5316 核心）。"""
+        handler = _make_handler()
+        cmd_consumer = MagicMock()
+        cmd_consumer.consumer = None  # Kafka 断连：GinkgoConsumer 置内部 consumer=None
+        cmd_consumer.is_connected = False
+        with patch.object(_cmd_mod.logger, "error") as mock_error:
+            handler.check_commands(cmd_consumer)
+        mock_error.assert_not_called()
+
+    def test_disconnected_consumer_does_not_poll(self):
+        """is_connected=False → 守卫拦住，不调 poll（断连信号而非 consumer=None）。"""
+        handler = _make_handler()
+        cmd_consumer = MagicMock()
+        cmd_consumer.is_connected = False  # 断连信号：consumer 可访问但不该被碰
+        handler.check_commands(cmd_consumer)
+        cmd_consumer.consumer.poll.assert_not_called()
+
+    def test_healthy_consumer_still_polls(self):
+        """正常连接（is_connected=True, consumer 非空）仍 poll（回归，防守卫过严）。"""
+        handler = _make_handler()
+        cmd_consumer = MagicMock()
+        cmd_consumer.is_connected = True
+        cmd_consumer.consumer.poll.return_value = {}  # 无消息
+        handler.check_commands(cmd_consumer)
+        cmd_consumer.consumer.poll.assert_called_once_with(timeout_ms=1000)
+
+    def test_none_wrapper_returns_early(self):
+        """command_consumer 为 None（未初始化）直接返回，不抛（既有守卫回归）。"""
+        handler = _make_handler()
+        handler.check_commands(None)  # 不应抛 AttributeError
+
+    def test_missing_is_connected_attr_falls_back_to_skip(self):
+        """消费者对象无 is_connected 属性 → getattr 默认 False，安全跳过（防御性）。"""
+        handler = _make_handler()
+        cmd_consumer = MagicMock()
+        del cmd_consumer.is_connected  # 模拟属性不存在
+        cmd_consumer.consumer = MagicMock()
+        with patch.object(_cmd_mod.logger, "error") as mock_error:
+            handler.check_commands(cmd_consumer)
+        mock_error.assert_not_called()


### PR DESCRIPTION
## Summary

修复 #5316：Kafka 断连时 `CommandHandler.check_commands` 每 ~5s 刷一条 `Error checking commands: 'NoneType' object has no attribute 'poll'`，命令永不消费。

**根因**：`GinkgoConsumer` 在 Kafka 连接失败时把内部 `self.consumer` 置 `None`（`ginkgo_kafka.py:202/237/242`），但**包装对象本身仍存在**。`check_commands` 原守卫 `if not command_consumer: return` 只查包装非 None，放行后 `command_consumer.consumer.poll()` 即 `None.poll()` → `AttributeError`，被 L70 `except Exception` 吞成 error log。

**调用链**：
```
scheduler.loop (每 ~5s)
  → CommandHandler.check_commands(command_consumer)
    → L63 if not command_consumer: return      ❌ 包装非 None，放行
      → L67 command_consumer.consumer.poll()    ❌ 内部 consumer=None → AttributeError
        → L70 except Exception → logger.error   ← 每 5s 一条噪音，命令丢弃
```

**修复**：守卫补 `is_connected` 检查（`GinkgoConsumer.is_connected` property 确存于 `ginkgo_kafka.py:247`），用 `getattr(..., False)` 防属性缺失：

```python
if not command_consumer or not getattr(command_consumer, "is_connected", False):
    return
```

## 为何用 is_connected 而非 consumer is None

两种都能挡，但 `is_connected` 是 `GinkgoConsumer` 对外暴露的**语义化连接状态**（property 内部已综合判断 consumer 是否就绪）。直接 `consumer is None` 只防「显式置 None」，漏过「consumer 非 None 但底层连接已断」的中间态。`is_connected` 是更准确的断连信号。

## 对齐既有模式

全仓消费者守卫已在三处用 `is_connected`，scheduler 这处是遗漏：

| 文件 | 行 | 守卫 |
|---|---|---|
| `notification_worker.py` | 155 | `if not self._consumer.is_connected` |
| `backtest_worker/node.py` | 385 | `if self.task_consumer and self.task_consumer.is_connected` |
| `data/worker/worker.py` | 349 | `and getattr(self._consumer, "is_connected", False)` ← 本 PR 同款 |
| `scheduler/command_handler.py` | 63 | **（本 PR 补）** |

## scope

- ✅ `command_handler.py`：L63 守卫补 `is_connected` + 注释说明 #5316 语义层次
- ✅ `test_command_handler_consumer_guard.py`：5 TDD 切片（断连无 error log / 不 poll / 健康仍 poll / None 包装回归 / 属性缺失 fallback）
- ⏭️ 不动 L70 `except Exception`（吞异常是另一层问题，本 PR 的守卫在 try 前拦，从源头消除该路径的异常）

## Test plan

- [x] TDD RED→GREEN：核心切片
  - 断连（consumer=None, is_connected=False）→ 无 error log（修复前 `error Called 1 times`）
  - is_connected=False → 不调 poll
- [x] 回归切片：健康 consumer 仍 poll；None 包装早返回；无 is_connected 属性时 getattr fallback
- [x] 回归：`test_scheduler_components.py` + `test_scheduler_command_handler_diag.py` + 新测试 **26 passed**（含既有 `test_check_commands_poll_exception_does_not_raise`）
- [x] py_compile OK

```
GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
  python -m pytest tests/unit/livecore/test_command_handler_consumer_guard.py \
    tests/unit/livecore/test_scheduler_components.py \
    tests/unit/workers/test_scheduler_command_handler_diag.py -o addopts= -q
# 26 passed in 0.63s
```

Closes #5316
