### PR TITLE
refactor: 统一 DeploymentService 返回类型为 dict + 移除 saga 死代码 (#3882)

### DIFF
--- a/api/api/portfolio.py
+++ b/api/api/portfolio.py
@@ -105,7 +105,7 @@ def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
             if deployments:
                 portfolio_svc = get_portfolio_service()
                 for dep in deployments:
-                    target_list = portfolio_svc.get(portfolio_id=dep.target_portfolio_id)
+                    target_list = portfolio_svc.get(portfolio_id=dep["target_portfolio_id"])
                     if target_list and target_list.data:
                         t = target_list.data[0]
                         mode_str = "PAPER" if t.mode == 1 else "LIVE"
@@ -125,7 +125,7 @@ def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
             deployments = dep_result.data if dep_result.is_success() else []
             if deployments:
                 portfolio_svc = get_portfolio_service()
-                source_id = deployments[0].source_portfolio_id
+                source_id = deployments[0]["source_portfolio_id"]
                 source_list = portfolio_svc.get(portfolio_id=source_id)
                 if source_list and source_list.data:
                     s = source_list.data[0]
@@ -140,8 +140,8 @@ def _get_related_portfolios(portfolio_id: str, mode_int: int) -> list:
                     })
                 # Other deployments from same source
                 for dep in deployments:
-                    if dep.target_portfolio_id != portfolio_id:
-                        other_list = portfolio_svc.get(portfolio_id=dep.target_portfolio_id)
+                    if dep["target_portfolio_id"] != portfolio_id:
+                        other_list = portfolio_svc.get(portfolio_id=dep["target_portfolio_id"])
                         if other_list and other_list.data:
                             o = other_list.data[0]
                             related.append({

--- a/api/services/saga_transaction.py
+++ b/api/services/saga_transaction.py
@@ -393,7 +393,7 @@ class PortfolioSagaFactory:
         # ==================== 步骤 2: 删除所有映射 ====================
         def remove_mappings():
             for mapping in context['mappings']:
-                file_id = mapping['file_id'] if isinstance(mapping, dict) else mapping.file_id
+                file_id = mapping['file_id']  # get_portfolio_mappings 始终返 dict（#3882）
                 mapping_service.remove_file(
                     portfolio_uuid=portfolio_uuid,
                     file_id=file_id
@@ -475,9 +475,9 @@ class PortfolioSagaFactory:
             mappings = mappings_result.data if mappings_result.is_success() else []
             context['old_mappings'] = [
                 {
-                    'file_id': m['file_id'] if isinstance(m, dict) else m.file_id,
-                    'type': m['type'] if isinstance(m, dict) else m.type,
-                    'params': m.get('params', {}) if isinstance(m, dict) else m.params,
+                    'file_id': m['file_id'],
+                    'type': m['type'],
+                    'params': m.get('params', {}),
                 }
                 for m in mappings
             ]

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -263,6 +263,19 @@ class DeploymentService(BaseService):
         }
         return result
 
+    def _deployment_to_dict(self, r) -> dict:
+        """部署记录 → dict（list_deployments / find_by_* 共用，#3882 统一返回类型）。"""
+        return {
+            "deployment_id": r.uuid,
+            "source_task_id": r.source_task_id,
+            "target_portfolio_id": r.target_portfolio_id,
+            "source_portfolio_id": r.source_portfolio_id,
+            "mode": r.mode,
+            "account_id": r.account_id,
+            "status": r.status,
+            "create_at": str(r.create_at) if r.create_at else None,
+        }
+
     def list_deployments(self, portfolio_id: str = None) -> ServiceResult:
         """列出部署记录"""
         if portfolio_id:
@@ -274,37 +287,25 @@ class DeploymentService(BaseService):
             return ServiceResult(success=True, data=[])
 
         result = ServiceResult(success=True)
-        result.data = [
-            {
-                "deployment_id": r.uuid,
-                "source_task_id": r.source_task_id,
-                "target_portfolio_id": r.target_portfolio_id,
-                "source_portfolio_id": r.source_portfolio_id,
-                "mode": r.mode,
-                "account_id": r.account_id,
-                "status": r.status,
-                "create_at": str(r.create_at) if r.create_at else None,
-            }
-            for r in records
-        ]
+        result.data = [self._deployment_to_dict(r) for r in records]
         return result
 
     # #3867: API 层不再直调 CRUD，通过 Service 封装
 
     def find_by_source_portfolio(self, source_portfolio_id: str) -> ServiceResult:
-        """查找源组合的所有部署记录"""
+        """查找源组合的所有部署记录（返回 dict 列表，字段对齐 list_deployments，#3882）。"""
         try:
             records = self._deployment_crud.get_by_source_portfolio(source_portfolio_id)
-            return ServiceResult.success(data=records or [])
+            return ServiceResult.success(data=[self._deployment_to_dict(r) for r in (records or [])])
         except Exception as e:
             GLOG.ERROR(f"Failed to find deployments by source: {e}")
             return ServiceResult.error(f"Failed to find deployments: {str(e)}")
 
     def find_by_target_portfolio(self, target_portfolio_id: str) -> ServiceResult:
-        """查找目标组合的所有部署记录"""
+        """查找目标组合的所有部署记录（返回 dict 列表，字段对齐 list_deployments，#3882）。"""
         try:
             records = self._deployment_crud.get_by_target_portfolio(target_portfolio_id)
-            return ServiceResult.success(data=records or [])
+            return ServiceResult.success(data=[self._deployment_to_dict(r) for r in (records or [])])
         except Exception as e:
             GLOG.ERROR(f"Failed to find deployments by target: {e}")
             return ServiceResult.error(f"Failed to find deployments: {str(e)}")

--- a/tests/api/test_portfolio_related_3882.py
+++ b/tests/api/test_portfolio_related_3882.py
@@ -1,0 +1,92 @@
+"""
+#3882: _get_related_portfolios 消费 find_by_source/target_portfolio 的 dict 返回。
+
+验证 dict 访问路径（dep["target_portfolio_id"] / deployments[0]["source_portfolio_id"]）
+在 BACKTEST 与 PAPER/LIVE 两分支均正确提取——防止回退到属性访问（[[arch_service_dict_wrapped_return]]）。
+"""
+
+import sys
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_path = os.path.join(os.path.dirname(__file__), '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _portfolio_model(uuid: str, mode: int = 1, state: str = "READY"):
+    return SimpleNamespace(
+        uuid=uuid,
+        name=f"name-{uuid}",
+        mode=mode,
+        state=state,
+        annual_return=0.12,
+        max_drawdown=0.05,
+    )
+
+
+class TestGetRelatedPortfoliosBacktestMode:
+    """BACKTEST(mode=0)：find_by_source_portfolio 返 dict 列表，提取 deployed PAPER/LIVE。"""
+
+    @pytest.mark.unit
+    @patch("api.portfolio._map_state", return_value="READY")
+    @patch("api.portfolio.get_portfolio_service")
+    @patch("api.portfolio._get_deployment_service")
+    def test_extracts_target_from_dict(self, mock_dep_svc, mock_port_svc, _map_state):
+        from api.portfolio import _get_related_portfolios
+
+        deployment_svc = MagicMock()
+        deployment_svc.find_by_source_portfolio.return_value = ServiceResult.success(
+            data=[{"deployment_id": "d1", "target_portfolio_id": "pf-tgt", "source_portfolio_id": "pf-src"}]
+        )
+        mock_dep_svc.return_value = deployment_svc
+
+        portfolio_svc = MagicMock()
+        portfolio_svc.get.return_value = ServiceResult.success(data=[_portfolio_model("pf-tgt", mode=1)])
+        mock_port_svc.return_value = portfolio_svc
+
+        related = _get_related_portfolios("pf-src", mode_int=0)
+
+        assert len(related) == 1
+        assert related[0]["uuid"] == "pf-tgt"
+        assert related[0]["mode"] == "PAPER"
+        # 验证 dict 访问而非属性访问：deployment_svc 收到的 target_portfolio_id 是 dict key 的值
+        _, kwargs = portfolio_svc.get.call_args
+        assert kwargs["portfolio_id"] == "pf-tgt"
+
+
+class TestGetRelatedPortfoliosPaperMode:
+    """PAPER/LIVE(mode!=0)：find_by_target_portfolio 返 dict 列表，提取 source BACKTEST。"""
+
+    @pytest.mark.unit
+    @patch("api.portfolio._get_latest_backtest_metrics", return_value={})
+    @patch("api.portfolio._map_state", return_value="READY")
+    @patch("api.portfolio.get_portfolio_service")
+    @patch("api.portfolio._get_deployment_service")
+    def test_extracts_source_from_dict(self, mock_dep_svc, mock_port_svc, _map_state, _bt_metrics):
+        from api.portfolio import _get_related_portfolios
+
+        deployment_svc = MagicMock()
+        deployment_svc.find_by_target_portfolio.return_value = ServiceResult.success(
+            data=[{"deployment_id": "d1", "source_portfolio_id": "pf-src", "target_portfolio_id": "pf-cur"}]
+        )
+        mock_dep_svc.return_value = deployment_svc
+
+        portfolio_svc = MagicMock()
+        portfolio_svc.get.return_value = ServiceResult.success(data=[_portfolio_model("pf-src", mode=0)])
+        mock_port_svc.return_value = portfolio_svc
+
+        related = _get_related_portfolios("pf-cur", mode_int=1)
+
+        assert len(related) >= 1
+        source_entry = next(r for r in related if r.get("relation") == "source")
+        assert source_entry["uuid"] == "pf-src"
+        assert source_entry["mode"] == "BACKTEST"
+        # dict 访问：source_id 来自 deployments[0]["source_portfolio_id"]
+        first_call_args = portfolio_svc.get.call_args_list[0]
+        assert first_call_args.kwargs["portfolio_id"] == "pf-src"

--- a/tests/unit/trading/services/test_deployment_return_type_3882.py
+++ b/tests/unit/trading/services/test_deployment_return_type_3882.py
@@ -1,0 +1,119 @@
+"""
+#3882: DeploymentService 返回类型统一 + saga_transaction 死代码移除
+
+守护契约：
+- find_by_source_portfolio / find_by_target_portfolio 返回 list[dict]，
+  字段对齐 list_deployments（消除 [[arch_service_dict_wrapped_return]] 陷阱：
+  消费方属性访问 service 返的 dict 静默失效）。
+- get_portfolio_mappings 始终返 list[dict]（saga_transaction isinstance
+  死分支移除的前提契约，防回退）。
+"""
+
+import sys
+import os
+import pytest
+from unittest.mock import MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.trading.services.deployment_service import DeploymentService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+@pytest.fixture
+def service():
+    deployment_crud = MagicMock()
+    return DeploymentService(deployment_crud=deployment_crud)
+
+
+def _mock_deployment():
+    """构造字段齐全的部署记录 mock。"""
+    dep = MagicMock()
+    dep.uuid = "dep-1"
+    dep.source_task_id = "task-1"
+    dep.target_portfolio_id = "pf-tgt"
+    dep.source_portfolio_id = "pf-src"
+    dep.mode = 1
+    dep.account_id = "acc-1"
+    dep.status = "DEPLOYED"
+    dep.create_at = None
+    return dep
+
+
+class TestFindBySourceReturnsDict:
+    """find_by_source_portfolio 返回 dict 列表，字段对齐 list_deployments（#3882）。"""
+
+    @pytest.mark.unit
+    def test_returns_dict_with_list_deployments_fields(self, service):
+        service._deployment_crud.get_by_source_portfolio.return_value = [_mock_deployment()]
+
+        result = service.find_by_source_portfolio(source_portfolio_id="pf-src")
+
+        assert result.is_success()
+        assert isinstance(result.data, list)
+        assert len(result.data) == 1
+        item = result.data[0]
+        assert isinstance(item, dict)
+        assert item["deployment_id"] == "dep-1"
+        assert item["source_task_id"] == "task-1"
+        assert item["target_portfolio_id"] == "pf-tgt"
+        assert item["source_portfolio_id"] == "pf-src"
+        assert item["mode"] == 1
+        assert item["account_id"] == "acc-1"
+        assert item["status"] == "DEPLOYED"
+
+
+class TestFindByTargetReturnsDict:
+    """find_by_target_portfolio 同样返回 dict 列表（#3882 对称契约）。"""
+
+    @pytest.mark.unit
+    def test_returns_dict_with_list_deployments_fields(self, service):
+        service._deployment_crud.get_by_target_portfolio.return_value = [_mock_deployment()]
+
+        result = service.find_by_target_portfolio(target_portfolio_id="pf-tgt")
+
+        assert result.is_success()
+        item = result.data[0]
+        assert isinstance(item, dict)
+        assert item["deployment_id"] == "dep-1"
+        assert item["target_portfolio_id"] == "pf-tgt"
+        assert item["source_portfolio_id"] == "pf-src"
+
+
+class TestPortfolioMappingsAlwaysReturnsDictList:
+    """
+    get_portfolio_mappings 始终返 list[dict]（#3882 saga_transaction 移除
+    isinstance 死分支的前提契约；若上游回退到返模型对象，此测试先红）。
+    """
+
+    @pytest.mark.unit
+    def test_returns_list_of_dict_with_file_id(self):
+        from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+
+        mapping_crud = MagicMock()
+        param_service = MagicMock()
+        param_service.find_by_mapping_id.return_value = []
+        m = MagicMock()
+        m.uuid = "m-1"
+        m.portfolio_id = "pf-1"
+        m.file_id = "f-1"
+        m.name = "n"
+        m.type = "T"
+        m.source = "S"
+        mapping_crud.find_by_portfolio.return_value = [m]
+
+        svc = PortfolioMappingService(
+            mapping_crud=mapping_crud,
+            param_service=param_service,
+            mongo_driver=MagicMock(),
+            file_service=MagicMock(),
+        )
+        result = svc.get_portfolio_mappings(portfolio_uuid="pf-1", include_params=False)
+
+        assert result.is_success()
+        assert isinstance(result.data, list)
+        assert len(result.data) == 1
+        assert isinstance(result.data[0], dict)
+        assert result.data[0]["file_id"] == "f-1"


### PR DESCRIPTION
## Summary

#3882（PR #3881 review 跟进，评分 75/50/25）：统一 DeploymentService 返回类型为 dict + 移除 saga_transaction 死代码。

**根因**：`find_by_source_portfolio` / `find_by_target_portfolio` 返回 CRUD 原始模型对象，而 `list_deployments` 返回 dict。消费方 `portfolio.py` 用 `dep.target_portfolio_id` 属性访问——一旦 service 返 dict（或反之），属性访问静默失效（[[arch_service_dict_wrapped_return]] 陷阱，被外层 `except: return []` 吞为空结果）。

**本次修复**：

### 问题 1（评分 75）— 返回类型统一
- 提取 `_deployment_to_dict(r)` helper（字段集对齐 list_deployments：deployment_id/source_task_id/target_portfolio_id/source_portfolio_id/mode/account_id/status/create_at）。
- `find_by_source_portfolio` / `find_by_target_portfolio` 改返 `list[dict]`，复用 helper。
- `list_deployments` 同步改用 helper（消除第三处字段提取重复，零行为变更）。
- `get_deployment_info` **不动**：其字段集少 deployment_id，强统一=加字段行为漂移，超范围。
- `_get_related_portfolios`（api/portfolio.py）属性访问改 dict 访问。

### 问题 2（评分 50）— saga_transaction 死代码
- 移除 4 处 `isinstance(mapping, dict) else mapping.file_id` 死分支（L396 + L478-480）。
- 前提坐实：`PortfolioMappingService.get_portfolio_mappings` 循环构造 `mapping_data` dict 后 `return ServiceResult.success(data=result)`，始终返 `list[dict]`；`mappings_result.data if is_success() else []`，故 `m` 恒 dict，else 永不执行。

### 问题 3（评分 25）— 风格统一
- body 指 backtest_task_service L829/831/847 风格不一致，但**行号漂移后已自然统一**（当前已是 `ServiceResult.success(data=...)` 关键字形式）。无需改。

## body 偏差校正

**portfolio.py 实际 4 处属性访问，body 仅标注 L108-109（2 处）**。实读发现 PAPER/LIVE 分支「Other deployments from same source」循环另有 2 处 `dep.target_portfolio_id`（L155/L156）漏报——这 2 处在 find_by_target 改返 dict 后会 AttributeError 被外层 `except: return []` 静默吞，正是本 issue 的核心危害。本次一并修复（TDD 读完整实现发现，非依赖 body 锚点）。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml`）全绿：
- **L1 py_compile**：src+api 全量语法 ✅
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29）✅
- **L3 变更相关**：
  - 新契约 `test_deployment_return_type_3882`（3）：find_by_source/target 返 dict 字段对齐 + `get_portfolio_mappings` 始终返 list[dict] 前提守护 ✅
  - 新消费覆盖 `test_portfolio_related_3882`（2）：`_get_related_portfolios` BACKTEST + PAPER/LIVE 双分支 dict 访问路径 ✅
  - 既有 `test_deployment_service` + `test_deployment_service_find`（11）：find/list 行为零回归 ✅
  - saga `test_saga_transaction`（7 passed / 7 failed）：7 failed 为 origin/master 预存（container 函数内 import 致 module 级 patch 失效，stash 基线对比确认），非本次引入

合计 45 测试全绿，零回归。

**TDD**：tracer bullet 先固化 find_by_source 返 dict 字段契约（RED），再驱动 `_deployment_to_dict` helper 实现；find_by_target 对称扩展；mapping 前提契约守护 saga 死代码移除不被回退。

Closes #3882

🤖 Generated with [Claude Code](https://claude.com/claude-code)
