### PR TITLE
fix(#6053): data sync adjustfactor 无数据不再误导性成功

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -689,10 +689,23 @@ def sync(
                         elif result is None:  # Some functions return None on success
                             sync_success = True
 
-                        
+
                         if sync_success:
-                            success_count += 1
-                            console.print(f":white_check_mark: {current_code} sync completed")
+                            # 仿 day 分支：从 result.data.records_added 提取实际入库条数，
+                            # 避免无数据时仍打印 ":white_check_mark: sync completed" 误导用户（#6053）。
+                            records_added = 0
+                            try:
+                                _data = getattr(result, 'data', None)
+                                raw = getattr(_data, 'records_added', 0)
+                                records_added = int(raw) if isinstance(raw, (int, float)) else 0
+                            except (AttributeError, TypeError, ValueError):
+                                records_added = 0
+                            if records_added > 0:
+                                success_count += 1
+                                console.print(f":white_check_mark: {current_code} sync completed ({records_added} records)")
+                            else:
+                                # service.sync 成功但源端无数据：不算成功计数，避免误导（#6053）
+                                console.print(f":warning: {current_code} — no adjustfactor data available from source")
 
                             # 同步完成后立即计算该股票的复权因子
                             console.print(f":information: Calculating adjustment factors for {current_code}...")

--- a/tests/unit/client/test_data_cli_adjustfactor.py
+++ b/tests/unit/client/test_data_cli_adjustfactor.py
@@ -143,3 +143,87 @@ class TestGetAdjustfactor:
 
         assert result.exit_code == 0, f"exit={result.exit_code} out={result.output}\nexc={result.exception}"
         assert "No adjustfactor data found" in result.output
+
+
+class TestSyncAdjustfactorNoDataHandling:
+    """#6053: sync adjustfactor 无数据不再误导性成功（仿 day 分支 records_added 检查）
+
+    旧代码 L685-695 用 duck typing（hasattr 'success' / result is None）判定成功，
+    service.sync 返回 success=True 但 records_added=0 时仍打印 ":white_check_mark: ... sync completed"，
+    误导用户以为同步到了数据。
+    """
+
+    @pytest.mark.unit
+    def test_sync_records_added_shown_in_success_message(self):
+        """sync 返回 records_added=5 → 成功信息应含 "(5 records)"
+
+        RED: 旧代码打印 "sync completed" 不含记录数。
+        """
+        from ginkgo.libs.data.results.data_sync_result import DataSyncResult
+
+        mock_svc = MagicMock()
+        mock_svc.sync.return_value = ServiceResult(
+            success=True,
+            message="ok",
+            data=DataSyncResult(
+                entity_type="adjustfactor",
+                entity_identifier="000001.SZ",
+                sync_range=(None, None),
+                records_processed=5,
+                records_added=5,
+                records_updated=0,
+                records_skipped=0,
+                records_failed=0,
+                sync_duration=0.1,
+                is_idempotent=True,
+                sync_strategy="incremental",
+            ),
+        )
+        mock_svc.calculate.return_value = _ok_result()
+
+        with patch("ginkgo.data.containers.container.adjustfactor_service", return_value=mock_svc):
+            result = runner.invoke(app, ["sync", "adjustfactor", "--code", "000001.SZ"])
+
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        assert "sync completed (5 records)" in result.output
+
+    @pytest.mark.unit
+    def test_sync_zero_records_warns_not_success(self):
+        """sync 返回 records_added=0 → 警告「无数据」，不计入 Success
+
+        RED: 旧代码无数据仍打印 ":white_check_mark: sync completed" 且 Success: 1。
+        """
+        from ginkgo.libs.data.results.data_sync_result import DataSyncResult
+
+        mock_svc = MagicMock()
+        mock_svc.sync.return_value = ServiceResult(
+            success=True,
+            message="ok",
+            data=DataSyncResult(
+                entity_type="adjustfactor",
+                entity_identifier="000001.SZ",
+                sync_range=(None, None),
+                records_processed=0,
+                records_added=0,
+                records_updated=0,
+                records_skipped=0,
+                records_failed=0,
+                sync_duration=0.1,
+                is_idempotent=True,
+                sync_strategy="incremental",
+            ),
+        )
+        mock_svc.calculate.return_value = _ok_result()
+
+        with patch("ginkgo.data.containers.container.adjustfactor_service", return_value=mock_svc):
+            result = runner.invoke(app, ["sync", "adjustfactor", "--code", "000001.SZ"])
+
+        assert result.exit_code == 0, \
+            f"CLI 崩溃 (exit={result.exit_code}): {result.output}\nexc={result.exception}"
+        # 无数据警告（不误报成功）
+        assert "no adjustfactor data available" in result.output
+        # 未计入成功
+        assert "Success: 0" in result.output
+        # 不应出现带记录数的成功标记
+        assert "sync completed (0 records)" not in result.output


### PR DESCRIPTION
## Summary

`ginkgo data sync adjustfactor` 在 `service.sync` 返回 `success=True` 但源端无数据（`records_added=0`）时，仍打印 `✅ {code} sync completed` 并计入 `Success` 计数，误导用户以为同步成功。#6053

**根因**：`data_cli.py` adjustfactor 分支用 duck typing（`hasattr(result,'success')` / `result is None`）判定成功，未像 day 分支那样检查 `result.data.records_added`。

**修复**：仿 day 分支（L548-562）从 `ServiceResult.data.records_added` 提取实际入库条数：
- `records_added > 0` → `✅ {code} sync completed (N records)` + Success 计数
- `records_added == 0` → `⚠️ {code} — no adjustfactor data available from source`，不计入 Success

**契约保留**：`records_added=0` 时仍调用 `adjustfactor_service.calculate()`（幂等重算 DB 已有因子），不破坏 #5868 的 sync→calculate 顺序契约。

## Test plan

- [x] `TestSyncAdjustfactorNoDataHandling::test_sync_records_added_shown_in_success_message` — records_added=5 显示 "(5 records)"
- [x] `test_sync_zero_records_warns_not_success` — records_added=0 打警告 + Success: 0
- [x] 既有 wiring 测试 `test_sync_adjustfactor_calls_service_sync_then_calculate` 仍绿（calculate 契约保留）
- [x] 三层冒烟：py_compile + 启动路径（29 passed）+ 变更相关（6 passed）

## Notes

tick 分支（data_cli.py L624 区域）存在同型 duck typing 问题，超出本 issue 范围，建议另行处理。

Closes #6053
