### PR TITLE
fix: portfolio 删除前校验关联回测 (#5688)

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, HTTPException, status, Query, Request
 from typing import Optional
 from core.logging import logger
 from core.response import ok, pagination_meta
-from core.exceptions import NotFoundError, ValidationError, BusinessError
+from core.exceptions import NotFoundError, ValidationError, BusinessError, ConflictError
 from datetime import datetime
 import sys
 from pathlib import Path
@@ -617,11 +617,23 @@ async def get_portfolio_events(
 
 
 @router.delete("/{uuid}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_portfolio(uuid: str):
+async def delete_portfolio(
+    uuid: str,
+    force: bool = Query(False, description="强制删除含回测的 portfolio（#5688）"),
+):
     """删除Portfolio（通过 service 层）"""
     try:
         # 获取 PortfolioService
         portfolio_service = get_portfolio_service()
+
+        # #5688: 含回测的 portfolio 误删不可恢复，删除前警告。
+        # 复用 _count_backtests（list 端点已用），有回测 + 未强制 → 409 阻止。
+        backtest_count = _count_backtests(uuid)
+        if backtest_count > 0 and not force:
+            raise ConflictError(
+                f"Portfolio has {backtest_count} backtest(s). "
+                f"Pass ?force=true to confirm deletion."
+            )
 
         # 调用 service 的 delete 方法
         result = portfolio_service.delete(portfolio_id=uuid)
@@ -631,7 +643,8 @@ async def delete_portfolio(uuid: str):
 
         logger.info(f"Portfolio {uuid} deleted successfully")
 
-    except NotFoundError:
+    except (NotFoundError, ConflictError):
+        # ConflictError 继承 APIError(Exception)，须在通用 except 前透传，否则被吞成 BusinessError
         raise
     except Exception as e:
         logger.error(f"Error deleting portfolio {uuid}: {str(e)}")

--- a/tests/api/test_portfolio_delete_backtest_guard.py
+++ b/tests/api/test_portfolio_delete_backtest_guard.py
@@ -1,0 +1,89 @@
+# #5688 — DELETE /api/v1/portfolios/{uuid} 含回测时无确认直接删，历史数据丢失
+"""
+验证 delete_portfolio 端点的回测守卫：
+- 含回测 + 未传 force → ConflictError(409)，不执行删除
+- 含回测 + force=true → 正常删除
+- 无回测 → 直接删除（默认行为回归）
+- portfolio 不存在 → NotFoundError(404)（既有行为回归）
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from core.exceptions import ConflictError, NotFoundError
+
+
+def _ok_result():
+    r = MagicMock()
+    r.is_success.return_value = True
+    return r
+
+
+def _fail_result():
+    r = MagicMock()
+    r.is_success.return_value = False
+    return r
+
+
+class TestDeletePortfolioBacktestGuard:
+    """#5688：delete_portfolio 删除前检查关联回测。"""
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio._count_backtests", return_value=3)
+    @patch("api.portfolio.get_portfolio_service")
+    async def test_backtests_without_force_raises_conflict(self, mock_svc, mock_count):
+        """含 3 条回测 + force=False → ConflictError(409)，不调 delete。"""
+        from api.portfolio import delete_portfolio
+
+        mock_svc.return_value.delete.return_value = _ok_result()
+        # 直接 await 绕过 FastAPI，force 须显式传 bool（签名默认 Query(False) 对象 truthy 会跳过守卫）
+        with pytest.raises(ConflictError) as exc:
+            await delete_portfolio("pid-1", force=False)
+        mock_svc.return_value.delete.assert_not_called()
+        assert "3" in exc.value.message  # 回测数出现在 message
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio._count_backtests", return_value=3)
+    @patch("api.portfolio.get_portfolio_service")
+    async def test_backtests_with_force_deletes(self, mock_svc, mock_count):
+        """含回测 + force=True → 强制删除，调 delete。"""
+        from api.portfolio import delete_portfolio
+
+        mock_svc.return_value.delete.return_value = _ok_result()
+        await delete_portfolio("pid-1", force=True)
+        mock_svc.return_value.delete.assert_called_once_with(portfolio_id="pid-1")
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio._count_backtests", return_value=0)
+    @patch("api.portfolio.get_portfolio_service")
+    async def test_no_backtests_deletes_without_force(self, mock_svc, mock_count):
+        """无回测 + force=False(默认) → 直接删除（回归默认行为）。"""
+        from api.portfolio import delete_portfolio
+
+        mock_svc.return_value.delete.return_value = _ok_result()
+        await delete_portfolio("pid-1")
+        mock_svc.return_value.delete.assert_called_once_with(portfolio_id="pid-1")
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio._count_backtests", return_value=0)
+    @patch("api.portfolio.get_portfolio_service")
+    async def test_not_found_raises_404(self, mock_svc, mock_count):
+        """portfolio 不存在 → NotFoundError(404)（既有行为回归）。"""
+        from api.portfolio import delete_portfolio
+
+        mock_svc.return_value.delete.return_value = _fail_result()
+        with pytest.raises(NotFoundError):
+            await delete_portfolio("missing-pid")
+
+    @pytest.mark.asyncio
+    @patch("api.portfolio._count_backtests", return_value=5)
+    @patch("api.portfolio.get_portfolio_service")
+    async def test_conflict_error_not_swallowed_by_general_except(self, mock_svc, mock_count):
+        """ConflictError 不被端点 except Exception 吞成 BusinessError(400)。"""
+        from api.portfolio import delete_portfolio
+
+        mock_svc.return_value.delete.return_value = _ok_result()
+        # 必须是 ConflictError(409) 而非被 except Exception 转成 BusinessError(400)
+        # 直接 await 同样须显式 force=False（见切片 1 注释）
+        with pytest.raises(ConflictError):
+            await delete_portfolio("pid-1", force=False)


### PR DESCRIPTION
## Summary

修复 #5688：`DELETE /api/v1/portfolios/{uuid}` 对含回测的 portfolio 无二次确认直接物理删除，关联回测历史数据丢失。

**调用链**：
```
DELETE /portfolios/{uuid}
  → delete_portfolio(uuid)
    → portfolio_service.delete(portfolio_id=uuid)   ❌ 删除前无任何关联回测检查
      → 物理删除 portfolio（回测记录成孤儿）
```

**根因**：`delete_portfolio` 端点直接调 `service.delete`，未复用同文件 `_count_backtests` helper（`list` 端点早已用它查关联回测数）。用户/API 误调即不可恢复删除。

**修复**：删除前查关联回测数，有回测 + 未显式 `force` → `ConflictError(409)` 阻止：
```
backtest_count = _count_backtests(uuid)
if backtest_count > 0 and not force:
    raise ConflictError(f"Portfolio has {backtest_count} backtest(s). Pass ?force=true to confirm deletion.")
```

- `?force=true` 显式确认 → 正常删除
- 无回测 → 直接删除（默认行为回归）

## 为何用 ConflictError(409) 而非 BusinessError(400)

409 Conflict 语义更准确（资源处于冲突状态：有关联依赖阻止删除）。`ConflictError` 已存在于 `core.exceptions`（APIError 子类，`status_code=409`）。关键陷阱：`ConflictError` 继承 `APIError(Exception)`，端点的 `except Exception` 会把它吞成 `BusinessError(400)`，所以必须 `except (NotFoundError, ConflictError): raise` 在前透传。

## scope

- ✅ `api/api/portfolio.py`：导入 `ConflictError`；`delete_portfolio` 加 `force: bool = Query(False)` 参数 + `_count_backtests` 守卫 + ConflictError 透传
- ✅ `tests/api/test_portfolio_delete_backtest_guard.py`：5 TDD 切片
  - 含回测 + force=False → ConflictError(409)，不调 delete
  - 含回测 + force=True → 强制删除
  - 无回测 → 直接删除（默认行为回归）
  - portfolio 不存在 → NotFoundError(404)（既有行为回归）
  - ConflictError 不被 except Exception 吞成 BusinessError
- ⏭️ 不改 service/CRUD 层（守卫属 API 语义，service.delete 保持纯删除）

## Test plan

- [x] TDD RED→GREEN：5 切片全绿
  ```
  GINKGO_DEBUG_MODE=TRUE PYTHONPATH=$PWD:$PWD/src \
    python -m pytest tests/api/test_portfolio_delete_backtest_guard.py \
      tests/api/test_portfolio_create_mode.py -o addopts= -q
  # 8 passed in 0.21s
  ```
- [x] py_compile OK
- [x] 回归：`test_portfolio_create_mode.py`（同端点文件创建路径）不受影响

Closes #5688
