### PR TITLE
fix: backtest Kafka 派发失败不再静默（done_callback 落库 failed）(#5478)

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -237,6 +237,32 @@ async def send_task_to_kafka(task_uuid: str, portfolio_uuids: list, name: str, c
     logger.info(f"Task {task_uuid} sent to Kafka with {len(portfolio_uuids)} portfolio(s)")
 
 
+def _on_kafka_dispatch_done(task_uuid: str, asyncio_task: "asyncio.Future") -> None:
+    """asyncio.create_task 的 done_callback：派发失败时记日志 + 落库 failed。
+
+    create_backtest 的 fire-and-forget 派发（asyncio.create_task）默认吞掉
+    producer.send 抛出的异常，任务会永远停在 PENDING，而 API 已返回 success。
+    此回调把派发失败显式落库，使任务状态 PENDING→FAILED 可查（#5478）。
+
+    - cancelled：不作处理（取消非失败）
+    - 无异常：成功，不作处理
+    - 有异常：记 ERROR 日志 + update_status(status="failed", error_message=...)
+    """
+    if asyncio_task.cancelled():
+        return
+    exc = asyncio_task.exception()
+    if exc is None:
+        return
+    logger.error(f"Kafka dispatch failed for backtest task {task_uuid}: {exc}")
+    try:
+        get_backtest_task_service().update_status(
+            task_uuid, status="failed", error_message=f"Kafka dispatch failed: {exc}"
+        )
+    except Exception as update_exc:
+        # 落库失败不应掩盖原始派发异常
+        logger.error(f"Failed to mark backtest task {task_uuid} as failed: {update_exc}")
+
+
 # ==================== API 路由 ====================
 
 @router.get("/")
@@ -376,12 +402,18 @@ async def create_backtest(data: BacktestTaskCreate):
 
         # 2. 发送到Kafka（后台任务，不阻塞响应）
         # 使用 asyncio.create_task 让 Kafka 发送在后台运行
-        asyncio.create_task(send_task_to_kafka(
+        dispatch_task = asyncio.create_task(send_task_to_kafka(
             task_uuid=task["uuid"],
             portfolio_uuids=data.portfolio_uuids,
             name=data.name,
             config=task["config"],
         ))
+        # 派发失败（producer.send 抛异常）不再被静默吞：done_callback 记日志 +
+        # 落库 failed，使任务状态可查（#5478）。lambda 用默认参数捕获当前 uuid，
+        # 避免闭包在并发/多任务下捕获到漂移后的 task["uuid"]。
+        dispatch_task.add_done_callback(
+            lambda t, _uuid=task["uuid"]: _on_kafka_dispatch_done(_uuid, t)
+        )
 
         # 立即返回响应，不等待 Kafka
         return ok(data=task, message="Backtest task created successfully")

--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -229,10 +229,19 @@ async def send_task_to_kafka(task_uuid: str, portfolio_uuids: list, name: str, c
         "priority": 0,
     }
 
-    producer.send(
+    result = producer.send(
         topic=KafkaTopics.BACKTEST_ASSIGNMENTS,
         msg=assignment,
     )
+    # GinkgoProducer.send 返 bool 不 raise（ginkgo_kafka.py:89-123 三处 return False：
+    # 未连接/KafkaError/异常，成功 return True）。不判返回值则协程无异常，create_task
+    # 的 done_callback 里 asyncio_task.exception() 永远 None，失败分支（落库 failed）
+    # 是死代码（#5478 review P0）。False 时显式 raise，让异常进入 asyncio 通道供
+    # _on_kafka_dispatch_done 捕获。
+    if not result:
+        raise RuntimeError(
+            f"Kafka dispatch failed for backtest task {task_uuid}: producer.send returned False"
+        )
 
     logger.info(f"Task {task_uuid} sent to Kafka with {len(portfolio_uuids)} portfolio(s)")
 
@@ -241,7 +250,8 @@ def _on_kafka_dispatch_done(task_uuid: str, asyncio_task: "asyncio.Future") -> N
     """asyncio.create_task 的 done_callback：派发失败时记日志 + 落库 failed。
 
     create_backtest 的 fire-and-forget 派发（asyncio.create_task）默认吞掉
-    producer.send 抛出的异常，任务会永远停在 PENDING，而 API 已返回 success。
+    send_task_to_kafka 抛出的异常（producer.send 返 False 时翻译为 RuntimeError，
+    见 send_task_to_kafka），任务会永远停在 PENDING，而 API 已返回 success。
     此回调把派发失败显式落库，使任务状态 PENDING→FAILED 可查（#5478）。
 
     - cancelled：不作处理（取消非失败）

--- a/tests/api/test_backtest_dispatch_callback_5478.py
+++ b/tests/api/test_backtest_dispatch_callback_5478.py
@@ -72,3 +72,91 @@ class TestBacktestDispatchFailureCallback:
             _on_kafka_dispatch_done("task-cancelled-789", fake_task)
 
             mock_svc.update_status.assert_not_called()
+
+
+class TestSendTaskToKafkaTranslatesBoolFailure:
+    """#5478 review P0：GinkgoProducer.send 返 bool 不 raise（ginkgo_kafka.py:89-123
+    三处 return False，成功 return True），send_task_to_kafka 必须判返回值
+    False→raise。否则协程无异常，create_task 的 done_callback 里
+    asyncio_task.exception() 永远 None，失败分支（落库 failed）是死代码。"""
+
+    @pytest.mark.asyncio
+    async def test_raises_when_producer_send_returns_false(self, api_modules):
+        """producer.send 返 False（未连接/KafkaError/异常）时，send_task_to_kafka
+        必须显式 raise，让异常进入 asyncio task 供 done_callback 捕获。"""
+        from api.backtest import send_task_to_kafka
+
+        fake_producer = MagicMock()
+        fake_producer.send.return_value = False  # send 契约：返 bool 非 raise
+
+        with patch("api.backtest.get_kafka_producer", return_value=fake_producer):
+            with pytest.raises(RuntimeError, match="Kafka dispatch failed"):
+                await send_task_to_kafka(
+                    task_uuid="task-fail-001",
+                    portfolio_uuids=["port-1"],
+                    name="bt",
+                    config={"k": "v"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_producer_send_returns_true(self, api_modules):
+        """producer.send 返 True（成功）时，send_task_to_kafka 正常完成不抛。"""
+        from api.backtest import send_task_to_kafka
+
+        fake_producer = MagicMock()
+        fake_producer.send.return_value = True
+
+        with patch("api.backtest.get_kafka_producer", return_value=fake_producer):
+            await send_task_to_kafka(
+                task_uuid="task-ok-002",
+                portfolio_uuids=["port-1"],
+                name="bt",
+                config={"k": "v"},
+            )
+            fake_producer.send.assert_called_once()
+
+
+class TestDispatchFailureE2eRealChain:
+    """#5478 端到端：走真实 asyncio.create_task → send_task_to_kafka →
+    _on_kafka_dispatch_done 链路（非 mock task.exception），证明死代码已激活——
+    send 返 False → send_task_to_kafka raise → 异常存入 task → done_callback
+    经 exception() 捕获 → 落库 failed。这是 AC2 的真实证据。"""
+
+    @pytest.mark.asyncio
+    async def test_e2e_send_false_marks_task_failed_via_done_callback(self, api_modules):
+        """producer.send 返 False 时，完整派发链路自动落库 failed（done_callback
+        经 asyncio_task.exception() 真实捕获，非测试直接注入异常）。"""
+        import asyncio
+        from api.backtest import send_task_to_kafka, _on_kafka_dispatch_done
+
+        fake_producer = MagicMock()
+        fake_producer.send.return_value = False
+
+        with patch("api.backtest.get_kafka_producer", return_value=fake_producer), \
+             patch("api.backtest.get_backtest_task_service") as mock_get_svc:
+            mock_svc = MagicMock()
+            mock_get_svc.return_value = mock_svc
+
+            task = asyncio.create_task(send_task_to_kafka(
+                task_uuid="task-e2e-003",
+                portfolio_uuids=["p1"],
+                name="bt",
+                config={},
+            ))
+            task.add_done_callback(lambda t: _on_kafka_dispatch_done("task-e2e-003", t))
+
+            # send_task_to_kafka 会 raise（Slice 1 已证）；await 重抛，吞掉让
+            # done_callback 执行。done_callback 经 call_soon 调度，await 返回后
+            # 让出一轮确保回调落库完成。
+            try:
+                await task
+            except RuntimeError:
+                pass
+            await asyncio.sleep(0)
+
+            # 真实链路：异常经 task.exception() 被 done_callback 捕获 → 落库 failed
+            mock_svc.update_status.assert_called_once()
+            call = mock_svc.update_status.call_args
+            assert call.args[0] == "task-e2e-003"
+            assert call.kwargs.get("status") == "failed"
+            assert "producer.send returned False" in call.kwargs.get("error_message", "")

--- a/tests/api/test_backtest_dispatch_callback_5478.py
+++ b/tests/api/test_backtest_dispatch_callback_5478.py
@@ -1,0 +1,74 @@
+# Issue #5478: backtest Kafka 派发 fire-and-forget 失败静默
+#
+# 根因：api/api/backtest.py:379 `asyncio.create_task(send_task_to_kafka(...))`
+#   无 add_done_callback；producer.send 失败时异常被 asyncio 吞，任务永留
+#   PENDING，API 已返回 success。
+# 修复：create_backtest 给 create_task 挂 add_done_callback，回调调模块级
+#   `_on_kafka_dispatch_done(task_uuid, asyncio_task)`——失败时记日志 +
+#   BacktestTaskService.update_status(status="failed", error_message=...)。
+#
+# 方案 A（保留异步语义）：create_backtest 仍立即返回 ok(task)；AC3「return 500」
+#   在异步架构下不可行（已 return），改为「任务状态 PENDING→FAILED 可查」。
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestBacktestDispatchFailureCallback:
+    """#5478: Kafka 派发失败不再静默——done_callback 记日志 + 更新任务 failed"""
+
+    def test_dispatch_failure_marks_task_failed(self, api_modules):
+        """派发协程抛异常时，任务状态更新为 failed 并记录错误日志"""
+        from api.backtest import _on_kafka_dispatch_done
+
+        fake_task = MagicMock()
+        fake_task.cancelled.return_value = False
+        fake_task.exception.return_value = RuntimeError("Kafka broker unreachable")
+
+        with patch("api.backtest.get_backtest_task_service") as mock_get_svc, \
+             patch("api.backtest.logger") as mock_logger:
+            mock_svc = MagicMock()
+            mock_get_svc.return_value = mock_svc
+
+            _on_kafka_dispatch_done("task-abc-123", fake_task)
+
+            # 失败时更新任务状态为 failed，含错误信息
+            mock_svc.update_status.assert_called_once()
+            call = mock_svc.update_status.call_args
+            assert call.args[0] == "task-abc-123"
+            assert call.kwargs.get("status") == "failed"
+            err_msg = call.kwargs.get("error_message", "")
+            assert "Kafka broker unreachable" in err_msg
+            # 记录错误日志
+            mock_logger.error.assert_called()
+
+    def test_dispatch_success_does_not_mark_failed(self, api_modules):
+        """派发协程成功（无异常）时，不应更新任务状态"""
+        from api.backtest import _on_kafka_dispatch_done
+
+        fake_task = MagicMock()
+        fake_task.cancelled.return_value = False
+        fake_task.exception.return_value = None  # 成功
+
+        with patch("api.backtest.get_backtest_task_service") as mock_get_svc:
+            mock_svc = MagicMock()
+            mock_get_svc.return_value = mock_svc
+
+            _on_kafka_dispatch_done("task-ok-456", fake_task)
+
+            mock_svc.update_status.assert_not_called()
+
+    def test_dispatch_cancelled_does_not_mark_failed(self, api_modules):
+        """派发协程被取消时，不应更新任务状态"""
+        from api.backtest import _on_kafka_dispatch_done
+
+        fake_task = MagicMock()
+        fake_task.cancelled.return_value = True
+
+        with patch("api.backtest.get_backtest_task_service") as mock_get_svc:
+            mock_svc = MagicMock()
+            mock_get_svc.return_value = mock_svc
+
+            _on_kafka_dispatch_done("task-cancelled-789", fake_task)
+
+            mock_svc.update_status.assert_not_called()


### PR DESCRIPTION
## Summary

#5478 `create_backtest` 的 `asyncio.create_task(send_task_to_kafka(...))` 无 `done_callback`，`producer.send` 失败时异常被 asyncio 吞，任务永留 PENDING，API 已返回 success（issue body「stuck in PENDING forever / no error logged」）。

### 根因
fire-and-forget 派发的失败路径无任何回调挂钩：
- `asyncio.create_task` 产生的 Task，若协程抛异常，异常被 Task 持有直到被 `await`/显式 `exception()` 取出——而此处从不取，异常静默丢弃。
- 任务记录在派发前已 `update_status(PENDING)`，API 返回 201 success；派发失败后无人改状态 → PENDING forever。

### 修复（方案 A，保留异步立即返回语义）
- **`_on_kafka_dispatch_done(task_uuid, asyncio_task)`**（backtest.py 模块级纯回调）：
  - `cancelled()` → no-op（取消非失败）
  - `exception() is None` → no-op（成功）
  - 否则 → `logger.error(...)` + `get_backtest_task_service().update_status(status="failed", error_message="Kafka dispatch failed: ...")`；落库失败再包一层 try/except，不掩盖原始派发异常。
- **`create_backtest` 接线**：`dispatch_task.add_done_callback(lambda t, _uuid=task["uuid"]: _on_kafka_dispatch_done(_uuid, t))`。lambda 用默认参数捕获 uuid，规避并发/漂移闭包陷阱。

### AC 对齐
| AC | 状态 | 说明 |
|---|---|---|
| done_callback + error logging | ✅ | `_on_kafka_dispatch_done` 记 ERROR 日志 |
| 派发失败任务不再 PENDING forever | ✅ | `update_status(status="failed")` 落库，任务可查 |
| Return 500 to client if dispatch fails | ⚠️ | 与异步立即返回（既有设计，注释「不等待 Kafka」）冲突 |

**AC3 权衡**：return 500 需同步 `await send_task_to_kafka`（失败时 return 500），会把 Kafka 延迟引入 API 响应链，与 create_backtest「立即返回不等待 Kafka」的有意设计冲突。本 PR 改为「任务状态 PENDING→FAILED 可查」（客户端 GET /backtests/{uuid} 可见 failed + error_message），达成「not silent」的可观测性意图，仅时序非同步。故用 `Refs` 非 `Closes`，待 maintainer 定夺 AC3 是否需要改架构（同步派发方案 B）。

## Test plan

新增 `tests/api/test_backtest_dispatch_callback_5478.py`（3 测，纯函数 + MagicMock，0.53s）：
- 派发抛 `RuntimeError` → `update_status(uuid, status="failed", error_message 含异常)` + `logger.error` 调用
- 成功（`exception() is None`）→ `update_status` 不调用
- `cancelled()` → `update_status` 不调用

冒烟 3 层（对齐 `.github/workflows/ci.yml` #6015）：
- Layer1 `py_compile` src+api ✅
- Layer2 启动路径（`test_user_crud_mock` / `test_containers` / `test_user_cli`）29 passed ✅
- Layer3 变更相关（`test_backtest_dispatch_callback_5478`）3 passed ✅

Refs #5478

🤖 Generated with [Claude Code](https://claude.com/claude-code)
