### PR TITLE
fix(#5521): log LIKE 注入转义 + statistics 移 print 返回结构化

### DIFF
--- a/src/ginkgo/libs/data/statistics.py
+++ b/src/ginkgo/libs/data/statistics.py
@@ -9,21 +9,42 @@
 
 import numpy as np
 import pandas as pd
+from collections import namedtuple
+
 # scipy使用延迟导入避免启动时冲突
 # import scipy.stats as stats
 # import matplotlib.pyplot as plt
+
+
+# 统计检验结构化结果（#5521：库函数返回结构化对象，不再以 print 作为副作用输出）
+TTestResult = namedtuple(
+    "TTestResult", ["statistic", "pvalue", "t_critical", "degree_of_freedom"]
+)
+Chi2TestResult = namedtuple(
+    "Chi2TestResult", ["chi2", "p", "degree_of_freedom", "expected"]
+)
 
 
 def t_test(
     backtest_values: list,
     observe_values: list,
     level_of_confidence: float = 0.99,
-):
+) -> TTestResult:
+    """独立样本 t 检验（回测 vs 实盘分布对比）。
+
+    Returns:
+        TTestResult(statistic, pvalue, t_critical, degree_of_freedom)。
+        #5521：移除 print 副作用，返回结构化结果含 t_critical。
+    """
     # 延迟导入scipy以避免启动时冲突
     try:
         import scipy.stats as stats
     except ImportError as e:
         raise ImportError(f"scipy is required for t_test function: {e}")
+
+    # 兼容 list / np.array 输入（签名标注 list，内部 .var() 需数组）
+    backtest_values = np.asarray(backtest_values, dtype=float)
+    observe_values = np.asarray(observe_values, dtype=float)
 
     len1 = len(backtest_values)
     len2 = len(observe_values)
@@ -36,19 +57,32 @@ def t_test(
     else:
         degree_of_freedom = (len1 - 1) * (len2 - 1) / (var1 / len1 + var2 / len2)
     t_critical = stats.t.ppf(level_of_confidence, degree_of_freedom)
-    print(result)
-    print(result.pvalue)
-    print(t_critical)
-    return result
+    return TTestResult(
+        statistic=result.statistic,
+        pvalue=result.pvalue,
+        t_critical=t_critical,
+        degree_of_freedom=degree_of_freedom,
+    )
 
 
-def chi2_test(backtest_values: list, observe_values: list, category_count: int = 7):
-    # Independent test
-    # H0: There is no relation between backtest_values and observe_values.
-    # H1: There is relation between backtest_values and observe_values.
-    # if p < 0.05, refuse H0. accept H1. Two samples are from the same distribution.
-    # if p > 0.05, accept H0. refuse H1. Two samples are from different distribution.
-    # 卡方检验要求观测频数表中的每个分类的观测频数都大于或等于 5。
+def chi2_test(
+    backtest_values: list,
+    observe_values: list,
+    category_count: int = 7,
+) -> Chi2TestResult:
+    """卡方独立性检验（回测 vs 实盘分布对比）。
+
+    Returns:
+        Chi2TestResult(chi2, p, degree_of_freedom, expected)。
+        #5521：移除 print 副作用返回结构化结果；修正原注释/文本与 p 值逻辑相反的错误。
+    """
+    # 卡方独立性检验
+    # H0: backtest_values 与 observe_values 独立（无关联）
+    # H1: 两者存在关联
+    # p < 0.05 拒 H0：两样本有关联（分布显著不同）
+    # p >= 0.05 接受 H0：无足够证据否定独立
+    # （原代码注释/文本与此逻辑完全相反，#5521 修正）
+    # 注：卡方检验要求观测频数表中每个分类的频数 >= 5
 
     # 延迟导入scipy以避免启动时冲突
     try:
@@ -78,16 +112,12 @@ def chi2_test(backtest_values: list, observe_values: list, category_count: int =
         raise ValueError("Insufficient non-empty bins for chi-square test")
 
     chi2, p, degree_of_freedom, expected = stats.chi2_contingency(observed_filtered)
-    print(chi2)
-    print(p)
-    print(degree_of_freedom)
-    # 检验结果
-    if p < 0.05:
-        print("Refuse the null hypothesis. Two samples are from the same distribution.")
-    else:
-        print("Accept the null hypothesis. Two samples are from the different distribution.")
-    
-    return chi2, p, degree_of_freedom, expected
+    return Chi2TestResult(
+        chi2=chi2,
+        p=p,
+        degree_of_freedom=degree_of_freedom,
+        expected=expected,
+    )
 
     # plt.bar(
     #     bins[:-1],

--- a/src/ginkgo/services/logging/log_service.py
+++ b/src/ginkgo/services/logging/log_service.py
@@ -14,6 +14,22 @@ from ginkgo.libs import GLOG, time_logger, cache_with_expiration
 from ginkgo.enums import LEVEL_TYPES
 
 
+def _escape_like(keyword: str) -> str:
+    r"""转义 LIKE 模式特殊字符（%/_/\），防止用户输入触发通配匹配。
+
+    ClickHouse LIKE 默认以反斜杠为 ESCAPE 字符：搜 "%" 不应匹配任意序列、
+    搜 "_" 不应匹配任意单字符。反斜杠本身必须最先转义，否则后续引入的
+    转义符会被二次解释。#5521。
+    """
+    if keyword is None:
+        raise TypeError("keyword must not be None")
+    return (
+        keyword.replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
+
+
 class LogService(BaseService):
     """
     日志查询服务 - 封装 ClickHouse 查询
@@ -371,11 +387,13 @@ class LogService(BaseService):
                 else:
                     return []
 
-                # ClickHouse 使用 LIKE 进行全文搜索
+                # ClickHouse 使用 LIKE 进行全文搜索；先转义用户输入的 %/_
+                # 通配字符，否则搜 "%" 会匹配任意序列（#5521）
+                escaped = _escape_like(keyword)
                 conditions = [
                     or_(
-                        model.message.like(f"%{keyword}%"),
-                        model.logger_name.like(f"%{keyword}%")
+                        model.message.like(f"%{escaped}%"),
+                        model.logger_name.like(f"%{escaped}%")
                     )
                 ]
                 if level is not None and hasattr(model, "level"):

--- a/tests/unit/libs/data/test_statistics_5521.py
+++ b/tests/unit/libs/data/test_statistics_5521.py
@@ -1,0 +1,62 @@
+# Upstream: src/ginkgo/libs/data/statistics.py
+# Context: #5521 — t_test/chi2_test 用 print() 污染 stdout，且 t_test 丢失 t_critical；
+#          chi2_test 注释/文本与 p 值逻辑相反。库函数应返回结构化结果，无副作用输出。
+import numpy as np
+import pytest
+
+scipy = pytest.importorskip("scipy")  # 无 scipy 环境跳过统计检验测试
+
+from ginkgo.libs.data.statistics import t_test  # noqa: E402
+
+
+class TestTTest:
+    """t_test 不再 print，返回含 t_critical 的结构化结果。"""
+
+    def test_does_not_print_to_stdout(self, capsys):
+        a = [1.0, 2.0, 3.0, 4.0, 5.0]
+        b = [2.0, 3.0, 4.0, 5.0, 6.0]
+        t_test(a, b)
+        out = capsys.readouterr()
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_returns_structured_with_critical_value(self):
+        # 原实现 return result（TtestResult）丢失 t_critical 计算结果
+        a = [1.0, 2.0, 3.0, 4.0, 5.0]
+        b = [2.0, 3.0, 4.0, 5.0, 6.0]
+        result = t_test(a, b)
+        assert hasattr(result, "t_critical")
+        assert hasattr(result, "pvalue")
+        assert hasattr(result, "statistic")
+        assert hasattr(result, "degree_of_freedom")
+
+    def test_pvalue_finite_for_different_samples(self):
+        a = [1.0, 2.0, 3.0, 4.0, 5.0]
+        b = [10.0, 11.0, 12.0, 13.0, 14.0]
+        result = t_test(a, b)
+        assert np.isfinite(result.pvalue)
+        assert np.isfinite(result.t_critical)
+
+
+from ginkgo.libs.data.statistics import chi2_test  # noqa: E402
+
+
+class TestChi2Test:
+    """chi2_test 不再 print，返回 namedtuple（原实现注释/文本与 p 值逻辑相反）。"""
+
+    def test_does_not_print_to_stdout(self, capsys):
+        a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        b = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        chi2_test(a, b)
+        out = capsys.readouterr()
+        assert out.out == ""
+        assert out.err == ""
+
+    def test_returns_structured_namedtuple(self):
+        a = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        b = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+        result = chi2_test(a, b)
+        assert hasattr(result, "chi2")
+        assert hasattr(result, "p")
+        assert hasattr(result, "degree_of_freedom")
+        assert hasattr(result, "expected")

--- a/tests/unit/services/logging/test_log_service_like_escape.py
+++ b/tests/unit/services/logging/test_log_service_like_escape.py
@@ -1,0 +1,37 @@
+# Upstream: src/ginkgo/services/logging/log_service.py
+# Context: #5521 — search_logs LIKE 查询未转义用户输入的 %/_，搜 "%" 返全部记录。
+#          提取 _escape_like 纯函数便于单测转义行为（无需 ClickHouse session）。
+import pytest
+
+from ginkgo.services.logging.log_service import _escape_like
+
+
+class TestEscapeLike:
+    """LIKE 特殊字符转义（ClickHouse 默认 `\` 为 ESCAPE 字符）。"""
+
+    def test_passthrough_normal_keyword(self):
+        # 无特殊字符原样返回
+        assert _escape_like("ERROR") == "ERROR"
+
+    def test_escape_percent(self):
+        # % 是 LIKE 通配（匹配任意序列），须转义
+        assert _escape_like("a%b") == "a\\%b"
+
+    def test_escape_underscore(self):
+        # _ 是 LIKE 通配（匹配单字符），须转义
+        assert _escape_like("a_b") == "a\\_b"
+
+    def test_escape_backslash_first(self):
+        # 反斜杠本身先转义，避免后续转义符被二次解释
+        assert _escape_like("a\\b") == "a\\\\b"
+
+    def test_escape_combined_all_special(self):
+        assert _escape_like("%_\\") == "\\%\\_\\\\"
+
+    def test_empty_keyword(self):
+        assert _escape_like("") == ""
+
+    def test_none_raises(self):
+        # None 输入显式失败（调用方应保证非 None）
+        with pytest.raises((TypeError, AttributeError)):
+            _escape_like(None)


### PR DESCRIPTION
## Summary

修复 #5521 报告的两类库代码问题。

### 1. 日志搜索 LIKE 注入（`log_service.search_logs`）

ClickHouse LIKE 查询未转义用户输入的 `%`/`_`/`\`，搜 `%` 会匹配任意序列返回全部记录（通配注入）。

- 提取 `_escape_like(keyword)` 纯函数：转义顺序先 `\` 再 `%`/`_`（否则后续转义符被二次解释）
- `search_logs` 在 `model.message.like(f"%{escaped}%")` 前先转义

### 2. 统计检验 print 副作用 + 逻辑反注释（`statistics.t_test`/`chi2_test`）

- **移除全部 print**：库函数返回结构化结果（`TTestResult`/`Chi2TestResult` namedtuple），调用方按需展示。`capsys` 断言保证不再污染 stdout。
- **修正 chi2_test 注释/文本与 p 值逻辑相反**：原注释 `p < 0.05 ... same distribution` 完全反了——卡方独立性检验中 `p < 0.05` 是拒 H0（独立）→ 两样本有关联（分布显著不同）。照原注释解读会得出相反的统计结论。
- **t_test 兼容 list 输入**：签名标注 `list` 但内部 `.var()` 需 np.array，加 `np.asarray(..., dtype=float)`。
- **t_test 返回 t_critical**：原实现 `return result` 丢失已计算的 `t_critical`，现包进 `TTestResult`。

## 改动文件

| 文件 | 改动 |
|---|---|
| `src/ginkgo/services/logging/log_service.py` | + `_escape_like` 模块级函数；`search_logs` 转义后 LIKE |
| `src/ginkgo/libs/data/statistics.py` | + `TTestResult`/`Chi2TestResult` namedtuple；`t_test`/`chi2_test` 移 print 返结构化；修注释逻辑反；t_test 兼容 list |
| `tests/unit/services/logging/test_log_service_like_escape.py` | 新增 7 个 `_escape_like` 单测 |
| `tests/unit/libs/data/test_statistics_5521.py` | 新增 5 个 t_test/chi2_test 测试（capsys + namedtuple 字段） |

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml`）：

- [x] L1 `py_compile`（src + api 全量）通过
- [x] L2 启动路径 smoke（`test_user_crud_mock` + `test_containers` + `test_user_cli`）29 passed
- [x] L3 变更相关（`test_log_service_like_escape` + `test_statistics_5521`）12 passed

## Notes

- `chi2_test` 内 pandas `groupby` 的 `FutureWarning`（`observed=False` 默认值变更）是预存警告，非本次引入，不在本 issue AC 范围，未顺手改（避免无关改动）。
- `statistics.py` 当前无生产调用者（仅 `__init__.py` 重新导出），改动对运行时无破坏性。

Closes #5521
