### PR TITLE
fix(#5633): Account 响应字段统一 uuid（对齐其他模块）

### DIFF
--- a/src/ginkgo/data/services/live_account_service.py
+++ b/src/ginkgo/data/services/live_account_service.py
@@ -69,7 +69,7 @@ class LiveAccountService(BaseService):
         Returns:
             Dict: {
                 "success": bool,
-                "data": {"account_uuid": str} or None,
+                "data": {"uuid": str} or None,
                 "message": str,
                 "error": str
             }
@@ -142,7 +142,7 @@ class LiveAccountService(BaseService):
             return {
                 "success": True,
                 "data": {
-                    "account_uuid": account.uuid,
+                    "uuid": account.uuid,
                     "validation_result": validation_result
                 },
                 "message": "Live account created successfully"
@@ -573,7 +573,7 @@ class LiveAccountService(BaseService):
                 "success": True,
                 "message": f"Account status updated to {status}",
                 "data": {
-                    "account_uuid": updated_account.uuid,
+                    "uuid": updated_account.uuid,
                     "status": updated_account.status
                 }
             }

--- a/tests/unit/data/services/test_live_account_uuid_field.py
+++ b/tests/unit/data/services/test_live_account_uuid_field.py
@@ -1,0 +1,76 @@
+"""#5633: Account 响应字段统一为 "uuid"（对齐 MLiveAccount.to_dict() 及其他模块）。
+
+根因: LiveAccountService.create_account / update_account_status 手动构造 data dict
+时用 key "account_uuid"，而 MLiveAccount.to_dict()（get/list/update 经此）统一用 "uuid"，
+导致 create/update_status 响应与其余端点字段名不一致，前端需按模块特判。
+
+注: service 方法 *参数名* account_uuid（validate_account/update_account 等）是内部契约，
+保留不动；本测试只钉 *响应 data 字段名* 必须为 "uuid"。
+"""
+import pytest
+from unittest.mock import Mock
+
+from ginkgo.data.services.live_account_service import LiveAccountService
+from ginkgo.data.models.model_live_account import (
+    MLiveAccount,
+    ExchangeType,
+    AccountStatusType,
+)
+
+
+class TestAccountResponseUuidField:
+    """#5633: Account 响应 data 必须用 "uuid" 字段（非 "account_uuid"）。"""
+
+    @pytest.fixture
+    def mock_crud_create(self):
+        mock = Mock()
+        account = Mock(spec=MLiveAccount)
+        account.uuid = "acc-uuid-123"
+        mock.add_live_account.return_value = account
+        mock.get_live_account_by_user_id.return_value = []
+        return mock
+
+    @pytest.fixture
+    def mock_crud_update_status(self):
+        mock = Mock()
+        existing = Mock(spec=MLiveAccount)
+        mock.get_live_account_by_uuid.return_value = existing
+        updated = Mock(spec=MLiveAccount)
+        updated.uuid = "acc-uuid-456"
+        updated.status = AccountStatusType.ENABLED
+        mock.update_status.return_value = updated
+        return mock
+
+    @pytest.mark.unit
+    def test_create_account_returns_uuid_field(self, mock_crud_create):
+        """create_account 响应 data 含 'uuid' key，不含 'account_uuid'。"""
+        service = LiveAccountService(live_account_crud=mock_crud_create)
+        result = service.create_account(
+            user_id="u1",
+            exchange=ExchangeType.OKX,
+            name="n",
+            api_key="k",
+            api_secret="s",
+            passphrase="p",
+            environment="testnet",
+            auto_validate=False,
+        )
+        assert result["success"] is True
+        assert result["data"]["uuid"] == "acc-uuid-123"
+        assert "account_uuid" not in result["data"], "不应再用 account_uuid 字段名"
+
+    @pytest.mark.unit
+    def test_update_account_status_returns_uuid_field(self, mock_crud_update_status):
+        """update_account_status 响应 data 含 'uuid' key。
+
+        注意调用 kwarg account_uuid 是 service 签名参数名（内部契约，保留），
+        响应字段才统一为 uuid。
+        """
+        service = LiveAccountService(live_account_crud=mock_crud_update_status)
+        result = service.update_account_status(
+            account_uuid="acc-uuid-456",
+            status=AccountStatusType.ENABLED,
+        )
+        assert result["success"] is True
+        assert result["data"]["uuid"] == "acc-uuid-456"
+        assert "account_uuid" not in result["data"]

--- a/tests/unit/data/test_live_account_service_existing.py
+++ b/tests/unit/data/test_live_account_service_existing.py
@@ -51,7 +51,7 @@ class TestLiveAccountServiceCreation:
         )
 
         assert result["success"] is True
-        assert result["data"]["account_uuid"] == "test-account-uuid"
+        assert result["data"]["uuid"] == "test-account-uuid"
         assert result["data"]["validation_result"] is None
 
     def test_create_account_missing_user_id(self, live_account_service):
@@ -160,7 +160,7 @@ class TestLiveAccountServiceCreation:
         )
 
         assert result["success"] is True
-        assert result["data"]["account_uuid"] == "test-account-uuid"
+        assert result["data"]["uuid"] == "test-account-uuid"
         assert result["data"]["validation_result"]["success"] is True
         # 验证validate_account被调用过
         mock_validate.assert_called_once()


### PR DESCRIPTION
## Summary

修复 #5633：Account API 响应字段 `account_uuid` 与其他模块不一致（Portfolio/Component/Backtest 统一用 `uuid`）。

**根因**：`MLiveAccount.to_dict()` 返回 `"uuid"`（list/get/update 端点经此✅），但 `LiveAccountService.create_account` 和 `update_account_status` 手动构造 data dict 时用 key `"account_uuid"`，导致 create/update_status 响应与其余端点字段名不一致，前端需针对 Account 特判。

**修复**（`src/ginkgo/data/services/live_account_service.py` 3 处）：
- `create_account` 响应 data：`account_uuid` → `uuid`
- `update_account_status` 响应 data：`account_uuid` → `uuid`
- docstring 同步

**不改动**：service 方法参数名 `account_uuid`（`validate_account(account_uuid=...)`、`update_account(account_uuid=...)` 等签名）是内部契约，保留——issue 只要求响应字段名对齐。

## Test plan

- [x] 新增 `tests/unit/data/services/test_live_account_uuid_field.py`：钉 `create_account` / `update_account_status` 响应 `data["uuid"]` 字段且不含 `account_uuid`（RED→GREEN）
- [x] 更新 `test_live_account_service_existing.py` 两处旧断言（`account_uuid` → `uuid`）
- [x] Layer1 py_compile（src+api）通过
- [x] Layer2 启动路径 smoke（user_crud_mock + containers + user_cli，29 tests）通过
- [x] service 全量测试 39 passed

Closes #5633
