### PR TITLE
fix: Paper Trading 创建端点 ID 字段统一为 uuid (#5611)

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -290,7 +290,7 @@ async def create_paper_account(data: CreatePaperAccountRequest):
         logger.info(f"Paper account created: {portfolio_id} ({data.name})")
 
         return ok(
-            data={"account_id": portfolio_id},
+            data={"uuid": portfolio_id},
             message="Paper account created successfully"
         )
 

--- a/tests/api/test_paper_trading_create_uuid.py
+++ b/tests/api/test_paper_trading_create_uuid.py
@@ -1,0 +1,65 @@
+# Issue: #5611
+# Upstream: api.trading.create_paper_account
+# Downstream: pytest
+# Role: Paper Trading 创建端点 ID 字段统一为 uuid（与列表/详情端点一致）
+
+"""
+Paper Trading 创建端点 uuid 字段测试
+
+根因：create_paper_account (trading.py:241) 返回 data={"account_id": portfolio_id}，
+而 list (line 180) / detail (line 270) 端点统一返回 "uuid"。创建端点是全文件唯一
+异类——内部变量名就是 portfolio_id（取自 portfolio.uuid），返回时却改名 account_id。
+前端按创建响应取 account_id、按详情取 uuid，需双字段适配；遗漏一端即静默 undefined。
+
+修复：创建端点返回 data={"uuid": portfolio_id}，与列表/详情统一。
+"""
+
+import pytest
+from types import SimpleNamespace
+
+
+class TestCreatePaperAccountUuidField:
+    """#5611: 创建端点必须返回 uuid 字段（与列表/详情端点统一），而非 account_id"""
+
+    def test_create_returns_uuid_not_account_id(self, monkeypatch):
+        """创建成功响应的 data 含 'uuid'，不含 'account_id'（验收核心）"""
+        import asyncio
+        from api import trading
+
+        class FakeResult:
+            data = {"uuid": "port-abc123"}
+            def is_success(self): return True
+
+        class FakeSvc:
+            def add(self, **kwargs): return FakeResult()
+
+        monkeypatch.setattr(trading, "_get_portfolio_service", lambda: FakeSvc())
+
+        req = trading.CreatePaperAccountRequest(name="test-account")
+        resp = asyncio.run(trading.create_paper_account(req))
+
+        assert resp["code"] == 0
+        assert resp["data"]["uuid"] == "port-abc123"
+        # account_id 必须消失，否则前端仍会按旧字段名取值
+        assert "account_id" not in resp["data"]
+
+    def test_create_uuid_value_matches_service_result_list_form(self, monkeypatch):
+        """service 返回 list 形式 result 时，uuid 仍正确提取并以 uuid 字段返回（回归）"""
+        import asyncio
+        from api import trading
+
+        portfolio = SimpleNamespace(uuid="port-from-list-xyz")
+        class FakeResult:
+            data = [portfolio]  # 生产 PortfolioService.get 经 crud find 返回 list 形状
+            def is_success(self): return True
+        class FakeSvc:
+            def add(self, **kwargs): return FakeResult()
+
+        monkeypatch.setattr(trading, "_get_portfolio_service", lambda: FakeSvc())
+
+        req = trading.CreatePaperAccountRequest(name="list-form-account")
+        resp = asyncio.run(trading.create_paper_account(req))
+
+        assert resp["code"] == 0
+        assert resp["data"]["uuid"] == "port-from-list-xyz"
+        assert "account_id" not in resp["data"]

--- a/web-ui/src/api/modules/trading.ts
+++ b/web-ui/src/api/modules/trading.ts
@@ -108,7 +108,7 @@ export function getPaperAccounts() {
  * 创建模拟盘账户
  */
 export function createPaperAccount(data: CreatePaperAccount) {
-  return request<APIResponse<{ account_id: string }>>({
+  return request<APIResponse<{ uuid: string }>>({
     url: '/api/v1/paper-trading/accounts',
     method: 'POST',
     data


### PR DESCRIPTION
## Summary

修复 #5611：Paper Trading 创建账户端点返回 `account_id`，而列表/详情端点返回 `uuid`，同一实体两套 ID 字段名，前端需双适配。

**根因**：`create_paper_account`（trading.py:241）手动构造返回 dict 时用 `"account_id"` 作 key——全文件唯一异类。内部变量名就是 `portfolio_id`（取自 portfolio.uuid），返回时却改名。列表端点（line 180）与详情端点（line 270）均已统一用 `"uuid"`。

**修复**（`api/api/trading.py`）：创建端点返回 `data={"uuid": portfolio_id}`，与列表/详情三端点统一。

**Breaking 影响评估**：grep 确认无前端/CLI 消费 `account_id`（client/、web 前端均无匹配），api 内部仅 trading.py 两处用 `"account_id"` 作 key——另一处（line 611）是订单记录的"归属账户"外键引用，语义正确不在本 issue 范围。web-ui 正整体重构中。

## Test plan

新增 `tests/api/test_paper_trading_create_uuid.py`（2 例，mock service，不触达 DB/Kafka，不启动 app）：
- 创建成功响应 `data.uuid` 存在且值正确，`account_id` 消失（验收核心）
- service 返回 list 形式 result 时，uuid 仍正确提取并以 uuid 字段返回（回归保护提取逻辑）

冒烟三层：
- Layer 1 py_compile（src+api）✅
- Layer 2 启动路径 smoke（user_crud/containers/user_cli 29 passed）✅
- Layer 3 本测试 2 passed + sibling test_paper_trading_status 6 passed（无回归）✅

Closes #5611
