### PR TITLE
fix(#5632): account schema 加 broker/account_name alias + 字段 description

### DIFF
--- a/api/models/accounts.py
+++ b/api/models/accounts.py
@@ -4,7 +4,7 @@ Live Account 相关数据模型
 与前端 web-ui/src/api/modules/live.ts 中的类型定义对应
 """
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, AliasChoices
 from typing import Optional, List, Dict, Any
 from enum import Enum
 from datetime import datetime
@@ -65,8 +65,17 @@ class LiveAccountDetail(LiveAccountSummary):
 
 class CreateLiveAccountRequest(BaseModel):
     """创建实盘账号请求"""
-    exchange: ExchangeType
-    name: str = Field(..., min_length=1, max_length=200)
+    exchange: ExchangeType = Field(
+        validation_alias=AliasChoices("exchange", "broker"),
+        description="交易所(OKX/BINANCE);也接受直觉别名 `broker`。",
+    )
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=200,
+        validation_alias=AliasChoices("name", "account_name"),
+        description="账户显示名称;也接受直觉别名 `account_name`。",
+    )
     api_key: str = Field(..., min_length=1)
     api_secret: str = Field(..., min_length=1)
     passphrase: Optional[str] = None
@@ -77,7 +86,13 @@ class CreateLiveAccountRequest(BaseModel):
 
 class UpdateLiveAccountRequest(BaseModel):
     """更新实盘账号请求"""
-    name: Optional[str] = Field(None, min_length=1, max_length=200)
+    name: Optional[str] = Field(
+        None,
+        min_length=1,
+        max_length=200,
+        validation_alias=AliasChoices("name", "account_name"),
+        description="账户显示名称;也接受直觉别名 `account_name`。",
+    )
     api_key: Optional[str] = None
     api_secret: Optional[str] = None
     passphrase: Optional[str] = None

--- a/tests/api/test_accounts_api_5632.py
+++ b/tests/api/test_accounts_api_5632.py
@@ -1,0 +1,52 @@
+"""#5632: Account 创建 schema 字段名与直觉不符。
+
+表象: 用户用直觉命名 `broker`/`account_name` POST 创建账户 → 422 missing `exchange`/`name`。
+根因: `CreateLiveAccountRequest`/`UpdateLiveAccountRequest` 字段无 alias 兼容直觉命名,
+      且 Pydantic extra="ignore" 静默丢弃 `broker`/`account_name` → 必填 `exchange`/`name` missing。
+契约:
+  - 输入接受 `exchange`/`broker` 任一(主名 exchange 不变,DB/前端契约不破坏);
+  - 输入接受 `name`/`account_name` 任一;
+  - OpenAPI schema 含字段 description,消除命名歧义。
+"""
+
+from pydantic import ValidationError
+
+
+def test_create_accepts_intuitive_aliases(api_modules):
+    """#5632: broker/account_name 别名输入应被接受(用户直觉命名)。"""
+    from models.accounts import CreateLiveAccountRequest
+
+    req = CreateLiveAccountRequest(
+        broker="okx", account_name="test", api_key="k", api_secret="s"
+    )
+    assert req.exchange.value == "okx"
+    assert req.name == "test"
+
+
+def test_create_still_accepts_canonical_names(api_modules):
+    """#5632: 加 alias 后主名 exchange/name 仍工作(向后兼容,DB/前端契约不破坏)。"""
+    from models.accounts import CreateLiveAccountRequest
+
+    req = CreateLiveAccountRequest(
+        exchange="binance", name="canonical", api_key="k", api_secret="s"
+    )
+    assert req.exchange.value == "binance"
+    assert req.name == "canonical"
+
+
+def test_openapi_schema_has_field_descriptions(api_modules):
+    """#5632: OpenAPI schema 字段含 description,消除命名歧义。"""
+    from models.accounts import CreateLiveAccountRequest
+
+    schema = CreateLiveAccountRequest.model_json_schema()
+    props = schema["properties"]
+    assert props["exchange"].get("description"), "exchange 缺 description"
+    assert props["name"].get("description"), "name 缺 description"
+
+
+def test_update_accepts_account_name_alias(api_modules):
+    """#5632: UpdateLiveAccountRequest.name 也接受 account_name 别名。"""
+    from models.accounts import UpdateLiveAccountRequest
+
+    req = UpdateLiveAccountRequest(account_name="renamed")
+    assert req.name == "renamed"


### PR DESCRIPTION
## Summary

#5632 创建实盘账户时 schema 字段名与直觉不符：用户用 `broker`/`account_name` POST → 422 missing `exchange`/`name`。

### 根因

`CreateLiveAccountRequest` / `UpdateLiveAccountRequest` 字段名为 `exchange`/`name`，Pydantic 默认 `extra="ignore"` 静默丢弃 `broker`/`account_name` → 必填 `exchange`/`name` 报 missing → 422。同时字段无 OpenAPI description，命名歧义无文档说明。

### 变更

| 文件 | 变更 |
|---|---|
| `api/models/accounts.py` | `exchange` 加 `validation_alias=AliasChoices("exchange","broker")`；`name` 加 `AliasChoices("name","account_name")`（Create + Update）；两字段补 `Field(description=...)` |

**向后兼容**：主名 `exchange`/`name` 不变（DB / 前端 `web-ui/src/api/modules/live.ts` 契约不破坏），AliasChoices 第一项为主名确保主名仍可用，`broker`/`account_name` 作为直觉别名输入也被接受。

## AC 映射

- **AC1** 统一字段命名（选 `exchange`，接受 `broker` 别名）✅ —— 主名 `exchange` 不变，`broker` 别名兼容
- **AC2** OpenAPI schema 字段描述 ✅ —— `Field(description=...)` 补全
- **AC3** 前后端同一命名 ✅ —— 前端已用 `exchange`/`name`（主名不变），现后端额外接受直觉别名

## Test plan

- [x] `pytest tests/api/test_accounts_api_5632.py` — 4 passed（别名接受 + 主名向后兼容 + OpenAPI description + Update alias）
- [x] `pytest tests/api/test_accounts_api_5782.py tests/api/test_accounts_api_5789.py` — 5 passed（既有不破）
- [x] Layer1 py_compile src+api ✅
- [x] Layer2 启动路径 smoke（user_crud/containers/user_cli 29）✅
- [ ] review

Closes #5632

🤖 Generated with [Claude Code](https://claude.com/claude-code)
