### PR TITLE
fix: settings api-keys 端点接 ApiKeyService 替代硬编码桩 (#5780) (#5816)

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -13,6 +13,7 @@ from ginkgo.data.models import MUserCredential, MUser
 from ginkgo.enums import CONTACT_TYPES, CONTACT_METHOD_STATUS_TYPES
 from ginkgo.data.services.notification_service import NotificationService
 from ginkgo.data.services.user_group_service import UserGroupService as DataUserGroupService
+from ginkgo.data.services.api_key_service import ApiKeyService
 from core.logging import logger
 from core.response import ok
 
@@ -39,6 +40,11 @@ def get_user_group_service():
 def get_notification_service() -> NotificationService:
     """获取NotificationService实例"""
     return NotificationService()
+
+
+def get_api_key_service() -> ApiKeyService:
+    """获取 ApiKeyService 实例（#5780/#5816: 替代硬编码桩端点）。"""
+    return container.api_key_service()
 
 
 def hash_password(password: str) -> str:
@@ -1797,33 +1803,40 @@ class APIStats(BaseModel):
 
 
 @router.get("/api-keys")
-async def list_api_keys():
-    """获取API密钥列表"""
-    # TODO: 从数据库获取API密钥
-    return ok(data=[
-        {
-            "key_id": "key-1",
-            "name": "生产环境密钥",
-            "masked_key": "ginkgo_sk_****",
-            "status": "active",
-            "expires_at": "2025-01-31T00:00:00Z",
-            "last_used": "2024-01-30T15:30:00Z"
-        }
-    ])
+async def list_api_keys(user_id: Optional[str] = None):
+    """获取API密钥列表（#5780: 接 ApiKeyService，不再返回硬编码桩）。
+
+    返回扁平数组（前端 apiKey.ts 期望 res.data 是 list），字段 uuid/key_prefix/
+    permissions_list 等对齐 service 返回，非旧桩的 key_id/masked_key。
+    """
+    result = get_api_key_service().list_api_keys(user_id=user_id)
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result.get("message", "Failed to list API keys"),
+        )
+    return ok(data=result["data"]["api_keys"])
 
 
 @router.post("/api-keys", status_code=201)
 async def create_api_key(data: dict):
-    """创建API密钥"""
-    # TODO: 创建API密钥
-    return ok(data={
-        "key_id": "new-key",
-        "name": data.get("name"),
-        "masked_key": "ginkgo_sk_****",
-        "status": "active",
-        "expires_at": None,
-        "last_used": None
-    })
+    """创建API密钥（#5816: 接 ApiKeyService，返回唯一 uuid + 完整 key_value 仅一次）。
+
+    service 生成 uuid + key_value（完整密钥仅在创建时返回一次），不再硬编码 new-key。
+    """
+    result = get_api_key_service().create_api_key(
+        name=data.get("name"),
+        permissions=data.get("permissions"),
+        description=data.get("description"),
+        expires_days=data.get("expires_days"),
+        auto_generate=data.get("auto_generate", False),
+    )
+    if not result.get("success"):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=result.get("message", "Failed to create API key"),
+        )
+    return ok(data=result["data"])
 
 
 @router.get("/api-stats")

--- a/tests/api/test_settings_api_keys.py
+++ b/tests/api/test_settings_api_keys.py
@@ -1,0 +1,156 @@
+# Issue #5780 + #5816: settings api-keys 端点接 ApiKeyService（不再返回硬编码桩）
+# Upstream: api.api.settings.list_api_keys / create_api_key
+# Downstream: ginkgo.data.services.api_key_service.ApiKeyService
+# Role: 验证 list/create 端点装配真实 ApiKeyService，返回扁平数组（前端 apiKey.ts
+#       期望 res.data 是 list，字段 uuid/key_prefix 对齐 service 非 key_id/masked_key）；
+#       create 返回唯一 uuid + key_value（仅一次），不再硬编码 new-key。
+
+"""
+#5780/#5816 回归测试：settings api-keys 端点返回硬编码桩。
+
+桩（settings.py:1799-1825）list 返固定 ``[{key_id:key-1, masked_key:...}]``、
+create 返固定 ``{key_id:new-key, masked_key:...}``，未接已存在的
+``ApiKeyService``（crud 真实查 DB，容器已注入）。前端 ``apiKey.ts`` 已按 service
+真实契约（uuid/key_prefix/permissions_list）写好，后端欠债。
+
+本测试用 ``MagicMock(spec=ApiKeyService)`` 强制 mock 只暴露真实方法，mock 返回值
+用 service 实际的裸 dict 格式（``{"success":True,"data":{...}}``，非 ServiceResult）。
+"""
+import asyncio
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.data.services.api_key_service import ApiKeyService
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(autouse=True)
+def _ensure_debug():
+    """连 test 库（Debug 模式），真实 service 冒烟隔离生产库。"""
+    GCONF.set_debug(True)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def _list_result(keys):
+    """ApiKeyService.list_api_keys 返回裸 dict（非 ServiceResult）。"""
+    return {
+        "success": True,
+        "data": {"api_keys": list(keys)},
+    }
+
+
+def _create_result(uuid="ak-uuid-1", key_value="ginkgo-abc123"):
+    """ApiKeyService.create_api_key 返回裸 dict。"""
+    return {
+        "success": True,
+        "data": {
+            "uuid": uuid,
+            "name": "TestKey",
+            "key_value": key_value,
+            "key_prefix": "ginkgo",
+            "permissions": "read",
+            "expires_at": None,
+            "is_active": True,
+            "user_id": None,
+        },
+    }
+
+
+class TestListApiKeysContract:
+    """GET /api-keys 端点契约测试（#5780）。"""
+
+    def test_returns_flat_array_from_service(self):
+        """list_api_keys 接 service，返回扁平数组（前端期望 res.data 是 list）。"""
+        mock_service = MagicMock(spec=ApiKeyService)
+        mock_service.list_api_keys.return_value = _list_result([
+            {"uuid": "k-1", "name": "Test", "key_prefix": "ginkgo"},
+        ])
+
+        from api.settings import list_api_keys
+
+        with patch("api.settings.get_api_key_service", return_value=mock_service):
+            result = run_async(list_api_keys())
+
+        assert result["code"] == 0
+        # 扁平数组，非 {"api_keys":[...]} 包装
+        assert isinstance(result["data"], list)
+        assert result["data"][0]["uuid"] == "k-1"
+
+    def test_empty_list_returns_empty_array(self):
+        """无 key 时返回空数组（非硬编码 key-1）。"""
+        mock_service = MagicMock(spec=ApiKeyService)
+        mock_service.list_api_keys.return_value = _list_result([])
+
+        from api.settings import list_api_keys
+
+        with patch("api.settings.get_api_key_service", return_value=mock_service):
+            result = run_async(list_api_keys())
+
+        assert result["code"] == 0
+        assert result["data"] == []
+
+    def test_service_failure_raises_http_exception(self):
+        """service success=False 时端点 raise HTTPException 500（不把失败当 ok 返）。"""
+        from fastapi import HTTPException
+
+        mock_service = MagicMock(spec=ApiKeyService)
+        mock_service.list_api_keys.return_value = {"success": False, "message": "DB down"}
+
+        from api.settings import list_api_keys
+
+        with patch("api.settings.get_api_key_service", return_value=mock_service):
+            with pytest.raises(HTTPException) as exc:
+                run_async(list_api_keys())
+
+        assert exc.value.status_code == 500
+
+
+class TestCreateApiKeyContract:
+    """POST /api-keys 端点契约测试（#5816）。"""
+
+    def test_returns_unique_uuid_not_new_key(self):
+        """create 返回 service 生成的唯一 uuid（不再硬编码 new-key）。"""
+        mock_service = MagicMock(spec=ApiKeyService)
+        mock_service.create_api_key.return_value = _create_result(
+            uuid="ak-real-uuid-xyz", key_value="ginkgo-secret-123"
+        )
+
+        from api.settings import create_api_key
+
+        with patch("api.settings.get_api_key_service", return_value=mock_service):
+            result = run_async(create_api_key({"name": "TestKey", "permissions": ["read"]}))
+
+        assert result["code"] == 0
+        assert result["data"]["uuid"] == "ak-real-uuid-xyz"
+        assert result["data"]["uuid"] != "new-key"  # 不再是桩的通用值
+
+    def test_returns_full_key_value_once(self):
+        """create 返回完整 key_value（仅创建时返回一次，#5816 验收）。"""
+        mock_service = MagicMock(spec=ApiKeyService)
+        mock_service.create_api_key.return_value = _create_result(key_value="ginkgo-full-secret")
+
+        from api.settings import create_api_key
+
+        with patch("api.settings.get_api_key_service", return_value=mock_service):
+            result = run_async(create_api_key({"name": "TestKey"}))
+
+        assert result["data"]["key_value"] == "ginkgo-full-secret"
+
+    def test_forwards_name_and_permissions_to_service(self):
+        """端点透传 name/permissions 给 service。"""
+        mock_service = MagicMock(spec=ApiKeyService)
+        mock_service.create_api_key.return_value = _create_result()
+
+        from api.settings import create_api_key
+
+        with patch("api.settings.get_api_key_service", return_value=mock_service):
+            run_async(create_api_key({"name": "MyKey", "permissions": ["read", "trade"]}))
+
+        mock_service.create_api_key.assert_called_once()
+        _, kwargs = mock_service.create_api_key.call_args
+        assert kwargs["name"] == "MyKey"
+        assert kwargs["permissions"] == ["read", "trade"]


### PR DESCRIPTION
## Summary

`settings.py` 的 `GET/POST /api-keys` 两端点原是 TODO 桩，返回硬编码 mock（list 固定 `key-1`/`ginkgo_sk_****`，create 固定 `new-key`），未接已存在的 `ApiKeyService`。前端 `web-ui/src/api/modules/apiKey.ts` 已按 service 真实契约（`uuid`/`key_prefix`/`permissions_list`）写好完整 CRUD+reveal+verify，后端欠债。

## 调用链

**修复前**：`GET/POST /api-keys` → `settings.py:1799-1825`（桩 `return ok(data=硬编码)`）→ 💥 未接 service

**修复后**：`GET/POST /api-keys` → `get_api_key_service()` → `ApiKeyService.list_api_keys/create_api_key` → `ApiKeyCRUD` → DB

## 改动

- `api/api/settings.py`：
  - 加 `get_api_key_service()` helper（`container.api_key_service()`，容器已注入）
  - `list_api_keys`：接 service，返回**扁平数组**（前端 `apiKey.ts:218` 期望 `res.data` 是 list），字段 `uuid/key_prefix/permissions_list/is_active/is_expired` 对齐 service
  - `create_api_key`：接 service，返回**唯一 uuid + key_value**（完整密钥仅创建时返回一次，#5816 验收），透传 `name/permissions/description/expires_days/auto_generate`
  - service `success=False` 时 raise `HTTPException(500)`（对齐 settings.py 既有异常模式）

## 字段对齐（service → 前端类型，逐字段一致）

| 端点 | service 返回 | 前端 TS 类型 |
|---|---|---|
| list | `uuid/name/key_prefix/permissions/permissions_list/is_active/is_expired/expires_at/last_used_at/created_at/description/user_id` | `ApiKey` |
| create | `uuid/name/key_value(仅一次)/key_prefix/permissions/expires_at/is_active/user_id` | `CreateApiKeyResponse` |

## Test plan

- [x] `tests/api/test_settings_api_keys.py`（6 passed）：list 扁平数组/空列表/service 失败 500；create 唯一 uuid/key_value/透传参数
- [x] Layer1 py_compile settings.py
- [x] Layer2 启动路径点名 smoke（user_crud/containers/user_cli 29 passed）
- [x] Layer3 api_key_service smoke（5 passed，接线未破坏 service）

Closes #5780
Closes #5816
