### PR TITLE
fix(#5646): 空 portfolio 回测启动返回明确错误而非误导性 uuid 报错

### DIFF
--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -600,6 +600,15 @@ class BacktestTaskService(BaseService):
                     f"Task must be in one of: {', '.join(startable_states)}"
                 )
 
+            # 校验 portfolio 关联：派发前确认 portfolio_uuid 可解析，否则 worker
+            # 消费空值时会报误导性的 'portfolio_uuid is required'（#5646）
+            if not (portfolio_uuid or task.portfolio_id):
+                return ServiceResult.error(
+                    f"Backtest task '{task.uuid[:8]}' has no portfolio associated. "
+                    f"Recreate the backtest with a valid --portfolio binding so the "
+                    f"worker receives a non-empty portfolio_uuid."
+                )
+
             # ========== 重新运行：删除旧数据 ==========
             task_id = task.task_id
 

--- a/tests/unit/services/test_backtest_task_service_start_empty_portfolio.py
+++ b/tests/unit/services/test_backtest_task_service_start_empty_portfolio.py
@@ -1,0 +1,92 @@
+"""#5646: 空 portfolio 关联的回测启动应返回明确错误，而非派发无效任务
+让 worker 报误导性的 'portfolio_uuid is required'。
+
+根因: start_task 派发 Kafka 前不校验 portfolio_uuid 解析结果。
+assignment["portfolio_uuid"] = portfolio_uuid or task.portfolio_id，
+task.portfolio_id（model 默认空串）为空时仍派发，worker node.py:290
+消费时报 'portfolio_uuid is required'，让用户以为 UUID 没传——
+实际是 backtest task 记录的 portfolio 关联为空。
+
+修复: 派发前（状态机检查后、清理旧数据前）校验
+resolved = portfolio_uuid or task.portfolio_id，空则返回明确 error，
+不派发、不误导。
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+
+_TASK_UUID = "aa11223344556677889900aabbccddee"
+
+
+def _make_task(portfolio_id: str = "", status: str = "created"):
+    """模拟一条 backtest task 记录（含 start_task 读取的属性）。"""
+    task = MagicMock()
+    task.uuid = _TASK_UUID
+    task.task_id = _TASK_UUID
+    task.status = status
+    task.portfolio_id = portfolio_id
+    task.config_snapshot = json.dumps(
+        {"start_date": "2025-01-01", "end_date": "2025-06-01"}
+    )
+    task.backtest_start_date = None
+    task.backtest_end_date = None
+    task.name = "bt"
+    return task
+
+
+class TestStartTaskEmptyPortfolio:
+    """#5646: portfolio 关联为空时 start_task 返回明确不误导的错误。"""
+
+    @pytest.mark.unit
+    def test_empty_portfolio_returns_clear_error_and_does_not_dispatch(self):
+        """portfolio_id 空 + 未传 portfolio_uuid → 明确 error + 不派发 Kafka。"""
+        crud = MagicMock()
+        crud.get_by_uuid.return_value = _make_task(portfolio_id="")
+        svc = BacktestTaskService(crud)
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as producer_cls:
+            result = svc.start_task(uuid=_TASK_UUID)
+
+        # 明确失败
+        assert not result.is_success(), "空 portfolio 关联应返回失败，而非派发无效任务"
+        # 不误导：不得复用 worker 的字面报错
+        assert "portfolio_uuid is required" not in result.error
+        # 点明 portfolio 关联问题
+        assert "portfolio" in result.error.lower()
+        # 不派发 Kafka（不产生 worker 会误报的无效任务）
+        producer_cls.assert_not_called()
+
+    @pytest.mark.unit
+    def test_valid_portfolio_dispatches_with_portfolio_uuid(self):
+        """回归保护：portfolio_id 非空 → 正常派发，assignment 含非空 portfolio_uuid。"""
+        port_uuid = "port11223344556677889900aabbccdd"
+        crud = MagicMock()
+        crud.get_by_uuid.return_value = _make_task(portfolio_id=port_uuid)
+        svc = BacktestTaskService(crud)
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as producer_cls:
+            result = svc.start_task(uuid=_TASK_UUID)
+
+        assert result.is_success(), "有效 portfolio 关联应正常启动，不受校验影响"
+        producer_instance = producer_cls.return_value
+        producer_instance.send.assert_called_once()
+        _topic, sent_assignment = producer_instance.send.call_args.args
+        assert sent_assignment["portfolio_uuid"] == port_uuid
+
+    @pytest.mark.unit
+    def test_explicit_portfolio_uuid_arg_overrides_empty_task_field(self):
+        """显式传 portfolio_uuid 参数时，即使 task.portfolio_id 空也正常派发
+        （校验的 or 语义：portfolio_uuid 参数优先）。"""
+        crud = MagicMock()
+        crud.get_by_uuid.return_value = _make_task(portfolio_id="")
+        svc = BacktestTaskService(crud)
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as producer_cls:
+            result = svc.start_task(uuid=_TASK_UUID, portfolio_uuid="explicit-port-uuid")
+
+        assert result.is_success(), "显式传 portfolio_uuid 时应正常派发"
+        _topic, sent_assignment = producer_cls.return_value.send.call_args.args
+        assert sent_assignment["portfolio_uuid"] == "explicit-port-uuid"


### PR DESCRIPTION
## Summary

修复 #5646：空 portfolio 关联的回测启动时，worker 报误导性 `portfolio_uuid is required`，让用户以为 UUID 没传。

**根因**：`BacktestTaskService.start_task` 派发 Kafka 前不校验 portfolio_uuid 解析结果。assignment 的 `portfolio_uuid = portfolio_uuid or task.portfolio_id`，`task.portfolio_id`（model 默认空串）为空且调用方未传 `portfolio_uuid` 参数时，仍派发空值任务。worker `node.py:290` 消费时检查 `assignment.get("portfolio_uuid")` 为空，报 `portfolio_uuid is required`——这是 worker 的字面参数检查，丢失了 service 层的业务语义（"该回测没有关联 portfolio"），用户被误导去查 UUID 传参，而非 portfolio 关联本身。

**修复**（`src/ginkgo/data/services/backtest_task_service.py`）：
派发前（状态机检查通过后、清理旧数据前）增加校验：`if not (portfolio_uuid or task.portfolio_id)` 返回明确 `ServiceResult.error("Backtest task ... has no portfolio associated. Recreate the backtest with a valid --portfolio binding ...")`。校验表达式与既有派发逻辑 `portfolio_uuid or task.portfolio_id` 精准对齐，只拦截真正会派发空值的情形，不影响任何正常路径。

API 层 `start_backtest` 已将 `ServiceResult.error` 转 `BusinessError` 返回，用户在启动回测时立即收到明确错误，根本不会产生 worker 会误报的无效任务。

## Test plan

新增 `tests/unit/services/test_backtest_task_service_start_empty_portfolio.py`（3 例，纯 mock，不触达 DB/Kafka）：
- 空 portfolio_id + 未传 portfolio_uuid → 明确 error（不含误导字面 "portfolio_uuid is required"）+ 不派发 Kafka
- valid portfolio_id → 正常派发，assignment 含非空 portfolio_uuid（回归保护）
- 显式传 portfolio_uuid 参数 → 即使 task.portfolio_id 空也正常派发（or 语义）

冒烟三层：
- Layer 1 py_compile（src+api）✅
- Layer 2 启动路径 smoke（user_crud/containers/user_cli 29 passed）✅
- Layer 3 本测试 3 passed + 同模块 service 回归 4 passed（netvalue/analyzer_groups/order_records）✅

Closes #5646
