### PR TITLE
fix: 禁 trailing slash 307 重定向丢失 Auth header (#5389)

### DIFF
--- a/api/api/accounts.py
+++ b/api/api/accounts.py
@@ -43,7 +43,7 @@ def _get_user_id(request: Request) -> str:
         return "default_user"
 
 
-@router.get("/")
+@router.get("")
 async def list_accounts(
     request: Request,
     exchange: Optional[str] = Query(None, description="过滤交易所"),
@@ -75,7 +75,7 @@ async def list_accounts(
         raise BusinessError(f"Error listing accounts: {e}")
 
 
-@router.post("/", status_code=status.HTTP_201_CREATED)
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_account(request: Request, data: CreateLiveAccountRequest):
     """创建实盘账号"""
     try:

--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -239,7 +239,7 @@ async def send_task_to_kafka(task_uuid: str, portfolio_uuids: list, name: str, c
 
 # ==================== API 路由 ====================
 
-@router.get("/")
+@router.get("")
 async def list_backtests(
     status: Optional[str] = Query(None, description="按状态筛选"),
     portfolio_id: Optional[str] = Query(None, description="按投资组合筛选"),
@@ -360,7 +360,7 @@ async def get_backtest(uuid: str):
         raise BusinessError(f"Error getting backtest: {str(e)}")
 
 
-@router.post("/", status_code=status.HTTP_201_CREATED)
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_backtest(data: BacktestTaskCreate):
     """
     创建回测任务

--- a/api/api/components.py
+++ b/api/api/components.py
@@ -89,7 +89,7 @@ def get_file_service():
 
 # ==================== API路由 ====================
 
-@router.get("/")
+@router.get("")
 async def list_components(
     component_type: Optional[str] = None,
     is_active: Optional[bool] = None,
@@ -231,7 +231,7 @@ async def get_component(uuid: str):
         )
 
 
-@router.post("/")
+@router.post("")
 async def create_component(data: ComponentCreate):
     """创建组件"""
     try:

--- a/api/api/dashboard.py
+++ b/api/api/dashboard.py
@@ -64,7 +64,7 @@ def _check_health() -> list[SystemHealthItem]:
     return health_items
 
 
-@router.get("/")
+@router.get("")
 async def get_dashboard_stats(request: Request):
     """获取仪表盘统计数据"""
     try:

--- a/api/api/deployment.py
+++ b/api/api/deployment.py
@@ -21,7 +21,7 @@ def _get_deployment_service():
     return trading_container.deployment_service()
 
 
-@router.post("/")
+@router.post("")
 async def deploy(req: DeployRequest):
     """一键部署（走 Saga 事务）"""
     from ginkgo.enums import PORTFOLIO_MODE_TYPES
@@ -66,7 +66,7 @@ async def get_deployment_info(portfolio_id: str):
     return ok(data=result.data, message="查询成功")
 
 
-@router.get("/")
+@router.get("")
 async def list_deployments(portfolio_id: Optional[str] = Query(None, description="按源组合 ID 筛选")):
     """列出部署记录"""
     service = _get_deployment_service()

--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -47,7 +47,7 @@ def get_file_service():
 
 # ==================== CRUD 操作 ====================
 
-@router.get("/")
+@router.get("")
 async def list_node_graphs(
     portfolio_uuid: Optional[str] = None,
     page: int = 1,
@@ -131,7 +131,7 @@ async def get_node_graph(
         )
 
 
-@router.post("/", status_code=status.HTTP_201_CREATED)
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_node_graph(
     data: NodeGraphCreate,
 ):

--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -174,7 +174,7 @@ def get_param_names(component_name: str, file_type: str = None):
     return get_component_parameter_names(component_name, None, file_type, None)
 
 
-@router.get("/")
+@router.get("")
 async def list_portfolios(
     mode: Optional[PortfolioMode] = Query(None, description="按运行模式筛选"),
     page: int = Query(0, ge=0, description="页码（0-based）"),
@@ -383,7 +383,7 @@ async def get_portfolio(uuid: str):
         raise BusinessError(f"Error getting portfolio: {str(e)}")
 
 
-@router.post("/", status_code=status.HTTP_201_CREATED)
+@router.post("", status_code=status.HTTP_201_CREATED)
 async def create_portfolio(data: PortfolioCreate):
     """创建Portfolio（使用Saga事务保证一致性）
 

--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -151,7 +151,7 @@ def _require_portfolio(portfolio_id: str):
 # Endpoints
 # ============================================================
 
-@router.get("/")
+@router.get("")
 async def list_paper_accounts_root():
     """[兼容旧路由] GET / → 等价于 GET /accounts"""
     return await list_paper_accounts()

--- a/api/main.py
+++ b/api/main.py
@@ -13,6 +13,7 @@ from core.logging import setup_logging
 from middleware.auth import JWTAuthMiddleware
 from middleware.error_handler import global_error_handler
 from middleware.rate_limit import RateLimitMiddleware
+from trailing_slash import strip_trailing_slash
 from core.exceptions import APIError
 from websocket.manager import connection_manager
 
@@ -79,6 +80,7 @@ app = FastAPI(
     redoc_url="/redoc",
     openapi_url="/openapi.json",
     lifespan=lifespan,
+    redirect_slashes=False,
 )
 
 # CORS中间件
@@ -93,6 +95,9 @@ app.add_middleware(
 # 自定义中间件
 app.add_middleware(JWTAuthMiddleware)
 app.add_middleware(RateLimitMiddleware)
+# trailing slash：strip 后路由匹配，禁 307 重定向避免 POST 丢 Auth header（#5389）
+# 最后注册 → 栈顶最先执行，JWT/RateLimit 读到 strip 后 path
+app.middleware("http")(strip_trailing_slash)
 
 # 全局错误处理
 app.exception_handler(Exception)(global_error_handler)

--- a/api/trailing_slash.py
+++ b/api/trailing_slash.py
@@ -1,0 +1,24 @@
+"""HTTP middleware: strip trailing slash from request path in-place.
+
+配合 FastAPI(redirect_slashes=False) 使用。路由统一注册无 slash 形式（列表
+端点 ``@router.get("")``），本 middleware 把带 trailing slash 的请求路径
+内部 rewrite（改 ``request.scope["path"]``），在路由匹配前生效——零 307
+重定向，避免 POST 丢 Authorization header（#5389）。
+"""
+from typing import Awaitable, Callable
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+async def strip_trailing_slash(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    path = request.url.path
+    # 根 "/" 与空路径不处理（docs / redoc / openapi.json 等根路由）
+    if len(path) > 1 and path.endswith("/"):
+        stripped = path.rstrip("/")
+        request.scope["path"] = stripped
+        # raw_path 同步（部分中间件 / access log 读 raw_path）
+        request.scope["raw_path"] = stripped.encode("utf-8")
+    return await call_next(request)

--- a/tests/unit/test_api_trailing_slash.py
+++ b/tests/unit/test_api_trailing_slash.py
@@ -1,0 +1,110 @@
+"""#5389: trailing slash 307 修复。
+
+核心逻辑：HTTP middleware 把带 trailing slash 的请求路径内部 strip
+（改 request.scope["path"]，路由匹配前生效），避免 307 重定向丢失 Auth header。
+"""
+import importlib.util
+from pathlib import Path
+
+from starlette.applications import Starlette
+from starlette.routing import Route
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+# 从文件路径加载（绕过 sys.path/sys.modules 缓存；worktree editable .pth 默认
+# 指向主仓库，见 arch_worktree_editable_import_divergence）
+_MOD_PATH = Path(__file__).parents[2] / "api" / "trailing_slash.py"
+_spec = importlib.util.spec_from_file_location("api_trailing_slash_under_test", _MOD_PATH)
+_ts = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_ts)
+strip_trailing_slash = _ts.strip_trailing_slash
+
+
+def _make_app(path: str = "/items"):
+    async def homepage(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route(path, homepage)])
+    app.middleware("http")(strip_trailing_slash)
+    return TestClient(app)
+
+
+def test_no_slash_matches():
+    """路由注册无 slash，请求无 slash → 200。"""
+    client = _make_app()
+    assert client.get("/items").status_code == 200
+
+
+def test_trailing_slash_stripped_no_redirect():
+    """带 slash 请求被 middleware strip → 200（非 307）。"""
+    client = _make_app()
+    r = client.get("/items/")
+    assert r.status_code == 200
+    assert r.status_code != 307
+
+
+def test_root_path_not_stripped():
+    """根 '/' 不应被 strip（len==1 守卫，docs/redoc 正常）。"""
+    app = Starlette(routes=[Route("/", PlainTextResponse("root"))])
+    app.middleware("http")(strip_trailing_slash)
+    client = TestClient(app)
+    assert client.get("/").status_code == 200
+
+
+# ---------- Slice 2: main.py 配置 ----------
+
+
+def test_main_redirect_slashes_false():
+    """FastAPI() 构造必须传 redirect_slashes=False（禁 307）。"""
+    import ast
+    tree = ast.parse((Path(__file__).parents[2] / "api" / "main.py").read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            f = node.func
+            is_fastapi = (isinstance(f, ast.Name) and f.id == "FastAPI") or (
+                isinstance(f, ast.Attribute) and f.attr == "FastAPI"
+            )
+            if is_fastapi:
+                for kw in node.keywords:
+                    if kw.arg == "redirect_slashes":
+                        assert isinstance(kw.value, ast.Constant) and kw.value.value is False, \
+                            "redirect_slashes 必须为 False"
+                        return
+                raise AssertionError("FastAPI() 缺 redirect_slashes=False")
+    raise AssertionError("FastAPI() 构造未找到")
+
+
+def test_main_registers_strip_middleware():
+    """main.py 必须注册 strip_trailing_slash middleware。"""
+    src = (Path(__file__).parents[2] / "api" / "main.py").read_text()
+    assert "strip_trailing_slash" in src, "main.py 未注册 strip_trailing_slash"
+
+
+# ---------- Slice 3: 10 列表端点路由迁移 "/" → "" ----------
+
+# 列表根端点（@router.*("/")），迁移后应为 @router.*("")
+LIST_ENDPOINT_FILES = [
+    "api/api/accounts.py",
+    "api/api/components.py",
+    "api/api/deployment.py",
+    "api/api/backtest.py",
+    "api/api/dashboard.py",
+    "api/api/trading.py",
+    "api/api/portfolio.py",
+    "api/api/node_graph.py",
+]
+
+
+def test_no_list_endpoint_uses_root_slash():
+    """所有列表根端点 @router.*("/") 必须迁移为 @router.*("")。
+
+    路由注册带 slash 会与 redirect_slashes=False 冲突（无 slash 请求 404）。
+    """
+    import re
+    root_slash_re = re.compile(r'@router\.(get|post|put|delete|patch)\(\s*"/"\s*[,)]')
+    offenders = []
+    for rel in LIST_ENDPOINT_FILES:
+        src = (Path(__file__).parents[2] / rel).read_text()
+        for m in root_slash_re.finditer(src):
+            offenders.append(f"{rel}: {m.group(0).strip()}")
+    assert not offenders, "以下列表端点仍用 \"/\" 路由（应迁移为 \"\"）:\n" + "\n".join(offenders)


### PR DESCRIPTION
## Summary

#5389 报告 API 列表/create 端点无 trailing slash 请求触发 **307 重定向**，POST 重定向丢失 Authorization header 致 401。根因：`FastAPI(redirect_slashes=True)`（默认）+ 路由注册 `@router.*("/")`（带 slash），无 slash 请求 match 失败 → 框架发 307。

## 修复（三件套，缺一不可）

1. **`FastAPI(redirect_slashes=False)`** — 禁 307 重定向
2. **HTTP middleware strip trailing slash**（`api/trailing_slash.py`）— 改 `request.scope["path"]` 内部 rewrite，路由匹配前生效，带 slash 请求被 strip 成无 slash 匹配路由。零 307、零 header 丢失
3. **14 个列表/create 端点 `@router.*("/")` → `@router.*("")`** — 路由注册无 slash 形式（与 `redirect_slashes=False` 配套，否则无 slash 请求会 404）

## 14 端点

| 文件 | 端点 |
|---|---|
| api/api/accounts.py | list_accounts / create_account |
| api/api/components.py | list_components / create_component |
| api/api/deployment.py | deploy / list_deployments |
| api/api/backtest.py | list_backtests / create_backtest |
| api/api/portfolio.py | list_portfolios / create_portfolio |
| api/api/node_graph.py | list_node_graphs / create_node_graph |
| api/api/dashboard.py | get_dashboard_stats |
| api/api/trading.py | list_paper_accounts_root |

## 为什么不能只设 redirect_slashes=False

`redirect_slashes=False` 单独使用会让无 slash 请求从「200 via 307」恶化成 **404**（路由仍注册 `/portfolios/`）。必须配套：路由迁 `""`（匹配无 slash）+ middleware strip（兼容前端带 slash 调用 `/api/v1/portfolios/`，见 web-ui `apiKey.ts`/`portfolio.ts`）。三件套协同 → 双形式都 200。

## 验收对照

- [x] **AC1**: `/api/v1/portfolios` 与 `/api/v1/portfolios/` 都返 200（middleware strip 兼容双形式）
- [x] **AC2**: POST 不带 trailing slash 不触发 307（`redirect_slashes=False` + middleware 内部 rewrite）
- [x] **AC3**: 14 个列表/create 端点行为一致（统一无 slash 注册 + middleware strip）

## Test plan

- [x] `tests/unit/test_api_trailing_slash.py`（6 passed）：
  - middleware 行为：无 slash 匹配 / 带 slash strip 不 307 / 根 `/` 不 strip
  - AST：`FastAPI()` 含 `redirect_slashes=False` / main.py 注册 strip middleware / 14 端点无 `@router.*("/")`
  - 用 `importlib` 从文件路径加载 middleware（绕过 sys.path/sys.modules 缓存 + api.core `__init__` 触发 Settings 校验的已知陷阱 #6064）
- [x] Layer1 py_compile（src + api 全量）
- [x] Layer2 启动路径点名（user_crud_mock / containers / user_cli 29 passed）

## 注意

- middleware 注册在 `JWTAuthMiddleware`/`RateLimitMiddleware` 之后（栈顶最先执行），确保 JWT 白名单读到 strip 后 path
- 根 `/`、`/docs`、`/redoc`、`/openapi.json` 等不经 strip（`len(path) > 1` 守卫）
- `api/trailing_slash.py` 放 `api/` 根而非 `api/core/`：`api/core/__init__.py` import `settings` 触发模块级 `Settings()` 构造（SECRET_KEY validator，#6064 范围），子模块 import 必崩

Closes #5389
