### PR TITLE
refactor(#6030): _load_today_records signal/order 走 Service 层 + 日期过滤下推

### DIFF
--- a/src/ginkgo/data/services/order_service.py
+++ b/src/ginkgo/data/services/order_service.py
@@ -125,6 +125,8 @@ class OrderService(BaseService):
         status: Any = None,
         page: Optional[int] = None,
         page_size: Optional[int] = None,
+        start_date: Optional[Any] = None,
+        end_date: Optional[Any] = None,
     ) -> ServiceResult:
         """
         按组合查询订单。
@@ -149,6 +151,10 @@ class OrderService(BaseService):
                 kwargs["page"] = page
             if page_size is not None:
                 kwargs["page_size"] = page_size
+            if start_date is not None:
+                kwargs["start_date"] = start_date
+            if end_date is not None:
+                kwargs["end_date"] = end_date
 
             orders = self._crud_repo.find_by_portfolio(**kwargs)
             return ServiceResult.success(data=orders)

--- a/src/ginkgo/data/services/signal_service.py
+++ b/src/ginkgo/data/services/signal_service.py
@@ -54,6 +54,36 @@ class SignalService(BaseService):
             GLOG.ERROR(f"查询信号失败: {e}")
             return ServiceResult.error(str(e))
 
+    def get_signals_by_portfolio(
+        self,
+        portfolio_id: str,
+        start_date: Optional[Any] = None,
+        end_date: Optional[Any] = None,
+    ) -> ServiceResult:
+        """
+        按组合查询信号（日期范围下推到 crud.find_by_portfolio，#6030）。
+
+        Args:
+            portfolio_id: 组合 UUID
+            start_date: 起始时间（可选，下推为 timestamp__gte）
+            end_date: 结束时间（可选，下推为 timestamp__lte）
+
+        Returns:
+            ServiceResult.data: List[Signal]
+        """
+        if not portfolio_id:
+            return ServiceResult.error("portfolio_id 不能为空")
+        try:
+            results = self._crud_repo.find_by_portfolio(
+                portfolio_id=portfolio_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+            return ServiceResult.success(data=results)
+        except Exception as e:
+            GLOG.ERROR(f"查询组合信号失败: {e}")
+            return ServiceResult.error(str(e))
+
     def _build_signal_filters(
         self,
         engine_id: Optional[str] = None,

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -436,6 +436,8 @@ class PaperTradingWorker:
             effective_date = self._engine.now if self._engine else datetime.now()
 
         target_date_str = effective_date.strftime("%Y-%m-%d")
+        day_start = effective_date.replace(hour=0, minute=0, second=0, microsecond=0)
+        day_end = effective_date.replace(hour=23, minute=59, second=59, microsecond=999999)
         records = {"analyzers": [], "signals": [], "orders": []}
 
         try:
@@ -455,13 +457,16 @@ class PaperTradingWorker:
         except Exception as e:
             GLOG.DEBUG(f"[PAPER-WORKER] Failed to load analyzer records: {e}")
 
-        # 补充 signal 记录
+        # 补充 signal 记录（走 Service 层 + 日期下推查询层，#6030）
         try:
-            signal_crud = services.data.cruds.signal()
-            signal_records = signal_crud.find(filters={"portfolio_id": portfolio_id})
-            for r in (signal_records or []):
-                ts = str(getattr(r, 'timestamp', ''))[:10]
-                if ts == target_date_str:
+            sig_service = services.data.services.signal_service()
+            sig_result = sig_service.get_signals_by_portfolio(
+                portfolio_id=portfolio_id,
+                start_date=day_start,
+                end_date=day_end,
+            )
+            if sig_result.is_success() and sig_result.data:
+                for r in sig_result.data:
                     records["signals"].append({
                         "code": getattr(r, 'code', ''),
                         "direction": getattr(r, 'direction', 0),
@@ -470,13 +475,16 @@ class PaperTradingWorker:
         except Exception as e:
             GLOG.DEBUG(f"[PAPER-WORKER] Failed to load signal records: {e}")
 
-        # 补充 order 记录
+        # 补充 order 记录（走 Service 层 + 日期下推查询层，#6030）
         try:
-            order_crud = services.data.cruds.order_record()
-            order_records = order_crud.find(filters={"portfolio_id": portfolio_id})
-            for r in (order_records or []):
-                ts = str(getattr(r, 'timestamp', ''))[:10]
-                if ts == target_date_str:
+            order_service = services.data.services.order_service()
+            order_result = order_service.get_orders_by_portfolio(
+                portfolio_id=portfolio_id,
+                start_date=day_start,
+                end_date=day_end,
+            )
+            if order_result.is_success() and order_result.data:
+                for r in order_result.data:
                     records["orders"].append({
                         "code": getattr(r, 'code', ''),
                         "volume": getattr(r, 'volume', 0),

--- a/tests/unit/data/services/test_order_service.py
+++ b/tests/unit/data/services/test_order_service.py
@@ -91,6 +91,28 @@ class TestGetOrdersByPortfolio:
             portfolio_id="p1", status=ORDERSTATUS_TYPES.FILLED, page=0, page_size=20
         )
 
+    def test_passes_date_range_to_crud(self, order_svc, mock_crud):
+        """start_date/end_date 透传到 crud.find_by_portfolio (#6030)"""
+        mock_crud.find_by_portfolio.return_value = []
+
+        order_svc.get_orders_by_portfolio(
+            "p1", start_date="2026-06-23", end_date="2026-06-24"
+        )
+
+        mock_crud.find_by_portfolio.assert_called_once_with(
+            portfolio_id="p1", start_date="2026-06-23", end_date="2026-06-24"
+        )
+
+    def test_date_omitted_when_not_passed(self, order_svc, mock_crud):
+        """未传 date 时不进 kwargs（仿 status 模式，#6030）"""
+        mock_crud.find_by_portfolio.return_value = []
+
+        order_svc.get_orders_by_portfolio("p1")
+
+        _, kwargs = mock_crud.find_by_portfolio.call_args
+        assert "start_date" not in kwargs
+        assert "end_date" not in kwargs
+
     def test_rejects_empty_portfolio_id(self, order_svc):
         result = order_svc.get_orders_by_portfolio("")
 

--- a/tests/unit/data/services/test_signal_service.py
+++ b/tests/unit/data/services/test_signal_service.py
@@ -58,3 +58,32 @@ class TestGetSignalsDfFilters:
 
         _, kwargs = mock_crud.find.call_args
         assert "task_id" not in kwargs["filters"]
+
+
+@pytest.mark.unit
+class TestGetSignalsByPortfolioDateFilter:
+    """get_signals_by_portfolio: 日期范围下推到 crud.find_by_portfolio (#6030)"""
+
+    def test_passes_start_end_date_to_crud(self, signal_svc, mock_crud):
+        mock_crud.find_by_portfolio.return_value = []
+        signal_svc.get_signals_by_portfolio(
+            portfolio_id="p1", start_date="2026-06-23", end_date="2026-06-24"
+        )
+        _, kwargs = mock_crud.find_by_portfolio.call_args
+        assert kwargs["portfolio_id"] == "p1"
+        assert kwargs["start_date"] == "2026-06-23"
+        assert kwargs["end_date"] == "2026-06-24"
+
+    def test_date_optional(self, signal_svc, mock_crud):
+        mock_crud.find_by_portfolio.return_value = []
+        signal_svc.get_signals_by_portfolio(portfolio_id="p1")
+        _, kwargs = mock_crud.find_by_portfolio.call_args
+        assert kwargs["portfolio_id"] == "p1"
+        assert kwargs.get("start_date") is None
+        assert kwargs.get("end_date") is None
+
+    def test_returns_crud_results_in_success(self, signal_svc, mock_crud):
+        mock_crud.find_by_portfolio.return_value = ["sig1", "sig2"]
+        result = signal_svc.get_signals_by_portfolio(portfolio_id="p1")
+        assert result.is_success()
+        assert result.data == ["sig1", "sig2"]

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -1101,3 +1101,84 @@ class TestSendDeviationAlert:
 
         # 不应抛异常
         worker._send_deviation_alert(MagicMock(), "SEVERE", {})
+
+
+class TestLoadTodayRecordsServiceLayer:
+    """_load_today_records 通过 Service 层访问 signal/order + 日期下推 (#6030)"""
+
+    def _setup_service_mocks(self, mock_services, signals=None, orders=None):
+        from ginkgo.data.services.base_service import ServiceResult
+
+        mock_sig = MagicMock()
+        mock_sig.get_signals_by_portfolio.return_value = ServiceResult.success(
+            data=signals if signals is not None else []
+        )
+        mock_services.data.services.signal_service.return_value = mock_sig
+
+        mock_order = MagicMock()
+        mock_order.get_orders_by_portfolio.return_value = ServiceResult.success(
+            data=orders if orders is not None else []
+        )
+        mock_services.data.services.order_service.return_value = mock_order
+
+        mock_analy = MagicMock()
+        mock_analy.get_by_task_id.return_value = ServiceResult.success(data=[])
+        mock_services.data.services.analyzer_service.return_value = mock_analy
+
+        return mock_sig, mock_order
+
+    def test_signal_via_service_with_date_range(self):
+        """AC1: signal 走 signal_service.get_signals_by_portfolio（非 cruds.signal）；
+        AC2: 透传 start_date/end_date"""
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+
+        with patch("ginkgo.services") as mock_services:
+            mock_sig, _ = self._setup_service_mocks(mock_services)
+            worker = PaperTradingWorker(worker_id="test-svc")
+            worker._engine = None
+            worker._load_today_records(
+                "p1", effective_date=datetime(2026, 6, 23, 12, 0)
+            )
+
+            mock_sig.get_signals_by_portfolio.assert_called_once()
+            _, kwargs = mock_sig.get_signals_by_portfolio.call_args
+            assert kwargs["portfolio_id"] == "p1"
+            assert kwargs.get("start_date") is not None
+            assert kwargs.get("end_date") is not None
+            mock_services.data.cruds.signal.assert_not_called()
+
+    def test_order_via_service_with_date_range(self):
+        """AC1: order 走 order_service.get_orders_by_portfolio（非 cruds.order_record）；
+        AC2: 透传 start_date/end_date"""
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+
+        with patch("ginkgo.services") as mock_services:
+            _, mock_order = self._setup_service_mocks(mock_services)
+            worker = PaperTradingWorker(worker_id="test-svc")
+            worker._engine = None
+            worker._load_today_records(
+                "p1", effective_date=datetime(2026, 6, 23, 12, 0)
+            )
+
+            mock_order.get_orders_by_portfolio.assert_called_once()
+            _, kwargs = mock_order.get_orders_by_portfolio.call_args
+            assert kwargs["portfolio_id"] == "p1"
+            assert kwargs.get("start_date") is not None
+            assert kwargs.get("end_date") is not None
+            mock_services.data.cruds.order_record.assert_not_called()
+
+    def test_no_python_layer_date_filter(self):
+        """AC2: 日期过滤在查询层，service 返回的记录全部收录（无 Python ts== 过滤）"""
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+
+        sig1 = MagicMock(code="A", direction=1, volume=100)
+        sig2 = MagicMock(code="B", direction=-1, volume=200)
+        with patch("ginkgo.services") as mock_services:
+            self._setup_service_mocks(mock_services, signals=[sig1, sig2])
+            worker = PaperTradingWorker(worker_id="test-nofilter")
+            worker._engine = None
+            records = worker._load_today_records(
+                "p1", effective_date=datetime(2026, 6, 23, 12, 0)
+            )
+
+        assert len(records["signals"]) == 2


### PR DESCRIPTION
## Summary

#6030 `PaperTradingWorker._load_today_records` 绕过 Service 层直调 CRUD + Python 层日期过滤。本次将 signal/order 两段迁移到 Service 层，日期过滤下推到查询层（crud.find_by_portfolio 的 `timestamp__gte`/`timestamp__lte`）。

### 变更

| 文件 | 变更 |
|---|---|
| signal_service.py | 新增 `get_signals_by_portfolio(portfolio_id, start_date, end_date)` 包装 crud.find_by_portfolio |
| order_service.py | `get_orders_by_portfolio` 增加 start_date/end_date 透传（crud 早已支持，仅服务层缺参数） |
| paper_trading_worker.py | _load_today_records signal/order 段改调 service；删 Python 层 `str(ts)[:10]==日期` 过滤；传 day_start/day_end datetime |

### AC 映射
- **AC1** 走 Service 层访问 signal/order ✅ — worker 改用 signal_service/order_service；测试断言 `services.data.cruds.signal` / `cruds.order_record` 未被调用
- **AC2** 日期过滤下推查询层 ✅ — start_date/end_date 透传到 crud.find_by_portfolio 的 `timestamp__gte`/`timestamp__lte`；删 Python 层 for-ts 过滤（测试断言 service 返回记录全收，无二次过滤）

### 测试（TDD 三 vertical slice）
- signal_service: 3 新（date 透传 + optional + 返回值）
- order_service: 2 新（date 透传 + optional）
- worker: 3 新（signal 走 service + order 走 service + 无 Python 过滤）

## Test plan
- [x] `pytest tests/unit/data/services/test_signal_service.py` — 5 passed
- [x] `pytest tests/unit/data/services/test_order_service.py` — 17 passed
- [x] `pytest tests/unit/workers/test_paper_trading_worker.py::TestLoadTodayRecordsServiceLayer` — 3 passed
- [x] Layer1 py_compile src+api ✅
- [x] Layer2 启动路径 smoke（user_crud/containers/user_cli 29）✅
- [x] worker 全量 48 passed（既有 2 Redis 失败 + 1 event-drain hang，非本次回归）
- [ ] review

Closes #6030

🤖 Generated with [Claude Code](https://claude.com/claude-code)
