### PR TITLE
fix(#5686): Portfolio Detail 暴露 performance metrics (与 List schema 统一)

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -93,6 +93,37 @@ def _count_backtests(portfolio_id: str) -> int:
     return 0
 
 
+def _compute_portfolio_metrics(p, mode_int: int) -> dict:
+    """计算 portfolio 的 performance metrics + 回测统计（list/detail 共用）。
+
+    backtest 模式走最新已完成回测的指标 + 回测次数；非 backtest 模式
+    取 portfolio 模型自身字段（annual_return 等）。返回统一 schema 的 dict，
+    供 list_portfolios 和 get_portfolio 共享，避免两端点 schema 漂移（#5686）。
+    """
+    from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+    if mode_int == PORTFOLIO_MODE_TYPES.BACKTEST.value:
+        metrics = _get_latest_backtest_metrics(p.uuid)
+        backtest_count = _count_backtests(p.uuid)
+    else:
+        metrics = {
+            "annual_return": float(getattr(p, "annual_return", 0) or 0),
+            "sharpe_ratio": float(getattr(p, "sharpe_ratio", 0) or 0),
+            "max_drawdown": float(getattr(p, "max_drawdown", 0) or 0),
+            "win_rate": float(getattr(p, "win_rate", 0) or 0),
+        }
+        backtest_count = 0
+
+    return {
+        "annual_return": metrics.get("annual_return"),
+        "sharpe_ratio": metrics.get("sharpe_ratio"),
+        "max_drawdown": metrics.get("max_drawdown"),
+        "win_rate": metrics.get("win_rate"),
+        "backtest_count": backtest_count,
+        "last_backtest_date": metrics.get("last_backtest_date"),
+    }
+
+
 def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
     """获取关联组合摘要"""
     try:
@@ -213,19 +244,8 @@ async def list_portfolios(
         items = []
         for p in (portfolios or []):
             mode_int = p.mode
-
-            # Performance metrics
-            if mode_int == PORTFOLIO_MODE_TYPES.BACKTEST.value:
-                metrics = _get_latest_backtest_metrics(p.uuid)
-                backtest_count = _count_backtests(p.uuid)
-            else:
-                metrics = {
-                    "annual_return": float(getattr(p, "annual_return", 0) or 0),
-                    "sharpe_ratio": float(getattr(p, "sharpe_ratio", 0) or 0),
-                    "max_drawdown": float(getattr(p, "max_drawdown", 0) or 0),
-                    "win_rate": float(getattr(p, "win_rate", 0) or 0),
-                }
-                backtest_count = 0
+            # #5686: metrics 计算提取为 _compute_portfolio_metrics，list/detail 共用
+            metrics = _compute_portfolio_metrics(p, mode_int)
 
             items.append({
                 "uuid": p.uuid,
@@ -233,12 +253,12 @@ async def list_portfolios(
                 "mode": _map_mode(p.mode),
                 "state": _map_state(p.state),
                 "config_locked": portfolio_service.is_portfolio_frozen(p.uuid),
-                "annual_return": metrics.get("annual_return"),
-                "sharpe_ratio": metrics.get("sharpe_ratio"),
-                "max_drawdown": metrics.get("max_drawdown"),
-                "win_rate": metrics.get("win_rate"),
-                "backtest_count": backtest_count,
-                "last_backtest_date": metrics.get("last_backtest_date"),
+                "annual_return": metrics["annual_return"],
+                "sharpe_ratio": metrics["sharpe_ratio"],
+                "max_drawdown": metrics["max_drawdown"],
+                "win_rate": metrics["win_rate"],
+                "backtest_count": metrics["backtest_count"],
+                "last_backtest_date": metrics["last_backtest_date"],
                 "related": _get_related_portfolios(p.uuid, mode_int),
                 "created_at": p.create_at.isoformat() if hasattr(p, 'create_at') and p.create_at else None,
             })
@@ -355,12 +375,21 @@ async def get_portfolio(uuid: str):
         from datetime import datetime
         create_at_value = portfolio_model.create_at if hasattr(portfolio_model, 'create_at') and portfolio_model.create_at else None
 
+        # #5686: detail 复用 list 的 metrics 计算，两端点 schema 统一
+        metrics = _compute_portfolio_metrics(portfolio_model, portfolio_model.mode)
+
         data = {
             "uuid": uuid,
             "name": portfolio_model.name,
             "mode": "BACKTEST" if portfolio_model.mode == 0 else ("PAPER" if portfolio_model.mode == 1 else "LIVE"),
             "state": _map_state(portfolio_model.state),
             "config_locked": portfolio_service.is_portfolio_frozen(uuid),
+            "annual_return": metrics["annual_return"],
+            "sharpe_ratio": metrics["sharpe_ratio"],
+            "max_drawdown": metrics["max_drawdown"],
+            "win_rate": metrics["win_rate"],
+            "backtest_count": metrics["backtest_count"],
+            "last_backtest_date": metrics["last_backtest_date"],
             "net_value": 1.0,
             "created_at": create_at_value.isoformat() if isinstance(create_at_value, datetime) else create_at_value,
             "initial_cash": float(portfolio_model.initial_capital) if hasattr(portfolio_model, 'initial_capital') else 100000.0,
@@ -371,6 +400,7 @@ async def get_portfolio(uuid: str):
             "sizers": sizers,
             "risk_managers": risk_managers,
             "analyzers": analyzers,
+            "related": _get_related_portfolios(uuid, portfolio_model.mode),
             "risk_alerts": []
         }
 

--- a/tests/api/test_portfolio_detail_metrics.py
+++ b/tests/api/test_portfolio_detail_metrics.py
@@ -1,0 +1,175 @@
+# Issue: #5686 — Portfolio Detail 响应缺 performance metrics（annual_return 等），与 List schema 不一致
+# Upstream: api.api.portfolio.list_portfolios (已有 metrics 计算 L209-224)
+# Downstream: _compute_portfolio_metrics (新提取 helper，list/detail 共用) + get_portfolio detail 端点
+# Role: 验证 (1) helper 在 backtest/非backtest 模式下正确计算 metrics；(2) detail 端点响应含 metrics 字段
+
+"""
+Portfolio Detail metrics schema 一致性测试
+
+真实场景：list 端点返回 annual_return/sharpe_ratio/max_drawdown/win_rate/backtest_count/
+last_backtest_date，但 detail 端点的 data dict 构造时漏了全部 metrics 字段，
+前端 detail 页拿不到 performance metrics，无法与 list 统一数据模型。
+
+修复：提取 _compute_portfolio_metrics(p, mode_int) 共享 helper（list 内联逻辑抽出），
+list + detail 共用；detail data dict 补齐 metrics + related 字段。
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestComputePortfolioMetrics:
+    """#5686 切片1: _compute_portfolio_metrics 在两种模式下正确计算 metrics"""
+
+    def test_backtest_mode_uses_latest_backtest_metrics(self):
+        """backtest 模式 → 走 _get_latest_backtest_metrics + _count_backtests"""
+        from api.portfolio import _compute_portfolio_metrics
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        p = MagicMock()
+        p.uuid = "p1"
+
+        with patch("api.portfolio._get_latest_backtest_metrics",
+                   return_value={"annual_return": 0.15, "sharpe_ratio": 1.2,
+                                 "max_drawdown": -0.1, "win_rate": 0.6,
+                                 "last_backtest_date": "2026-01-01"}), \
+             patch("api.portfolio._count_backtests", return_value=3):
+            result = _compute_portfolio_metrics(p, PORTFOLIO_MODE_TYPES.BACKTEST.value)
+
+        assert result["annual_return"] == 0.15
+        assert result["sharpe_ratio"] == 1.2
+        assert result["max_drawdown"] == -0.1
+        assert result["win_rate"] == 0.6
+        assert result["backtest_count"] == 3
+        assert result["last_backtest_date"] == "2026-01-01"
+
+    def test_non_backtest_mode_uses_model_fields(self):
+        """非 backtest 模式 → 从 portfolio 模型字段取，backtest_count=0"""
+        from api.portfolio import _compute_portfolio_metrics
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        p = MagicMock()
+        p.uuid = "p1"
+        p.annual_return = 0.08
+        p.sharpe_ratio = 0.9
+        p.max_drawdown = -0.05
+        p.win_rate = 0.55
+
+        with patch("api.portfolio._get_latest_backtest_metrics") as mock_metrics:
+            result = _compute_portfolio_metrics(p, PORTFOLIO_MODE_TYPES.LIVE.value)
+
+        assert result["annual_return"] == 0.08
+        assert result["sharpe_ratio"] == 0.9
+        assert result["max_drawdown"] == -0.05
+        assert result["win_rate"] == 0.55
+        assert result["backtest_count"] == 0
+        mock_metrics.assert_not_called()  # 非 backtest 不查回测指标
+
+    def test_returns_all_six_fields(self):
+        """返回 dict 必须含 6 个字段（schema 完整性，供 list/detail 共用）"""
+        from api.portfolio import _compute_portfolio_metrics
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        p = MagicMock()
+        p.uuid = "p1"
+        p.annual_return = 0
+        p.sharpe_ratio = 0
+        p.max_drawdown = 0
+        p.win_rate = 0
+
+        result = _compute_portfolio_metrics(p, PORTFOLIO_MODE_TYPES.LIVE.value)
+
+        required = {"annual_return", "sharpe_ratio", "max_drawdown",
+                    "win_rate", "backtest_count", "last_backtest_date"}
+        assert required.issubset(result.keys()), f"缺字段: {required - set(result.keys())}"
+
+
+def _make_portfolio_model(uuid="p1", mode=0):
+    """构造 detail 端点用的 portfolio 模型 mock"""
+    pm = MagicMock()
+    pm.uuid = uuid
+    pm.name = "test"
+    pm.mode = mode
+    pm.state = 0
+    pm.initial_capital = 100000.0
+    pm.cash = 95000.0
+    pm.create_at = None
+    return pm
+
+
+def _make_result(data, success=True):
+    r = MagicMock()
+    r.is_success = MagicMock(return_value=success)
+    r.data = data
+    return r
+
+
+class TestDetailResponseIncludesMetrics:
+    """#5686 切片2: get_portfolio (detail) 响应含 performance metrics + related（与 list 统一）"""
+
+    @pytest.mark.asyncio
+    async def test_detail_includes_all_metrics_fields(self):
+        """detail data 必须含 list 的全部 metrics 字段 + related（schema 统一）"""
+        from api.portfolio import get_portfolio
+
+        pm = _make_portfolio_model(mode=0)  # BACKTEST
+
+        ps = MagicMock()
+        ps.get.return_value = _make_result(pm)
+        ps.is_portfolio_frozen.return_value = False
+
+        ms = MagicMock()
+        ms.get_portfolio_mappings.return_value = _make_result([], success=False)
+
+        with patch("api.portfolio.get_portfolio_service", return_value=ps), \
+             patch("api.portfolio.get_mapping_service", return_value=ms), \
+             patch("api.portfolio.get_file_service", return_value=MagicMock()), \
+             patch("api.portfolio._get_latest_backtest_metrics",
+                   return_value={"annual_return": 0.12, "sharpe_ratio": 1.1,
+                                 "max_drawdown": -0.08, "win_rate": 0.55,
+                                 "last_backtest_date": "2026-06-01"}), \
+             patch("api.portfolio._count_backtests", return_value=2), \
+             patch("api.portfolio._get_related_portfolios", return_value=[]):
+            result = await get_portfolio("p1")
+
+        data = result["data"]
+        # 与 list 共享的全部字段
+        for field in ("annual_return", "sharpe_ratio", "max_drawdown",
+                      "win_rate", "backtest_count", "last_backtest_date", "related"):
+            assert field in data, f"detail 响应缺字段 {field}"
+        assert data["annual_return"] == 0.12
+        assert data["backtest_count"] == 2
+        assert data["last_backtest_date"] == "2026-06-01"
+        assert data["related"] == []
+
+
+class TestListMetricsRegression:
+    """#5686 切片3: list 端点改调 _compute_portfolio_metrics 后 metrics 不变（特征化基线）"""
+
+    @pytest.mark.asyncio
+    async def test_list_metrics_fields_preserved(self):
+        """list 响应 metrics 字段在 helper 重构后保持不变"""
+        from api.portfolio import list_portfolios
+
+        p = _make_portfolio_model(mode=0)  # BACKTEST
+        ps = MagicMock()
+        ps.list_paginated.return_value = MagicMock(
+            success=True, data={"items": [p], "total": 1})
+        ps.is_portfolio_frozen.return_value = False
+
+        with patch("api.portfolio.get_portfolio_service", return_value=ps), \
+             patch("api.portfolio._get_latest_backtest_metrics",
+                   return_value={"annual_return": 0.2, "sharpe_ratio": 1.5,
+                                 "max_drawdown": -0.12, "win_rate": 0.6,
+                                 "last_backtest_date": "2026-05-01"}), \
+             patch("api.portfolio._count_backtests", return_value=4), \
+             patch("api.portfolio._get_related_portfolios", return_value=[]):
+            result = await list_portfolios(mode=None, page=0, page_size=20, keyword=None)
+
+        item = result["data"][0]
+        assert item["annual_return"] == 0.2
+        assert item["sharpe_ratio"] == 1.5
+        assert item["max_drawdown"] == -0.12
+        assert item["win_rate"] == 0.6
+        assert item["backtest_count"] == 4
+        assert item["last_backtest_date"] == "2026-05-01"


### PR DESCRIPTION
## Summary

**#5686** Portfolio Detail 响应缺 performance metrics，与 List schema 不一致。

`list_portfolios` 已返回 `annual_return / sharpe_ratio / max_drawdown / win_rate / backtest_count / last_backtest_date`，但 `get_portfolio` (detail) 端点构造 data dict 时漏写全部 metrics + `related`，前端详情页拿不到 performance metrics。

### 根因
两处独立维护同一 metrics schema（list 内联计算 + detail 未写）必然漂移。

### 修复
- 提取 `_compute_portfolio_metrics(p, mode_int)` 共享 helper（从 list 内联逻辑抽出）：
  - BACKTEST 模式 → 查最近一次完成回测的 metrics + 回测数
  - 其余模式 → 取 portfolio 模型字段，`backtest_count=0`
- detail data dict 补齐 6 个 metrics + `related` 字段
- `list_portfolios` 重构为调用同一 helper（消除两处独立维护）

## Test plan
- [x] `tests/api/test_portfolio_detail_metrics.py` — 5 测试（helper 三模式 / detail 含全字段 / list 重构回归）
- [x] `tests/api/test_portfolio_create_mode.py` — 3 测试回归（模块未坏）
- [x] 三层冒烟：py_compile ✅ / 启动路径 smoke 29 passed ✅ / 变更相关 5 passed ✅

## 文件
- `api/api/portfolio.py` — 提取 helper + detail 连接 + list 重构（DRY）
- `tests/api/test_portfolio_detail_metrics.py` — 新增

Closes #5686
