### PR TITLE
fix(#5400): Arena 对比端点接 analyzer_service 返净值曲线与统计

### DIFF
--- a/api/api/arena.py
+++ b/api/api/arena.py
@@ -2,11 +2,70 @@
 竞技场相关API路由
 """
 
+from typing import List, Optional
+
 from fastapi import APIRouter
+from pydantic import BaseModel, Field
 
 from core.response import ok
 
 router = APIRouter()
+
+
+class ArenaComparisonRequest(BaseModel):
+    """Arena 对比请求体（#5400）
+
+    task_ids 为回测任务ID列表，端点按此读取各任务的 net_value 分析器记录，
+    聚合为净值曲线与基础统计。
+    """
+
+    task_ids: List[str] = Field(..., min_length=1, description="对比的回测任务ID列表")
+
+
+def _compute_statistics(net_values: List[dict]) -> dict:
+    """从净值序列计算基础统计（#5400）
+
+    Args:
+        net_values: [{"date": ..., "value": float}, ...]，按时间升序
+
+    Returns:
+        final_value: 末点净值
+        total_return: 相对首点的累计回报率（%）
+        max_drawdown: 峰值到谷底的最大回撤（%，非负）
+    """
+    if not net_values:
+        return {"final_value": 0, "total_return": 0, "max_drawdown": 0}
+
+    values = [float(nv["value"]) for nv in net_values]
+    final_value = values[-1]
+    initial = values[0]
+    total_return = round((final_value / initial - 1) * 100, 4) if initial else 0
+
+    # 最大回撤：running peak → (peak - v) / peak
+    peak = values[0]
+    max_dd = 0.0
+    for v in values:
+        if v > peak:
+            peak = v
+        if peak > 0:
+            dd = (peak - v) / peak * 100
+            if dd > max_dd:
+                max_dd = dd
+
+    return {
+        "final_value": round(final_value, 4),
+        "total_return": total_return,
+        "max_drawdown": round(max_dd, 4),
+    }
+
+
+def _to_date_str(raw) -> Optional[str]:
+    """将时间戳归一为字符串（datetime → isoformat，str 原样，None 透传）"""
+    if raw is None:
+        return None
+    if hasattr(raw, "isoformat"):
+        return raw.isoformat()
+    return str(raw)
 
 
 @router.get("/portfolios")
@@ -17,7 +76,44 @@ async def get_arena_portfolios():
 
 
 @router.post("/comparison")
-async def get_arena_comparison():
-    """获取Portfolio对比数据"""
-    # TODO: 实现实际的对比数据获取逻辑
-    return ok(data={"net_values": {}, "statistics": []})
+async def get_arena_comparison(request: ArenaComparisonRequest):
+    """获取Portfolio对比数据（#5400）
+
+    按请求的 task_ids 读取各回测任务的 net_value 分析器记录，
+    聚合为净值曲线（按业务时间升序）与基础统计（最终值/总回报率/最大回撤）。
+    无数据或查询失败的 task 跳过，不中断整体响应。
+    """
+    from ginkgo.data.containers import container
+
+    analyzer_service = container.analyzer_service()
+
+    net_values = {}
+    statistics = []
+
+    for task_id in request.task_ids:
+        result = analyzer_service.get_by_task_id(
+            task_id=task_id, analyzer_name="net_value", limit=10000
+        )
+        if not result.is_success() or not result.data:
+            continue
+
+        records = result.data
+        curve = sorted(
+            [
+                {
+                    "date": _to_date_str(
+                        getattr(r, "business_timestamp", None)
+                        or getattr(r, "timestamp", None)
+                    ),
+                    "value": float(getattr(r, "value", 0)),
+                }
+                for r in records
+            ],
+            key=lambda x: x["date"] or "",
+        )
+        net_values[task_id] = curve
+        stats = _compute_statistics(curve)
+        stats["task_id"] = task_id
+        statistics.append(stats)
+
+    return ok(data={"net_values": net_values, "statistics": statistics})

--- a/tests/api/test_arena_comparison.py
+++ b/tests/api/test_arena_comparison.py
@@ -1,0 +1,178 @@
+"""Arena 对比端点测试 (#5400)
+
+验证 POST /api/v1/arena/comparison：
+- requestBody schema (task_ids 必填、min_length=1)
+- 净值曲线聚合（按 task_id 分组时序）
+- 基础统计计算（最终值/总回报率/最大回撤）
+- service 失败/无数据时跳过不崩
+
+参考 mock 模式：tests/api/test_dashboard_aggregation.py
+"""
+import pytest
+
+
+class TestArenaComparisonSchema:
+    """Slice 1: ArenaComparisonRequest schema"""
+
+    def test_task_ids_required(self, api_modules):
+        """task_ids 必填，缺失触发 ValidationError"""
+        from pydantic import ValidationError
+        from api.arena import ArenaComparisonRequest
+
+        with pytest.raises(ValidationError):
+            ArenaComparisonRequest()
+
+    def test_empty_task_ids_rejected(self, api_modules):
+        """空 task_ids 列表被拒（min_length=1）"""
+        from pydantic import ValidationError
+        from api.arena import ArenaComparisonRequest
+
+        with pytest.raises(ValidationError):
+            ArenaComparisonRequest(task_ids=[])
+
+    def test_valid_task_ids(self, api_modules):
+        """有效 task_ids 列表构造成功"""
+        from api.arena import ArenaComparisonRequest
+
+        req = ArenaComparisonRequest(task_ids=["t1", "t2"])
+        assert req.task_ids == ["t1", "t2"]
+
+
+class TestComputeStatistics:
+    """Slice 2: _compute_statistics 纯函数（净值序列 → 基础统计）"""
+
+    def test_empty_curve(self, api_modules):
+        """空序列返零统计"""
+        from api.arena import _compute_statistics
+        stats = _compute_statistics([])
+        assert stats == {"final_value": 0, "total_return": 0, "max_drawdown": 0}
+
+    def test_basic_stats_with_drawdown(self, api_modules):
+        """[1.0, 1.2, 0.9] → final=0.9, return=-10%, max_dd=25%
+        peak=1.2（第二点）, trough=0.9 → (1.2-0.9)/1.2 = 25%
+        """
+        from api.arena import _compute_statistics
+        curve = [
+            {"date": "d1", "value": 1.0},
+            {"date": "d2", "value": 1.2},
+            {"date": "d3", "value": 0.9},
+        ]
+        stats = _compute_statistics(curve)
+        assert stats["final_value"] == 0.9
+        assert stats["total_return"] == -10.0
+        assert stats["max_drawdown"] == 25.0
+
+    def test_monotonic_increase_no_drawdown(self, api_modules):
+        """[1.0, 1.5, 2.0] → max_dd=0, return=100%"""
+        from api.arena import _compute_statistics
+        curve = [
+            {"date": "d1", "value": 1.0},
+            {"date": "d2", "value": 1.5},
+            {"date": "d3", "value": 2.0},
+        ]
+        stats = _compute_statistics(curve)
+        assert stats["max_drawdown"] == 0
+        assert stats["total_return"] == 100.0
+        assert stats["final_value"] == 2.0
+
+
+class TestArenaComparisonEndpoint:
+    """Slice 3: POST /comparison 端点集成（mock container）"""
+
+    @staticmethod
+    def _make_record(ts, value):
+        from unittest.mock import MagicMock
+        rec = MagicMock()
+        rec.business_timestamp = ts
+        rec.timestamp = ts
+        rec.value = value
+        return rec
+
+    def test_aggregates_net_values_and_statistics(self, api_modules):
+        """两 task 各返 net_value records → 聚合净值曲线（排序）+ 统计"""
+        import asyncio
+        from unittest.mock import patch, MagicMock
+        from api.arena import ArenaComparisonRequest, get_arena_comparison
+
+        def fake_get(task_id, analyzer_name=None, limit=None):
+            if task_id == "t1":
+                # 故意乱序，验证按 date 升序排序
+                records = [
+                    self._make_record("2025-01-03", 0.9),
+                    self._make_record("2025-01-01", 1.0),
+                    self._make_record("2025-01-02", 1.2),
+                ]
+            else:
+                records = [
+                    self._make_record("2025-01-01", 1.0),
+                    self._make_record("2025-01-02", 2.0),
+                ]
+            return MagicMock(is_success=lambda: True, data=records)
+
+        mock_service = MagicMock()
+        mock_service.get_by_task_id.side_effect = fake_get
+        mock_container = MagicMock()
+        mock_container.analyzer_service.return_value = mock_service
+
+        req = ArenaComparisonRequest(task_ids=["t1", "t2"])
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = asyncio.run(get_arena_comparison(request=req))
+
+        data = result["data"]
+        # 净值曲线按 task 分组
+        assert set(data["net_values"].keys()) == {"t1", "t2"}
+        assert len(data["net_values"]["t1"]) == 3
+        # 排序验证（乱序输入 → 升序输出）
+        dates = [nv["date"] for nv in data["net_values"]["t1"]]
+        assert dates == ["2025-01-01", "2025-01-02", "2025-01-03"]
+        # statistics 衍生自净值序列
+        stats_by_task = {s["task_id"]: s for s in data["statistics"]}
+        assert stats_by_task["t1"]["final_value"] == 0.9
+        assert stats_by_task["t1"]["max_drawdown"] == 25.0
+        assert stats_by_task["t2"]["total_return"] == 100.0
+        # service 按 net_value analyzer + 大 page_size 查询（防截断，见 arch_analyzer_read_page_size）
+        mock_service.get_by_task_id.assert_any_call(
+            task_id="t1", analyzer_name="net_value", limit=10000
+        )
+
+    def test_skips_task_with_no_data(self, api_modules):
+        """无数据 task 跳过，不崩"""
+        import asyncio
+        from unittest.mock import patch, MagicMock
+        from api.arena import ArenaComparisonRequest, get_arena_comparison
+
+        mock_service = MagicMock()
+        mock_service.get_by_task_id.return_value = MagicMock(
+            is_success=lambda: True, data=[]
+        )
+        mock_container = MagicMock()
+        mock_container.analyzer_service.return_value = mock_service
+
+        req = ArenaComparisonRequest(task_ids=["empty"])
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = asyncio.run(get_arena_comparison(request=req))
+
+        data = result["data"]
+        assert data["net_values"] == {}
+        assert data["statistics"] == []
+
+    def test_skips_task_on_service_failure(self, api_modules):
+        """service 失败（is_success=False）task 跳过"""
+        import asyncio
+        from unittest.mock import patch, MagicMock
+        from api.arena import ArenaComparisonRequest, get_arena_comparison
+
+        mock_service = MagicMock()
+        mock_service.get_by_task_id.return_value = MagicMock(
+            is_success=lambda: False, data=None
+        )
+        mock_container = MagicMock()
+        mock_container.analyzer_service.return_value = mock_service
+
+        req = ArenaComparisonRequest(task_ids=["fail"])
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = asyncio.run(get_arena_comparison(request=req))
+
+        data = result["data"]
+        assert data["net_values"] == {}
+        assert data["statistics"] == []


### PR DESCRIPTION
## Summary

`POST /api/v1/arena/comparison` 原是 TODO 桩（`arena.py:20` 无 requestBody，返固定空 `{net_values:{}, statistics:[]}`）。前端 Arena 对比功能无数据。

**修复**：定义 `ArenaComparisonRequest` schema + 接已注册的 `container.analyzer_service()` 读取各 task 的 `net_value` 分析器记录，聚合为净值曲线 + 基础统计。

## 调用链

**修复前**：`POST /comparison` → `arena.py` TODO 桩 → 返固定空
**修复后**：`POST /comparison(task_ids)` → `container.analyzer_service()` → `get_by_task_id(task_id, analyzer_name="net_value", limit=10000)` → 聚合净值曲线 + 统计

## 改动

- `ArenaComparisonRequest(BaseModel)`：`task_ids: List[str] = Field(..., min_length=1)` — requestBody schema，参数缺失/空列表 FastAPI 自动 422
- `_compute_statistics(net_values)` 纯函数：从净值序列算**最终值/总回报率/最大回撤**（running-peak 算法）
- `_to_date_str(raw)` helper：datetime→isoformat / str 原样 / None 透传（统一排序键与 JSON 序列化）
- `get_arena_comparison(request)`：
  - 逐 task 读 net_value analyzer 记录（`limit=10000` 防 page_size 截断，见 arch_analyzer_read_page_size）
  - 按 `business_timestamp` 升序排净值曲线
  - 聚合 `net_values: {task_id: [{date, value}]}` + `statistics: [{task_id, final_value, total_return, max_drawdown}]`
  - 无数据 / 查询失败（`is_success=False`）的 task 跳过，不中断整体响应

## 验收对照

- [x] **AC1**: requestBody schema — `ArenaComparisonRequest` 定义，OpenAPI 自动生成 requestBody
- [x] **AC2**: 读指定回测的分析器数据返对比统计和净值曲线 — net_values（时序）+ statistics（最终值/回报/最大回撤）
- [x] **AC3**: 参数缺失返 422 — `task_ids` 必填 + `min_length=1`，FastAPI 路由层自动 422

## Test plan

- [x] `tests/api/test_arena_comparison.py`（9 passed，三切片）：
  - **Slice 1 schema**（3）：task_ids 必填报 ValidationError / 空列表被拒 / 有效列表构造
  - **Slice 2 `_compute_statistics`**（3）：空序列零统计 / `[1.0,1.2,0.9]`→final=0.9,return=-10%,max_dd=25% / 单调递增 max_dd=0
  - **Slice 3 端点集成**（3）：两 task 聚合+排序+统计 / 无数据 task 跳过 / service 失败 task 跳过
  - mock 模式参考 `test_dashboard_aggregation.py`（`patch("ginkgo.data.containers.container", ...)` + 直接 await 端点）
- [x] Layer1 py_compile（src + api 全量）
- [x] Layer2 启动路径点名 smoke（user_crud_mock / containers / user_cli 29 passed）
- [x] Layer3 变更相关（arena 9 passed）

## 注意

- 容器 `analyzer_service` provider 已存在（`data/containers.py:259`），端点只需 `container.analyzer_service()`，无需新接线
- `statistics` 本 PR 提供基础三项（最终值/总回报率/最大回撤），均为可纯从净值序列计算的指标；夏普/胜率等需行情数据的高级指标留 follow-up
- `get_arena_portfolios`（GET /portfolios）仍是 TODO 桩，不在本 PR scope

Closes #5400
