### PR TITLE
fix(#5551): 删除 TimeControlledEventEngine.stop() 重复定义

### DIFF
--- a/src/ginkgo/trading/engines/time_controlled_engine.py
+++ b/src/ginkgo/trading/engines/time_controlled_engine.py
@@ -184,18 +184,6 @@ class TimeControlledEventEngine(EventEngine, ITimeAwareComponent):
         )
         return result
 
-    def stop(self) -> bool:
-        """停止引擎（带调试信息）"""
-        import traceback
-
-        GLOG.ERROR(f"{self.name}: 🔥 stop() called! Call stack:")
-        for line in traceback.format_stack()[-3:-1]:  # 显示最近3层调用栈
-            GLOG.ERROR(f"    {line.strip()}")
-
-        result = super().stop()
-        GLOG.DEBUG(f"{self.name}: stop() completed - result={result}")
-        return result
-
     def _initialize_components(self):
         """初始化引擎组件"""
 

--- a/src/ginkgo/trading/engines/time_controlled_engine.py
+++ b/src/ginkgo/trading/engines/time_controlled_engine.py
@@ -158,23 +158,6 @@ class TimeControlledEventEngine(EventEngine, ITimeAwareComponent):
 
             GLOG.INFO(f"Time range set: {start_date} to {end_date}")
 
-    def set_time_provider(self, provider) -> None:
-        """替换时间提供者（用于 REPLAY → LIVE_PAPER 切换）
-
-        Args:
-            provider: ITimeProvider 实例
-        """
-        self._time_provider = provider
-        if hasattr(provider, "register_time_listener"):
-            provider.register_time_listener(self)
-        try:
-            from ginkgo.trading.time.clock import set_global_time_provider
-            set_global_time_provider(provider)
-        except Exception as e:
-            GLOG.WARNING(f"{e}")
-            pass
-        GLOG.INFO(f"Time provider swapped to: {type(provider).__name__}")
-
     def start(self) -> bool:
         """启动引擎（带调试信息）"""
         GLOG.INFO(f"{self.name}: 🔥 start() called - _main_thread_started={self._main_thread_started}, is_alive={self._main_thread.is_alive()}",

--- a/tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py
+++ b/tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py
@@ -1,0 +1,57 @@
+"""AST guard: TimeControlledEventEngine.stop() 单一定义且保留 executor shutdown。
+
+回归守护 #5551：曾有两个 stop() 定义共存（@187 调试残留 `🔥+traceback` 被
+@251 正式版遮蔽为死代码，且 @187 的 `-> bool` 标注错误——经 EventEngine.stop()
+实返 None）。重新引入重复定义或误删 executor 清理时此测试立即 RED。
+
+采用 AST 静态扫描（参照 tests/unit/workers/test_no_naive_datetime_guard.py
+先例），无需实例化重资源引擎，专注守护结构不变量。
+"""
+import ast
+from pathlib import Path
+
+ENGINE_FILE = (
+    Path(__file__).resolve().parents[4]
+    / "src/ginkgo/trading/engines/time_controlled_engine.py"
+)
+
+
+def _class_body(class_name: str) -> ast.ClassDef:
+    tree = ast.parse(ENGINE_FILE.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return node
+    raise AssertionError(f"类 {class_name} 未在 {ENGINE_FILE} 中找到")
+
+
+def _method_source(class_def: ast.ClassDef, method_name: str) -> str:
+    """返回指定方法名的源码段（取第一个匹配）。"""
+    for n in class_def.body:
+        if isinstance(n, ast.FunctionDef) and n.name == method_name:
+            return ast.unparse(n)
+    raise AssertionError(f"方法 {method_name} 未找到")
+
+
+def test_stop_defined_once():
+    """stop() 在 TimeControlledEventEngine 中只能定义一次（#5551 AC1）。
+
+    重复定义时后定义遮蔽前定义，前者成死代码——这是 #5551 的根因。
+    """
+    cls = _class_body("TimeControlledEventEngine")
+    stop_defs = [n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name == "stop"]
+    assert len(stop_defs) == 1, (
+        f"stop() 应只定义一次，实际 {len(stop_defs)} 次"
+        "（重复定义会互相遮蔽，见 #5551）"
+    )
+
+
+def test_stop_preserves_executor_shutdown():
+    """保留下来的 stop() 必须清理线程池 _executor（#5551 AC2）。
+
+    合并重复定义时不得丢失 @251 正式版的 executor.shutdown(wait=True)，
+    否则引擎停止后线程池泄漏。
+    """
+    cls = _class_body("TimeControlledEventEngine")
+    src = _method_source(cls, "stop")
+    assert "_executor" in src, "stop() 必须引用 _executor（清理线程池资源）"
+    assert "shutdown" in src, "stop() 必须调用 _executor.shutdown(wait=True)"

--- a/tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py
+++ b/tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py
@@ -55,3 +55,34 @@ def test_stop_preserves_executor_shutdown():
     src = _method_source(cls, "stop")
     assert "_executor" in src, "stop() 必须引用 _executor（清理线程池资源）"
     assert "shutdown" in src, "stop() 必须调用 _executor.shutdown(wait=True)"
+
+
+def test_set_time_provider_defined_once():
+    """set_time_provider() 只能定义一次（#5551 AC: remove duplicate definitions）。
+
+    曾有两处定义：@161 静默吞版（无模式校验，try/except 吞异常 + 设 global）
+    被 @360 带校验版（BACKTEST/LIVE 模式 + ITimeProvider 注解）遮蔽为死代码，
+    与 stop() 同构。后定义覆盖前定义的命名空间绑定，前者从不被调用。
+    """
+    cls = _class_body("TimeControlledEventEngine")
+    defs = [
+        n for n in cls.body
+        if isinstance(n, ast.FunctionDef) and n.name == "set_time_provider"
+    ]
+    assert len(defs) == 1, (
+        f"set_time_provider() 应只定义一次，实际 {len(defs)} 次"
+        "（重复定义会互相遮蔽，见 #5551）"
+    )
+
+
+def test_set_time_provider_keeps_mode_validation():
+    """保留的 set_time_provider() 必须含模式校验（#5551 AC: keep validated version）。
+
+    带校验版校验 BACKTEST→LogicalTimeProvider / LIVE→SystemTimeProvider，
+    合并重复定义时不得丢失校验逻辑（否则退回静默吞版的无校验行为）。
+    """
+    cls = _class_body("TimeControlledEventEngine")
+    src = _method_source(cls, "set_time_provider")
+    assert "BACKTEST" in src, "set_time_provider 必须校验 BACKTEST 模式"
+    assert "LogicalTimeProvider" in src, "set_time_provider 必须校验 LogicalTimeProvider"
+    assert "SystemTimeProvider" in src, "set_time_provider 必须校验 SystemTimeProvider"


### PR DESCRIPTION
## Summary

`TimeControlledEventEngine` 有**两处同构的重复方法定义**（#5551）：

### 1. `stop()` 重复（首个提交 8985b8a3）
- **@187 调试残留**：`🔥 stop() called!` + `traceback.format_stack()` 打印调用栈，`-> bool` 标注（**错误**——经 `EventEngine.stop()` 实返 None）
- **@251 正式版**：`super().stop()` + `_executor.shutdown(wait=True)` 清理线程池，`-> None`
- @187 被遮蔽为死代码，已删。

### 2. `set_time_provider()` 重复（本次补修 9b033655）
- **@161 静默吞版**：无类型注解，无模式校验，`try/except` 吞异常设 global provider
- **@360 带校验版**：`ITimeProvider` 注解 + BACKTEST→LogicalTimeProvider / LIVE→SystemTimeProvider 模式校验 + 传播 portfolios/feeder
- @161 被 @360 遮蔽为死代码，已删。

**根因同构**：Python 类体后定义覆盖前定义的命名空间绑定，前者成死代码。两处重复都是此模式。

> 注：issue body 笔误写 `_set_time_provider`（带下划线），实际代码方法名是 `set_time_provider`（无下划线）。评审 @23:26 用正确方法名识破首轮 PR 的遗漏。

## 改动

| 文件 | 改动 |
|---|---|
| `src/ginkgo/trading/engines/time_controlled_engine.py` | 删 @187 调试残留 `stop()`（-12 行）+ 删 @161 静默吞版 `set_time_provider`（-17 行） |
| `tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py` | AST guard（+88 行）：stop 2 测试 + set_time_provider 2 测试 |

## AC

- [x] Remove duplicate method definitions — `stop()` 单一 @239 + `set_time_provider()` 单一 @343
- [x] Merge logic (keep executor shutdown) — 保留 `stop()` 的 `_executor.shutdown(wait=True)`
- [x] Keep the validated version of set_time_provider — 保留 @360 带校验版（BACKTEST/LIVE 模式校验），删 @161 静默吞版
- [x] Add tests for method signatures — AST guard 守护"单一 + 校验逻辑保留"

## 防回归

AST guard `test_time_controlled_engine_stop_guard.py`（参照 `test_no_naive_datetime_guard.py` 先例）：
- `test_stop_defined_once` / `test_set_time_provider_defined_once`：扫描类体，断言各只定义一次
- `test_stop_preserves_executor_shutdown`：保留的 `stop()` 含 `_executor` + `shutdown`
- `test_set_time_provider_keeps_mode_validation`：保留的 `set_time_provider()` 含 BACKTEST/LogicalTimeProvider/SystemTimeProvider 校验

未来若在引擎类 reintroduce 重复定义或误删校验/executor 清理，guard 立即 RED。

## Test plan

- [x] L1 py_compile（变更文件）✅
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed ✅
- [x] L3 guard + 引擎行为回归：`test_time_controlled_engine_stop_guard`(4) + `test_time_controlled_engine_basic/core/modes` + `test_historic_engine` → 100 passed, 3 skipped ✅（零回归，证实 @161/@187 删除确为死代码）

Closes #5551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
