### PR TITLE
fix: execution engine naive datetime.now() 统一为 timezone-aware UTC (#5548)

### DIFF
--- a/src/ginkgo/trading/brokers/okx_broker.py
+++ b/src/ginkgo/trading/brokers/okx_broker.py
@@ -7,7 +7,7 @@ import time
 import asyncio
 from functools import wraps
 from typing import Optional, Callable, Any, List
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 try:
@@ -855,7 +855,7 @@ class OKXBroker(IBroker):
                 fee=fee,
                 fee_currency=fee_currency,
                 order_type=order_type,
-                trade_time=datetime.now()
+                trade_time=datetime.now(timezone.utc)
             )
 
             GLOG.DEBUG(f"Trade recorded: {symbol} {side} {quantity} @ {price}")

--- a/src/ginkgo/trading/engines/event_engine.py
+++ b/src/ginkgo/trading/engines/event_engine.py
@@ -163,7 +163,7 @@ class EventEngine(BaseEngine):
     @property
     def now(self) -> datetime.datetime:
         """获取当前时间 - 子类应重写此方法"""
-        return datetime.datetime.now()
+        return datetime.datetime.now(datetime.timezone.utc)
 
     def add_portfolio(self, portfolio: "PortfolioBase") -> None:
         """

--- a/src/ginkgo/workers/backtest_worker/node.py
+++ b/src/ginkgo/workers/backtest_worker/node.py
@@ -16,7 +16,7 @@ BacktestWorker Node
 
 from typing import Dict, Optional
 from threading import Thread, RLock, Event
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 import logging
 from ginkgo.libs import GLOG
@@ -91,7 +91,7 @@ class BacktestWorker:
 
         self.should_stop = False
         self.is_running = True
-        self.started_at = datetime.now().isoformat()
+        self.started_at = datetime.now(timezone.utc).isoformat()
 
         GLOG.INFO(f"Starting BacktestWorker {self.worker_id}")
 

--- a/src/ginkgo/workers/execution_node/backpressure.py
+++ b/src/ginkgo/workers/execution_node/backpressure.py
@@ -25,7 +25,7 @@ BackpressureChecker监控PortfolioProcessor的队列使用率，防止内存溢�
 """
 
 from typing import Dict, List
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Lock
 
 
@@ -106,7 +106,7 @@ class BackpressureChecker:
         # 记录历史
         with self.lock:
             self.backpressure_history.append({
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "portfolio_id": portfolio_id,
                 "usage": usage,
                 "level": level,

--- a/src/ginkgo/workers/execution_node/heartbeat_manager.py
+++ b/src/ginkgo/workers/execution_node/heartbeat_manager.py
@@ -21,7 +21,7 @@ HeartbeatManager - 心跳管理器
 from ginkgo.libs import GLOG
 import logging
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -191,7 +191,7 @@ class HeartbeatManager:
             heartbeat_key = RedisKeyBuilder.execution_node_heartbeat(node.node_id)
 
             # 设置心跳值（当前时间戳）
-            heartbeat_value = datetime.now().isoformat()
+            heartbeat_value = datetime.now(timezone.utc).isoformat()
 
             # 设置键并附带TTL
             redis_client.setex(
@@ -392,9 +392,9 @@ class HeartbeatManager:
             uptime_seconds = 0
             if node.started_at:
                 try:
-                    from datetime import datetime
+                    from datetime import datetime, timezone
                     started = datetime.fromisoformat(node.started_at)
-                    uptime_seconds = int((datetime.now() - started).total_seconds())
+                    uptime_seconds = int((datetime.now(timezone.utc) - started).total_seconds())
                 except Exception as e:
                     GLOG.WARNING(f"{e}")
                     pass

--- a/src/ginkgo/workers/execution_node/metrics.py
+++ b/src/ginkgo/workers/execution_node/metrics.py
@@ -3,7 +3,7 @@
 # Role: 监控指标收集器，负责ExecutionNode和Portfolio的运行状态指标收集和Redis缓存
 
 from typing import Dict, Any, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ class MetricsCollector:
         """
         try:
             state_key = f"portfolio:{portfolio_id}:state"
-            state["last_update"] = datetime.now().isoformat()
+            state["last_update"] = datetime.now(timezone.utc).isoformat()
 
             # 写入Redis Hash
             self.redis_client.hset(state_key, mapping=state)
@@ -82,7 +82,7 @@ class MetricsCollector:
         """
         try:
             info_key = f"execution_node:{self.node_id}:info"
-            state["last_update"] = datetime.now().isoformat()
+            state["last_update"] = datetime.now(timezone.utc).isoformat()
 
             # 写入Redis Hash
             self.redis_client.hset(info_key, mapping=state)

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -33,7 +33,7 @@ ExecutionNode是Portfolio的运行容器，负责：
 from typing import Dict, Optional, TYPE_CHECKING, List
 from threading import Thread, Lock, Event
 from queue import Queue
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 import logging
 
@@ -174,7 +174,7 @@ class ExecutionNode:
 
         # 设置运行标志
         self.is_running = True
-        self.started_at = datetime.now().isoformat()
+        self.started_at = datetime.now(timezone.utc).isoformat()
 
         if self.is_paused:
             GLOG.INFO(f"Resuming ExecutionNode {self.node_id} (was paused)")
@@ -1215,9 +1215,9 @@ class ExecutionNode:
             return "未知"
 
         try:
-            from datetime import datetime
+            from datetime import datetime, timezone
             start_time = datetime.fromisoformat(self.started_at)
-            uptime_seconds = (datetime.now() - start_time).total_seconds()
+            uptime_seconds = (datetime.now(timezone.utc) - start_time).total_seconds()
 
             hours = int(uptime_seconds // 3600)
             minutes = int((uptime_seconds % 3600) // 60)

--- a/src/ginkgo/workers/execution_node/portfolio_processor.py
+++ b/src/ginkgo/workers/execution_node/portfolio_processor.py
@@ -38,7 +38,7 @@ PortfolioProcessor是Portfolio的完整运行控制器，类似于回测Engine�
 from threading import Thread
 from queue import Queue, Empty
 from typing import TYPE_CHECKING, Optional, List
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 from ginkgo.trading.portfolios.portfolio_live import PortfolioLive
@@ -314,7 +314,7 @@ class PortfolioProcessor(Thread):
                     self._route_event(event)
                     # 更新统计信息
                     self.processed_count += 1
-                    self.last_event_time = datetime.now()
+                    self.last_event_time = datetime.now(timezone.utc)
                 except Empty:
                     # 超时，继续轮询Kafka控制命令
                     pass
@@ -552,7 +552,7 @@ class PortfolioProcessor(Thread):
                 for selector in self.portfolio._selectors:
                     try:
                         # 调用selector.pick()获取选中codes
-                        current_time = datetime.now()
+                        current_time = datetime.now(timezone.utc)
                         codes = selector.pick(current_time)
 
                         if codes:
@@ -573,7 +573,7 @@ class PortfolioProcessor(Thread):
             event = EventInterestUpdate(
                 portfolio_id=self.portfolio_id,
                 codes=all_codes,
-                timestamp=datetime.now()
+                timestamp=datetime.now(timezone.utc)
             )
 
             # 发布到output_queue（由ExecutionNode转发到Kafka）

--- a/tests/unit/workers/test_no_naive_datetime_guard.py
+++ b/tests/unit/workers/test_no_naive_datetime_guard.py
@@ -1,0 +1,77 @@
+# Guard: execution engine 模块不得使用 naive datetime.now()
+#
+# DST 切换/跨时区部署下 naive datetime 导致 timestamp 跳变、心跳/事件时间戳不一致 (#5548)。
+# 所有时间戳必须用 aware datetime（datetime.now(timezone.utc)）。
+#
+# 本测试用 AST 扫描，匹配裸调用（无参数）的 datetime.now / datetime.datetime.now，
+# 兼容 `from datetime import datetime` 与 `import datetime` 两种导入风格。
+import ast
+from pathlib import Path
+
+
+EXECUTION_MODULES = [
+    "src/ginkgo/trading/brokers/okx_broker.py",
+    "src/ginkgo/trading/engines/event_engine.py",
+    "src/ginkgo/workers/execution_node/portfolio_processor.py",
+    "src/ginkgo/workers/execution_node/heartbeat_manager.py",
+    "src/ginkgo/workers/execution_node/metrics.py",
+    "src/ginkgo/workers/execution_node/node.py",
+    "src/ginkgo/workers/backtest_worker/node.py",
+    "src/ginkgo/workers/execution_node/backpressure.py",
+]
+
+
+def _worktree_root() -> Path:
+    """从测试文件向上找到含 src/ 与 tests/ 的仓库根。"""
+    p = Path(__file__).resolve()
+    for parent in p.parents:
+        if (parent / "src").is_dir() and (parent / "tests").is_dir():
+            return parent
+    raise RuntimeError("worktree root not found")
+
+
+def _is_bare_datetime_now(func: ast.AST) -> bool:
+    """匹配 datetime.now 或 datetime.datetime.now 属性访问节点。"""
+    if not isinstance(func, ast.Attribute) or func.attr != "now":
+        return False
+    value = func.value
+    # `from datetime import datetime` → datetime.now
+    if isinstance(value, ast.Name) and value.id == "datetime":
+        return True
+    # `import datetime` → datetime.datetime.now
+    if (
+        isinstance(value, ast.Attribute)
+        and value.attr == "datetime"
+        and isinstance(value.value, ast.Name)
+        and value.value.id == "datetime"
+    ):
+        return True
+    return False
+
+
+def _find_bare_datetime_now(file_path: Path) -> list[int]:
+    """返回文件中裸 datetime.now() 调用（无 tz 参数）的行号列表。"""
+    tree = ast.parse(file_path.read_text(encoding="utf-8"))
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_bare_datetime_now(node.func):
+            if not node.args:
+                lines.append(node.lineno)
+    return lines
+
+
+def test_no_bare_datetime_now_in_execution_modules():
+    """execution engine 模块不得有裸 datetime.now() (#5548)。"""
+    root = _worktree_root()
+    offenders: dict[str, list[int]] = {}
+    for rel in EXECUTION_MODULES:
+        f = root / rel
+        if not f.exists():
+            continue
+        lines = _find_bare_datetime_now(f)
+        if lines:
+            offenders[rel] = lines
+    assert not offenders, (
+        f"naive datetime.now() (无 timezone) 发现于: {offenders}；"
+        f"请改为 datetime.now(timezone.utc) (#5548)"
+    )


### PR DESCRIPTION
## Summary

执行引擎模块共 13 处裸 `datetime.now()`（无 timezone）统一为 `datetime.now(timezone.utc)`，消除夏令时跳变与跨时区时间戳不一致。心跳/状态/背压时间戳现在一律带 UTC tz 信息，下游（Redis isoformat 解析、时间差计算）不再受本地时区/DST 影响。

## 改动（AC1）

| 文件 | 改动 |
|---|---|
| `trading/brokers/okx_broker.py` | import +1 处调用 |
| `trading/engines/event_engine.py` | 1 处（`import datetime` 风格 → `datetime.timezone.utc`） |
| `workers/backtest_worker/node.py` | import +1 处 |
| `workers/execution_node/backpressure.py` | import +1 处 |
| `workers/execution_node/heartbeat_manager.py` | import（模块级+函数内）+2 处 |
| `workers/execution_node/metrics.py` | import +2 处 |
| `workers/execution_node/node.py` | import（模块级+函数内）+2 处 |
| `workers/execution_node/portfolio_processor.py` | import +3 处 |

纯机械替换，共 22 行改动（+22/-22），无逻辑变更。

## AC2 防回归：AST guard test

新增 `tests/unit/workers/test_no_naive_datetime_guard.py`：扫描上述执行模块的 AST，断言无裸 `datetime.now()` 调用。一旦后续 PR 在执行引擎 reintroduce naive datetime，guard test 立即 RED。

**未启用全仓 ruff DTZ 规则**：全仓有 420+ 处预存裸 `datetime`（`portfolio_interface`/`time_mixin`/`validation/models` 等，超出本 issue 范围）。全仓开 DTZ 会让 CI 立即报 420 违规、阻塞所有 PR。guard test 精确覆盖执行引擎范围，是务实替代。全仓 datetime 一致性是独立技术债，可建后续 issue 跟进。

## AC3 DST 一致性

执行引擎模块已无 naive datetime → 所有时间戳带 UTC tz → isoformat 输出含 `+00:00` → `datetime.fromisoformat` 回读为 aware → 时间差计算不受 DST 影响。由 guard test 持续守护。

## Test plan

- [x] L1 py_compile（9 文件：8 src + guard test）
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed
- [x] L3 guard test：`test_no_naive_datetime_guard` → 1 passed
- [x] L3 改动模块直接测试：`test_execution_node_load_portfolio` + `test_historic_engine` → 全 passed；`test_okx_broker_unit` 2 失败为**预存**（OKX SDK `timeout` kwarg 不兼容，stash 实证与本次 datetime 改动无关）

## 覆盖率说明

8 个改动 src 文件无直接单测（mechanical 1-line replacement）。防回归由 AST guard test 覆盖（验证模块级不变量"无 naive datetime"），符合 TDD 行为测试原则——测不变量而非实现。

Closes #5548

🤖 Generated with [Claude Code](https://claude.com/claude-code)
