### PR TITLE
docs(#6203): CLAUDE.md debug 命令与组件名对齐 0.8.1 实际

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 - ClickHouse=时序 | MySQL=关系 | Redis=缓存 | MongoDB=文档
 
 ### Debug 模式
-数据库操作前必须开启：`ginkgo system config set --debug on`
+数据库操作前必须开启：`ginkgo debug on`
 
 ### 基础组件
 **禁止擅自修改 Base 类**（BaseCRUD、BaseService 等），在具体实现层处理
@@ -47,7 +47,7 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 ## Key Commands
 ```bash
 ginkgo version / status                       # 版本/状态
-ginkgo system config set --debug on           # 开启 debug（必须）
+ginkgo debug on                                # 开启 debug（必须）
 ginkgo serve api                              # API 服务器 (:8000)
 ginkgo serve webui                            # Web UI (:5173)
 ginkgo serve worker-backtest -id test2        # 回测 Worker
@@ -92,6 +92,6 @@ ginkgo backtest cat <backtest_id>
 
 ### 可用组件
 - **Strategy**: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor, social_signal, game_theory, random_choice
-- **Selector**: fixed, cn_all, momentum, popularity, multi_params
-- **Sizer**: fixed, atr, ratio
+- **Selector**: fixed_selector, cn_all_selector, momentum_selector, popularity_selector
+- **Sizer**: fixed_sizer, atr_sizer, ratio_sizer
 - **Risk**: no_risk, position_ratio, loss_limit, profit_target, max_drawdown, volatility, concentration, capital, liquidity, margin, market_cap, sector_rotation, correlation, currency, suspension, trading_time

--- a/tests/unit/test_claude_md_cli_docs_guard.py
+++ b/tests/unit/test_claude_md_cli_docs_guard.py
@@ -1,0 +1,60 @@
+"""CLAUDE.md CLI 文档一致性守护 (#6203)。
+
+断言 CLAUDE.md 中的 debug 命令与组件名清单与 ginkgo 0.8.1 实际行为一致，
+防止 CLI 重构/组件命名演进后文档再次漂移。
+
+验收锚点 (issue #6203 AC):
+- debug 命令为 `ginkgo debug on`（非已删除的 `system config set --debug on`）
+- Selector/Sizer 组件名带后缀（与 `ginkgo component list` 实际一致）
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _read_claude_md() -> str:
+    # tests/unit/ → repo root (worktree root holds CLAUDE.md)
+    repo_root = Path(__file__).resolve().parents[2]
+    claude_md = repo_root / "CLAUDE.md"
+    assert claude_md.exists(), f"CLAUDE.md not found at {claude_md}"
+    return claude_md.read_text(encoding="utf-8")
+
+
+def test_debug_command_uses_top_level_debug_not_system_config():
+    """AC1: debug 命令应为 `ginkgo debug on`，而非已删除的 `system config set --debug on`。"""
+    content = _read_claude_md()
+    assert "ginkgo system config set --debug" not in content, (
+        "CLAUDE.md 仍含已删除的 `ginkgo system config set --debug` 命令；"
+        "0.8.1 起 debug 是顶层命令，应为 `ginkgo debug on`。"
+    )
+    assert "ginkgo debug on" in content, (
+        "CLAUDE.md 缺少 `ginkgo debug on` 命令。"
+    )
+
+
+def _component_line(content: str, label: str) -> str:
+    for line in content.splitlines():
+        if line.lstrip().startswith(f"- **{label}**"):
+            return line
+    pytest.fail(f"未找到 {label} 组件清单行")
+
+
+def test_selector_names_have_suffix_and_no_phantom():
+    """AC2: Selector 组件名带 `_selector` 后缀，且不含未实现的 multi_params 幽灵组件。"""
+    line = _component_line(_read_claude_md(), "Selector")
+    for real in ("fixed_selector", "cn_all_selector", "momentum_selector", "popularity_selector"):
+        assert real in line, f"Selector 清单缺少实际组件 {real}"
+    # multi_params 仅存在于 fixed_selector.py 注释愿景，无文件/类/seed 实现
+    assert "multi_params" not in line, (
+        "Selector 清单含 multi_params——该组件未实现（无文件/类/seed），属文档幽灵。"
+    )
+
+
+def test_sizer_names_have_suffix():
+    """AC2: Sizer 组件名带 `_sizer` 后缀。"""
+    line = _component_line(_read_claude_md(), "Sizer")
+    for real in ("fixed_sizer", "atr_sizer", "ratio_sizer"):
+        assert real in line, f"Sizer 清单缺少实际组件 {real}"


### PR DESCRIPTION
## Summary

同步 `CLAUDE.md` 中的 CLI 命令与组件名文档，使其与 ginkgo 0.8.1 实际行为一致。当前两处文档偏差会误导新会话与用户照文档操作时报错（#6203）。

### AC1：debug 命令

`ginkgo system config set --debug on` → `ginkgo debug on`（2 处：Debug 模式散文 + Key Commands 代码块）。

`system config` 命令在 0.8.1 已删除，`debug` 现为顶层命令（`MODE:{on|off}`）。原命令报「No such command system」。

### AC2：组件名带后缀

| 行 | 旧（短名，bind-component 查无） | 新（与 `ginkgo component list` 一致） |
|---|---|---|
| Selector | `fixed, cn_all, momentum, popularity, multi_params` | `fixed_selector, cn_all_selector, momentum_selector, popularity_selector` |
| Sizer | `fixed, atr, ratio` | `fixed_sizer, atr_sizer, ratio_sizer` |

权威来源：`src/ginkgo/trading/selectors/*.py`（4 文件）与 `src/ginkgo/trading/sizers/*.py`（3 文件）的实际文件名，及 `data/seeding.py:546-547` 默认 seed 名。

### multi_params 删除

`multi_params` 仅存在于 `fixed_selector.py:5` 注释（"实盘策略应使用动态选股器（如 MomentumSelector、MultiParamsSelector）"）作为愿景举例，**无实现文件、无类定义、无 seed**（grep 全仓 `class MultiParamsSelector` 零命中）。保留即违反 AC「与实际名字一致」，删除。

Strategy 与 Risk 清单未改：Strategy 文件名本就不带后缀（`dual_thrust.py`/`momentum.py`），Risk 同理，清单已正确。

## 防回归

新增 `tests/unit/test_claude_md_cli_docs_guard.py`（3 测试，内容不变量守护）：
- debug 命令不含已删除的 `system config set --debug`、含 `ginkgo debug on`
- Selector 含 4 个实际带后缀名、不含幽灵 `multi_params`
- Sizer 含 3 个实际带后缀名

后续 CLI 重构/组件命名演进若致 CLAUDE.md 再漂移，guard test 立即 RED。

## Test plan

- [x] L1 py_compile（全 src/api + guard test）✅
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed ✅
- [x] L3 guard test：3 passed ✅
- [x] 手动核对：`ginkgo debug on` 命令存在（CLI 重构已验证）；selector/sizer 文件名带后缀已 grep 确认

Closes #6203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
