### PR TITLE
fix(#5564): BaseMongoCRUD update/modify 防御性 copy 输入 dict 避免原地污染

### DIFF
--- a/src/ginkgo/data/crud/base_mongo_crud.py
+++ b/src/ginkgo/data/crud/base_mongo_crud.py
@@ -235,6 +235,8 @@ class BaseMongoCRUD(Generic[T], ABC):
         try:
             collection = self._get_collection()
 
+            # 防御性 copy：隔离 caller 输入，避免 setdefault 原地污染 (#5564)
+            update_dict = dict(update_dict)
             # 自动更新 update_at 字段
             update_dict.setdefault("update_at", pd.Timestamp.now().isoformat())
 
@@ -411,6 +413,8 @@ class BaseMongoCRUD(Generic[T], ABC):
         try:
             collection = self._get_collection()
 
+            # 防御性 copy：隔离 caller 输入，避免 setdefault 原地污染 (#5564)
+            updates = dict(updates)
             # 自动更新 update_at 字段
             updates.setdefault("update_at", pd.Timestamp.now().isoformat())
 

--- a/tests/unit/data/crud/test_base_mongo_crud_input_mutation.py
+++ b/tests/unit/data/crud/test_base_mongo_crud_input_mutation.py
@@ -1,0 +1,75 @@
+"""
+性能: 待测
+"""
+
+# Upstream: BaseMongoCRUD (继承)
+# Downstream: None (单元测试)
+# Role: BaseMongoCRUD update/modify 输入突变防护测试 (#5564)
+#
+# 验证 update_dict / updates 不被原地 setdefault("update_at") 污染：
+# caller 复用同一 dict 批量调用，不会累积 stale 字段。
+
+
+from unittest.mock import MagicMock
+
+from ginkgo.data.crud.base_mongo_crud import BaseMongoCRUD
+from ginkgo.data.models.model_mongobase import MMongoBase
+
+
+class _ConcreteMongoCRUD(BaseMongoCRUD):
+    """最小具体子类：满足 __init_subclass__ 的 _model_class 要求，
+    override _get_collection 返回注入的 mock collection，绕过真实 driver。"""
+
+    _model_class = MMongoBase
+
+    def __init__(self, collection):
+        super().__init__(MMongoBase, MagicMock())
+        self._collection = collection
+
+    def _get_collection(self):
+        return self._collection
+
+
+def test_update_does_not_mutate_caller_update_dict():
+    """update() 自动补 update_at 时，不应污染 caller 传入的 update_dict。"""
+    collection = MagicMock()
+    collection.update_one.return_value = MagicMock(modified_count=1)
+    crud = _ConcreteMongoCRUD(collection)
+
+    caller_dict = {"name": "updated"}
+    crud.update("some-uuid", caller_dict)
+
+    # caller 的原 dict 保持纯净，未被加上 update_at
+    assert "update_at" not in caller_dict
+    # 传给 MongoDB 的 $set 仍应包含自动补的 update_at
+    set_doc = collection.update_one.call_args[0][1]["$set"]
+    assert "update_at" in set_doc
+
+
+def test_modify_does_not_mutate_caller_updates():
+    """modify() 自动补 update_at 时，不应污染 caller 传入的 updates dict。"""
+    collection = MagicMock()
+    collection.update_many.return_value = MagicMock(modified_count=2)
+    crud = _ConcreteMongoCRUD(collection)
+
+    caller_updates = {"status": "active"}
+    crud.modify({"category": "x"}, caller_updates)
+
+    assert "update_at" not in caller_updates
+    set_doc = collection.update_many.call_args[0][1]["$set"]
+    assert "update_at" in set_doc
+
+
+def test_same_dict_reused_across_updates_keeps_caller_pure():
+    """验收第2条：同一 dict 被多次 update 复用，caller dict 不累积 stale update_at。"""
+    collection = MagicMock()
+    collection.update_one.return_value = MagicMock(modified_count=1)
+    crud = _ConcreteMongoCRUD(collection)
+
+    shared = {"name": "x"}
+    crud.update("u1", shared)
+    crud.update("u2", shared)
+    crud.update("u3", shared)
+
+    # caller 的 shared dict 三次调用后仍只有原始 key，不累积 update_at
+    assert set(shared.keys()) == {"name"}


### PR DESCRIPTION
## Summary

修复 #5564：`BaseMongoCRUD.update()` 和 `.modify()` 原地修改 caller 传入的 `update_dict`/`updates` 字典（`setdefault("update_at", ...)`），caller 复用同一 dict 批量调用会累积 stale `update_at` 字段，导致数据污染。

**根因**：base_mongo_crud.py 所有 filter/query 路径都已 `.copy()` 隔离 caller 输入，唯独 update 的 `update_dict`(239) 和 modify 的 `updates`(415) 两处遗漏——modify 内紧邻的 `filters` 已 `filters.copy()`(418)，却漏了 `updates`，防护不对称。

**审计（验收第3条）**：

| 行 | 方法 | 输入 | copy? |
|---|---|---|---|
| 191 | get_by_filters | filter_dict | ✅ |
| 239 | **update** | update_dict | ❌ 本次修 |
| 298 | delete_by_filters | filters | ✅ |
| 354 | count_by_filters | filter_dict | ✅ |
| 415 | **modify** | updates | ❌ 本次修 |
| 418 | modify | filters | ✅ |

仅 2 处需修，范围精确。

**修复**：update/modify 开头各加一行 `dict()` 浅 copy，与既有 filter/query 路径防护对称。无签名变更，无契约变更。

**基类禁令评估**：BaseMongoCRUD 是抽象基类，但本次为 issue 驱动的防御性浅 copy（无签名/契约变更，无子类 override base update/modify，grep 确认），同 #5514 模式，不违反"禁止擅自修改 Base 类"。

## Test plan

新增 `tests/unit/data/crud/test_base_mongo_crud_input_mutation.py`（3 例，纯 mock，不触达 DB）：
- update() 不污染 caller update_dict（setdefault update_at 后 caller dict 无 update_at，传给 MongoDB 的 $set 含）
- modify() 不污染 caller updates
- 验收第2条：同 dict 多次 update 复用，caller dict 不累积 stale（三次调用后 keys 仍只原始字段）

冒烟三层：
- Layer 1 py_compile（src+api）✅
- Layer 2 启动路径 smoke（user_crud/containers/user_cli 29 passed）✅
- Layer 3 新测试 3 passed + 同模块 mongo crud 回归（notification_template/record 33 passed，portfolio_config 12 passed）✅

Closes #5564
