### PR TITLE
fix(#6048): trading positions/orders 接 StockinfoService 填充股票名称

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -130,7 +130,9 @@ def _resolve_stock_names(codes: list) -> dict:
     for code in unique_codes:
         result = svc.get_stockinfos(code=code)
         if result.success and result.data:
-            name = getattr(result.data[0], 'name', '') or ''
+            # StockInfo Entity 中文字段是 code_name（非 name，arch_stockinfo_entity_code_name_field）。
+            # 出口 API key 仍为 "name"（前端契约），值从 code_name 取。
+            name = getattr(result.data[0], 'code_name', '') or ''
             if name:
                 names[code] = name
     return names

--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -110,6 +110,32 @@ def _get_kafka_producer():
     return GinkgoProducer()
 
 
+def _get_stockinfo_service():
+    """获取 StockinfoService 实例（#6048: 查询股票名称）。"""
+    from ginkgo.data.containers import container
+    return container.stockinfo_service()
+
+
+def _resolve_stock_names(codes: list) -> dict:
+    """批量查询股票名称，返回 {code: name}（#6048）。
+
+    去重后逐 code 查询，避免 N+1（同类陷阱见 #5675 settings user-groups）。
+    未查到的 code 不进 dict，消费方用 ``names.get(code, "")`` 降级为空。
+    """
+    unique_codes = {c for c in codes if c}
+    if not unique_codes:
+        return {}
+    svc = _get_stockinfo_service()
+    names = {}
+    for code in unique_codes:
+        result = svc.get_stockinfos(code=code)
+        if result.success and result.data:
+            name = getattr(result.data[0], 'name', '') or ''
+            if name:
+                names[code] = name
+    return names
+
+
 def _format_datetime(dt) -> Optional[str]:
     """安全格式化 datetime 对象为 ISO 字符串"""
     if dt is None:
@@ -541,8 +567,12 @@ def _query_positions(account_id: str) -> list:
         positions_result = result_service.get_current_positions(account_id, min_volume=1)
         records = positions_result.data if positions_result.success else []
 
+        # #6048: 批量查股票名称（去重避免 N+1）
+        names = _resolve_stock_names([getattr(r, 'code', '') for r in (records or [])])
+
         positions = []
         for r in (records or []):
+            code = getattr(r, 'code', '')
             cost = float(getattr(r, 'cost', 0) or 0)
             price = float(getattr(r, 'price', 0) or 0)
             volume = int(getattr(r, 'volume', 0) or 0)
@@ -552,8 +582,8 @@ def _query_positions(account_id: str) -> list:
             pnl_ratio = (pnl / cost * 100) if cost > 0 else 0
 
             positions.append({
-                "code": getattr(r, 'code', ''),
-                "name": "",  # TODO: 从 stock_info 查询股票名称
+                "code": code,
+                "name": names.get(code, ""),  # #6048: 从 stock_info 查询
                 "shares": volume,
                 "cost": round(cost, 4),
                 "current": round(price, 4),
@@ -597,6 +627,9 @@ def _query_orders(account_id: str, status_filter: Optional[List[str]] = None) ->
         )
         records = orders_result.data.get("data", []) if orders_result.success else []
 
+        # #6048: 批量查股票名称（去重避免 N+1）
+        names = _resolve_stock_names([getattr(r, 'code', '') for r in (records or [])])
+
         orders = []
         for r in (records or []):
             direction = getattr(r, 'direction', 0)
@@ -604,13 +637,14 @@ def _query_orders(account_id: str, status_filter: Optional[List[str]] = None) ->
             side = "buy" if direction_value == 1 else "sell"
 
             order_id = getattr(r, 'uuid', '') or getattr(r, 'order_id', '')
+            code = getattr(r, 'code', '')
 
             orders.append({
                 "order_id": order_id,
                 "strategy_id": "",
                 "account_id": account_id,
-                "code": getattr(r, 'code', ''),
-                "name": "",  # TODO: 从 stock_info 查询
+                "code": code,
+                "name": names.get(code, ""),  # #6048: 从 stock_info 查询
                 "side": side,
                 "price": float(getattr(r, 'limit_price', 0) or 0),
                 "volume": int(getattr(r, 'volume', 0) or 0),

--- a/tests/api/test_trading_stock_name.py
+++ b/tests/api/test_trading_stock_name.py
@@ -46,7 +46,9 @@ def _order(code="000001"):
 
 
 def _stock(code="000001", name="平安银行"):
-    return SimpleNamespace(code=code, name=name)
+    # StockInfo Entity 中文字段是 code_name（非 name，arch_stockinfo_entity_code_name_field）；
+    # SimpleNamespace 用 code_name 属性名对齐真实结构，避免伪造 name 属性掩盖提取 bug。
+    return SimpleNamespace(code=code, code_name=name)
 
 
 class TestQueryPositionsStockName:

--- a/tests/api/test_trading_stock_name.py
+++ b/tests/api/test_trading_stock_name.py
@@ -1,0 +1,132 @@
+# Issue #6048: trading API 股票名称查询（_query_positions/_query_orders 接 StockinfoService）
+# Upstream: api.api.trading._query_positions / _query_orders
+# Downstream: ginkgo.data.services.stockinfo_service.StockinfoService.get_stockinfos
+# Role: 验证 positions/orders 返回的 name 从 stock_info 真实查询（不再硬编码 ""）。
+
+"""
+#6048 子集测试：trading 端点股票名称硬编码空。
+
+``_query_positions`` (trading.py:556) 和 ``_query_orders`` (trading.py:613) 的
+``name`` 字段是 TODO 桩（固定 ""），未接已存在的 ``StockinfoService``（容器已注入，
+``get_stockinfos(code=)`` 返 ``ServiceResult.success(data=[StockInfo])``）。
+
+本测试 mock result_service + stockinfo_service，断言 name 从 stockinfo 填充，
+未查到的 code 降级为 ""（不崩）。
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.data.services.stockinfo_service import StockinfoService
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(autouse=True)
+def _ensure_debug():
+    GCONF.set_debug(True)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def _pos(code="000001", cost=10.0, price=11.0, volume=100):
+    return SimpleNamespace(code=code, cost=cost, price=price, volume=volume)
+
+
+def _order(code="000001"):
+    return SimpleNamespace(
+        code=code, direction=1, uuid="ord-1", limit_price=10.0, volume=100,
+        transaction_volume=100, transaction_price=10.0, status=1,
+        business_timestamp=None,
+    )
+
+
+def _stock(code="000001", name="平安银行"):
+    return SimpleNamespace(code=code, name=name)
+
+
+class TestQueryPositionsStockName:
+    """_query_positions 从 stockinfo 填充 name（#6048）。"""
+
+    def test_fills_name_from_stockinfo(self):
+        """position name 从 StockinfoService 查询填充（不再 ""）。"""
+        mock_result = MagicMock()
+        mock_result.get_current_positions.return_value = ServiceResult.success(
+            data=[_pos(code="000001")]
+        )
+        mock_stockinfo = MagicMock(spec=StockinfoService)
+        mock_stockinfo.get_stockinfos.return_value = ServiceResult.success(
+            data=[_stock(code="000001", name="平安银行")]
+        )
+
+        from api.trading import _query_positions
+
+        with patch("api.trading._get_result_service", return_value=mock_result), \
+             patch("api.trading._get_stockinfo_service", return_value=mock_stockinfo):
+            positions = _query_positions("acc-1")
+
+        assert len(positions) == 1
+        assert positions[0]["name"] == "平安银行"
+
+    def test_unknown_code_name_falls_back_to_empty(self):
+        """stockinfo 未查到的 code，name 降级为 ""（不崩）。"""
+        mock_result = MagicMock()
+        mock_result.get_current_positions.return_value = ServiceResult.success(
+            data=[_pos(code="999999")]
+        )
+        mock_stockinfo = MagicMock(spec=StockinfoService)
+        mock_stockinfo.get_stockinfos.return_value = ServiceResult.success(data=[])  # 未查到
+
+        from api.trading import _query_positions
+
+        with patch("api.trading._get_result_service", return_value=mock_result), \
+             patch("api.trading._get_stockinfo_service", return_value=mock_stockinfo):
+            positions = _query_positions("acc-1")
+
+        assert positions[0]["name"] == ""
+
+
+class TestQueryOrdersStockName:
+    """_query_orders 从 stockinfo 填充 name（#6048）。"""
+
+    def test_fills_name_from_stockinfo(self):
+        """order name 从 StockinfoService 查询填充（不再 ""）。"""
+        mock_result = MagicMock()
+        mock_result.get_orders_by_portfolio.return_value = ServiceResult.success(
+            data={"data": [_order(code="600000")]}
+        )
+        mock_stockinfo = MagicMock(spec=StockinfoService)
+        mock_stockinfo.get_stockinfos.return_value = ServiceResult.success(
+            data=[_stock(code="600000", name="浦发银行")]
+        )
+
+        from api.trading import _query_orders
+
+        with patch("api.trading._get_result_service", return_value=mock_result), \
+             patch("api.trading._get_stockinfo_service", return_value=mock_stockinfo):
+            orders = _query_orders("acc-1")
+
+        assert len(orders) >= 1
+        assert orders[0]["name"] == "浦发银行"
+
+    def test_distinct_codes_dedup_stockinfo_queries(self):
+        """多个 position 同 code 去重查询（避免 N+1，#5675 同类陷阱）。"""
+        mock_result = MagicMock()
+        mock_result.get_current_positions.return_value = ServiceResult.success(
+            data=[_pos(code="000001"), _pos(code="000001"), _pos(code="000002")]
+        )
+        mock_stockinfo = MagicMock(spec=StockinfoService)
+        mock_stockinfo.get_stockinfos.return_value = ServiceResult.success(data=[])
+
+        from api.trading import _query_positions
+
+        with patch("api.trading._get_result_service", return_value=mock_result), \
+             patch("api.trading._get_stockinfo_service", return_value=mock_stockinfo):
+            _query_positions("acc-1")
+
+        # 去重后只查 2 次（000001 + 000002），不是 3 次
+        assert mock_stockinfo.get_stockinfos.call_count == 2


### PR DESCRIPTION
## Summary

`trading.py` 的 `_query_positions`(L556) 和 `_query_orders`(L613) 的 `name` 字段是 TODO 桩（固定 `""`），未接已存在的 `StockinfoService`。前端 trading 面板的持仓/订单列表股票名称永远为空。

**这是 #6048 的子集（2/6 字段）**。`position_value`/`daily_return`/`today_trades`/`pnl` 涉及计算逻辑（持仓市值求和、盈亏历史对比、当日成交过滤），留后续 slice 单独处理。

## 改动

- `api/api/trading.py`：
  - 加 `_get_stockinfo_service()` getter（`container.stockinfo_service()`，容器已注入）
  - 加 `_resolve_stock_names(codes)` helper：**去重批量查**避免 N+1（同类陷阱见 #5675 settings user-groups），未查到的 code 降级为空不崩
  - `_query_positions`：循环前批量查 names，`"name": names.get(code, "")`
  - `_query_orders`：同模式

## Test plan

- [x] `tests/api/test_trading_stock_name.py`（4 passed）：
  - positions 填充 name / 未查到降级空
  - orders 填充 name
  - 同 code 去重查询（N+1 防护，2 次 query 非 3 次）
- [x] Layer1 py_compile trading.py
- [x] Layer2 启动路径点名 smoke（29 passed）
- [x] Layer3 既有 `test_paper_trading_status.py`（6 passed，未破坏）

## 后续 slice（#6048 剩余 4 字段）

- `position_value`/`total_asset`：`_query_positions` 已算 `market_value`，list 端点求和即可（接线 + 求和）
- `today_pnl`/`total_pnl`：盈亏计算，需 result_service 历史数据
- `daily_return`：前日市值对比
- `today_trades`：order_record 当日成交过滤
