### PR TITLE
refactor(#4607): PortfolioBase 提取 _propagate_context 助手消除绑定传播重复

### DIFF
--- a/src/ginkgo/trading/bases/portfolio_base.py
+++ b/src/ginkgo/trading/bases/portfolio_base.py
@@ -506,6 +506,29 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
 
     # ========== 绑定方法 ==========
 
+    def _propagate_context(self, component) -> None:
+        """
+        把 portfolio 当前上下文同步给单个组件（#4607 提取，消除 add/bind 系列重复传播）。
+
+        bind_portfolio 总是执行；bind_engine / set_time_provider / bind_data_feeder
+        仅当 portfolio 已持有对应对象时传播（与原 add_strategy/bind_selector/bind_sizer 行为一致）。
+        """
+        component.bind_portfolio(self)
+        if self._bound_engine is not None:
+            component.bind_engine(self._bound_engine)
+        if self._time_provider is not None:
+            component.set_time_provider(self._time_provider)
+        if self._data_feeder is not None:
+            component.bind_data_feeder(self._data_feeder)
+
+    def _rebind_portfolio_and_engine(self, component, engine) -> None:
+        """
+        bind_engine 变更引擎时对已注册组件重绑（#4607 提取，消除 bind_engine 循环内重复）。
+        仅重绑 portfolio 引用与新 engine，不触碰 time_provider/data_feeder（保持原两步语义）。
+        """
+        component.bind_portfolio(self)
+        component.bind_engine(engine)
+
     def bind_selector(self, selector: SelectorBase) -> None:
         """
         Bind selector to portfolio, and bind portfolio itself to selector.
@@ -515,17 +538,8 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
             GLOG.ERROR(f"Selector bind only support Selector, {type(selector)} {selector} is not supported.")
             return
         self._selectors.append(selector)
-        # 绑定portfolio引用，让selector可以直接从portfolio获取ID
-        selector.bind_portfolio(self)
-        # 如果portfolio已绑定引擎，也绑定引擎到selector
-        if self._bound_engine is not None:
-            selector.bind_engine(self._bound_engine)
-        # 如果portfolio有TimeProvider，也设置给selector
-        if self._time_provider is not None:
-            selector.set_time_provider(self._time_provider)
-        # 如果portfolio已有data_feeder，也传播给selector
-        if self._data_feeder is not None:
-            selector.bind_data_feeder(self._data_feeder)
+        # 传播 portfolio 上下文（engine/time_provider/data_feeder）
+        self._propagate_context(selector)
 
     def bind_engine(self, engine: BaseEngine):
         """
@@ -544,24 +558,20 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
         # 通过统一的ContextMixin同步给所有已绑定的组件
         # 策略组件（支持多个）- 先 bind_portfolio 设置 _context，后 bind_engine
         for strategy in self._strategies:
-            strategy.bind_portfolio(self)     # 先绑定 Portfolio（设置 PortfolioContext）
-            strategy.bind_engine(engine)      # 后绑定 Engine（保留引擎引用，不覆盖 context）
+            self._rebind_portfolio_and_engine(strategy, engine)
 
         # Sizer组件（单个）- 需要engine_id创建Order
         if self._sizer is not None:
-            self._sizer.bind_portfolio(self)  # 先绑定 Portfolio（设置 PortfolioContext）
-            self._sizer.bind_engine(engine)   # 后绑定 Engine（保留引擎引用，不覆盖 context）
+            self._rebind_portfolio_and_engine(self._sizer, engine)
 
         # Selector组件（支持多个）
         for selector in self._selectors:
-            selector.bind_portfolio(self)     # 先绑定 Portfolio（设置 PortfolioContext）
-            selector.bind_engine(engine)      # 后绑定 Engine（保留引擎引用，不覆盖 context）
+            self._rebind_portfolio_and_engine(selector, engine)
 
         # 分析器组件（支持多个）- 需要更新 context 引用
         # 当 portfolio 绑定到 engine 后，analyzer 需要重新绑定以获取正确的 engine_context
         for analyzer in self._analyzers.values():
-            analyzer.bind_portfolio(self)    # 重新绑定 Portfolio（更新 PortfolioContext）
-            analyzer.bind_engine(engine)     # 绑定 Engine（设置引擎引用）
+            self._rebind_portfolio_and_engine(analyzer, engine)
 
     def set_time_provider(self, time_provider) -> None:
         """
@@ -594,17 +604,8 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
     def add_strategy(self, strategy: "BaseStrategy") -> None:
         if strategy not in self.strategies:
             self.strategies.append(strategy)
-            # 绑定portfolio引用给strategy
-            strategy.bind_portfolio(self)
-            # 如果portfolio已绑定引擎，也绑定引擎到strategy
-            if self._bound_engine is not None:
-                strategy.bind_engine(self._bound_engine)
-            # 如果portfolio有TimeProvider，也设置给strategy
-            if self._time_provider is not None:
-                strategy.set_time_provider(self._time_provider)
-            # 如果portfolio已有data_feeder，也传播给strategy
-            if self._data_feeder is not None:
-                strategy.bind_data_feeder(self._data_feeder)
+            # 传播 portfolio 上下文（engine/time_provider/data_feeder）
+            self._propagate_context(strategy)
 
     def add_position(self, position: Position) -> None:
         code = position.code
@@ -621,17 +622,8 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
             GLOG.ERROR(f"Sizer bind only support Sizer, {type(sizer)} {sizer} is not supported.")
             return
         self._sizer = sizer
-        # 绑定portfolio引用，让sizer可以直接从portfolio获取ID
-        sizer.bind_portfolio(self)
-        # 如果portfolio已绑定engine，也绑定给sizer
-        if self._bound_engine is not None:
-            sizer.bind_engine(self._bound_engine)
-        # 传递时间提供者给sizer
-        if self.get_time_provider() is not None:
-            sizer.set_time_provider(self.get_time_provider())
-        # 如果portfolio已有data_feeder，也传播给sizer
-        if self._data_feeder is not None:
-            sizer.bind_data_feeder(self._data_feeder)
+        # 传播 portfolio 上下文（engine/time_provider/data_feeder）
+        self._propagate_context(sizer)
 
     def freeze(self, money: any) -> bool:
         """

--- a/tests/unit/backtest/test_portfolio_propagate_context_4607.py
+++ b/tests/unit/backtest/test_portfolio_propagate_context_4607.py
@@ -1,0 +1,74 @@
+"""
+#4607: 提取 PortfolioBase._propagate_context(component) 助手方法。
+
+背景：add_strategy / bind_selector / bind_sizer 各自重复同一套 4 步上下文传播：
+  bind_portfolio → bind_engine → set_time_provider → bind_data_feeder
+bind_engine 循环又对已注册组件重复 bind_portfolio + bind_engine 两步。
+提取助手方法消除重复，使"新增一个 bind 步骤"只需改一处。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.trading.bases.portfolio_base import PortfolioBase
+from ginkgo.trading.portfolios import PortfolioT1Backtest
+from ginkgo.trading.selectors import FixedSelector
+from ginkgo.trading.sizers import FixedSizer
+from ginkgo.trading.strategies.strategy_base import BaseStrategy
+
+
+@pytest.fixture
+def portfolio():
+    return PortfolioT1Backtest()
+
+
+class TestPropagateContextDelegation:
+    """add_*/bind_* 必须委托给 _propagate_context（契约守护 #4607 重构不被回退）。"""
+
+    def test_add_strategy_delegates(self, portfolio):
+        s = BaseStrategy()
+        with patch.object(portfolio, "_propagate_context") as spy:
+            portfolio.add_strategy(s)
+        spy.assert_called_once_with(s)
+
+    def test_bind_selector_delegates(self, portfolio):
+        sel = FixedSelector()
+        with patch.object(portfolio, "_propagate_context") as spy:
+            portfolio.bind_selector(sel)
+        spy.assert_called_once_with(sel)
+
+    def test_bind_sizer_delegates(self, portfolio):
+        sizer = FixedSizer()
+        with patch.object(portfolio, "_propagate_context") as spy:
+            portfolio.bind_sizer(sizer)
+        spy.assert_called_once_with(sizer)
+
+
+class TestPropagateContext:
+    """_propagate_context 把 portfolio 当前上下文同步给单个组件。"""
+
+    def test_binds_all_four_contexts_when_populated(self, portfolio):
+        engine, tp, feeder = MagicMock(), MagicMock(), MagicMock()
+        portfolio._bound_engine = engine
+        portfolio._time_provider = tp
+        portfolio._data_feeder = feeder
+
+        component = MagicMock()
+        portfolio._propagate_context(component)
+
+        component.bind_portfolio.assert_called_once_with(portfolio)
+        component.bind_engine.assert_called_once_with(engine)
+        component.set_time_provider.assert_called_once_with(tp)
+        component.bind_data_feeder.assert_called_once_with(feeder)
+
+    def test_skips_none_optional_contexts(self, portfolio):
+        # engine/time_provider/data_feeder 均未设置（默认 None）
+        component = MagicMock()
+        portfolio._propagate_context(component)
+
+        # portfolio 自身总是传播（非可选）
+        component.bind_portfolio.assert_called_once_with(portfolio)
+        # 可选上下文为 None 时不传播
+        component.bind_engine.assert_not_called()
+        component.set_time_provider.assert_not_called()
+        component.bind_data_feeder.assert_not_called()


### PR DESCRIPTION
## Summary

#4607：提取 `PortfolioBase` 组件上下文传播助手，消除 `add_*`/`bind_*` 系列的 4 步传播重复。

**根因**：`add_strategy` / `bind_selector` / `bind_sizer` 各自内联同一套 4 步上下文传播（`bind_portfolio` → `bind_engine` → `set_time_provider` → `bind_data_feeder`），`bind_engine` 循环又对 strategy/sizer/selector/analyzer 重复 `bind_portfolio` + `bind_engine` 两步。新增一个 bind 步骤需改 5+ 处，易漏。

**本次重构**（纯行为不变）：
- **`_propagate_context(component)`**：封装 4 步传播（portfolio 总传；engine/time_provider/data_feeder 仅在 portfolio 已持有时传）。
- **`_rebind_portfolio_and_engine(component, engine)`**：封装 `bind_engine` 变更时的 2 步重绑（保持原两步语义，不混入 time_provider/data_feeder 传播——避免纯重构夹带行为变更）。
- **3 处 4 步传播**（`add_strategy` / `bind_selector` / `bind_sizer`）改委托 `_propagate_context`。
- **`bind_engine` 循环** 4 类组件改委托 `_rebind_portfolio_and_engine`。
- **`bind_sizer` 原 `self.get_time_provider()` 统一为 `self._time_provider`**（`get_time_provider` 直接 `return self._time_provider`，等价无 lazy）。

**body 偏差校正**：#4607 body 称 `add_risk_manager` 也重复 4 步传播，实测它只 `append` 到列表、**无任何 bind 传播**（portfolio_base.py:584-591）。强加传播=行为变更（回归风险），不在本次纯重构范围；真正重复的是 3 处 + `bind_engine` 循环。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml`）全绿：
- **L1 py_compile**：src+api 全量语法 ✅
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29）✅
- **L3 变更 + 装配链依赖**：
  - 新契约测试 `test_portfolio_propagate_context_4607`（5）：helper 正确性 + add/bind 委托契约 ✅
  - `test_portfolio_base` + `test_base_portfolio`（89）既有行为回归 ✅
  - `test_component_loader_smoke` + `test_engine_assembly_paper_mode` + `test_enhanced_backtest_integration`（21）装配链 ✅

合计 144 测试全绿，零回归。（`test_strategy_integration::test_strategy_signal_validation` 在 origin/master 单跑即 FAIL，预存非本次引入。）

**TDD**：tracer bullet 先固化 `_propagate_context` 4 步语义（`MagicMock` component 断言 4 bind 各调一次 + None 守卫跳过），再驱动实现；委托契约测试守护重构不被回退。

Closes #4607

🤖 Generated with [Claude Code](https://claude.com/claude-code)
