### PR TITLE
fix(#5562): backtest cleanup MySQL 组单事务原子化

### DIFF
--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -605,26 +605,53 @@ class BacktestTaskService(BaseService):
 
             GLOG.INFO(f"Cleaning old data for task_id: {task_id[:8]}...")
 
-            # 清理与 task_id 关联的所有历史数据（CRUD 由容器注入）
-            _cleanup_cruds = [
-                ("signal",          self._signal_crud),
+            # 库归属分组（_is_clickhouse 运行时属性为裁判，非 CRUD 注释）：
+            #   MySQL 4 个：共享单事务，任一失败全 rollback，cleanup 失败则不启动回测
+            #   ClickHouse 5 个：CH 无事务（ALTER DELETE 异步 mutation），best-effort 删除+告警，不阻断
+            # 设计变更见 #5562：原逐表 try-except 半清理仍启动 → 新回测用残留数据致结果污染。
+            # driver 经 get_db_connection 单例返回，4 个 MySQL CRUD 共享同一 session_factory。
+            _mysql_cleanups = [
                 ("order",           self._order_crud),
                 ("position",        self._position_crud),
+                ("transfer",        self._transfer_crud),
+                ("signal_tracker",  self._signal_tracker_crud),
+            ]
+            _click_cleanups = [
+                ("signal",          self._signal_crud),
                 ("position_record", self._position_record_crud),
                 ("analyzer_record", self._analyzer_record_crud),
                 ("order_record",    self._order_record_crud),
                 ("transfer_record", self._transfer_record_crud),
-                ("transfer",        self._transfer_crud),
-                ("signal_tracker",  self._signal_tracker_crud),
             ]
-            for name, crud in _cleanup_cruds:
-                # CRUD 未注入时走 None.remove() → AttributeError → except 转 WARN
-                # （刻意不静默跳过：清理路径缺注必须大声告警，否则旧数据残留致回测静默污染）
+
+            # ClickHouse 无事务：尽力删除，失败告警不阻断（CH 固有限制，无回滚能力）
+            for name, crud in _click_cleanups:
                 try:
                     crud.remove(filters={"task_id": task_id})
-                    GLOG.DEBUG(f"Deleted old {name}")
+                    GLOG.DEBUG(f"Deleted old {name} (clickhouse)")
                 except Exception as e:
-                    GLOG.WARN(f"Failed to delete {name}: {e}")
+                    GLOG.WARN(f"Failed to delete {name} (clickhouse, no rollback): {e}")
+
+            # MySQL 4 个：None 告警跳过，其余共享单事务（任一失败全 rollback）
+            # （清理路径缺注必须大声告警，否则旧数据残留致回测静默污染）
+            _mysql_present = []
+            for name, crud in _mysql_cleanups:
+                if crud is None:
+                    GLOG.WARN(f"Failed to delete {name}: CRUD not injected")
+                else:
+                    _mysql_present.append((name, crud))
+
+            if _mysql_present:
+                try:
+                    # 4 个 MySQL CRUD 共享同一 driver 单例 → 同一 session_factory → 单事务
+                    _mysql_driver = _mysql_present[0][1]._get_connection()
+                    with _mysql_driver.get_session() as _cleanup_session:
+                        for name, crud in _mysql_present:
+                            crud.remove(filters={"task_id": task_id}, session=_cleanup_session)
+                            GLOG.DEBUG(f"Deleted old {name} (mysql, in transaction)")
+                except Exception as e:
+                    GLOG.ERROR(f"MySQL cleanup transaction failed (rolled back): {e}")
+                    return ServiceResult.error(f"Cleanup failed and rolled back: {str(e)}")
 
             # 发送启动命令到Kafka（task_id 保持不变）
             from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer

--- a/tests/unit/data/services/test_backtest_task_rerun_cleanup.py
+++ b/tests/unit/data/services/test_backtest_task_rerun_cleanup.py
@@ -88,16 +88,32 @@ class TestRerunCleanupLoop:
 
     @pytest.mark.unit
     def test_all_nine_cruds_remove_called_with_task_id(self):
-        """重跑时 9 个注入 CRUD 全部以 filters={"task_id": task_id} 调用 remove"""
+        """重跑时 9 个注入 CRUD 全部以 filters={"task_id": task_id} 调用 remove
+
+        MySQL 4 个额外传 session（共享单事务，#5562）；CH 5 个无 session（CH 无事务）。
+        filters 契约对 9 个一致，session 按库归属区分。
+        """
         svc, cruds = _make_service_with_cruds()
+        # MySQL 组走 driver.get_session() 事务，需装上 contextmanager 否则 with MagicMock() 失败
+        TestRerunCleanupAtomicity._wire_mysql_transaction(cruds)
         task = svc._crud_repo.get_by_uuid.return_value
 
         with _mock_kafka_and_container():
             svc.start_task(uuid="uuid-1234")
 
-        for name, crud in cruds.items():
+        mysql_names = TestRerunCleanupAtomicity.MYSQL_CRUD_NAMES
+        click_names = TestRerunCleanupAtomicity.CLICK_CRUD_NAMES
+        for name in mysql_names + click_names:
+            crud = cruds[name]
             assert crud.remove.called, f"{name} 未被清理"
-            crud.remove.assert_called_once_with(filters={"task_id": task.task_id})
+            _, kwargs = crud.remove.call_args
+            assert kwargs.get("filters") == {"task_id": task.task_id}, \
+                f"{name} filters 契约破裂"
+            if name in mysql_names:
+                assert "session" in kwargs, f"{name} (MySQL) 应传入共享 session"
+            else:
+                assert "session" not in kwargs or kwargs["session"] is None, \
+                    f"{name} (ClickHouse) 不应参与 MySQL 事务"
 
     @pytest.mark.unit
     def test_none_crud_warns_others_still_cleaned(self):
@@ -135,19 +151,109 @@ class TestRerunCleanupLoop:
         assert result.success is True
 
     @pytest.mark.unit
-    def test_partial_crud_failure_does_not_abort_cleanup(self):
-        """中间某 CRUD.remove 抛异常时，后续 CRUD 仍被清理（逐表 try-except 容错）"""
+    def test_clickhouse_cleanup_failure_does_not_abort_start(self):
+        """ClickHouse 组 cleanup 失败 → best-effort 告警，不阻断 MySQL 事务与启动（CH 无事务，#5562）
+
+        语义变更：原 test_partial_crud_failure_does_not_abort_cleanup 用 position(MySQL) 测容错，
+        但 #5562 后 MySQL 组原子（任一失败→回滚→error，见 TestRerunCleanupAtomicity）。
+        best-effort 容错仅对 ClickHouse 成立（CH 无事务能力）。
+        """
         svc, cruds = _make_service_with_cruds()
-        # 位于列表中段的 position_crud 抛异常
-        cruds["position_crud"].remove.side_effect = Exception("position 表锁")
+        TestRerunCleanupAtomicity._wire_mysql_transaction(cruds)
+        cruds["analyzer_record_crud"].remove.side_effect = Exception("analyzer CH 表锁")
+
+        with _mock_kafka_and_container() as producer:
+            result = svc.start_task(uuid="uuid-1234")
+
+        # CH 失败被吞，best-effort 不阻断
+        assert result.is_success() is True, "CH cleanup 失败应 best-effort，不阻断启动"
+        assert producer.send.called, "CH 失败不应阻止发 Kafka"
+        # MySQL 组仍清理（在事务内）
+        assert cruds["position_crud"].remove.called
+        assert cruds["signal_tracker_crud"].remove.called
+        # CH analyzer_record 确实尝试过
+        cruds["analyzer_record_crud"].remove.assert_called_once()
+
+
+class TestRerunCleanupAtomicity:
+    """start_task 重跑清理的原子性（#5562）
+
+    库归属（_is_clickhouse 运行时属性为裁判）：
+      MySQL 4 个（order/position/transfer/signal_tracker）—— 共享单事务，任一失败全回滚
+      ClickHouse 5 个（signal/position_record/analyzer_record/order_record/transfer_record）
+        —— CH 无事务（ALTER DELETE 异步 mutation），best-effort 删除+告警，不阻断
+
+    设计变更：原逐表 try-except 容错（半清理仍启动）会让新回测用残留数据致结果污染（#5562 核心）。
+    新契约：MySQL 组原子，失败→回滚→不启动；CH 组保留 best-effort。
+    """
+
+    # 与实现 _mysql_cleanups / _click_cleanups 对齐（_is_clickhouse 权威）
+    MYSQL_CRUD_NAMES = ("order_crud", "position_crud", "transfer_crud", "signal_tracker_crud")
+    CLICK_CRUD_NAMES = (
+        "signal_crud", "position_record_crud", "analyzer_record_crud",
+        "order_record_crud", "transfer_record_crud",
+    )
+
+    @staticmethod
+    def _wire_mysql_transaction(cruds):
+        """给 4 个 MySQL CRUD 装上共享 driver 事务 contextmanager（模拟单例 driver）。
+
+        返回 (shared_session, stats) —— stats={'committed':int,'rolled_back':int}。
+        """
+        shared_session = MagicMock(name="shared_mysql_session")
+        stats = {"committed": 0, "rolled_back": 0}
+
+        @contextmanager
+        def fake_tx():
+            try:
+                yield shared_session
+                stats["committed"] += 1
+            except Exception:
+                stats["rolled_back"] += 1
+                raise
+
+        shared_driver = MagicMock(name="shared_mysql_driver")
+        shared_driver.get_session.side_effect = fake_tx
+        for name in TestRerunCleanupAtomicity.MYSQL_CRUD_NAMES:
+            cruds[name]._get_connection.return_value = shared_driver
+        return shared_session, stats
+
+    @pytest.mark.unit
+    def test_mysql_cleanup_failure_rolls_back_and_aborts_start(self):
+        """MySQL 组 cleanup 中途失败 → 事务回滚 + start_task 返回 error，不发 Kafka（#5562）"""
+        svc, cruds = _make_service_with_cruds()
+        shared_session, stats = self._wire_mysql_transaction(cruds)
+        cruds["position_crud"].remove.side_effect = RuntimeError("position 表锁")
+
+        with _mock_kafka_and_container() as producer:
+            result = svc.start_task(uuid="uuid-1234")
+
+        assert result.is_success() is False, "MySQL cleanup 失败应返回 error，不启动半清理回测"
+        assert producer.send.called is False, "cleanup 失败不应发 Kafka 启动命令"
+        assert stats["rolled_back"] >= 1, "MySQL 事务应回滚"
+        assert stats["committed"] == 0, "回滚路径不应 commit"
+
+    @pytest.mark.unit
+    def test_mysql_cruds_share_single_transaction_session(self):
+        """4 个 MySQL CRUD 的 remove 收到同一 session 对象（事务共享，#5562）
+
+        driver 单例 → 4 CRUD 共享 session_factory → 单事务（commit 一次）。
+        CH 5 个不传 session（不参与 MySQL 事务）。
+        """
+        svc, cruds = _make_service_with_cruds()
+        shared_session, stats = self._wire_mysql_transaction(cruds)
 
         with _mock_kafka_and_container():
             result = svc.start_task(uuid="uuid-1234")
 
-        # 异常被吞，start_task 仍成功
-        assert result.success is True
-        # position_crud 确实尝试过清理
-        cruds["position_crud"].remove.assert_called_once()
-        # 位于其后的 analyzer_record / signal_tracker 仍被清理（未中断）
-        assert cruds["analyzer_record_crud"].remove.called
-        assert cruds["signal_tracker_crud"].remove.called
+        assert result.is_success() is True
+        for name in self.MYSQL_CRUD_NAMES:
+            _, kwargs = cruds[name].remove.call_args
+            assert kwargs.get("session") is shared_session, \
+                f"{name} 应收到共享 session，实际 {kwargs.get('session')}"
+        for name in self.CLICK_CRUD_NAMES:
+            _, kwargs = cruds[name].remove.call_args
+            assert "session" not in kwargs or kwargs["session"] is None, \
+                f"{name} (CH) 不应参与 MySQL 事务"
+        assert stats["committed"] == 1, "MySQL 组应单事务 commit 一次"
+        assert stats["rolled_back"] == 0


### PR DESCRIPTION
## Summary

`BacktestTaskService.start_task()` 重跑清理原 9 个 `CRUD.remove` 各自独立事务（`session=None` 自建），中途崩溃留半清理数据，新回测用残留数据致结果污染（#5562）。

## 根因 + 库归属发现

库归属以 `_is_clickhouse` **运行时属性**为裁判（非 CRUD 文件注释——注释与实际不符）：

| 库 | CRUD | 事务能力 |
|---|---|---|
| **MySQL** (4) | order, position, transfer, signal_tracker | ✅ 单事务原子 |
| **ClickHouse** (5) | signal, position_record, analyzer_record, order_record, transfer_record | ❌ 无事务（ALTER DELETE 异步 mutation） |

> 注：`position_record`/`order_record` 实为 ClickHouse（`MClickBase`），与 CRUD 文件头部注释的"MySQL"描述不符。以运行时 `_is_clickhouse` 为准。

## 改动

`src/ginkgo/data/services/backtest_task_service.py` cleanup 按库分治：
- **MySQL 4 个**：包进 `driver.get_session()` 单事务（contextmanager，commit/rollback），任一失败全 rollback，cleanup 失败则 `return ServiceResult.error` **不发 Kafka**（不启动半清理回测）
- **ClickHouse 5 个**：best-effort 删除+告警，不阻断（CH 引擎无事务能力，固有限制）

**不改 Base**：`BaseCRUD.remove(session=)` 已原生支持外部 session 复用；driver 经 `get_db_connection` 单例返回，4 MySQL CRUD 共享同一 `session_factory`（实证：3 CRUD `_get_connection()` 返回同一对象 ID）。

## 验收对照（#5562）

- [x] **MySQL 组单事务 + rollback**（核心：消除半清理污染）
- [x] **crash 测试**（MySQL 中途异常→回滚+不发 Kafka）
- [⚠️] **"Wrap all 9 in single transaction"**：跨库（MySQL+ClickHouse）技术上不可行——CH 引擎不支持事务。降级为 MySQL 原子 + CH best-effort，这是架构约束下的最优解。

## Test plan

- [x] `test_backtest_task_rerun_cleanup.py`（5 passed）：
  - MySQL 失败→回滚+返回 error+不发 Kafka（#5562 核心）
  - CH 失败→best-effort 告警，不阻断 MySQL 事务与启动
  - 4 MySQL CRUD 共享同一 session，单事务 commit 一次
  - 更新 2 既有测试反映新契约（MySQL 原子 vs CH best-effort 分治）
- [x] Layer1 py_compile（src + api）
- [x] Layer2 启动路径点名（29 passed）
- [x] Layer3 全部 backtest_task_service 测试（unit 16 + integration smoke 6，未破坏其他方法）

Closes #5562
