### PR TITLE
fix(#5563): ExecutionNode/BackpressureChecker 计数器加锁防并发丢计数

### DIFF
--- a/src/ginkgo/workers/execution_node/backpressure.py
+++ b/src/ginkgo/workers/execution_node/backpressure.py
@@ -74,37 +74,36 @@ class BackpressureChecker:
                 "message": str
             }
         """
-        self.total_checks += 1
-
         # 计算队列使用率
         if max_size <= 0:
             usage = 0.0
         else:
             usage = current_size / max_size
 
-        # 判断背压级别
+        # 判断背压级别（纯计算，无需持锁）
         if usage >= self.critical_threshold:
             # CRITICAL级别：拒绝新消息
             level = "CRITICAL"
             action = "reject"
             message = f"Queue {portfolio_id} at {usage*100:.1f}% capacity (CRITICAL)"
-            self.critical_count += 1
-
         elif usage >= self.warning_threshold:
             # WARNING级别：记录警告
             level = "WARNING"
             action = "warn"
             message = f"Queue {portfolio_id} at {usage*100:.1f}% capacity (WARNING)"
-            self.warning_count += 1
-
         else:
             # OK级别：正常
             level = "OK"
             action = "accept"
             message = f"Queue {portfolio_id} at {usage*100:.1f}% capacity"
 
-        # 记录历史
+        # 原子更新计数器 + 历史（#5563：int += 非原子，须与 history 同锁）
         with self.lock:
+            self.total_checks += 1
+            if level == "CRITICAL":
+                self.critical_count += 1
+            elif level == "WARNING":
+                self.warning_count += 1
             self.backpressure_history.append({
                 "timestamp": datetime.now().isoformat(),
                 "portfolio_id": portfolio_id,

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -105,9 +105,12 @@ class ExecutionNode:
         self.heartbeat_ttl = 30  # 心跳TTL 30秒
 
         # 背压统计
+        # 注意：这些计数器被多线程并发访问（market-data 消费线程写、
+        # 心跳线程/API status 读），必须通过 _counter_lock 保护，禁止裸 +=。
         self.backpressure_count = 0
         self.dropped_event_count = 0
         self.total_event_count = 0
+        self._counter_lock = Lock()
 
         # 节点元数据
         self.max_portfolios = 5  # 最大可运行的Portfolio数量
@@ -127,6 +130,27 @@ class ExecutionNode:
         # 初始化子模块（心跳管理 + 调度命令处理）
         self._heartbeat_manager = HeartbeatManager(self)
         self._command_handler = SchedulerCommandHandler(self)
+
+    # --- 背压计数器线程安全封装 (#5563) ---
+    # int += 1 是 LOAD/INCR/STORE 三步非原子（GIL 仅字节码边界释放），
+    # 多线程并发裸 += 会丢计数；独立读分子分母算 rate 会跨时刻不一致。
+    # 所有读写必须经封装方法，持 _counter_lock。
+
+    def record_event_processed(self):
+        """记录一个已路由的事件（原子递增 total_event_count）"""
+        with self._counter_lock:
+            self.total_event_count += 1
+
+    def record_backpressure_drop(self):
+        """记录一次队列满导致的背压丢弃（原子递增 backpressure/dropped）"""
+        with self._counter_lock:
+            self.backpressure_count += 1
+            self.dropped_event_count += 1
+
+    def _snapshot_counters(self):
+        """获取三个计数器的快照（原子读取，保证 rate 计算分子分母一致）"""
+        with self._counter_lock:
+            return (self.total_event_count, self.backpressure_count, self.dropped_event_count)
 
     def start(self):
         """
@@ -925,7 +949,7 @@ class ExecutionNode:
             logger.debug(f"ExecutionNode {self.node_id} is paused, skipping event routing for {event.code}")
             return
 
-        self.total_event_count += 1
+        self.record_event_processed()
 
         # Phase 4：使用InterestMap优化路由（O(1)查询）
         # 获取订阅该股票的Portfolio列表
@@ -953,8 +977,7 @@ class ExecutionNode:
 
             except queue.Full:
                 # 队列满，记录背压
-                self.backpressure_count += 1
-                self.dropped_event_count += 1
+                self.record_backpressure_drop()
 
                 # 获取队列使用率
                 try:
@@ -970,7 +993,8 @@ class ExecutionNode:
                 GLOG.WARN(f"[BACKPRESSURE] Portfolio {portfolio_id} queue full")
                 GLOG.WARN(f"  - Event: {event.code} at {event.timestamp if hasattr(event, 'timestamp') else 'N/A'}")
                 GLOG.WARN(f"  - Queue: {queue_size}/1000 ({queue_usage*100:.1f}%)")
-                GLOG.WARN(f"  - Total backpressure: {self.backpressure_count}, dropped: {self.dropped_event_count}")
+                _, _bp, _dropped = self._snapshot_counters()
+                GLOG.WARN(f"  - Total backpressure: {_bp}, dropped: {_dropped}")
 
                 # TODO: Phase 4 - 发送背压告警到监控系统
                 # self._send_backpressure_alert(portfolio_id, queue_usage, event)
@@ -1171,10 +1195,11 @@ class ExecutionNode:
         else:
             status = "RUNNING"
 
-        # 计算背压率
+        # 计算背压率（snapshot 保证分子分母来自同一时刻，#5563）
+        _total, _bp, _dropped = self._snapshot_counters()
         backpressure_rate = 0.0
-        if self.total_event_count > 0:
-            backpressure_rate = self.backpressure_count / self.total_event_count
+        if _total > 0:
+            backpressure_rate = _bp / _total
 
         # 获取所有Portfolio的详细状态
         with self.portfolio_lock:
@@ -1197,9 +1222,9 @@ class ExecutionNode:
 
             # 背压统计
             "backpressure": {
-                "total_events": self.total_event_count,
-                "backpressure_count": self.backpressure_count,
-                "dropped_events": self.dropped_event_count,
+                "total_events": _total,
+                "backpressure_count": _bp,
+                "dropped_events": _dropped,
                 "backpressure_rate": backpressure_rate
             }
         }

--- a/tests/unit/workers/test_execution_node_counters.py
+++ b/tests/unit/workers/test_execution_node_counters.py
@@ -1,0 +1,150 @@
+"""
+ExecutionNode 背压计数器线程安全测试 (#5563)
+
+验证 market-data 消费线程(写)、心跳线程(读)、API status(读) 并发访问
+total_event_count / backpressure_count / dropped_event_count 时不丢计数、
+读到的三元组自洽（rate 计算分子分母一致）。
+
+根因：`int += 1` 是 LOAD/INCR/STORE 三步非原子，GIL 仅字节码边界释放，
+多线程并发递增会丢计数；独立读分子/分母算 rate 会跨时刻不一致。
+
+构造方式：object.__new__ 跳过 ExecutionNode.__init__（GinkgoProducer 构造可能
+连 Kafka），只设 _counter_lock + 三个 counter，专注测"线程安全计数"这一行为。
+"""
+import threading
+import pytest
+from pathlib import Path
+import sys
+
+project_root = Path(__file__).parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.workers.execution_node.node import ExecutionNode
+from ginkgo.workers.execution_node.backpressure import BackpressureChecker
+
+
+def _make_node_counters_only() -> ExecutionNode:
+    """构造仅含计数器 + lock 的 ExecutionNode（跳过 Kafka/Redis init 副作用）"""
+    from threading import Lock
+    node = object.__new__(ExecutionNode)
+    node._counter_lock = Lock()
+    node.total_event_count = 0
+    node.backpressure_count = 0
+    node.dropped_event_count = 0
+    return node
+
+
+@pytest.mark.unit
+class TestCounterThreadSafety:
+    """#5563: 并发递增计数器应精确（无丢计数）"""
+
+    def test_record_event_processed_thread_safe(self):
+        """10 线程并发 record_event_processed，total_event_count 应精确等于总和
+
+        无锁的 `+= 1` 在高并发下会丢计数；封装方法用 Lock 保护后必须精确。
+        """
+        node = _make_node_counters_only()
+        THREADS, PER_THREAD = 10, 5000
+
+        def worker():
+            for _ in range(PER_THREAD):
+                node.record_event_processed()
+
+        threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert node.total_event_count == THREADS * PER_THREAD
+
+    def test_record_backpressure_drop_thread_safe(self):
+        """record_backpressure_drop 原子递增 backpressure + dropped，两者须相等"""
+        node = _make_node_counters_only()
+        THREADS, PER_THREAD = 8, 2000
+
+        def worker():
+            for _ in range(PER_THREAD):
+                node.record_backpressure_drop()
+
+        threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        expected = THREADS * PER_THREAD
+        assert node.backpressure_count == expected
+        assert node.dropped_event_count == expected
+
+    def test_snapshot_counters_consistent_under_concurrent_rw(self):
+        """并发写事件 + 背压丢弃，snapshot 三元组自洽（bp==dropped，total/bp 精确）"""
+        node = _make_node_counters_only()
+        EVENTS, DROPS = 10000, 3000
+
+        def event_worker():
+            for _ in range(EVENTS):
+                node.record_event_processed()
+
+        def drop_worker():
+            for _ in range(DROPS):
+                node.record_backpressure_drop()
+
+        threads = [threading.Thread(target=event_worker),
+                   threading.Thread(target=drop_worker)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        total, bp, dropped = node._snapshot_counters()
+        assert total == EVENTS
+        assert bp == DROPS
+        assert dropped == DROPS
+
+
+@pytest.mark.unit
+class TestBackpressureCheckerCounterSafety:
+    """#5563: BackpressureChecker 的 int counter (total_checks/warning_count/
+    critical_count) 的 += 原在锁外，与 history list 的锁分离；重构后须并入
+    同一 self.lock，保证并发 check_queue_status 不丢计数。
+    """
+
+    def test_check_queue_status_counters_thread_safe(self):
+        """并发 check_queue_status，total_checks 精确等于调用总数"""
+        checker = BackpressureChecker(warning_threshold=0.5, critical_threshold=0.8)
+        THREADS, PER = 8, 500
+
+        def worker():
+            for i in range(PER):
+                checker.check_queue_status("p1", current_size=(i % 10) * 100, max_size=1000)
+
+        threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stats = checker.get_statistics()
+        expected = THREADS * PER
+        assert stats["total_checks"] == expected
+        # OK 不计入 warning/critical，故两者之和 <= total
+        assert stats["warning_count"] + stats["critical_count"] <= expected
+
+    def test_history_size_never_exceeds_max_under_concurrency(self):
+        """并发写入历史，history_size 不超过 history_max_size（trim 在锁内原子）"""
+        checker = BackpressureChecker()
+        checker.history_max_size = 50
+        THREADS, PER = 6, 100
+
+        def worker():
+            for _ in range(PER):
+                checker.check_queue_status("p1", current_size=600, max_size=1000)
+
+        threads = [threading.Thread(target=worker) for _ in range(THREADS)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(checker.backpressure_history) <= checker.history_max_size


### PR DESCRIPTION
## Summary

#5563 ExecutionNode / BackpressureChecker 共享计数器缺少线程同步，多线程并发访问会丢计数、rate 计算跨时刻不一致。

### 根因
- `int += 1` 是 `LOAD_ATTR`→`BINARY_ADD`→`STORE_ATTR` 三步非原子，CPython GIL 仅在字节码边界释放，递增中途可切线程 → 丢计数。
- `get_status` 中 `backpressure_rate = self.backpressure_count / self.total_event_count` 是两次独立读，分子分母可能来自不同时刻 → rate 不自洽。
- `BackpressureChecker` 的 `total_checks/warning_count/critical_count` 三个 int counter 的 `+=` 在 `self.lock` 之外（原锁仅保护 history list）。

### 并发场景
ExecutionNode 有三类线程并发访问计数器：
- **market-data 消费线程**（写：`_route_event` 递增 total/backpressure/dropped）
- **心跳线程**（读：`HeartbeatManager` 上报 backpressure_count）
- **API status 请求**（读：`get_status` 算 rate）

### 改动

**`node.py`** — 加 `self._counter_lock`，封装三个原子方法替换裸 `+=` 与独立读：
- `record_event_processed()` — 原子递增 `total_event_count`（替换 `_route_event:928`）
- `record_backpressure_drop()` — 原子递增 `backpressure_count` + `dropped_event_count`（替换 `queue.Full` 分支 `956-957`）
- `_snapshot_counters()` — 原子读取三元组，`get_status` 的 rate 计算与 status dict、`queue.Full` 的 WARN 日志均改用 snapshot，保证分子分母一致

**`backpressure.py`** — `check_queue_status` 中 `total_checks/warning_count/critical_count` 的 `+=` 并入既有 `self.lock` 块（与 history append/trim 同锁），level 判定保留锁外（纯计算）。

### 与既有锁的关系
- node.py 原有 `self.portfolio_lock` 仅保护 `portfolios` dict，与计数器无关；新增 `_counter_lock` 专责计数器，职责分离。
- backpressure.py 原有 `self.lock` 已保护 history list，本次把 int counter 并入同一锁，不新增锁（避免双锁死锁风险）。

## Test plan

新增 `tests/unit/workers/test_execution_node_counters.py`（5 个并发测试）：
- `test_record_event_processed_thread_safe` — 10 线程 ×5000 次并发递增，`total_event_count == 50000`
- `test_record_backpressure_drop_thread_safe` — 并发递增，`backpressure_count == dropped_event_count == N`
- `test_snapshot_counters_consistent_under_concurrent_rw` — 并发写事件+背压，snapshot 三元组自洽
- `test_check_queue_status_counters_thread_safe` — 并发 `check_queue_status`，`total_checks` 精确
- `test_history_size_never_exceeds_max_under_concurrency` — 并发写入，history trim 不超上限

测试用 `object.__new__` 跳过 `ExecutionNode.__init__`（`GinkgoProducer` 构造会连 Kafka），只设 lock + 三 counter，专注测线程安全行为。

冒烟 3 层（对齐 ci.yml）：
- Layer 1 `py_compile` src+api ✅
- Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）29 passed ✅
- Layer 3 变更相关（test_execution_node_counters + test_execution_node_load_portfolio）8 passed ✅

Closes #5563
