### PR TITLE
feat(#5466): rate limit 计数改 Redis 持久化 + 内存 fallback

### DIFF
--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -4,11 +4,13 @@
 
 from fastapi import Request, HTTPException, status
 from starlette.middleware.base import BaseHTTPMiddleware
-from typing import Dict
+from typing import Dict, Optional
 import os
 import time
+import uuid
 
 from core.logging import logger
+from core.redis_client import get_redis
 
 # Issue #3847: 防止 IP 记录无限累积
 _MAX_IPS = 10000
@@ -26,7 +28,11 @@ def _load_trusted_proxies() -> set:
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """基于内存的请求限流中间件（开发环境）"""
+    """请求限流中间件。
+
+    计数优先存 Redis（滑动窗口 ZSET），实现跨重启/多进程一致的限流；
+    Redis 不可用时 fallback 回进程内 dict（开发环境），请求处理永不中断。
+    """
 
     def __init__(
         self,
@@ -49,21 +55,64 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         client_ip = self.get_client_ip(request)
 
-        if self.is_rate_limited(client_ip):
+        if await self.check_and_record(client_ip):
             logger.warning(f"Rate limit exceeded for {client_ip}")
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Too many requests"
             )
 
-        self.record_request(client_ip)
-        self._cleanup_current_ip(client_ip)
-
+        # _full_cleanup 仅作用于 fallback 内存 dict（Redis 路径下 dict 恒空）
         self._request_count += 1
         if self._request_count % _FULL_CLEANUP_INTERVAL == 0:
             self._full_cleanup()
 
         return await call_next(request)
+
+    async def check_and_record(self, client_ip: str) -> bool:
+        """检查并记录请求。返回 True 表示该请求应被限流。
+
+        优先 Redis（持久化 + 多进程一致），任何 Redis 异常 fallback 回内存。
+        fallback 路径复用既有同步 is_rate_limited/record_request/_cleanup_current_ip。
+        """
+        redis_result = await self._redis_check_and_record(client_ip)
+        if redis_result is not None:
+            return redis_result
+        # Redis 不可用 → 内存 fallback（AC4 + 热路径安全网）
+        if self.is_rate_limited(client_ip):
+            return True
+        self.record_request(client_ip)
+        self._cleanup_current_ip(client_ip)
+        return False
+
+    async def _redis_check_and_record(self, client_ip: str) -> Optional[bool]:
+        """Redis 滑动窗口检查 + 记录。
+
+        返回值：True=限流 / False=放行（已记录）/ None=Redis 不可用（调用方 fallback）。
+        语义对齐内存版：先查窗口内既有请求数，达阈值则限流且不记录本次；
+        否则记录本次（唯一 member 防 ZADD 覆盖）。
+        """
+        try:
+            redis = await get_redis()
+        except Exception as e:
+            logger.warning(f"Rate limit Redis unavailable, fallback to in-memory: {e}")
+            return None
+
+        key = f"ratelimit:{client_ip}"
+        now = time.time()
+        window_start = now - self.window_seconds
+        try:
+            # 清窗口外 → 数窗口内 → 不足阈值才记录本次
+            await redis.zremrangebyscore(key, 0, window_start)
+            count = await redis.zcard(key)
+            if count >= self.max_requests:
+                return True
+            await redis.zadd(key, {uuid.uuid4().hex: now})
+            await redis.expire(key, self.window_seconds + 1)
+            return False
+        except Exception as e:
+            logger.warning(f"Rate limit Redis op failed, fallback to in-memory: {e}")
+            return None
 
     def get_client_ip(self, request: Request) -> str:
         # #5475: 先取 TCP 直连 IP，仅当它来自可信反向代理时才采信 XFF/X-Real-IP

--- a/tests/api/test_rate_limit_redis.py
+++ b/tests/api/test_rate_limit_redis.py
@@ -1,0 +1,90 @@
+"""#5466: Rate limit 中间件 Redis 持久化 + 内存 fallback 测试。
+
+AC:
+1. 计数入 Redis（Redis 路径下内存 dict 保持空）
+2. 重启留存（新实例共享 Redis 计数）
+3. 多进程一致（多实例共享同一 Redis）
+4. Redis 不可用时 fallback 内存（请求处理不中断）
+"""
+import asyncio
+
+import pytest
+
+
+class _FakeRedis:
+    """最小 in-memory Redis，仅实现 ZSET 滑动窗口所需命令。"""
+
+    def __init__(self):
+        self._zsets = {}  # key -> {member: score}
+
+    async def zremrangebyscore(self, key, min_score, max_score):
+        s = self._zsets.setdefault(key, {})
+        for m in [m for m, v in s.items() if min_score <= v <= max_score]:
+            del s[m]
+
+    async def zcard(self, key):
+        return len(self._zsets.get(key, {}))
+
+    async def zadd(self, key, mapping):
+        self._zsets.setdefault(key, {}).update(mapping)
+
+    async def expire(self, key, ttl):
+        return True
+
+
+def _make_middleware(max_requests=3, window_seconds=60):
+    from middleware.rate_limit import RateLimitMiddleware
+    return RateLimitMiddleware(app=None, max_requests=max_requests, window_seconds=window_seconds)
+
+
+def test_fallback_to_in_memory_when_redis_unavailable(monkeypatch):
+    """AC4: Redis 不可用时，fallback 到内存，限流仍生效且不中断。"""
+    import middleware.rate_limit as rl
+
+    async def _boom():
+        raise ConnectionError("Redis down")
+
+    monkeypatch.setattr(rl, "get_redis", _boom)
+    mw = _make_middleware(max_requests=3, window_seconds=60)
+
+    # 3 次放行，第 4 次限流 —— 全走内存 fallback，无异常抛出
+    results = [asyncio.run(mw.check_and_record("10.0.0.1")) for _ in range(4)]
+    assert results == [False, False, False, True]
+
+
+def test_redis_path_limits_and_dict_stays_empty(monkeypatch):
+    """AC1: Redis 路径下限流生效，且进程内 dict 保持空（证明用了 Redis）。"""
+    import middleware.rate_limit as rl
+
+    fake = _FakeRedis()
+    monkeypatch.setattr(rl, "get_redis", _async_value(fake))
+    mw = _make_middleware(max_requests=3, window_seconds=60)
+
+    results = [asyncio.run(mw.check_and_record("10.0.0.2")) for _ in range(4)]
+    assert results == [False, False, False, True]
+    # 关键判别：Redis 被使用，内存 dict 不应累积
+    assert mw.requests == {}
+
+
+def test_redis_counters_shared_across_instances(monkeypatch):
+    """AC2+AC3: 新实例（重启/多进程）共享 Redis 计数 → 立即触发限流。"""
+    import middleware.rate_limit as rl
+
+    shared_fake = _FakeRedis()
+    monkeypatch.setattr(rl, "get_redis", _async_value(shared_fake))
+
+    mw1 = _make_middleware(max_requests=3, window_seconds=60)
+    # 实例 1 耗尽配额
+    [asyncio.run(mw1.check_and_record("10.0.0.3")) for _ in range(3)]
+
+    # 实例 2 模拟「重启 / 另一进程」，共享同一 Redis
+    mw2 = _make_middleware(max_requests=3, window_seconds=60)
+    limited = asyncio.run(mw2.check_and_record("10.0.0.3"))
+    assert limited is True
+    assert mw2.requests == {}
+
+
+def _async_value(value):
+    async def _ret():
+        return value
+    return _ret


### PR DESCRIPTION
## Summary

`RateLimitMiddleware` 计数由进程内 dict 改为优先存 Redis（ZSET 滑动窗口），Redis 不可用时 fallback 回既有内存逻辑。解决 #5466：计数重启即丢、多进程不共享。

## 改动

| 文件 | 改动 |
|---|---|
| `api/middleware/rate_limit.py` | 新增 `check_and_record` + `_redis_check_and_record`（async）；`dispatch` 改调 `check_and_record`；同步 `is_rate_limited`/`record_request` 保留为 fallback 路径 |

**设计要点**：
- **零签名变更**：同步 `is_rate_limited`/`record_request` 保留不动（=fallback + 既有调用方不受影响）；新逻辑纯增量。
- **语义对齐内存版**：Redis 路径用 `ZREMRANGEBYSCORE`(清窗口外) → `ZCARD`(数窗口内) → 不足阈值才 `ZADD`(本次)，阻塞请求不计入（与内存版「先查 past 再 record」一致）。
- **fallback = 热路径安全网**：`get_redis()` 或任何 Redis op 抛异常 → `_redis_check_and_record` 返 `None` → `check_and_record` 回退同步内存路径。中间件在请求热路径，绝不让 Redis 故障进 500。

## AC

- [x] 计数入 Redis — `test_redis_path_limits_and_dict_stays_empty`（限流生效 + 内存 dict 恒空，证明用了 Redis）
- [x] 重启留存 + 多进程一致 — `test_redis_counters_shared_across_instances`（双实例共享 Redis，第二实例立即触发限流）
- [x] fallback 内存 — `test_fallback_to_in_memory_when_redis_unavailable`（Redis 故障仍限流、不中断）

阻塞 #5447（Redis 属性名错误）已由 PR#6075 修复确认（`redis_client.py:16` 用 `GCONF.REDISHOST/PORT`）。

## Test plan

- [x] L1 py_compile（src + api）✅
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed ✅
- [x] L3 新增测试：`test_rate_limit_redis` → 3 passed ✅
- [x] 回归：`test_response_format`（含 RateLimitError）→ 27 passed ✅

Closes #5466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
