### PR TITLE
fix: DatabaseDriverBase 流式连接生命周期管理（return + context manager）(#5514)

### DIFF
--- a/src/ginkgo/data/drivers/base_driver.py
+++ b/src/ginkgo/data/drivers/base_driver.py
@@ -243,6 +243,40 @@ class DatabaseDriverBase(ABC):
             GLOG.ERROR(f"Failed to get streaming connection for {self.driver_name}: {e}")
             raise
 
+    def return_streaming_connection(self, connection):
+        """归还流式查询原生连接：close 连接 + 递减活跃计数。
+
+        get_streaming_connection 返回裸连接无归还机制（#5514），调用方用完须显式
+        调本方法归还，否则连接泄漏且 active_streaming_connections 计数虚高。
+        close 异常不阻塞计数递减（finally），active>0 guard 防计数越界致负。
+        """
+        if connection is None:
+            return
+        try:
+            connection.close()
+        except Exception as e:
+            GLOG.ERROR(f"Failed to close streaming connection for {self.driver_name}: {e}")
+        finally:
+            with self._lock:
+                self._connection_stats["streaming_connections_closed"] += 1
+                # guard 防负数：get +1 与 return -1 不配对时不下穿下界
+                if self._connection_stats["active_streaming_connections"] > 0:
+                    self._connection_stats["active_streaming_connections"] -= 1
+
+    @contextmanager
+    def streaming_connection(self):
+        """流式查询原生连接的上下文管理器（自动归还）。
+
+        推荐用法：``with driver.streaming_connection() as conn: ...``，退出时自动
+        close 连接并递减计数器，杜绝忘记归还导致的泄漏（#5514）。try/finally 保证
+        异常路径也归还。底层复用 get_streaming_connection，与裸获取路径计数一致。
+        """
+        connection = self.get_streaming_connection()
+        try:
+            yield connection
+        finally:
+            self.return_streaming_connection(connection)
+
     # ==================== 健康检查 ====================
 
     @cache_with_expiration(expiration_seconds=300)

--- a/tests/unit/data/drivers/test_streaming_connection_lifecycle.py
+++ b/tests/unit/data/drivers/test_streaming_connection_lifecycle.py
@@ -1,0 +1,104 @@
+# Issue: #5514
+# Upstream: ginkgo.data.drivers.base_driver.DatabaseDriverBase
+# Downstream: pytest
+# Role: 流式查询连接生命周期管理（return 方法 + context manager + 计数器对称）
+
+"""
+DatabaseDriverBase 流式连接生命周期测试
+
+根因：get_streaming_connection (base_driver.py:226-244) 返回裸连接无归还机制，
+active_streaming_connections 计数器 +1（line 240）无配对 -1 路径，调用方无法
+归还连接 → 连接泄漏 + 计数虚高/负数。对比 streaming_session（line 201-224）有
+完整 try/finally，get_streaming_connection 没有。
+
+修复：新增 return_streaming_connection()（显式归还）+ streaming_connection()
+context manager（自动归还，try/finally），计数器 increment/decrement 对称，
+return 带 active>0 guard 防负数。
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.data.drivers.base_driver import DatabaseDriverBase
+
+
+class _ConcreteDriver(DatabaseDriverBase):
+    """最小具体子类（测试抽象基类，mock 掉抽象方法）"""
+    def __init__(self):
+        super().__init__("TestDriver")
+    def _create_engine(self): return MagicMock()
+    def _create_streaming_engine(self): return MagicMock()
+    def _health_check_query(self): return "SELECT 1"
+    def _get_uri(self): return "test://localhost"
+    def _get_streaming_uri(self): return "test://localhost/streaming"
+
+
+def _make_driver():
+    """构造已启用 streaming 的 driver（mock _streaming_engine，跳过真实初始化）"""
+    driver = _ConcreteDriver()
+    driver._streaming_enabled = True
+    driver._streaming_engine = MagicMock()
+    return driver
+
+
+@pytest.mark.unit
+class TestStreamingConnectionLifecycle:
+    """#5514: 流式连接必须可归还，计数器对称（get +1 / return -1）"""
+
+    def test_context_manager_releases_on_exit(self):
+        """context manager 退出时 close 连接 + 计数器归零（验收：连接生命周期）"""
+        driver = _make_driver()
+        mock_conn = MagicMock()
+        driver._streaming_engine.raw_connection.return_value = mock_conn
+
+        with driver.streaming_connection() as conn:
+            assert conn is mock_conn
+            # 进入时计数 +1（与 get_streaming_connection 的 increment 对称）
+            assert driver._connection_stats["active_streaming_connections"] == 1
+
+        # 退出后计数归零 + 连接被 close
+        assert driver._connection_stats["active_streaming_connections"] == 0
+        mock_conn.close.assert_called_once()
+
+    def test_context_manager_releases_on_exception(self):
+        """context manager 内抛异常时，finally 仍 close + 计数归零（验收：try/finally 对称）"""
+        driver = _make_driver()
+        mock_conn = MagicMock()
+        driver._streaming_engine.raw_connection.return_value = mock_conn
+
+        with pytest.raises(ValueError, match="boom"):
+            with driver.streaming_connection() as conn:
+                assert driver._connection_stats["active_streaming_connections"] == 1
+                raise ValueError("boom")
+
+        # 异常路径也归还，否则一次失败永久泄漏一个连接 + 计数虚高
+        assert driver._connection_stats["active_streaming_connections"] == 0
+        mock_conn.close.assert_called_once()
+
+    def test_return_streaming_connection_decrements_counter(self):
+        """显式 return_streaming_connection：close 连接 + 计数 -1（验收：return 方法存在）"""
+        driver = _make_driver()
+        mock_conn = MagicMock()
+        driver._streaming_engine.raw_connection.return_value = mock_conn
+
+        conn = driver.get_streaming_connection()
+        assert driver._connection_stats["active_streaming_connections"] == 1
+
+        driver.return_streaming_connection(conn)
+
+        assert driver._connection_stats["active_streaming_connections"] == 0
+        assert driver._connection_stats["streaming_connections_closed"] == 1
+        mock_conn.close.assert_called_once()
+
+    def test_return_guard_prevents_negative_counter(self):
+        """多余 return 不致 active 计数下穿 0 变负（验收：counter 不负）"""
+        driver = _make_driver()
+        mock_conn = MagicMock()
+        driver._streaming_engine.raw_connection.return_value = mock_conn
+
+        conn = driver.get_streaming_connection()   # active 0 → 1
+        driver.return_streaming_connection(conn)    # active 1 → 0
+        driver.return_streaming_connection(conn)    # guard：active 已 0，不减；close 仍调用
+
+        assert driver._connection_stats["active_streaming_connections"] == 0
+        assert mock_conn.close.call_count == 2


### PR DESCRIPTION
## Summary

修复 #5514：`DatabaseDriverBase.get_streaming_connection()` 返回裸连接无归还机制，`active_streaming_connections` 计数器 +1（line 240）无配对 -1 路径，调用方无法归还 → 连接泄漏 + 计数虚高/负数。

**根因**：get_streaming_connection（base_driver.py:226-244）line 240 `active += 1` 后裸 `return connection`，无 finally/return 方法。对比同文件 streaming_session（line 201-224）有完整 try/finally（finally 内 close + 计数 -1）。get_streaming_connection 是唯一缺失对称释放的资源接口。

**修复**（`src/ginkgo/data/drivers/base_driver.py`，增量加方法，不改现有 get 签名）：
- `return_streaming_connection(connection)`：显式归还——close 连接 + 计数 -1，`active>0` guard 防越界致负，close 异常不阻塞计数递减（finally）
- `streaming_connection()` context manager：自动归还（try/finally），底层复用 get_streaming_connection，与裸获取路径计数一致

**Base 类说明**：DatabaseDriverBase 是抽象基类，但本次为 issue 验收明确要求的增量接口补全（加新方法），不修改现有 get_streaming_connection 签名/行为，所有子类（ClickHouse/MySQL/Mongo/Redis）自动继承向后兼容。grep 确认无生产代码调用 get_streaming_connection（仅测试引用），加 context manager 不破坏任何生产路径。

## Test plan

新增 `tests/unit/data/drivers/test_streaming_connection_lifecycle.py`（4 例，纯 mock，不触达真实 DB）：
- context manager 退出 close 连接 + 计数归零（验收：连接生命周期）
- context manager 异常时 finally 仍归还（验收：try/finally 对称）
- 显式 return_streaming_connection：close + 计数 -1（验收：return 方法）
- 多余 return 不致 active 计数变负（验收：counter 不负）

冒烟三层：
- Layer 1 py_compile（src+api）✅
- Layer 2 启动路径 smoke（user_crud/containers/user_cli 29 passed）✅
- Layer 3 本测试 4 passed + sibling test_base_driver.py 50 passed（get_streaming_connection 等现有方法无回归）✅

Closes #5514
