### PR TITLE
fix(#5529): 补 84a2 merge node 修 migration 链断裂 + gitignore *credential* 误伤

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ docker-compose.override.yml
 private_*
 *secret*
 *credential*
+!*.py
 credentials.*
 api_key.*
 access_token.*

--- a/migrations/mysql/versions/84a2de8c7c00_add_deployment_and_user_credentials_.py
+++ b/migrations/mysql/versions/84a2de8c7c00_add_deployment_and_user_credentials_.py
@@ -1,0 +1,69 @@
+"""add deployment and user_credentials tables
+
+Revision ID: 84a2de8c7c00
+Revises: 0336f9b2c8a2, t088_trade_records
+Create Date: 2026-03-30 10:59:58.419459
+
+Merge node: 收敛 0336f9b2c8a2 (extend_models_for_live_trading) 与
+t088_trade_records 两条分支（两者 down_revision 均为 0245d8e3a9f1）。
+此前该文件仅存在于未合并的 feature 分支，master 缺失导致 a1b2c3d4e5f6
+的 down_revision='84a2de8c7c00' 悬空、alembic upgrade head 报 multiple heads (#5529)。
+
+user_credentials 表镜像 MUserCredential(model_user_credential.py)：user_id
+外键指向 users.uuid（users 表由 create_all 建立，属项目 create_all + alembic
+混合建表惯例）。
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '84a2de8c7c00'
+down_revision: Union[str, Sequence[str], None] = ('0336f9b2c8a2', 't088_trade_records')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'deployment',
+        sa.Column('uuid', sa.String(32), primary_key=True),
+        sa.Column('source_task_id', sa.String(32), server_default='', comment='回测任务ID'),
+        sa.Column('target_portfolio_id', sa.String(32), server_default='', comment='部署后的Portfolio ID'),
+        sa.Column('source_portfolio_id', sa.String(32), server_default='', comment='原始回测Portfolio ID'),
+        sa.Column('mode', sa.Integer(), server_default='-1', comment='运行模式: 0=回测, 1=纸上交易, 2=实盘'),
+        sa.Column('account_id', sa.String(32), nullable=True, comment='实盘账号ID (live模式)'),
+        sa.Column('status', sa.Integer(), server_default='0', comment='部署状态'),
+        sa.Column('meta', sa.String(255), server_default='{}'),
+        sa.Column('desc', sa.String(255), server_default='This man is lazy, there is no description.'),
+        sa.Column('create_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('update_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('is_del', sa.Boolean(), server_default='0'),
+        sa.Column('source', sa.SmallInteger(), server_default='-1'),
+        comment='部署记录表',
+    )
+    op.create_table(
+        'user_credentials',
+        sa.Column('uuid', sa.String(32), primary_key=True),
+        sa.Column('user_id', sa.String(32), sa.ForeignKey('users.uuid'), nullable=False,
+                  unique=True, index=True, comment='关联用户UUID（外键 users.uuid）'),
+        sa.Column('password_hash', sa.String(256), nullable=False, server_default='', comment='密码哈希'),
+        sa.Column('is_active', sa.Boolean(), server_default=sa.text('1'), comment='凭据是否启用'),
+        sa.Column('is_admin', sa.Boolean(), server_default=sa.text('0'), comment='是否管理员'),
+        sa.Column('meta', sa.String(255), server_default='{}'),
+        sa.Column('desc', sa.String(255), server_default='This man is lazy, there is no description.'),
+        sa.Column('create_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('update_at', sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column('is_del', sa.Boolean(), server_default='0'),
+        sa.Column('source', sa.SmallInteger(), server_default='-1'),
+        comment='用户凭据表',
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('user_credentials')
+    op.drop_table('deployment')

--- a/tests/unit/database/migrations/test_migration_chain_integrity.py
+++ b/tests/unit/database/migrations/test_migration_chain_integrity.py
@@ -1,0 +1,185 @@
+"""
+MySQL migration 链完整性测试 (#5529)
+
+验证 migrations/mysql/versions/ 形成**线性链**（无分支冲突、无悬空 down_revision），
+且 merge node 84a2de8c7c00 正确合并 0336f9b2c8a2 + t088_trade_records 两分支，
+upgrade 同时建 deployment 与 user_credentials 表。
+
+纯 ast 静态解析（不 import alembic / 不连 DB），聚焦链结构与建表声明的正确性。
+"""
+
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[4] / "migrations" / "mysql" / "versions"
+
+
+def _parse_module(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _extract_revision_metadata(tree: ast.AST):
+    """从模块 ast 提取 revision / down_revision（str 或 tuple）。"""
+    revision = None
+    down_revision = None
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is None:
+                continue
+            if node.target.id == "revision":
+                revision = ast.literal_eval(node.value)
+            elif node.target.id == "down_revision":
+                down_revision = ast.literal_eval(node.value)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    if target.id == "revision":
+                        revision = ast.literal_eval(node.value)
+                    elif target.id == "down_revision":
+                        down_revision = ast.literal_eval(node.value)
+    return revision, down_revision
+
+
+def _first_string_arg(call: ast.Call):
+    """op.create_table('name', ...) / op.drop_table('name') 的第一个字面量参数。"""
+    if call.args and isinstance(call.args[0], ast.Constant):
+        return call.args[0].value
+    return None
+
+
+def _tables_in_func(tree: ast.AST, func_name: str, method: str):
+    """收集某函数体里 op.<method>('table') 的所有表名。"""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            tables = []
+            for inner in ast.walk(node):
+                if (isinstance(inner, ast.Call)
+                        and isinstance(inner.func, ast.Attribute)
+                        and inner.func.attr == method
+                        and isinstance(inner.func.value, ast.Name)):
+                    name = _first_string_arg(inner)
+                    if name is not None:
+                        tables.append(name)
+            return tables
+    return []
+
+
+def _load_all_migrations():
+    """返回 {revision: {'path', 'down_revision', 'tree'}}。down_revision 归一为 tuple。"""
+    result = {}
+    for py in sorted(MIGRATIONS_DIR.glob("*.py")):
+        if py.name == "__init__.py":
+            continue
+        tree = _parse_module(py)
+        revision, down = _extract_revision_metadata(tree)
+        if revision is None:
+            continue
+        down_tuple = down if isinstance(down, tuple) else ((down,) if down else ())
+        result[revision] = {"path": py, "down": down_tuple, "raw_down": down, "tree": tree}
+    return result
+
+
+# ---------- 84a2 merge node 存在性与结构 ----------
+
+def _find_84a2_path():
+    for py in MIGRATIONS_DIR.glob("*.py"):
+        if py.name.startswith("84a2de8c7c00"):
+            return py
+    return None
+
+
+def test_84a2_merge_node_exists_on_master():
+    """84a2 必须存在于 master（#5529：a1b2 down=84a2 但文件缺失致链断裂）。"""
+    path = _find_84a2_path()
+    assert path is not None, "84a2de8c7c00 merge node 不存在 → a1b2c3d4e5f6 的 down_revision 悬空"
+
+
+def test_84a2_down_revision_merges_both_branches():
+    """84a2.down_revision 必须是 tuple 合并 0336f9b2c8a2 + t088_trade_records。"""
+    path = _find_84a2_path()
+    if path is None:
+        pytest.skip("84a2 不存在（前置测试未通过）")
+    tree = _parse_module(path)
+    revision, down = _extract_revision_metadata(tree)
+    assert revision == "84a2de8c7c00"
+    assert isinstance(down, tuple), f"down_revision 应为 tuple（merge node），实际 {type(down).__name__}: {down}"
+    assert "0336f9b2c8a2" in down and "t088_trade_records" in down
+
+
+def test_84a2_upgrade_creates_deployment_and_user_credentials():
+    """upgrade 必须同时建 deployment 与 user_credentials（#5529：原仅建 deployment 漏 user_credentials）。"""
+    path = _find_84a2_path()
+    if path is None:
+        pytest.skip("84a2 不存在")
+    tree = _parse_module(path)
+    created = set(_tables_in_func(tree, "upgrade", "create_table"))
+    assert "deployment" in created, f"upgrade 未建 deployment，实际 {created}"
+    assert "user_credentials" in created, f"upgrade 未建 user_credentials（#5529 缺口），实际 {created}"
+
+
+def test_84a2_downgrade_drops_both_tables():
+    """downgrade 必须 drop user_credentials 与 deployment（逆序）。"""
+    path = _find_84a2_path()
+    if path is None:
+        pytest.skip("84a2 不存在")
+    tree = _parse_module(path)
+    dropped = _tables_in_func(tree, "downgrade", "drop_table")
+    assert "user_credentials" in dropped
+    assert "deployment" in dropped
+    # user_credentials 后建，必须先 drop（逆序）
+    assert dropped.index("user_credentials") < dropped.index("deployment")
+
+
+# ---------- 全链完整性 ----------
+
+def test_no_dangling_down_revision():
+    """每个 down_revision 必须指向链中存在的 revision（或为空=根）。"""
+    migrations = _load_all_migrations()
+    known = set(migrations.keys())
+    dangling = []
+    for rev, meta in migrations.items():
+        for parent in meta["down"]:
+            if parent not in known:
+                dangling.append((rev, parent))
+    assert not dangling, f"悬空 down_revision: {dangling}（指向不存在的 revision）"
+
+
+def test_migration_chain_has_single_head():
+    """链必须有唯一 head（无下游的 revision）。多个 head = 分支未 merge = upgrade head 歧义。"""
+    migrations = _load_all_migrations()
+    if not migrations:
+        pytest.skip("无 migration 文件")
+    all_parents = {p for meta in migrations.values() for p in meta["down"]}
+    heads = [rev for rev in migrations if rev not in all_parents]
+    assert len(heads) == 1, (
+        f"期望单一 head，实际 {len(heads)} 个 heads: {heads}（存在未 merge 的分支）"
+    )
+
+
+def test_branch_points_have_merge_nodes():
+    """每个分支点（>1 子节点）必须被某 merge node 收敛（down_revision tuple）。"""
+    migrations = _load_all_migrations()
+    # parent -> 子节点列表
+    children_count = {}
+    for meta in migrations.values():
+        for parent in meta["down"]:
+            children_count[parent] = children_count.get(parent, 0) + 1
+    # 分支点：有 >1 子节点
+    branch_points = {p for p, c in children_count.items() if c > 1}
+    if not branch_points:
+        return
+    # 每个 branch_point 必须存在某 migration 的 down_revision(tuple) 收敛其所有子节点
+    for bp in branch_points:
+        # 找该 branch_point 的所有子 revision
+        children_of_bp = {rev for rev, meta in migrations.items() if bp in meta["down"]}
+        # 找 merge node：down_revision 为 tuple 且包含全部 children_of_bp
+        merged = False
+        for rev, meta in migrations.items():
+            if isinstance(meta["raw_down"], tuple) and children_of_bp <= set(meta["down"]):
+                merged = True
+                break
+        assert merged, f"分支点 {bp} 的子节点 {children_of_bp} 未被 merge node 收敛"


### PR DESCRIPTION
## Summary

修复 master 上 MySQL migration 链断裂：`a1b2c3d4e5f6.down_revision='84a2de8c7c00'` 指向的 merge node **从未进 master**，导致 `alembic upgrade head` 报 multiple heads / 找不到 revision。

## 根因（双层）

**层 1 — .gitignore 误伤（真正根因）**：`.gitignore` 的 `*credential*` 规则宽泛匹配任何路径含 "credential" 的文件，静默拦截了文件名含 `user_credentials` 的 84a2 migration 文件。开发者 `git add` 后文件不出现，误以为已提交 → 84a2 从未进 master。此前 84a2 存在于多个 feature 分支（6257-6261…），但都被这条规则阻断合并。

**层 2 — 链断裂后果**：master 缺 84a2 →
- `a1b2c3d4e5f6.down_revision='84a2de8c7c00'` 悬空（指向不存在的 revision）
- `0336f9b2c8a2` 与 `t088_trade_records` 都 `down_revision='0245d8e3a9f1'` 形成分支，无 merge node 收敛
- `alembic heads` 显示 3 个 head（0336/t088/t091），`upgrade head` 歧义失败

## 改动

- **补 `migrations/mysql/versions/84a2de8c7c00_add_deployment_and_user_credentials_.py`**：merge node，`down_revision=('0336f9b2c8a2','t088_trade_records')` 收敛两分支。upgrade 建 `deployment` + `user_credentials` 表（feature 分支旧版本漏建 user_credentials，本 PR 补齐，镜像 `MUserCredential` model 字段：user_id FK→users.uuid / password_hash / is_active / is_admin + MMysqlBase 7 base 字段）
- **`.gitignore` 加 `!*.py` negation**（`*credential*` 之后）：保留凭据文件安全网（`fake_credential.env`/`credentials.json` 验证仍被 ignore），解除合法 `.py` 误伤（migration/model/crud）

## 验收对照

- [x] **线性链无分支**：`alembic heads` → 单一 `t091 (head)`（修复前 3 heads）
- [x] **user_credentials 表正确创建**：84a2 upgrade `create_table('user_credentials')` 镜像 model
- [x] **migration 链无悬空 down_revision**：所有 down_revision 指向存在的 revision
- [ ] 新 DB `alembic upgrade head` 成功：user_credentials 外键依赖 `users` 表（由 `create_all` 建立，项目混合建表惯例），纯 alembic 路径需先 create_all 基础表（留 follow-up，非本 issue scope）

## Test plan

- [x] `tests/unit/database/migrations/test_migration_chain_integrity.py`（7 passed，纯 ast 静态解析不连 DB）：
  - 84a2 存在 / down_revision 为 tuple 合并两分支 / upgrade 建双表 / downgrade 逆序 drop 双表
  - 全链：无悬空 down_revision / 单一 head / 分支点被 merge node 收敛
- [x] `alembic heads` 权威验证：`t091 (head)` 单一（alembic 自身判定）
- [x] Layer1 py_compile（src+api+migrations）
- [x] Layer2 启动路径点名 smoke（user_crud_mock / containers / user_cli 29 passed）
- [x] .gitignore 安全网回归：`fake_credential.env` + `credentials.json` 验证仍被 ignore

## 注意

- 84a2 同时建 deployment 表（feature 分支旧版本已有，master 缺失，本 PR 一并补入，保持链完整）
- 现有 `model_user_credential.py` / `user_credential_crud.py` 历史 tracked（.gitignore 规则前加入），本 PR 的 `!*.py` 不影响它们的已 tracked 状态，只保护未来新增 .py
- user_credentials 外键 `users.uuid`：users 表无 migration（由 create_all 建），混合模式下 upgrade 前需 create_all

Closes #5529
