### PR TITLE
fix(#5341): record position 读流水表修回测持仓空

### DIFF
--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -147,8 +147,11 @@ def position(
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
-        position_svc = Container.position_service()
-        result = position_svc.get_positions_df(
+        # #5341: 回测持仓经 create_position_record 写 MPositionRecord（流水表），
+        # PositionService 查 MPosition（当前态表）永远空。改读 ResultService
+        # （get_positions_df 查 PositionRecordCRUD，与写路径同表）。
+        result_svc = Container.result_service()
+        result = result_svc.get_positions_df(
             portfolio_id=portfolio,
             engine_id=engine,
             task_id=task,
@@ -161,13 +164,15 @@ def position(
         # ADR-010 R2b: get_positions_df 出口已保证 data 为 DataFrame（类型即契约）
         positions_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
+        # MPositionRecord 流水字段（volume/cost/price/fee），非 MPosition 当前态字段
         position_columns_config = {
             "uuid": {"display_name": "Position ID", "style": "dim"},
             "portfolio_id": {"display_name": "Portfolio ID", "style": "dim"},
             "code": {"display_name": "Code", "style": "cyan"},
-            "quantity": {"display_name": "Quantity", "style": "yellow"},
-            "average_price": {"display_name": "Avg Price", "style": "yellow"},
-            "market_value": {"display_name": "Market Value", "style": "green"},
+            "volume": {"display_name": "Volume", "style": "yellow"},
+            "cost": {"display_name": "Cost", "style": "yellow"},
+            "price": {"display_name": "Price", "style": "yellow"},
+            "fee": {"display_name": "Fee", "style": "green"},
             "timestamp": {"display_name": "Timestamp", "style": "dim"}
         }
 

--- a/src/ginkgo/data/services/result_service.py
+++ b/src/ginkgo/data/services/result_service.py
@@ -557,6 +557,45 @@ class ResultService(BaseService):
             GLOG.ERROR(f"获取持仓记录失败: {e}")
             return ServiceResult.error(f"获取持仓记录失败: {e}")
 
+    def get_positions_df(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        page_size: int = 50,
+    ) -> ServiceResult:
+        """出口①：data 是 pandas.DataFrame（查 MPositionRecord 流水表）。
+
+        #5341: 回测持仓经 create_position_record 写 MPositionRecord（持仓流水），
+        非 MPosition（当前态表）。record position 读 MPosition 永远空，须查流水表。
+        filter 域与 position_service.get_positions_df 对称（portfolio/engine/task），
+        出口契约同为 DataFrame（ADR-010）。
+        """
+        try:
+            from ginkgo.data.crud.position_record_crud import PositionRecordCRUD
+            position_record_crud = PositionRecordCRUD()
+
+            filters = {"is_del": False}
+            if portfolio_id:
+                filters["portfolio_id"] = portfolio_id
+            if engine_id:
+                filters["engine_id"] = engine_id
+            if task_id:
+                filters["task_id"] = task_id
+
+            model_list = position_record_crud.find(
+                filters=filters,
+                page_size=page_size if page_size > 0 else None,
+            )
+            df = model_list.to_dataframe() if model_list else pd.DataFrame()
+            return ServiceResult.success(
+                data=df,
+                message=f"Retrieved {len(df)} position records (DataFrame)",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"查询持仓记录(df)失败: {str(e)}")
+            return ServiceResult.error(f"查询持仓记录(df)失败: {str(e)}")
+
     @retry(max_try=3)
     def create_order_record(self, **kwargs) -> ServiceResult:
         """

--- a/tests/unit/client/test_record_cli.py
+++ b/tests/unit/client/test_record_cli.py
@@ -46,15 +46,18 @@ def mock_orders_df():
 
 @pytest.fixture
 def mock_positions_df():
+    # #5341: record position 读流水表 MPositionRecord，字段是 volume/cost/price/fee
+    # （非 MPosition 当前态的 quantity/average_price/market_value）
     return pd.DataFrame({
         "uuid": ["pos1"],
         "portfolio_id": ["p1"],
         "engine_id": ["e1"],
         "task_id": ["t1"],
         "code": ["000001.SZ"],
-        "quantity": [100],
-        "average_price": [10.5],
-        "market_value": [1050.0],
+        "volume": [100],
+        "cost": [10.5],
+        "price": [10.8],
+        "fee": [5.0],
         "timestamp": ["2026-01-01"],
     })
 
@@ -100,14 +103,19 @@ class TestRecordOrderFilters:
 @pytest.mark.unit
 @pytest.mark.cli
 class TestRecordPositionFilters:
-    """record position 的 engine/task 过滤透传（#4743）"""
+    """record position 的 engine/task 过滤透传（#4743）+ 读流水表（#5341）
+
+    #5341 根因：回测持仓写 MPositionRecord（流水），record position 原读
+    PositionService（MPosition 当前态）永远空。改读 ResultService.get_positions_df
+    （查 PositionRecordCRUD）。
+    """
 
     @patch("ginkgo.data.containers.Container")
     def test_position_passes_engine_and_task(self, mock_container, cli_runner, mock_positions_df):
-        """-e/-t 透传到 service.get_positions_df"""
+        """-e/-t 透传到 result_service.get_positions_df"""
         mock_service = MagicMock()
         mock_service.get_positions_df.return_value = ServiceResult.success(data=mock_positions_df)
-        mock_container.position_service.return_value = mock_service
+        mock_container.result_service.return_value = mock_service
 
         result = cli_runner.invoke(record_cli.app, [
             "position", "--portfolio", "p1", "--engine", "e1", "--task", "t1",
@@ -117,6 +125,25 @@ class TestRecordPositionFilters:
         assert kwargs.get("portfolio_id") == "p1"
         assert kwargs.get("engine_id") == "e1"
         assert kwargs.get("task_id") == "t1"
+
+    @patch("ginkgo.data.containers.Container")
+    def test_position_reads_result_service_not_position_service(
+        self, mock_container, cli_runner, mock_positions_df
+    ):
+        """#5341 核心：必须读 result_service（流水表），不得读 position_service（当前态）"""
+        mock_result_svc = MagicMock()
+        mock_result_svc.get_positions_df.return_value = ServiceResult.success(data=mock_positions_df)
+        mock_container.result_service.return_value = mock_result_svc
+        mock_position_svc = MagicMock()
+        mock_container.position_service.return_value = mock_position_svc
+
+        result = cli_runner.invoke(record_cli.app, [
+            "position", "--portfolio", "p1", "--engine", "e1", "--task", "t1",
+        ])
+        assert result.exit_code == 0
+        mock_result_svc.get_positions_df.assert_called_once()
+        # 关键：position_service（当前态表）绝不能被调用——那是 #5341 的 bug 源头
+        mock_position_svc.get_positions_df.assert_not_called()
 
 
 # ============================================================================

--- a/tests/unit/services/test_result_service_positions.py
+++ b/tests/unit/services/test_result_service_positions.py
@@ -1,0 +1,106 @@
+"""result_service.get_positions_df 单元测试。
+
+#5341: record position 读错表。回测持仓经 create_position_record 写
+MPositionRecord（流水表），但 record_cli 读 PositionCRUD（MPosition 当前态表）。
+result_service 新增 get_positions_df 查 PositionRecordCRUD，对齐
+position_service 出口签名（portfolio/engine/task 三过滤 + DataFrame）。
+"""
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pandas as pd
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.data.services.result_service import ResultService
+
+
+@pytest.fixture
+def service():
+    # ResultService.__init__ 要求 analyzer_crud（Container 注入）；单测用 MagicMock
+    return ResultService(analyzer_crud=MagicMock())
+
+
+@pytest.fixture
+def mock_record_crud():
+    crud = MagicMock()
+    model_list = MagicMock()
+    model_list.to_dataframe.return_value = pd.DataFrame([{
+        "uuid": "pr1",
+        "portfolio_id": "p1",
+        "engine_id": "e1",
+        "task_id": "t1",
+        "code": "000001.SZ",
+        "volume": 100,
+        "cost": 10.5,
+        "price": 10.8,
+        "fee": 5.0,
+    }])
+    crud.find.return_value = model_list
+    return crud
+
+
+@pytest.mark.unit
+class TestResultServiceGetPositionsDf:
+    """get_positions_df 必须查 PositionRecordCRUD（MPositionRecord 流水表）——
+    回测只写该表，读 PositionCRUD（MPosition 当前态）永远空（#5341 根因）。"""
+
+    def test_filters_by_portfolio_engine_task(self, service, mock_record_crud):
+        """portfolio/engine/task 三过滤透传到 PositionRecordCRUD.find"""
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD",
+            return_value=mock_record_crud,
+        ):
+            service.get_positions_df(
+                portfolio_id="p1", engine_id="e1", task_id="t1"
+            )
+        mock_record_crud.find.assert_called_once()
+        _, kwargs = mock_record_crud.find.call_args
+        assert kwargs["filters"] == {
+            "is_del": False,
+            "portfolio_id": "p1",
+            "engine_id": "e1",
+            "task_id": "t1",
+        }
+
+    def test_returns_dataframe_with_records(self, service, mock_record_crud):
+        """to_dataframe() 结果透传到 ServiceResult.data（pandas.DataFrame）"""
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD",
+            return_value=mock_record_crud,
+        ):
+            result = service.get_positions_df(
+                portfolio_id="p1", engine_id="e1", task_id="t1"
+            )
+        assert result.is_success()
+        assert isinstance(result.data, pd.DataFrame)
+        assert len(result.data) == 1
+        # MPositionRecord 流水字段（非 MPosition 当前态）
+        assert result.data.iloc[0]["code"] == "000001.SZ"
+        assert result.data.iloc[0]["volume"] == 100
+        assert result.data.iloc[0]["cost"] == 10.5
+
+    def test_empty_returns_empty_dataframe(self, service, mock_record_crud):
+        """find 返回空时 data 是空 DataFrame（非 None/非 list），CLI 下游 len() 安全"""
+        mock_record_crud.find.return_value = None
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD",
+            return_value=mock_record_crud,
+        ):
+            result = service.get_positions_df(
+                portfolio_id="p1", engine_id="e1", task_id="t1"
+            )
+        assert result.is_success()
+        assert isinstance(result.data, pd.DataFrame)
+        assert len(result.data) == 0
+
+    def test_omits_unset_filters(self, service, mock_record_crud):
+        """未传的过滤维度不进 filters（避免 None 污染）"""
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD",
+            return_value=mock_record_crud,
+        ):
+            service.get_positions_df(portfolio_id="p1")
+        _, kwargs = mock_record_crud.find.call_args
+        assert kwargs["filters"] == {"is_del": False, "portfolio_id": "p1"}


### PR DESCRIPTION
## Summary

**#5341 根因**：`record position` 回测后永远空（"❗ 没有数据可显示"）。

回测持仓经 `create_position_record` 写入 **`MPositionRecord`**（持仓流水表），但 `record_cli.position` 读的是 `PositionService`（查 `MPosition` 当前态表）——**跨表同名不匹配**，读端永远查不到写端的数据（[[arch-signal-ch-vs-tracker-mysql]] 同型陷阱）。

**修复**：
- `result_service` 新增 `get_positions_df`，查 `PositionRecordCRUD`（与写路径 `create_position_record` 同表），出口签名对齐 `position_service`（portfolio/engine/task 三过滤 + DataFrame）。
- `record_cli.position` 切到 `Container.result_service()`，`columns_config` 切 MPositionRecord 流水字段（volume/cost/price/fee）。

## Test plan

- [x] `tests/unit/services/test_result_service_positions.py`（新增 4 测试：三过滤透传 / 返回 DataFrame / 空表空 DataFrame / 未传维度不污染）
- [x] `tests/unit/client/test_record_cli.py` 更新：fixture 切流水字段 + 新增 `test_position_reads_result_service_not_position_service`（核心断言：不得读 position_service）
- [x] 冒烟三层：py_compile(src+api) ✅ / 启动路径 smoke（user_crud+containers+user_cli 29 passed）✅ / 变更相关 19 passed ✅
- [ ] 实测：回测后 `ginkgo record position --portfolio <pid> --engine <eid> --task <tid>` 应列出持仓流水

## 备注（超 #5341 范围）

`record order` / `record signal` 同类空问题需独立核实其写/读表配对（order 写 `create_order_record` → MOrderRecord？signal 同理）。本次仅聚焦 position（#5341 范围），order/signal 留待对应 issue。

Closes #5341
