### PR TITLE
fix(#5559): create_from_graph_editor 跨库写失败补偿删 Mongo

### DIFF
--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -130,16 +130,23 @@ class PortfolioMappingService(BaseService):
             )
 
             # 4. 同步到 MySQL Mapping
-            mapping_sync_result = self._sync_mappings_from_files(
-                portfolio_uuid=portfolio_uuid,
-                file_mappings=file_mappings
-            )
-
             # 5. 同步到 MySQL MParam
-            param_sync_result = self._sync_params_from_nodes(
-                portfolio_uuid=portfolio_uuid,
-                node_params=node_params
-            )
+            # 下游 MySQL sync 失败时补偿删 Mongo 孤儿（#5559）：
+            # Mongo 已在步骤3写入，若 MySQL sync 抛异常，反向删除已写的 Mongo 文档，
+            # 保持跨库一致性。raise 让外层 @retry/except 决定重试或返错。
+            try:
+                mapping_sync_result = self._sync_mappings_from_files(
+                    portfolio_uuid=portfolio_uuid,
+                    file_mappings=file_mappings
+                )
+
+                param_sync_result = self._sync_params_from_nodes(
+                    portfolio_uuid=portfolio_uuid,
+                    node_params=node_params
+                )
+            except Exception:
+                self._delete_graph_from_mongo(mongo_id)
+                raise
 
             GLOG.INFO(f"从图编辑器创建配置: {portfolio_uuid} ({mongo_id})")
             GLOG.DEBUG(f"  同步了 {len(file_mappings)} 个文件映射")
@@ -552,6 +559,27 @@ class PortfolioMappingService(BaseService):
 
         collection.insert_one(document)
         return doc_id
+
+    def _delete_graph_from_mongo(self, doc_id: str) -> bool:
+        """从 MongoDB 删除图数据文档（补偿原语，#5559）
+
+        用于跨库写失败时反向补偿：create_from_graph_editor 写入 MongoDB 后，
+        若 MySQL Mapping/MParam 同步失败，调用此方法删除已写的 Mongo 文档，
+        避免孤儿。delete_one 对不存在的 _id 无害（幂等）。
+
+        Args:
+            doc_id: MongoDB 文档 ID（_save_graph_to_mongo 返回值）
+
+        Returns:
+            True 表示删除了一条文档；False 表示文档不存在或删除异常
+        """
+        try:
+            collection = self._mongo_driver.get_collection("portfolio_graph_data")
+            result = collection.delete_one({"_id": doc_id})
+            return result.deleted_count > 0
+        except Exception as e:
+            GLOG.ERROR(f"补偿删除 MongoDB 图文档失败: {doc_id}, {e}")
+            return False
 
     def _update_graph_in_mongo(
         self,

--- a/tests/unit/data/services/test_portfolio_mapping_compensation.py
+++ b/tests/unit/data/services/test_portfolio_mapping_compensation.py
@@ -1,0 +1,104 @@
+"""PortfolioMappingService 跨库孤儿补偿测试 (#5559)
+
+create_from_graph_editor 先写 MongoDB 后 sync MySQL，下游失败时
+MongoDB 文档成孤儿。验证补偿事务：sync 失败 → 反向删 Mongo。
+
+update_from_graph_editor / remove_file 同类非原子问题留 follow-up（本 PR 聚焦 create）。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _make_service():
+    """实例化 service（4 个依赖均 MagicMock，无需 DB）"""
+    from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+    return PortfolioMappingService(
+        mapping_crud=MagicMock(),
+        param_service=MagicMock(),
+        mongo_driver=MagicMock(),
+        file_service=MagicMock(),
+    )
+
+
+class TestDeleteGraphFromMongo:
+    """Slice 1: _delete_graph_from_mongo helper（补偿原语）"""
+
+    def test_calls_delete_one_with_doc_id(self):
+        """调 collection.delete_one({_id: doc_id})"""
+        svc = _make_service()
+        mock_collection = MagicMock()
+        mock_collection.delete_one.return_value = MagicMock(deleted_count=1)
+        svc._mongo_driver.get_collection.return_value = mock_collection
+
+        result = svc._delete_graph_from_mongo("doc-123")
+
+        svc._mongo_driver.get_collection.assert_called_with("portfolio_graph_data")
+        mock_collection.delete_one.assert_called_once_with({"_id": "doc-123"})
+        assert result is True
+
+    def test_returns_false_when_nothing_deleted(self):
+        """文档不存在时 delete_count=0 返 False（幂等：对不存在 _id 无害）"""
+        svc = _make_service()
+        mock_collection = MagicMock()
+        mock_collection.delete_one.return_value = MagicMock(deleted_count=0)
+        svc._mongo_driver.get_collection.return_value = mock_collection
+
+        result = svc._delete_graph_from_mongo("missing-doc")
+
+        assert result is False
+
+
+class TestCreateCompensationOnSyncFailure:
+    """Slice 2: create_from_graph_editor sync 失败补偿
+
+    @retry 重试 3 次，每次 sync 失败都补偿删当前 mongo_id。
+    mock _save_graph_to_mono 返固定 doc_id，故补偿每次删同值。
+    """
+
+    def test_deletes_mongo_when_mapping_sync_fails(self):
+        """步骤4 sync Mapping 失败 → 补偿删 Mongo + 返 error"""
+        svc = _make_service()
+        with patch.object(svc, "_save_graph_to_mongo", return_value="doc-123"), \
+             patch.object(svc, "_sync_mappings_from_files", side_effect=RuntimeError("mysql down")), \
+             patch.object(svc, "_extract_files_from_graph", return_value=[]), \
+             patch.object(svc, "_extract_params_from_graph", return_value=[]), \
+             patch.object(svc, "_delete_graph_from_mongo") as mock_delete:
+            result = svc.create_from_graph_editor(
+                portfolio_uuid="p1", graph_data={"nodes": []}, name="t"
+            )
+        # 补偿删 Mongo 被调（每次重试都删 doc-123）
+        assert mock_delete.called
+        assert all(call.args == ("doc-123",) for call in mock_delete.call_args_list)
+        # 最终返 error
+        assert not result.is_success()
+
+    def test_deletes_mongo_when_param_sync_fails(self):
+        """步骤5 sync MParam 失败（步骤4成功）→ 补偿删 Mongo"""
+        svc = _make_service()
+        with patch.object(svc, "_save_graph_to_mongo", return_value="doc-456"), \
+             patch.object(svc, "_sync_mappings_from_files", return_value=MagicMock()), \
+             patch.object(svc, "_sync_params_from_nodes", side_effect=RuntimeError("param sync fail")), \
+             patch.object(svc, "_extract_files_from_graph", return_value=[]), \
+             patch.object(svc, "_extract_params_from_graph", return_value=[]), \
+             patch.object(svc, "_delete_graph_from_mongo") as mock_delete:
+            result = svc.create_from_graph_editor(
+                portfolio_uuid="p1", graph_data={"nodes": []}, name="t"
+            )
+        assert mock_delete.called
+        assert all(call.args == ("doc-456",) for call in mock_delete.call_args_list)
+        assert not result.is_success()
+
+    def test_no_delete_on_success(self):
+        """全部成功 → 不调补偿删（回归保护）"""
+        svc = _make_service()
+        with patch.object(svc, "_save_graph_to_mongo", return_value="doc-ok"), \
+             patch.object(svc, "_sync_mappings_from_files", return_value=MagicMock()), \
+             patch.object(svc, "_sync_params_from_nodes", return_value=MagicMock()), \
+             patch.object(svc, "_extract_files_from_graph", return_value=[]), \
+             patch.object(svc, "_extract_params_from_graph", return_value=[]), \
+             patch.object(svc, "_delete_graph_from_mongo") as mock_delete:
+            result = svc.create_from_graph_editor(
+                portfolio_uuid="p1", graph_data={"nodes": []}, name="t"
+            )
+        assert result.is_success()
+        mock_delete.assert_not_called()


### PR DESCRIPTION
## Summary

`PortfolioMappingService.create_from_graph_editor` 跨库写非原子：步骤3 写 MongoDB 成功后，步骤4/5 sync MySQL Mapping/MParam 失败时，外层 `try-except` 返 error 但 **MongoDB 文档已成孤儿**（已持久化不回滚）。本 PR 聚焦 **create 路径**补偿。

## 根因

跨库（Mongo + MySQL）无法用单一 DB 事务保证原子性。原实现 try-except 只保证"不崩"，不保证"原子"——Mongo `insert_one` 已提交，下游 sync 抛异常后 Mongo 数据残留。

## 改动

- **`_delete_graph_from_mongo(doc_id)` 补偿原语**：`collection.delete_one({"_id": doc_id})`，返 `deleted_count > 0`。幂等（对不存在 _id 无害），异常时 log + 返 False 不抛
- **`create_from_graph_editor` 内层补偿 try-except**：步骤4/5（sync MySQL）包裹，失败立即调 `_delete_graph_from_mongo(mongo_id)` 删 Mongo 孤儿 + `raise`，让外层 `@retry`/`except` 决定重试或返错
  - `@retry` 重试时整个方法重跑 → 新 `save`（新 mongo_id）→ 若再失败 → 删新 mongo_id → 每次重试都补偿干净，不留累积孤儿

## 验收对照（#5559 原文：No compensating transactions or rollback logic exists）

- [x] **create_from_graph_editor**：MySQL sync 失败时补偿删 Mongo ✓
- [ ] **update_from_graph_editor**：同类问题（_update_graph_in_mongo 后 sync 失败），但 update 补偿需"恢复旧值快照"，逻辑更复杂，留 follow-up
- [ ] **remove_file**：删除路径补偿需"恢复已删数据"，逻辑不同，留 follow-up

本 PR 修最核心的**创建孤儿**（最高频、补偿最直接）。update/remove 的补偿语义不同（非简单 delete），单独 slice 处理更稳妥。

## Test plan

- [x] `tests/unit/data/services/test_portfolio_mapping_compensation.py`（5 passed，两切片）：
  - **Slice 1 `_delete_graph_from_mongo`**（2）：调 `delete_one({"_id": doc_id})` / 文档不存在 deleted_count=0 返 False（幂等）
  - **Slice 2 create 补偿**（3）：步骤4 sync Mapping 失败 → 删 Mongo + 返 error / 步骤5 sync MParam 失败（步骤4成功）→ 删 Mongo / 全成功不删（回归保护）
  - mock 模式：4 依赖 MagicMock 实例化 service + `patch.object` 方法，绕过真实 DB
- [x] Layer1 py_compile（src + api 全量）
- [x] Layer2 启动路径点名 smoke（user_crud_mock / containers / user_cli 29 passed）
- [x] Layer3 既有 `test_portfolio_mapping_service_smoke.py`（5 passed，未破坏）

## 注意

- 补偿在内层 try-except（sync 步骤），非外层 except —— 避免依赖外层 `@retry` 的最终 except（重试期间会累积孤儿）
- `@retry`（MAX_ATTEMPTS=3）重试时每次重新 save + 补偿，测试 mock `_save_graph_to_mongo` 返固定 doc_id，故补偿 3 次删同值；真实场景每次 save 返新 uuid，各自补偿
- `_delete_graph_from_mongo` 补偿失败（如 Mongo 也宕机）时 log + 返 False，不抛——避免补偿故障掩盖原始 sync 错误

Refs #5559
