### PR TITLE
fix(#5867): Walk Forward/Sensitivity 验证端点接 service

### DIFF
--- a/api/api/validation.py
+++ b/api/api/validation.py
@@ -35,6 +35,21 @@ class MonteCarloRequest(BaseModel):
     confidence: float = Field(default=0.95, ge=0.8, le=0.99, description="置信水平")
 
 
+class WalkForwardRequest(BaseModel):
+    task_id: str = Field(..., description="回测任务 UUID")
+    portfolio_id: str = Field(..., description="组合 UUID")
+    n_folds: int = Field(default=5, ge=2, le=20, description="验证折数（train/test 窗口对数）")
+    train_ratio: float = Field(default=0.7, ge=0.5, le=0.9, description="训练期占比")
+    window_type: str = Field(default="expanding", description="窗口类型：expanding（扩展）或 rolling（滚动）")
+
+
+class SensitivityRequest(BaseModel):
+    task_id: str = Field(..., description="回测任务 UUID")
+    portfolio_id: str = Field(..., description="组合 UUID")
+    param_name: str = Field(default="n_segments", description="敏感参数名（当前支持 n_segments）")
+    param_values: List[str] = Field(..., description="参数值列表，如 [\"2\", \"4\", \"8\"]")
+
+
 def get_validation_service():
     from ginkgo.data.containers import container
     return container.validation_service()
@@ -97,6 +112,49 @@ async def monte_carlo(req: MonteCarloRequest):
     except Exception as e:
         logger.error(f"蒙特卡洛接口异常: {e}")
         raise BusinessError(f"蒙特卡洛模拟失败: {e}")
+
+
+@router.post("/walk-forward")
+async def walk_forward(req: WalkForwardRequest):
+    """走步验证：将回测区间切为多个 train/test 窗口，基于已有净值算每折绩效，以训练/测试绩效差异检测过拟合"""
+    try:
+        svc = get_validation_service()
+        result = svc.walk_forward(
+            task_id=req.task_id,
+            portfolio_id=req.portfolio_id,
+            n_folds=req.n_folds,
+            train_ratio=req.train_ratio,
+            window_type=req.window_type,
+        )
+        if not result.is_success():
+            raise BusinessError(result.error)
+        return ok(data=result.data)
+    except BusinessError:
+        raise
+    except Exception as e:
+        logger.error(f"走步验证接口异常: {e}")
+        raise BusinessError(f"走步验证失败: {e}")
+
+
+@router.post("/sensitivity")
+async def sensitivity(req: SensitivityRequest):
+    """敏感性分析：策略绩效对回测分段数（n_segments）的稳健性，sensitivity_score 为跨分段绩效变异系数"""
+    try:
+        svc = get_validation_service()
+        result = svc.sensitivity(
+            task_id=req.task_id,
+            portfolio_id=req.portfolio_id,
+            param_name=req.param_name,
+            param_values=req.param_values,
+        )
+        if not result.is_success():
+            raise BusinessError(result.error)
+        return ok(data=result.data)
+    except BusinessError:
+        raise
+    except Exception as e:
+        logger.error(f"敏感性分析接口异常: {e}")
+        raise BusinessError(f"敏感性分析失败: {e}")
 
 
 @router.get("/results")

--- a/src/ginkgo/data/services/validation_service.py
+++ b/src/ginkgo/data/services/validation_service.py
@@ -416,3 +416,176 @@ class ValidationService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"蒙特卡洛模拟失败: {e}")
             return ServiceResult.error(f"模拟失败: {e}")
+
+    @staticmethod
+    def _records_in_date_range(records, start_str: str, end_str: str) -> list:
+        """筛出 business_timestamp 落在 [start_str, end_str]（含）的记录，日期粒度比较"""
+        import datetime as _dt
+        start_d = _dt.datetime.strptime(start_str, "%Y-%m-%d").date()
+        end_d = _dt.datetime.strptime(end_str, "%Y-%m-%d").date()
+        out = []
+        for r in records:
+            ts = r.business_timestamp or r.timestamp
+            if ts is None:
+                continue
+            d = ts.date() if hasattr(ts, "date") else ts
+            if start_d <= d <= end_d:
+                out.append(r)
+        return out
+
+    def walk_forward(
+        self,
+        task_id: str,
+        portfolio_id: str,
+        n_folds: int = 5,
+        train_ratio: float = 0.7,
+        window_type: str = "expanding",
+    ) -> ServiceResult:
+        """走步验证：将回测区间切为 n_folds 个 train/test 窗口，每折基于已有 net_value 收益率算绩效，
+        以训练期与测试期绩效差异（退化程度）作为过拟合信号。
+
+        借用 ginkgo.validation.WalkForwardValidator 的日期窗口生成逻辑（generate_folds），
+        但不重跑回测（区别于其 validate() 需 set_backtest_function）——与 monte_carlo 同风格基于已有数据。
+        """
+        try:
+            records = self._get_net_value_records(task_id, portfolio_id)
+            if len(records) < 10:
+                return ServiceResult.error("数据不足：net_value 记录少于 10 条")
+
+            time_start, time_end = self._get_time_range(records)
+            if not time_start or not time_end:
+                return ServiceResult.error("无法确定回测时间范围")
+
+            from ginkgo.validation.walk_forward import WalkForwardValidator
+            validator = WalkForwardValidator(
+                start_date=time_start,
+                end_date=time_end,
+                n_folds=n_folds,
+                train_ratio=train_ratio,
+                expanding=(window_type == "expanding"),
+            )
+            folds = validator.generate_folds()
+
+            fold_records = []
+            for fold in folds:
+                train_recs = self._records_in_date_range(records, fold.train_start, fold.train_end)
+                test_recs = self._records_in_date_range(records, fold.test_start, fold.test_end)
+                train_m = self._calc_segment_metrics(self._records_to_returns(train_recs)) if len(train_recs) >= 2 else {}
+                test_m = self._calc_segment_metrics(self._records_to_returns(test_recs)) if len(test_recs) >= 2 else {}
+                fold_records.append({
+                    "fold_num": fold.fold_num,
+                    "train_start": fold.train_start,
+                    "train_end": fold.train_end,
+                    "test_start": fold.test_start,
+                    "test_end": fold.test_end,
+                    "train_return": train_m.get("total_return", 0.0),
+                    "test_return": test_m.get("total_return", 0.0),
+                    "train_sharpe": train_m.get("sharpe", 0.0),
+                    "test_sharpe": test_m.get("sharpe", 0.0),
+                    "train_max_drawdown": train_m.get("max_drawdown", 0.0),
+                    "test_max_drawdown": test_m.get("max_drawdown", 0.0),
+                })
+
+            avg_train_return = float(np.mean([f["train_return"] for f in fold_records])) if fold_records else 0.0
+            avg_test_return = float(np.mean([f["test_return"] for f in fold_records])) if fold_records else 0.0
+            # 退化程度：训练期收益高于测试期的幅度，正值提示过拟合
+            overfit_score = round(avg_train_return - avg_test_return, 6)
+
+            data = {
+                "n_folds": n_folds,
+                "train_ratio": train_ratio,
+                "window_type": window_type,
+                "folds": fold_records,
+                "avg_train_return": round(avg_train_return, 6),
+                "avg_test_return": round(avg_test_return, 6),
+                "overfit_score": overfit_score,
+            }
+
+            if self._result_crud:
+                self._save_result(
+                    task_id=task_id, portfolio_id=portfolio_id, method="walk_forward",
+                    config={"n_folds": n_folds, "train_ratio": train_ratio, "window_type": window_type},
+                    result_data=data,
+                )
+
+            return ServiceResult.success(data=data)
+
+        except Exception as e:
+            GLOG.ERROR(f"走步验证失败: {e}")
+            return ServiceResult.error(f"走步验证失败: {e}")
+
+    def sensitivity(
+        self,
+        task_id: str,
+        portfolio_id: str,
+        param_name: str = "n_segments",
+        param_values=None,
+    ) -> ServiceResult:
+        """敏感性分析：策略绩效对回测区间划分粒度（n_segments）的稳健性。
+
+        真参数扫描需对每个参数值重跑回测（dispatch + worker，超单 PR 范围）。
+        此处提供基于已有 net_value 收益率的统计敏感性：以不同分段数切 returns，
+        看综合绩效（跨段均值）随分段粒度的变化；sensitivity_score 为跨分段数的
+        total_return 变异系数（CV），值越大表示绩效对区间划分越敏感（稳健性越差）。
+        """
+        try:
+            records = self._get_net_value_records(task_id, portfolio_id)
+            if len(records) < 10:
+                return ServiceResult.error("数据不足：net_value 记录少于 10 条")
+            returns = self._records_to_returns(records)
+
+            # param_values 规范化：逗号字符串（前端传入）或 list
+            if isinstance(param_values, str):
+                param_values = [v.strip() for v in param_values.split(",") if v.strip()]
+            if not param_values:
+                return ServiceResult.error("param_values 不能为空")
+
+            if param_name != "n_segments":
+                return ServiceResult.error(
+                    f"不支持的 param_name: {param_name}（当前仅支持 n_segments：策略绩效对回测分段数的稳健性；"
+                    f"真参数扫描重跑回测超本端点范围）"
+                )
+
+            records_out = []
+            for pv in param_values:
+                n = int(float(pv))
+                if n < 1 or n > len(returns):
+                    continue
+                segs = self._split_returns(returns, n)
+                seg_metrics = [self._calc_segment_metrics(s) for s in segs]
+                avg_return = float(np.mean([m["total_return"] for m in seg_metrics])) if seg_metrics else 0.0
+                avg_sharpe = float(np.mean([m["sharpe"] for m in seg_metrics])) if seg_metrics else 0.0
+                avg_dd = float(np.mean([m["max_drawdown"] for m in seg_metrics])) if seg_metrics else 0.0
+                records_out.append({
+                    "param_value": n,
+                    "total_return": round(avg_return, 6),
+                    "sharpe": round(avg_sharpe, 4),
+                    "max_drawdown": round(avg_dd, 6),
+                })
+
+            if not records_out:
+                return ServiceResult.error("param_values 均超出数据长度范围")
+
+            # 变异系数 CV = std/|mean|，越大越不稳健（对分段粒度越敏感）
+            rets = [r["total_return"] for r in records_out]
+            mean_r = float(np.mean(rets))
+            sensitivity_score = round(float(np.std(rets) / abs(mean_r)), 4) if abs(mean_r) > 1e-9 else 0.0
+
+            data = {
+                "param_name": param_name,
+                "records": records_out,
+                "sensitivity_score": sensitivity_score,
+            }
+
+            if self._result_crud:
+                self._save_result(
+                    task_id=task_id, portfolio_id=portfolio_id, method="sensitivity",
+                    config={"param_name": param_name, "param_values": list(param_values)},
+                    result_data=data,
+                )
+
+            return ServiceResult.success(data=data)
+
+        except Exception as e:
+            GLOG.ERROR(f"敏感性分析失败: {e}")
+            return ServiceResult.error(f"敏感性分析失败: {e}")

--- a/tests/api/test_validation_walk_forward_sensitivity.py
+++ b/tests/api/test_validation_walk_forward_sensitivity.py
@@ -1,0 +1,94 @@
+# Issue: #5867 Walk Forward/Sensitivity 端点 404
+# Upstream: api.api.validation.walk_forward / sensitivity
+# Downstream: ValidationService.walk_forward / sensitivity
+# Role: 端点 wiring 契约——参数透传到 service + error 传播为 BusinessError
+
+"""
+#5867 端点契约测试
+
+验证 walk-forward / sensitivity 端点：
+1. 将 Request 字段正确透传给 ValidationService
+2. service 返回 error 时传播为 BusinessError
+3. service 返回 success 时包装为 ok(data=...)
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+class TestWalkForwardEndpoint:
+    """walk-forward 端点契约"""
+
+    def test_success_passes_params_and_returns_data(self):
+        from api.validation import walk_forward, WalkForwardRequest
+        from ginkgo.data.services.base_service import ServiceResult
+
+        mock_svc = MagicMock()
+        mock_svc.walk_forward.return_value = ServiceResult.success(
+            data={"n_folds": 3, "folds": [], "avg_train_return": 0.1, "avg_test_return": 0.05, "overfit_score": 0.05}
+        )
+        req = WalkForwardRequest(task_id="t-1", portfolio_id="p-1", n_folds=3, train_ratio=0.7, window_type="rolling")
+
+        with patch("api.validation.get_validation_service", return_value=mock_svc):
+            resp = run_async(walk_forward(req))
+
+        # 参数透传到 service
+        kwargs = mock_svc.walk_forward.call_args.kwargs
+        assert kwargs["task_id"] == "t-1" and kwargs["portfolio_id"] == "p-1"
+        assert kwargs["n_folds"] == 3 and kwargs["train_ratio"] == 0.7
+        assert kwargs["window_type"] == "rolling"
+        # response 包装
+        assert resp["data"]["n_folds"] == 3
+
+    def test_error_propagates_as_business_error(self):
+        from api.validation import walk_forward, WalkForwardRequest
+        from ginkgo.data.services.base_service import ServiceResult
+        from core.exceptions import BusinessError
+
+        mock_svc = MagicMock()
+        mock_svc.walk_forward.return_value = ServiceResult.error("数据不足：net_value 记录少于 10 条")
+        req = WalkForwardRequest(task_id="t-1", portfolio_id="p-1")
+
+        with patch("api.validation.get_validation_service", return_value=mock_svc):
+            with pytest.raises(BusinessError):
+                run_async(walk_forward(req))
+
+
+class TestSensitivityEndpoint:
+    """sensitivity 端点契约"""
+
+    def test_success_passes_params_and_returns_data(self):
+        from api.validation import sensitivity, SensitivityRequest
+        from ginkgo.data.services.base_service import ServiceResult
+
+        mock_svc = MagicMock()
+        mock_svc.sensitivity.return_value = ServiceResult.success(
+            data={"param_name": "n_segments", "records": [{"param_value": 2}], "sensitivity_score": 0.12}
+        )
+        req = SensitivityRequest(task_id="t-1", portfolio_id="p-1", param_name="n_segments", param_values=["2", "4", "8"])
+
+        with patch("api.validation.get_validation_service", return_value=mock_svc):
+            resp = run_async(sensitivity(req))
+
+        kwargs = mock_svc.sensitivity.call_args.kwargs
+        assert kwargs["param_name"] == "n_segments"
+        assert kwargs["param_values"] == ["2", "4", "8"]
+        assert resp["data"]["sensitivity_score"] == 0.12
+
+    def test_error_propagates_as_business_error(self):
+        from api.validation import sensitivity, SensitivityRequest
+        from ginkgo.data.services.base_service import ServiceResult
+        from core.exceptions import BusinessError
+
+        mock_svc = MagicMock()
+        mock_svc.sensitivity.return_value = ServiceResult.error("不支持的 param_name: foo")
+        req = SensitivityRequest(task_id="t-1", portfolio_id="p-1", param_values=["2"])
+
+        with patch("api.validation.get_validation_service", return_value=mock_svc):
+            with pytest.raises(BusinessError):
+                run_async(sensitivity(req))

--- a/tests/unit/test_validation_service.py
+++ b/tests/unit/test_validation_service.py
@@ -182,3 +182,79 @@ class TestMonteCarlo:
         actual_return = 0.05
         result = svc._calc_monte_carlo_stats(simulated_returns, actual_return, 0.95)
         assert result["cvar"] <= result["var"]
+
+
+class TestWalkForward:
+    """#5867: walk_forward 走步验证——基于已有 net_value 切 train/test 窗口算绩效"""
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_walk_forward_insufficient_data(self, mock_get_records):
+        from ginkgo.data.services.validation_service import ValidationService
+        mock_get_records.return_value = []
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.walk_forward(task_id="t", portfolio_id="p")
+        assert not result.is_success()
+        assert "数据不足" in result.error
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_walk_forward_basic(self, mock_get_records):
+        from ginkgo.data.services.validation_service import ValidationService
+        # 120 天稳定正收益
+        daily_returns = [0.001] * 120
+        records = _make_net_value_records("2024-01-02", daily_returns, task_id="test-task")
+        mock_get_records.return_value = records
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.walk_forward(task_id="test-task", portfolio_id="pf-001", n_folds=3, train_ratio=0.7)
+        assert result.is_success(), result.error
+        data = result.data
+        assert data["n_folds"] == 3
+        assert len(data["folds"]) == 3
+        fold = data["folds"][0]
+        # 每折含 train/test 日期窗口 + 绩效
+        assert "train_start" in fold and "test_end" in fold
+        assert "train_return" in fold and "test_return" in fold
+        # 汇总指标
+        assert "avg_train_return" in data and "avg_test_return" in data
+        assert "overfit_score" in data
+
+
+class TestSensitivity:
+    """#5867: sensitivity 敏感性分析——策略绩效对回测分段数（n_segments）的稳健性。
+    真参数扫描需重跑回测（超范围），此处为基于已有 net_value 的统计敏感性：不同分段粒度下绩效的离散度。"""
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_sensitivity_unsupported_param_name(self, mock_get_records):
+        from ginkgo.data.services.validation_service import ValidationService
+        records = _make_net_value_records("2024-01-02", [0.001] * 100, task_id="t")
+        mock_get_records.return_value = records
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.sensitivity(task_id="t", portfolio_id="p", param_name="unknown_param", param_values=[2, 4])
+        assert not result.is_success()
+        assert "param_name" in result.error or "不支持" in result.error
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_sensitivity_n_segments(self, mock_get_records):
+        from ginkgo.data.services.validation_service import ValidationService
+        records = _make_net_value_records("2024-01-02", [0.001] * 200, task_id="t")
+        mock_get_records.return_value = records
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.sensitivity(task_id="t", portfolio_id="p", param_name="n_segments", param_values=[2, 4, 8])
+        assert result.is_success(), result.error
+        data = result.data
+        assert data["param_name"] == "n_segments"
+        assert len(data["records"]) == 3
+        rec = data["records"][0]
+        assert rec["param_value"] == 2
+        assert "total_return" in rec and "sharpe" in rec and "max_drawdown" in rec
+        assert "sensitivity_score" in data
+
+    @patch("ginkgo.data.services.validation_service.ValidationService._get_net_value_records")
+    def test_sensitivity_accepts_csv_string(self, mock_get_records):
+        from ginkgo.data.services.validation_service import ValidationService
+        # 前端 paramValues 是逗号分隔字符串，service 应兼容
+        records = _make_net_value_records("2024-01-02", [0.001] * 200, task_id="t")
+        mock_get_records.return_value = records
+        svc = ValidationService(analyzer_record_crud=MagicMock(), validation_result_crud=None)
+        result = svc.sensitivity(task_id="t", portfolio_id="p", param_name="n_segments", param_values="2,4,8")
+        assert result.is_success(), result.error
+        assert len(result.data["records"]) == 3


### PR DESCRIPTION
## Summary

#5867：回测验证页 Walk Forward（走步验证）/ Sensitivity（敏感性分析）两个端点返回 404。本 PR 接通 service 方法 + API 端点。

**根因**：`web-ui` 前端两个 Vue 页面调用 `/api/v1/validation/walk-forward` 与 `/sensitivity`，但后端 `api/api/validation.py` 只实现了 segment-stability / monte-carlo / results 三组端点，walk-forward / sensitivity 从未接线（前端 `runValidation` 仍是 `// TODO`）。

**背景**：`ginkgo.validation` 模块早已实现 `WalkForwardValidator` / `SensitivityAnalyzer` 类（含单测），但其 `validate()` 路径需要 `set_backtest_function` 回调**重跑回测**——在「基于已有回测结果的验证端点」语义下不适用（重跑属于另一次 backtest 任务）。

**设计（路径 B，对齐 monte_carlo 内联风格）**：service 不走重跑路径，而是复用已有 net_value 记录 + 既有辅助函数：
- `walk_forward`：用 `WalkForwardValidator.generate_folds()` 仅取**日期窗口划分**逻辑，对每折 train/test 窗口分别 `_calc_segment_metrics`（已有：total_return / sharpe / max_drawdown），输出 train/test 绩效对比，`overfit_score = avg_train_return − avg_test_return`。
- `sensitivity`：真参数扫描需重跑回测（超本端点范围）。当前 `param_name` 限定 `n_segments`（回测分段粒度的稳健性），对每个分段数算分段绩效，`sensitivity_score = std(total_returns) / |mean|`（变异系数 CV，值越高=对分段越敏感=鲁棒性越差）。非 `n_segments` 的 param_name 返回明确错误，引导用户该端点的能力边界。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml`）全绿：
- **L1 py_compile**：src + api 全量语法 ✅
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29）✅
- **L3 变更相关**：
  - 新 service 契约 `TestWalkForward`（2）+ `TestSensitivity`（3）：数据不足 error / 基本切窗 / n_segments 扫描 / CSV 字符串兼容 / 不支持 param_name ✅
  - 新端点契约 `test_validation_walk_forward_sensitivity`（4）：参数透传到 service + error 传播为 BusinessError ✅
  - 既有 `TestSegmentStability` + `TestMonteCarlo`（10）：零回归 ✅

合计 48 测试全绿，零回归。

**TDD**：垂直切片——service 方法 tracer bullet（数据不足 error）→ 基本切窗 → 端点 wiring → CSV 兼容，每片一测试一实现。

**Sensitivity 语义诚实说明**：本端点不是通用参数扫描器（那需重跑回测）。`param_name` 当前只支持 `n_segments`，衡量「同一回测在不同分段粒度下绩效的离散度」。真参数扫描应作为独立的「参数网格回测」任务，不在本端点范围。

Closes #5867

🤖 Generated with [Claude Code](https://claude.com/claude-code)
