### PR TITLE
fix(#6000): tick get 单日/区间查询 end_date 覆盖整天盘中时段

### DIFF
--- a/src/ginkgo/data/services/tick_service.py
+++ b/src/ginkgo/data/services/tick_service.py
@@ -384,7 +384,12 @@ class TickService(BaseService):
             if start_date:
                 filters["timestamp__gte"] = datetime_normalize(start_date)
             if end_date:
-                filters["timestamp__lte"] = datetime_normalize(end_date)
+                end_dt = datetime_normalize(end_date)
+                # date-only 输入（归一化为午夜）须延展到 23:59:59，否则盘中 tick
+                # 全被 `<=` 排除（#6000）；带时间分量的精确 datetime 尊重其精度。
+                if end_dt.hour == 0 and end_dt.minute == 0 and end_dt.second == 0:
+                    end_dt = end_dt.replace(hour=23, minute=59, second=59)
+                filters["timestamp__lte"] = end_dt
 
             # Get original tick data using TickCRUD
             if not self._crud_repo:
@@ -440,6 +445,9 @@ class TickService(BaseService):
 
         filter 域与现有 get() 一致（code / timestamp__gte / timestamp__lte），
         start_date/end_date 经 datetime_normalize 规范化。未抽改 get()，保持纯增量。
+        end_date 作闭区间上界，归一化到当日 23:59:59（end-of-day），使单日查询
+        （start==end）与区间查询的最后一日都能命中盘中 09:30–15:00 的 tick
+        （#6000：原归一化到 00:00:00 致盘中 tick 全被 `<=` 排除）。
         """
         filters = {}
         if code:
@@ -447,7 +455,12 @@ class TickService(BaseService):
         if start_date:
             filters["timestamp__gte"] = datetime_normalize(start_date)
         if end_date:
-            filters["timestamp__lte"] = datetime_normalize(end_date)
+            end_dt = datetime_normalize(end_date)
+            # date-only 输入（归一化为午夜）须延展到 23:59:59，否则盘中 tick
+            # 全被 `<=` 排除（#6000）；带时间分量的精确 datetime 尊重其精度。
+            if end_dt.hour == 0 and end_dt.minute == 0 and end_dt.second == 0:
+                end_dt = end_dt.replace(hour=23, minute=59, second=59)
+            filters["timestamp__lte"] = end_dt
         return filters
 
     def get_ticks_df(

--- a/tests/unit/data/services/test_tick_service_end_of_day.py
+++ b/tests/unit/data/services/test_tick_service_end_of_day.py
@@ -1,0 +1,92 @@
+"""
+#6000: data get tick 单日/区间查询返回空。
+根因：tick_service `_build_tick_filters` / `get` 把 end_date 经 datetime_normalize
+归一化为当日 00:00:00，作 inclusive `timestamp__lte` 上界，盘中 09:30–15:00 的
+tick 全部 > 00:00:00 被排除 → 单日查询整天空、区间查询丢最后一天。
+
+本测试 pin 的行为：end_date 作为闭区间上界必须覆盖到当日 23:59:59（end-of-day），
+使单日/区间查询都能命中盘中 tick。
+"""
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.tick_service import TickService
+
+
+def _make_service(crud):
+    """纯 mock 注入 TickService，不触达 Redis / Adjustfactor / DB。"""
+    return TickService(
+        data_source=Mock(),
+        stockinfo_service=Mock(),
+        crud_repo=crud,
+        redis_service=Mock(),
+        adjustfactor_service=Mock(),
+    )
+
+
+class TestTickEndDateCoversFullDay:
+    """end_date 闭区间上界须覆盖整天盘中时段（#6000）。"""
+
+    @pytest.mark.unit
+    def test_get_ticks_df_same_day_end_filter_is_end_of_day(self):
+        """单日查询（start==end）的 timestamp__lte 必须到当日 23:59:59，
+        否则盘中 tick 全被排除（#6000 根因）。"""
+        crud = Mock()
+        crud.find.return_value = None
+        service = _make_service(crud)
+
+        service.get_ticks_df(code="000001.SZ", start_date="20250605", end_date="20250605")
+
+        filters = crud.find.call_args.kwargs["filters"]
+        assert filters["timestamp__lte"] == datetime(2025, 6, 5, 23, 59, 59)
+
+    @pytest.mark.unit
+    def test_get_ticks_df_range_last_day_covers_intraday(self):
+        """区间查询的最后一日也必须覆盖到 23:59:59（不能只到 00:00:00 丢整天）。"""
+        crud = Mock()
+        crud.find.return_value = None
+        service = _make_service(crud)
+
+        service.get_ticks_df(code="000001.SZ", start_date="20250601", end_date="20250610")
+
+        filters = crud.find.call_args.kwargs["filters"]
+        assert filters["timestamp__gte"] == datetime(2025, 6, 1, 0, 0)
+        assert filters["timestamp__lte"] == datetime(2025, 6, 10, 23, 59, 59)
+
+    @pytest.mark.unit
+    def test_get_same_day_end_filter_is_end_of_day(self):
+        """get()（API 路径，独立构建 filters）同样须覆盖到当日 23:59:59（#6000）。"""
+        crud = Mock()
+        crud.find.return_value = None
+        service = _make_service(crud)
+
+        service.get(code="000001.SZ", start_date="20250605", end_date="20250605")
+
+        filters = crud.find.call_args.kwargs["filters"]
+        assert filters["timestamp__lte"] == datetime(2025, 6, 5, 23, 59, 59)
+
+    @pytest.mark.unit
+    def test_get_ticks_df_precise_datetime_end_is_respected(self):
+        """传入带时间分量的精确 datetime（如 API 层 fromisoformat）须保持精度，
+        不被错误延展到 23:59:59（API 层 data.py:411 传 datetime 对象）。"""
+        crud = Mock()
+        crud.find.return_value = None
+        service = _make_service(crud)
+
+        service.get_ticks_df(
+            code="000001.SZ",
+            start_date="2025-06-05",
+            end_date=datetime(2025, 6, 5, 14, 30, 0),
+        )
+
+        filters = crud.find.call_args.kwargs["filters"]
+        assert filters["timestamp__lte"] == datetime(2025, 6, 5, 14, 30, 0)


### PR DESCRIPTION
## Summary

修复 `data get tick` 单日查询返回空数据的问题（#6000）。

**根因**：`tick_service` 的 `_build_tick_filters` 与 `get()` 把 `end_date` 经 `datetime_normalize` 归一化为当日 **00:00:00**，作为 inclusive `timestamp__lte` 上界。盘中 09:30–15:00 的 tick 全部 `> 00:00:00`，被 `<=` 条件排除：

- 单日查询（`--start 20250605 --end 20250605`）：`timestamp <= 2025-06-05 00:00:00` → 只匹配午夜 → 空
- 区间查询：丢失最后一日的盘中数据

**修复**（`src/ginkgo/data/services/tick_service.py` 两处）：
- 仅对 date-only 输入（归一化后为午夜）延展到当日 `23:59:59`
- 传入带时间分量的精确 datetime（API 层 `datetime.fromisoformat` 传 datetime 对象）尊重其精度，不延展

对比 `count()` 方法已用 `timestamp__lt date + 1day` 正确覆盖全天，本次修复对齐该语义（保持 `timestamp__lte` 闭区间约定不变）。

## Test plan

新增 `tests/unit/data/services/test_tick_service_end_of_day.py`（纯 mock 注入，不触达 DB/Redis）：
- ✅ `get_ticks_df` 单日查询 → `timestamp__lte = 23:59:59`
- ✅ `get_ticks_df` 区间查询最后一日 → `23:59:59`
- ✅ `get()` 单日查询（API 路径）→ `23:59:59`
- ✅ 精确 datetime 输入 → 保持精度不延展

冒烟三层：
- Layer 1 py_compile ✅
- Layer 2 启动路径 smoke（user_crud/containers/user_cli 29 passed）✅
- Layer 3 新测试 4 passed + 现有 tick_service 测试 26 passed/4 skipped 无回归 ✅

Closes #6000
