### PR TITLE
fix: data sync tick 无市场后缀不再 IndexError 崩溃 (#5999)

### DIFF
--- a/src/ginkgo/data/sources/ginkgo_tdx.py
+++ b/src/ginkgo/data/sources/ginkgo_tdx.py
@@ -118,8 +118,14 @@ class GinkgoTDX(GinkgoSourceBase):
             time = datetime.datetime.strptime(time, "%H:%M").time()
             return datetime.datetime.combine(new_date, time)
 
-        code_num = code.split(".")[0]
-        code_market = code.split(".")[1]
+        code_parts = code.split(".")
+        code_num = code_parts[0]
+        if len(code_parts) < 2:
+            console.print(
+                f"TDX tick 需要完整代码格式（如 000001.SZ），收到: {code}"
+            )
+            return
+        code_market = code_parts[1]
         if code_market.upper() not in ["SH", "SZ"]:
             console.print("TDX api just support SH and SZ now.")
             return

--- a/tests/unit/data/sources/test_ginkgo_tdx.py
+++ b/tests/unit/data/sources/test_ginkgo_tdx.py
@@ -170,3 +170,57 @@ class TestTDXFetchLive:
         mock_client.quotes.assert_called_once()
         call_kwargs = mock_client.quotes.call_args[1]
         assert "symbol" in call_kwargs
+
+
+@pytest.mark.unit
+class TestTDXFetchTransactionDetailSuffixGuard:
+    """fetch_history_transaction_detail 代码后缀防御 (#5999)
+
+    无市场后缀（如 000001）曾导致 code.split(".")[1] 抛 IndexError 崩溃。
+    """
+
+    @patch("ginkgo.data.sources.ginkgo_tdx.Quotes")
+    def test_no_suffix_does_not_raise_indexerror(self, mock_quotes):
+        """无市场后缀（000001）不抛 IndexError，对齐无效 market 的 return None 模式"""
+        mock_client = MagicMock()
+        mock_quotes.factory.return_value = mock_client
+
+        tdx = GinkgoTDX()
+        # 核心断言：不抛 IndexError（修复前 code.split(".")[1] 越界）
+        result = tdx.fetch_history_transaction_detail(
+            "000001", datetime.datetime(2025, 6, 5)
+        )
+        # 对齐现有无效 market 的 return None 行为
+        assert result is None
+        # 提前返回，不应触达 mootdx transactions
+        mock_client.transactions.assert_not_called()
+
+    @patch("ginkgo.data.sources.ginkgo_tdx.Quotes")
+    def test_invalid_market_returns_none(self, mock_quotes):
+        """无效市场后缀（000001.XX）返回 None（现有行为回归守护）"""
+        mock_client = MagicMock()
+        mock_quotes.factory.return_value = mock_client
+
+        tdx = GinkgoTDX()
+        result = tdx.fetch_history_transaction_detail(
+            "000001.XX", datetime.datetime(2025, 6, 5)
+        )
+        assert result is None
+        mock_client.transactions.assert_not_called()
+
+    @patch("ginkgo.data.sources.ginkgo_tdx.Quotes")
+    def test_valid_sz_code_extracts_num_and_market(self, mock_quotes):
+        """合法 .SZ 代码正常提取 code_num 并调用 transactions（回归守护）"""
+        mock_client = MagicMock()
+        mock_quotes.factory.return_value = mock_client
+        mock_client.transactions.return_value = pd.DataFrame(
+            {"price": [10.0], "volume": [100], "time": ["09:30"]}
+        )
+
+        tdx = GinkgoTDX()
+        tdx.fetch_history_transaction_detail(
+            "000001.SZ", datetime.datetime(2025, 6, 5)
+        )
+
+        call_kwargs = mock_client.transactions.call_args[1]
+        assert call_kwargs["symbol"] == "000001"


### PR DESCRIPTION
## Summary

`ginkgo data sync tick --code 000001`（无 `.SZ`/`.SH` 市场后缀）曾抛 `IndexError` 崩溃（#5999）。

**根因**：`ginkgo_tdx.py:122` `code_market = code.split(".")[1]` 未检查 split 结果长度。`000001` 无 `.` → split 只有 1 元素 → `[1]` 越界。`@retry` 装饰器重试 3 次（debug 模式跳退避）后抛出。

**body 行号修正**：issue body 写"`tick_service.py` 第 122 行"，真实崩溃在 **`ginkgo_tdx.py:122`**（数据源文件，非 service）。

**对比**：`data sync day` 走 `fetch_history_daybar` 只取 `split(".")[0]`（code_num），不取 market，故 `000001` 不崩 —— AC"day 能处理"成立。

## 改动

| 文件 | 改动 |
|---|---|
| `src/ginkgo/data/sources/ginkgo_tdx.py` | `fetch_history_transaction_detail` 加长度检查：无后缀时 `console.print` 明确错误 + `return None`，对齐现有无效 market（非 SH/SZ）处理模式 |
| `tests/unit/data/sources/test_ginkgo_tdx.py` | 新增 `TestTDXFetchTransactionDetailSuffixGuard`：无后缀不崩 / 无效 market / 合法 .SZ 三测试 |

## 设计决策

AC 给两选项（自动补全 vs 友好错误）。选**友好错误**：
- `mootdx.get_stock_market` import 失败（API 路径漂移）→ 自动补全不可靠
- 不引入新的市场归属硬编码（避开 `arch_ashare_code_market_prefix_gap` 架构缺口，#6262/#6308 已各自硬编码漂移）
- 对齐现有 line 124 无效 market 的 `console.print + return None` 模式，blast radius 最小

## AC

- [x] `--code 000001` 显示明确错误（console "TDX tick 需要完整代码格式（如 000001.SZ）"）+ return None
- [x] 不再出现 IndexError（长度检查前置）

## Test plan

- [x] L1 py_compile（全 src/api）✅
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → ✅
- [x] L3 变更相关：`test_ginkgo_tdx`(13p) + `test_tick_service` + `test_source_tdx` → 66 passed, 5 skipped，零回归 ✅

Closes #5999

🤖 Generated with [Claude Code](https://claude.com/claude-code)
