### PR TITLE
fix: 7 API 端点 page_size 加 Query(ge=1, le=500) 上限约束 (#5566)

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -2,7 +2,7 @@
 数据相关API路由
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, model_validator
 from typing import List, Optional, Dict, Any
 from datetime import datetime
@@ -239,7 +239,7 @@ async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: in
 async def get_stockinfo(
     search: Optional[str] = None,
     page: int = 1,
-    page_size: int = 50
+    page_size: int = Query(default=50, ge=1, le=500)
 ):
     """获取股票信息列表（分页，搜索下推到DB层）"""
     try:
@@ -314,7 +314,7 @@ async def get_bars(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = 100
+    page_size: int = Query(default=100, ge=1, le=500)
 ):
     """获取K线数据列表（分页）"""
     try:
@@ -390,7 +390,7 @@ async def get_ticks(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = 100
+    page_size: int = Query(default=100, ge=1, le=500)
 ):
     """获取Tick数据列表（分页）"""
     try:
@@ -476,7 +476,7 @@ async def get_adjust_factors(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = 100
+    page_size: int = Query(default=100, ge=1, le=500)
 ):
     """获取复权因子列表（分页）"""
     try:
@@ -728,7 +728,7 @@ async def sync_data(request: DataUpdateRequest):
 async def get_sync_history(
     sync_type: Optional[str] = None,
     page: int = 1,
-    page_size: int = 20,
+    page_size: int = Query(default=20, ge=1, le=500),
 ):
     """获取同步历史记录"""
     try:

--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -3,7 +3,7 @@
 提供节点图的 CRUD、验证、编译等接口
 """
 
-from fastapi import APIRouter, HTTPException, status
+from fastapi import APIRouter, HTTPException, status, Query
 from typing import Optional
 import uuid
 from datetime import datetime
@@ -51,7 +51,7 @@ def get_file_service():
 async def list_node_graphs(
     portfolio_uuid: Optional[str] = None,
     page: int = 1,
-    page_size: int = 20,
+    page_size: int = Query(default=20, ge=1, le=500),
 ):
     """
     获取节点图列表

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -2,7 +2,7 @@
 系统设置相关API路由
 """
 
-from fastapi import APIRouter, HTTPException, status, Request
+from fastapi import APIRouter, HTTPException, status, Request, Query
 from pydantic import BaseModel, ConfigDict
 from typing import List, Optional
 from datetime import datetime
@@ -1375,7 +1375,7 @@ async def toggle_notification_template(uuid: str, enabled: bool):
 async def list_notification_history(
     type: Optional[str] = None,
     page: int = 1,
-    page_size: int = 20
+    page_size: int = Query(default=20, ge=1, le=500)
 ):
     """获取通知历史"""
     try:

--- a/tests/unit/test_api_page_size_bounds.py
+++ b/tests/unit/test_api_page_size_bounds.py
@@ -1,0 +1,65 @@
+"""#5566 AC1: 7 端点 page_size 加 Query(ge=1, le=500) 上限约束。
+
+防 `?page_size=999999` 无界查询直达 DB LIMIT N 致内存膨胀。
+用 AST 源码级断言（零 import，绕过 api 层命名空间/容器启动问题）。
+"""
+import ast
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).parents[2]  # tests/unit/xxx.py → worktree root
+
+CASES = [
+    ("api/api/data.py", "get_stockinfo"),
+    ("api/api/data.py", "get_bars"),
+    ("api/api/data.py", "get_ticks"),
+    ("api/api/data.py", "get_adjust_factors"),
+    ("api/api/data.py", "get_sync_history"),
+    ("api/api/settings.py", "list_notification_history"),
+    ("api/api/node_graph.py", "list_node_graphs"),
+]
+
+
+def _page_size_default(rel: str, fn_name: str):
+    """返回 page_size 参数默认值的 AST 节点，或 None。"""
+    tree = ast.parse((REPO / rel).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == fn_name:
+            args = node.args
+            all_args = list(args.posonlyargs) + list(args.args)
+            for i, a in enumerate(all_args):
+                if a.arg == "page_size":
+                    ndef = len(args.defaults)
+                    start = len(all_args) - ndef  # defaults 对齐普通参数末尾
+                    j = i - start
+                    return args.defaults[j] if 0 <= j < ndef else None
+            return None
+    raise AssertionError(f"{fn_name} not found in {rel}")
+
+
+def _is_bounded_query(node) -> bool:
+    """page_size 默认须是 Query(...) 调用且 keywords 含 le=500, ge=1。"""
+    if not isinstance(node, ast.Call):
+        return False
+    f = node.func
+    name = f.id if isinstance(f, ast.Name) else getattr(getattr(f, "attr", None), None)
+    if name != "Query":
+        return False
+    le = ge = None
+    for kw in node.keywords:
+        if kw.arg == "le" and isinstance(kw.value, ast.Constant):
+            le = kw.value.value
+        if kw.arg == "ge" and isinstance(kw.value, ast.Constant):
+            ge = kw.value.value
+    return le == 500 and ge == 1
+
+
+@pytest.mark.parametrize("rel,fn_name", CASES)
+def test_page_size_bounded(rel, fn_name):
+    default = _page_size_default(rel, fn_name)
+    assert default is not None, f"{fn_name}: page_size has no default value"
+    assert _is_bounded_query(default), (
+        f"{fn_name}: page_size must be Query(default=…, ge=1, le=500), "
+        f"got {ast.dump(default)}"
+    )


### PR DESCRIPTION
## Summary

#5566 报告 7 个 API 端点 `page_size: int = N` 裸默认无上限约束，`?page_size=999999` 直达 DB `LIMIT N` 致内存膨胀/查询卡死。

**修复**：7 端点签名加 `Query(ge=1, le=500)`，FastAPI 在**路由层**就拒绝越界值返 422，不进端点函数体。

## 7 端点

| 文件 | 端点 | 默认 |
|---|---|---|
| api/api/data.py | get_stockinfo | 50 |
| api/api/data.py | get_bars | 100 |
| api/api/data.py | get_ticks | 100 |
| api/api/data.py | get_adjust_factors | 100 |
| api/api/data.py | get_sync_history | 20 |
| api/api/settings.py | list_notification_history | 20 |
| api/api/node_graph.py | list_node_graphs | 20 |

## 根因

FastAPI 参数校验两层：`Query(ge=1, le=500)` 在路由层拒绝越界（422）；裸 `int = N` 框架不校验，任意 int 直达 DB `LIMIT N`。修在签名声明，非函数体。

## 验收对照

- [x] **AC1**: 7 端点加 `Query(ge=1, le=500)` ✅
- [x] **AC2**: 审计其他端点 — `grep -rn "page_size: int = [0-9]" api/` 仅剩 `api/core/response.py:paginated()` helper（非路由，内部工具）+ `api/docs/` 文档；src/ 全是 service/crud 内部方法（约束属端点层）。**无其他端点漏网**
- [ ] **AC3**: 全局默认 max page_size in config — 架构级（需 config 加 `DEFAULT_MAX_PAGE_SIZE` + 端点引用），**留 follow-up slice**（本 PR 聚焦 AC1 机械修复）

## Test plan

- [x] `tests/unit/test_api_page_size_bounds.py`（AST 源码级，7 passed）：参数化断言 7 端点 page_size 默认是 `Query(le=500, ge=1)`。AST 测试零 import，绕过 api 层 `core` 命名空间/容器启动问题
- [x] Layer1 py_compile（data/settings/node_graph）
- [x] Layer2 启动路径点名 smoke（user_crud_mock/containers/user_cli 29 passed）

Refs #5566
