### PR TITLE
fix(#5654): bars API 暴露 order 参数 (asc/desc，默认 desc)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -314,9 +314,15 @@ async def get_bars(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = 100
+    page_size: int = 100,
+    order: str = "desc"
 ):
-    """获取K线数据列表（分页）"""
+    """获取K线数据列表（分页）
+
+    order: 排序方向，'desc'=最新在前（默认），'asc'=最旧在前
+    """
+    if order not in ("asc", "desc"):
+        raise HTTPException(status_code=400, detail="order must be 'asc' or 'desc'")
     try:
         bar_service = get_bar_service()
 
@@ -340,7 +346,7 @@ async def get_bars(
             page=page - 1,  # Service层page是0-based
             page_size=page_size,
             order_by="timestamp",
-            desc_order=True
+            desc_order=(order == "desc")
         )
 
         if not result.is_success() or not result.data:

--- a/tests/api/test_data_bars_order_param.py
+++ b/tests/api/test_data_bars_order_param.py
@@ -1,0 +1,104 @@
+# Issue: #5654 — GET /api/v1/data/bars 无 order 参数，用户无法控制排序
+# Upstream: api.api.data.get_bars
+# Downstream: BarService.get(order_by, desc_order)
+# Role: 验证 get_bars 暴露 order 参数并正确透传 service.desc_order
+
+"""
+data/bars order 参数测试
+
+真实场景：bars endpoint 硬编码 desc_order=True，未暴露 order 参数。
+用户传 order=desc 被忽略，无法显式控制 asc/desc。
+
+修复：get_bars 加 order 参数（默认 desc），desc_order=(order == "desc")。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(data=None, success=True):
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.data = data
+    return result
+
+
+def make_bar(uuid="b1", code="000001.SZ"):
+    """模拟真实 MBar（有 uuid/code/timestamp/open 等，无 to_entities）"""
+    bar = MagicMock()
+    bar.uuid = uuid
+    bar.code = code
+    bar.timestamp = datetime(2025, 1, 1)
+    bar.open = 1.0
+    bar.high = 2.0
+    bar.low = 0.5
+    bar.close = 1.5
+    bar.volume = 100.0
+    bar.amount = 200.0
+    del bar.to_entities
+    return bar
+
+
+class TestGetBarsOrderParam:
+    """#5654: get_bars 暴露 order 参数并透传 service.desc_order"""
+
+    def test_order_asc_flips_desc_order_false(self):
+        """order=asc → service.get(desc_order=False) 升序"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[make_bar()])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            result = run_async(get_bars(order="asc"))
+
+        assert result.get("code") == 0
+        _, kwargs = mock_service.get.call_args
+        assert kwargs.get("desc_order") is False
+
+    def test_order_desc_keeps_desc_order_true(self):
+        """order=desc → service.get(desc_order=True) 降序（最新在前）"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[make_bar()])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            result = run_async(get_bars(order="desc"))
+
+        assert result.get("code") == 0
+        _, kwargs = mock_service.get.call_args
+        assert kwargs.get("desc_order") is True
+
+    def test_default_order_is_desc(self):
+        """未传 order → 默认 desc（最新在前）"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[make_bar()])
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars())
+
+        _, kwargs = mock_service.get.call_args
+        assert kwargs.get("desc_order") is True
+
+    def test_invalid_order_returns_400(self):
+        """order=invalid → 400（清晰错误，不静默）"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[make_bar()])
+
+        from api.data import get_bars
+        from fastapi import HTTPException
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            with pytest.raises(HTTPException) as exc_info:
+                run_async(get_bars(order="invalid"))
+
+        assert exc_info.value.status_code == 400


### PR DESCRIPTION
## Summary
`GET /api/v1/data/bars` 原先硬编码 `desc_order=True`（最新在前），未对外暴露排序参数。用户即使传 `order=desc` 也被忽略，无法显式取升序（最旧在前）做时间序列分析。

本 PR 给 `get_bars` 加 `order` 查询参数（默认 `desc` 保持向后兼容），透传 `BarService.get(desc_order=...)`。非法值返回 400 而非静默吞。

## 变更
- `api/api/data.py` `get_bars`：新增 `order: str = "desc"` 参数 + 白名单校验（`asc`/`desc`，否则 400）+ docstring + `desc_order=True` → `desc_order=(order == "desc")`。

## 根因
调用链：`GET /data/bars → get_bars → bar_service.get(order_by="timestamp", desc_order=True)`。`desc_order=True` 写死在 endpoint 层，service 层本已支持 `desc_order` 形参，只是 endpoint 没把用户意图传下去。

## Test plan
- [x] `test_order_asc_flips_desc_order_false`：order=asc → service.get(desc_order=False)
- [x] `test_order_desc_keeps_desc_order_true`：order=desc → service.get(desc_order=True)
- [x] `test_default_order_is_desc`：不传 → 默认 desc（向后兼容）
- [x] `test_invalid_order_returns_400`：order=invalid → 400
- [x] 回归：`test_data_bars_500_fix.py` 3 个（裸 list 处理未回归）
- [x] py_compile 全绿 / 启动路径 smoke 29 通过

采用纯函数直测（`from api.data import get_bars` + patch service），绕开 TestClient 启动（避开根 main.py 遮蔽）。

Closes #5654
