### PR TITLE
test(#6062): AShareBroker 拒绝状态改行为测试替 inspect.getsource 源码检查

### DIFF
--- a/tests/unit/trading/brokers/test_broker_type_fixes.py
+++ b/tests/unit/trading/brokers/test_broker_type_fixes.py
@@ -77,16 +77,49 @@ class TestLiveBrokerBaseInitType:
 class TestAShareBrokerRejectedStatus:
     """#5484: AShareBroker 被拒绝的订单应使用 REJECTED 而非 NEW 状态"""
 
-    def test_rejected_uses_correct_status(self):
-        """验证 AShareBroker 中所有 # REJECTED 注释处使用 ORDERSTATUS_TYPES.REJECTED"""
-        import inspect
-        from ginkgo.trading.brokers.ashare_broker import AShareBroker
-        from ginkgo.enums import ORDERSTATUS_TYPES
+    def test_rejected_volume_below_min_returns_rejected(self):
+        """#6062: volume<100 违反 A股最小交易量 → _submit_to_exchange 返回 REJECTED。
 
-        source = inspect.getsource(AShareBroker)
-        # 不应存在 NEW + REJECTED 注释的组合
-        assert 'ORDERSTATUS_TYPES.NEW,  # REJECTED' not in source, \
-            "Found ORDERSTATUS_TYPES.NEW with # REJECTED comment - should use ORDERSTATUS_TYPES.REJECTED"
+        行为测试：构造违规 order 调提交入口，断言返回 ``status`` 而非源码文本。
+        原测试用 ``inspect.getsource`` 检查源码无 'NEW, # REJECTED' 字符串——耦合
+        实现细节，删注释/换行即假过/假败，且 REJECTED→NEW 逻辑回归但注释保留时漏检。
+        """
+        from ginkgo.trading.brokers.ashare_broker import AShareBroker
+        from ginkgo.entities import Order
+        from ginkgo.enums import ORDERSTATUS_TYPES, DIRECTION_TYPES
+
+        broker = AShareBroker(name="test_rejected")
+        # volume=50 < 100 → _validate_order_rules 返回 False → 风控拒绝路径
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=50)
+
+        result = broker._submit_to_exchange(order)
+
+        assert result.status == ORDERSTATUS_TYPES.REJECTED
+        # 风控拒绝的 error_message 标识规则违反
+        assert result.error_message is not None
+
+    def test_exception_path_returns_rejected(self, monkeypatch):
+        """#6062: 提交过程抛异常 → except 兜底返回 REJECTED（异常失败场景）。
+
+        覆盖 _submit_to_exchange try/except 的 REJECTED 分支，与风控拒绝
+        共同满足「≥2 个 REJECTED 场景」验收。
+        """
+        from ginkgo.trading.brokers.ashare_broker import AShareBroker
+        from ginkgo.entities import Order
+        from ginkgo.enums import ORDERSTATUS_TYPES, DIRECTION_TYPES
+
+        broker = AShareBroker(name="test_exception")
+
+        def _boom(order):
+            raise RuntimeError("模拟提交失败")
+
+        monkeypatch.setattr(broker, "_validate_order_rules", _boom)
+
+        order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=100)
+        result = broker._submit_to_exchange(order)
+
+        assert result.status == ORDERSTATUS_TYPES.REJECTED
+        assert "失败" in (result.error_message or "")
 
 
 class TestTradeGatewayRejectedStatus:


### PR DESCRIPTION
## Summary

#6062 `TestAShareBrokerRejectedStatus.test_rejected_uses_correct_status` 原用 `inspect.getsource(AShareBroker)` 检查源码无 `'NEW, # REJECTED'` 字符串——测试耦合**实现细节**（源码文本），代码格式变（删注释/换行）即假过/假败，且 `REJECTED→NEW` 真实逻辑回归但注释保留时漏检。改为**行为测试**：构造违规 order 调 `_submit_to_exchange`，断言返回 `result.status`。

## Changes

`tests/unit/trading/brokers/test_broker_type_fixes.py` — `TestAShareBrokerRejectedStatus`：

替换 `test_rejected_uses_correct_status`（inspect.getsource 源码检查）为两个行为测试：

| 测试 | 触发路径 | 断言 |
|---|---|---|
| `test_rejected_volume_below_min_returns_rejected` | `Order(volume=50)` < 100 → `_validate_order_rules` False | `result.status == REJECTED`（风控拒绝） |
| `test_exception_path_returns_rejected` | monkeypatch `_validate_order_rules` raise → except 兜底 | `result.status == REJECTED`（异常失败） |

`TestTradeGatewayRejectedStatus` 不在本次范围（issue 仅针对 AShareBroker 类）。

## Why behavior test over source inspection

| | `inspect.getsource` 源码检查 | 行为测试 |
|---|---|---|
| 耦合 | 源码字符串（注释/格式） | 公共接口返回值 |
| 删注释 | ❌ 假败 | ✅ 仍过（行为没变） |
| `REJECTED→NEW` 回归（注释保留）| ❌ 假过 | ✅ 捕获（status 不符） |
| 重命名内部变量 | ❌ 可能假败 | ✅ 不受影响 |

## Test plan

- [x] Layer1 py_compile（src+api 全量）
- [x] Layer2 启动路径 smoke（user_crud / containers / user_cli，29 passed）
- [x] Layer3 `test_broker_type_fixes.py` 全文件（11 passed，含保留的 TestTradeGatewayRejectedStatus）

## Acceptance criteria

- [x] 不再使用 `inspect.getsource` 做源码文本断言（TestAShareBrokerRejectedStatus 已移除）
- [x] 覆盖 2 个 REJECTED 场景：风控拒绝 + 异常失败
- [x] 断言返回值 `status` 而非源码文本
- [x] `pytest tests/unit/trading/brokers/test_broker_type_fixes.py` 全部通过（11 passed）

Closes #6062

🤖 Generated with [Claude Code](https://claude.com/claude-code)
