### PR TITLE
fix: record position 读路径切 result_service（读写同源 PositionRecordCRUD）(#5964)

### DIFF
--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -147,7 +147,9 @@ def position(
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
-        position_svc = Container.position_service()
+        # #5964: 读流水表 PositionRecordCRUD（与回测 create_position_record 同源），
+        # 非 PositionService 的状态表（实盘当前持仓，回测从不写）→ 原误调致读空
+        position_svc = Container.result_service()
         result = position_svc.get_positions_df(
             portfolio_id=portfolio,
             engine_id=engine,
@@ -161,13 +163,14 @@ def position(
         # ADR-010 R2b: get_positions_df 出口已保证 data 为 DataFrame（类型即契约）
         positions_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
+        # #5964: 列对齐 PositionRecord 流水表字段（code/volume/cost/price/fee）
         position_columns_config = {
-            "uuid": {"display_name": "Position ID", "style": "dim"},
-            "portfolio_id": {"display_name": "Portfolio ID", "style": "dim"},
+            "uuid": {"display_name": "ID", "style": "dim"},
             "code": {"display_name": "Code", "style": "cyan"},
-            "quantity": {"display_name": "Quantity", "style": "yellow"},
-            "average_price": {"display_name": "Avg Price", "style": "yellow"},
-            "market_value": {"display_name": "Market Value", "style": "green"},
+            "volume": {"display_name": "Volume", "style": "yellow"},
+            "cost": {"display_name": "Cost", "style": "yellow"},
+            "price": {"display_name": "Price", "style": "green"},
+            "fee": {"display_name": "Fee", "style": "dim"},
             "timestamp": {"display_name": "Timestamp", "style": "dim"}
         }
 

--- a/src/ginkgo/data/services/result_service.py
+++ b/src/ginkgo/data/services/result_service.py
@@ -557,6 +557,45 @@ class ResultService(BaseService):
             GLOG.ERROR(f"获取持仓记录失败: {e}")
             return ServiceResult.error(f"获取持仓记录失败: {e}")
 
+    def get_positions_df(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        page_size: int = 50,
+    ) -> ServiceResult:
+        """出口①：data 是 pandas.DataFrame（类型即契约）。
+
+        ADR-010：API/CLI 消费 DataFrame 语义时走此出口。查 PositionRecordCRUD
+        （回测流水表，与 create_position_record 写入同源），task_id 可选支持
+        portfolio-only 查询。#5964 修 record position 读空——原误查 PositionCRUD
+        状态表（实盘当前持仓，回测从不写）。
+        """
+        try:
+            from ginkgo.data.crud.position_record_crud import PositionRecordCRUD
+            position_record_crud = PositionRecordCRUD()
+
+            filters: dict = {}
+            if portfolio_id:
+                filters["portfolio_id"] = portfolio_id
+            if engine_id:
+                filters["engine_id"] = engine_id
+            if task_id:
+                filters["task_id"] = task_id
+
+            model_list = position_record_crud.find(
+                filters=filters,
+                page_size=page_size if page_size > 0 else None,
+            )
+            df = model_list.to_dataframe() if model_list else pd.DataFrame()
+            return ServiceResult.success(
+                data=df,
+                message=f"Retrieved {len(df)} position records (DataFrame)",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"查询持仓(df)失败: {str(e)}")
+            return ServiceResult.error(f"查询持仓(df)失败: {str(e)}")
+
     @retry(max_try=3)
     def create_order_record(self, **kwargs) -> ServiceResult:
         """

--- a/tests/unit/client/test_record_cli.py
+++ b/tests/unit/client/test_record_cli.py
@@ -46,15 +46,17 @@ def mock_orders_df():
 
 @pytest.fixture
 def mock_positions_df():
+    # #5964: 字段对齐 PositionRecord 流水表（volume/cost/price/fee）
     return pd.DataFrame({
         "uuid": ["pos1"],
         "portfolio_id": ["p1"],
         "engine_id": ["e1"],
         "task_id": ["t1"],
         "code": ["000001.SZ"],
-        "quantity": [100],
-        "average_price": [10.5],
-        "market_value": [1050.0],
+        "volume": [100],
+        "cost": [1000.0],
+        "price": [10.5],
+        "fee": [5.0],
         "timestamp": ["2026-01-01"],
     })
 
@@ -107,7 +109,7 @@ class TestRecordPositionFilters:
         """-e/-t 透传到 service.get_positions_df"""
         mock_service = MagicMock()
         mock_service.get_positions_df.return_value = ServiceResult.success(data=mock_positions_df)
-        mock_container.position_service.return_value = mock_service
+        mock_container.result_service.return_value = mock_service
 
         result = cli_runner.invoke(record_cli.app, [
             "position", "--portfolio", "p1", "--engine", "e1", "--task", "t1",
@@ -117,6 +119,29 @@ class TestRecordPositionFilters:
         assert kwargs.get("portfolio_id") == "p1"
         assert kwargs.get("engine_id") == "e1"
         assert kwargs.get("task_id") == "t1"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestRecordPositionReadPath:
+    """#5964: record position 读流水表（PositionRecordCRUD），读写同源。
+
+    原误调 position_service（查状态表 PositionCRUD，回测从不写）→ 读空。
+    改调 result_service.get_positions_df（查流水表，与 create_position_record 同源）。
+    """
+
+    @patch("ginkgo.data.containers.Container")
+    def test_position_uses_result_service(self, mock_container, cli_runner, mock_positions_df):
+        """record position 应调 result_service，非 position_service。"""
+        result_svc = MagicMock()
+        result_svc.get_positions_df.return_value = ServiceResult.success(data=mock_positions_df)
+        mock_container.result_service.return_value = result_svc
+        mock_container.position_service = MagicMock()
+
+        result = cli_runner.invoke(record_cli.app, ["position", "--portfolio", "p1"])
+        assert result.exit_code == 0
+        result_svc.get_positions_df.assert_called_once()
+        mock_container.position_service.assert_not_called()
 
 
 # ============================================================================

--- a/tests/unit/services/test_result_service_positions_df.py
+++ b/tests/unit/services/test_result_service_positions_df.py
@@ -1,0 +1,66 @@
+"""#5964: record position 读路径修复——读写同源 PositionRecordCRUD。
+
+根因: record_cli.position 调 PositionService.get_positions_df（查状态表
+PositionCRUD），但回测引擎 t1backtest 通过 result_service.create_position_record
+写流水表 PositionRecordCRUD。读写表不匹配 → record position 读空。
+
+修复: result_service 新增 get_positions_df（DataFrame 出口，查 PositionRecordCRUD，
+task_id 可选支持 portfolio-only），record_cli.position 改调它（读写同源）。
+"""
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.data.services.result_service import ResultService
+
+
+class TestGetPositionsDf:
+    """#5964: get_positions_df 查 PositionRecordCRUD（流水表），返回 DataFrame。"""
+
+    @pytest.mark.unit
+    def test_returns_dataframe_from_position_record_crud(self):
+        """查 PositionRecordCRUD（非 PositionCRUD 状态表），to_dataframe 转换。"""
+        svc = ResultService(MagicMock())
+        crud = MagicMock()
+        df = pd.DataFrame([{"code": "000001.SZ", "volume": 100, "cost": 1000.0}])
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = df
+        crud.find.return_value = model_list
+
+        with patch("ginkgo.data.crud.position_record_crud.PositionRecordCRUD", return_value=crud):
+            result = svc.get_positions_df(portfolio_id="p1")
+
+        assert result.is_success()
+        assert isinstance(result.data, pd.DataFrame)
+        assert len(result.data) == 1
+        crud.find.assert_called_once()
+
+    @pytest.mark.unit
+    def test_portfolio_only_filters_passed_to_crud(self):
+        """portfolio-only 查询（无 task_id）仍查流水表，filters 含 portfolio_id。"""
+        svc = ResultService(MagicMock())
+        crud = MagicMock()
+        crud.find.return_value = MagicMock(to_dataframe=MagicMock(return_value=pd.DataFrame()))
+
+        with patch("ginkgo.data.crud.position_record_crud.PositionRecordCRUD", return_value=crud):
+            svc.get_positions_df(portfolio_id="p1", engine_id="e1", task_id="t1")
+
+        _, kwargs = crud.find.call_args
+        assert kwargs["filters"]["portfolio_id"] == "p1"
+        assert kwargs["filters"]["engine_id"] == "e1"
+        assert kwargs["filters"]["task_id"] == "t1"
+
+    @pytest.mark.unit
+    def test_empty_result_returns_empty_dataframe(self):
+        """crud 返空（None）→ 空 DataFrame，不抛异常。"""
+        svc = ResultService(MagicMock())
+        crud = MagicMock()
+        crud.find.return_value = None
+
+        with patch("ginkgo.data.crud.position_record_crud.PositionRecordCRUD", return_value=crud):
+            result = svc.get_positions_df(portfolio_id="p1")
+
+        assert result.is_success()
+        assert isinstance(result.data, pd.DataFrame)
+        assert result.data.empty


### PR DESCRIPTION
## Summary

#5964 `record position -p <portfolio>` 对有 26 笔订单的 portfolio 返回"没有数据"。

### 根因：读写表不匹配

| 路径 | CRUD | 表语义 |
|---|---|---|
| **写** `t1backtest.add_position` → `result_service.create_position_record` | `PositionRecordCRUD` | 流水表（每笔变更一行） |
| **读**（修复前）`record_cli.position` → `PositionService.get_positions_df` | `PositionCRUD` | 状态表（实盘当前持仓快照） |

回测从不写状态表（那是 `PortfolioLive` 实盘用的），所以 record position 读状态表必空。PR#6384 曾改 `result_service` 但 `record_cli` 切错了 service（调 `PositionService` 而非 `ResultService`）。同时列配置引用状态表字段（`quantity`/`average_price`/`market_value`），`PositionRecord` 流水表无这些字段。

### 变更

| 文件 | 变更 |
|---|---|
| `result_service.py` | 新增 `get_positions_df(portfolio_id, engine_id, task_id, page_size)` —— DataFrame 出口（ADR-010），查 `PositionRecordCRUD`（与 `create_position_record` 同源），`task_id` 可选支持 portfolio-only |
| `record_cli.py` | position 命令改调 `Container.result_service()`（非 `position_service`）；列配置对齐 `PositionRecord` 字段（`volume`/`cost`/`price`/`fee`） |

### AC 映射

- **AC1** record position 显示持仓变更记录 ✅ —— 读 PositionRecord 流水表（回测写入的表）
- **AC2** 每笔订单对应至少一条持仓变更 ✅ —— 读端切到与写端同源的表
- **AC3** 数据与 backtest cat 订单数一致 ✅ —— 同源 PositionRecordCRUD，读写对齐

## Test plan

- [x] `pytest tests/unit/services/test_result_service_positions_df.py` — 3 passed（查 PositionRecordCRUD + filter 透传 + 空结果返空 DataFrame）
- [x] `pytest tests/unit/client/test_record_cli.py` — 7 passed（新 ReadPath 切 result_service + 更新 Filters mock + 既有不破）
- [x] Layer1 py_compile src+api ✅
- [x] Layer2 启动路径 smoke（user_crud/containers/user_cli 29）✅
- [ ] review
- [ ] 回测后 `record position -p <portfolio>` 实测（需真实回测数据，留 issue 关闭前人工验证）

Closes #5964

🤖 Generated with [Claude Code](https://claude.com/claude-code)
