### PR TITLE
fix(#5676): 回测 fills/results 子端点返回 200

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -651,6 +651,53 @@ async def get_backtest_order_records(uuid: str):
         raise BusinessError(f"Error getting order records: {str(e)}")
 
 
+@router.get("/{uuid}/fills")
+async def get_backtest_fills(uuid: str):
+    """获取回测已成交订单填充(仅 status==FILLED 的订单子集)。
+
+    与 /orders 区分: /orders 返回全部去重订单(含未成交/已撤);
+    /fills 只返回已成交(FILLED)订单, 用于成交明细分析。
+    """
+    try:
+        task_service = get_backtest_task_service()
+        result = task_service.list_fills(uuid)
+
+        if not result.is_success():
+            return paginated(items=[], total=0,
+                             message=result.error or "Failed to retrieve fills")
+
+        items = result.data
+        total = result.metadata.get("total", 0)
+        return paginated(items=[o.dict() for o in items], total=total,
+                         page=1, page_size=max(total, 1),
+                         message="Fills retrieved successfully")
+
+    except NotFoundError:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting fills for {uuid}: {str(e)}")
+        raise BusinessError(f"Error getting fills: {str(e)}")
+
+
+@router.get("/{uuid}/results")
+async def get_backtest_results(uuid: str):
+    """获取回测运行结果摘要(组合/分析器/记录数/时间范围等聚合指标)。"""
+    try:
+        task_service = get_backtest_task_service()
+        result = task_service.get_results(uuid)
+
+        if not result.is_success():
+            return ok(data=None, message=result.error or "Failed to retrieve results")
+
+        return ok(data=result.data, message="Results retrieved successfully")
+
+    except NotFoundError:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting results for {uuid}: {str(e)}")
+        raise BusinessError(f"Error getting results: {str(e)}")
+
+
 @router.get("/{uuid}/positions")
 async def get_backtest_positions(uuid: str):
     """获取回测持仓记录"""

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -1080,6 +1080,76 @@ class BacktestTaskService(BaseService):
             GLOG.ERROR(f"list_orders failed: {e}")
             return ServiceResult.error(f"Failed to list orders: {e}")
 
+    def list_fills(self, uuid: str) -> "ServiceResult":
+        """获取回测已成交订单（fills），返回 list[BacktestOrderItem]。
+
+        fills = status==FILLED 的订单子集（订单被成交的填充语义）。
+        与 list_orders 同源（result_service.get_orders 去重订单），仅过滤成交态；
+        在 raw record 层过滤（status 字段未 str 化），兼容 int 值与 enum 实例。
+        """
+        from ginkgo.data.services.backtest_task_schemas import BacktestOrderItem
+        from ginkgo.enums import ORDERSTATUS_TYPES
+
+        try:
+            task_id, portfolio_id, err = self._resolve_task_id(uuid)
+            if err:
+                return err
+
+            from ginkgo.data.containers import container
+            result_service = container.result_service()
+            result = result_service.get_orders(task_id=task_id)
+            if not result.is_success():
+                return ServiceResult.success(data=[], message=result.error)
+
+            orders = result.data.get("data", [])
+            filled_value = ORDERSTATUS_TYPES.FILLED.value
+            filled = [o for o in orders
+                      if getattr(o, "status", None) == ORDERSTATUS_TYPES.FILLED
+                      or getattr(o, "status", None) == filled_value]
+
+            items = []
+            for o in filled:
+                items.append(BacktestOrderItem(
+                    uuid=getattr(o, "uuid", ""),
+                    portfolio_id=getattr(o, "portfolio_id", ""),
+                    engine_id=getattr(o, "engine_id", ""),
+                    task_id=getattr(o, "task_id", ""),
+                    code=getattr(o, "code", ""),
+                    direction=str(getattr(o, "direction", "")) if getattr(o, "direction", None) is not None else None,
+                    order_type=str(getattr(o, "order_type", "")) if getattr(o, "order_type", None) is not None else None,
+                    status=str(getattr(o, "status", "")) if getattr(o, "status", None) is not None else None,
+                    volume=int(getattr(o, "volume", 0) or 0),
+                    limit_price=str(getattr(o, "limit_price", 0)),
+                    transaction_price=str(getattr(o, "transaction_price", 0)),
+                    transaction_volume=int(getattr(o, "transaction_volume", 0) or 0),
+                    fee=str(getattr(o, "fee", 0)),
+                    timestamp=self._format_dt(getattr(o, "timestamp", None)),
+                ))
+
+            sr = ServiceResult.success(data=items, message="Fills retrieved")
+            sr.set_metadata("total", len(items))
+            return sr
+        except Exception as e:
+            GLOG.ERROR(f"list_fills failed: {e}")
+            return ServiceResult.error(f"Failed to list fills: {e}")
+
+    def get_results(self, uuid: str) -> "ServiceResult":
+        """获取回测运行结果摘要（portfolios/analyzers/time_range/total_records）。
+
+        透传 result_service.get_run_summary(task_id)；uuid 经 _resolve_task_id 解析。
+        """
+        try:
+            task_id, portfolio_id, err = self._resolve_task_id(uuid)
+            if err:
+                return err
+
+            from ginkgo.data.containers import container
+            result_service = container.result_service()
+            return result_service.get_run_summary(task_id)
+        except Exception as e:
+            GLOG.ERROR(f"get_results failed: {e}")
+            return ServiceResult.error(f"Failed to get results: {e}")
+
     def list_order_records(self, uuid: str) -> "ServiceResult":
         """获取回测订单记录流水(完整状态流转, 不去重), 返回 list[BacktestOrderItem]。
 

--- a/tests/api/test_backtest_fills_results_endpoint.py
+++ b/tests/api/test_backtest_fills_results_endpoint.py
@@ -1,0 +1,68 @@
+"""#5676: 新增 GET /{uuid}/fills 与 GET /{uuid}/results 端点。
+
+/fills    → task_service.list_fills(uuid)（已成交订单填充）
+/results  → task_service.get_results(uuid)（运行结果摘要）
+
+修两子端点 404。直调路由函数, mock task_service（仿 #5842 order-records 端点测试）。
+"""
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _mock_item(order_id, status):
+    m = MagicMock()
+    m.dict.return_value = {"order_id": order_id, "status": status}
+    return m
+
+
+class TestFillsEndpoint:
+    """#5676: /{uuid}/fills 端点返回已成交订单。"""
+
+    @pytest.mark.unit
+    def test_fills_calls_list_fills_and_returns_filled(self):
+        from api.backtest import get_backtest_fills
+
+        fills = [_mock_item("ord-A", 4), _mock_item("ord-B", 4)]
+        sr = ServiceResult(success=True, data=fills)
+        sr.set_metadata("total", 2)
+
+        task_service = MagicMock()
+        task_service.list_fills.return_value = sr
+
+        with patch("api.backtest.get_backtest_task_service", return_value=task_service):
+            resp = asyncio.run(get_backtest_fills("any-uuid"))
+
+        # 路由调用 list_fills（非 list_orders）
+        task_service.list_fills.assert_called_once_with("any-uuid")
+        assert len(resp["data"]) == 2
+        assert resp["meta"]["total"] == 2
+
+
+class TestResultsEndpoint:
+    """#5676: /{uuid}/results 端点返回运行结果摘要(dict, 非 list)。"""
+
+    @pytest.mark.unit
+    def test_results_calls_get_results_and_returns_summary(self):
+        from api.backtest import get_backtest_results
+
+        summary = {
+            "task_id": "task-1", "engine_id": "eng-1",
+            "portfolio_count": 1, "total_records": 10,
+        }
+        sr = ServiceResult(success=True, data=summary)
+
+        task_service = MagicMock()
+        task_service.get_results.return_value = sr
+
+        with patch("api.backtest.get_backtest_task_service", return_value=task_service):
+            resp = asyncio.run(get_backtest_results("any-uuid"))
+
+        # 路由调用 get_results（透传 uuid）
+        task_service.get_results.assert_called_once_with("any-uuid")
+        # results 是摘要 dict, 用 ok() 包装 → data 直接是 summary（无 meta 分页）
+        assert resp["data"] == summary
+        assert "meta" not in resp, "results 是单个摘要, 不应带分页 meta"

--- a/tests/unit/services/test_backtest_task_service_fills_results.py
+++ b/tests/unit/services/test_backtest_task_service_fills_results.py
@@ -1,0 +1,101 @@
+"""#5676: task_service 层 fills/results 双端点数据源。
+
+list_fills  → result_service.get_orders(task_id) 后过滤 status==FILLED（已成交订单子集）
+get_results → result_service.get_run_summary(task_id)（运行结果摘要）
+
+修 /backtests/{uuid}/fills 与 /backtests/{uuid}/results 返回 404（端点未实现）。
+"""
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.enums import ORDERSTATUS_TYPES
+
+
+def _rec(order_id: str, status: int, day: int):
+    return SimpleNamespace(
+        uuid=f"u-{order_id}-{status}", order_id=order_id,
+        portfolio_id="port-1", engine_id="eng-1", task_id="task-1",
+        code="000001.SZ", direction=1, order_type=1, status=status,
+        volume=100, limit_price=10.0, transaction_price=10.0,
+        transaction_volume=100, fee=5.0,
+        timestamp=datetime.datetime(2025, 6, day, 9, 30),
+    )
+
+
+class TestListFillsFiltersFilled:
+    """#5676: list_fills 只返回 status==FILLED 的订单（成交填充）。"""
+
+    @pytest.mark.unit
+    def test_list_fills_returns_only_filled_orders(self):
+        """去重订单含 FILLED + CANCELED → list_fills 仅返 FILLED。
+
+        RED: list_fills 方法不存在。
+        """
+        svc = BacktestTaskService(MagicMock())
+
+        # 去重订单: 2 个 FILLED + 1 个 CANCELED(status=2)
+        deduped = [
+            _rec("ord-A", ORDERSTATUS_TYPES.FILLED.value, 3),
+            _rec("ord-B", ORDERSTATUS_TYPES.FILLED.value, 4),
+            _rec("ord-C", 2, 2),  # CANCELED，非成交
+        ]
+        result_svc = MagicMock()
+        result_svc.get_orders.return_value = ServiceResult(
+            success=True, data={"data": deduped, "total": 3})
+
+        container = MagicMock()
+        container.result_service.return_value = result_svc
+
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            fills = svc.list_fills("any-uuid")
+
+        assert fills.is_success()
+        # 仅 2 个 FILLED（CANCELED 被过滤）
+        assert len(fills.data) == 2, "list_fills 应只返回 FILLED 订单"
+        assert fills.metadata.get("total") == 2
+        # 走 get_orders 源（与 list_orders 同源，非另查）
+        result_svc.get_orders.assert_called_once()
+
+
+class TestGetResultsSummary:
+    """#5676: get_results 透传 result_service.get_run_summary 的运行摘要。"""
+
+    @pytest.mark.unit
+    def test_get_results_returns_run_summary(self):
+        """get_results(uuid) → _resolve_task_id → result_service.get_run_summary(task_id)。
+
+        RED: get_results 方法不存在。
+        """
+        svc = BacktestTaskService(MagicMock())
+
+        summary = {
+            "task_id": "task-1", "engine_id": "eng-1",
+            "portfolio_count": 1, "portfolios": ["port-1"],
+            "analyzer_count": 1, "analyzers": ["SharpeRatio"],
+            "total_records": 10,
+            "time_range": {"start": "2025-06-01", "end": "2025-06-30"},
+        }
+        result_svc = MagicMock()
+        result_svc.get_run_summary.return_value = ServiceResult(
+            success=True, data=summary)
+
+        container = MagicMock()
+        container.result_service.return_value = result_svc
+
+        with patch.object(svc, "_resolve_task_id",
+                          return_value=("task-1", "port-1", None)), \
+             patch("ginkgo.data.containers.container", container):
+            res = svc.get_results("any-uuid")
+
+        assert res.is_success()
+        assert res.data == summary
+        # 透传 task_id（非 uuid）
+        result_svc.get_run_summary.assert_called_once_with("task-1")
+


### PR DESCRIPTION
## Summary

#5676: `GET /backtests/{uuid}/fills` 与 `GET /backtests/{uuid}/results` 返回 404（端点未实现）。

补齐两个子端点 + 对应 service 方法：

- **service 层** (`backtest_task_service.py`)
  - `list_fills(uuid)`: 复用 `list_orders` 的去重转换路径，在 RAW record 层过滤 `status == ORDERSTATUS_TYPES.FILLED`（4），只返回已成交订单
  - `get_results(uuid)`: `_resolve_task_id` 后透传 `result_service.get_run_summary(task_id)`，返回组合/分析器/记录数/时间范围摘要
- **端点层** (`api/api/backtest.py`)
  - `GET /{uuid}/fills`: `paginated` 包装（列表语义，带 total meta）
  - `GET /{uuid}/results`: `ok` 包装（单个摘要 dict，非列表，无分页 meta）

## Root cause

两子端点从未实现（路由表缺失），前端/CLI 调用直接 404。非逻辑错误，纯缺口。

## Test plan

- [x] `tests/unit/services/test_backtest_task_service_fills_results.py`：list_fills 过滤 FILLED（2 FILLED + 1 CANCELED → 仅返 2）；get_results 透传 get_run_summary(task_id)
- [x] `tests/api/test_backtest_fills_results_endpoint.py`：fills 端点调 list_fills + paginated；results 端点调 get_results + ok（无 meta）
- [x] L1 py_compile (src+api) 通过
- [x] L2 启动路径 smoke (user_crud_mock + containers + user_cli, 29 passed)
- [x] L3 变更相关测试单跑全绿（api/unit 分跑规避 core.logging 命名空间污染）

Closes #5676
