### PR TITLE
fix(#5861): stub 端点改诚实信号（Arena 501 / API Stats implemented 标记）

### DIFF
--- a/api/api/arena.py
+++ b/api/api/arena.py
@@ -1,23 +1,22 @@
 """
 竞技场相关API路由
+
+fix(#5861): Arena 竞技场功能尚未实现，端点返 501 而非假装成功的空数据，
+避免前端/用户误判「竞技场无数据」为「功能可用但空」。
 """
 
-from fastapi import APIRouter
-
-from core.response import ok
+from fastapi import APIRouter, HTTPException
 
 router = APIRouter()
 
 
 @router.get("/portfolios")
 async def get_arena_portfolios():
-    """获取竞技场Portfolio列表"""
-    # TODO: 实现实际的竞技场数据获取逻辑
-    return ok(data={"items": []})
+    """获取竞技场Portfolio列表（尚未实现）"""
+    raise HTTPException(status_code=501, detail="Arena 竞技场功能尚未实现")
 
 
 @router.post("/comparison")
 async def get_arena_comparison():
-    """获取Portfolio对比数据"""
-    # TODO: 实现实际的对比数据获取逻辑
-    return ok(data={"net_values": {}, "statistics": []})
+    """获取Portfolio对比数据（尚未实现）"""
+    raise HTTPException(status_code=501, detail="Arena 对比功能尚未实现")

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -1828,11 +1828,16 @@ async def create_api_key(data: dict):
 
 @router.get("/api-stats")
 async def get_api_stats():
-    """获取API统计"""
-    # TODO: 获取实际统计数据
+    """获取API统计
+
+    fix(#5861): 统计基础设施尚未实现（rate_limit 中间件仅做 IP 限流，无全局调用统计）。
+    前端 settings.ts 依赖本端点结构，故保留字段但归零假数据并标记 implemented=False，
+    避免硬编码 99.8% success_rate 误导用户以为系统健康。
+    """
     return ok(data={
-        "today_calls": 15234,
-        "month_calls": 456789,
-        "success_rate": 99.8,
-        "avg_response_time": 85.0
+        "implemented": False,
+        "today_calls": 0,
+        "month_calls": 0,
+        "success_rate": 0.0,
+        "avg_response_time": 0.0,
     })

--- a/tests/api/test_stub_endpoints_honest_5861.py
+++ b/tests/api/test_stub_endpoints_honest_5861.py
@@ -1,0 +1,48 @@
+# Issue: #5861 stub 端点返假数据 → 改诚实信号（501 / implemented 标记）
+# Upstream: api.api.arena / api.api.settings
+# Role: 未实现端点返 501，mock 端点标记 implemented:false，消除假数据误导
+
+"""
+#5861 端点诚实信号测试
+
+验证：
+1. Arena 端点（完全 TODO stub）返回 501 Not Implemented，而非假空数据
+2. API Stats（硬编码 mock）保留结构但标记 implemented:false，前端不破坏
+3. User Groups / Notification Recipients 已接线（非 stub），不在本测试范围
+"""
+
+import asyncio
+import pytest
+from fastapi import HTTPException
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+class TestArenaStubReturns501:
+    """Arena 2 端点是完全 TODO stub（前端无依赖），应返 501 而非假装成功的空数据"""
+
+    def test_arena_portfolios_returns_501(self):
+        from api.arena import get_arena_portfolios
+        with pytest.raises(HTTPException) as exc:
+            run_async(get_arena_portfolios())
+        assert exc.value.status_code == 501
+
+    def test_arena_comparison_returns_501(self):
+        from api.arena import get_arena_comparison
+        with pytest.raises(HTTPException) as exc:
+            run_async(get_arena_comparison())
+        assert exc.value.status_code == 501
+
+
+class TestApiStatsHonestMarker:
+    """API Stats 硬编码 mock（前端 settings.ts:446 有依赖），
+    保留结构不破坏前端，但加 implemented:false 标记消除 99.8% 假统计误导"""
+
+    def test_api_stats_marks_not_implemented(self):
+        from api.settings import get_api_stats
+        resp = run_async(get_api_stats())
+        assert resp["data"]["implemented"] is False
+        # 保留原有字段结构（前端兼容）
+        assert "today_calls" in resp["data"]


### PR DESCRIPTION
## Summary

#5861：多个端点返回硬编码 mock / TODO stub，应统一为诚实信号。本 PR 处理其中**确认为真 stub** 的 Arena + API Stats 两组，并核实其余项已接线。

### 验证结论（先验证后修复）

逐端点核实 #5861 列出的 5 类，区分「真 stub」与「陈旧误判」：

| 端点 | 现状 | 处理 |
|---|---|---|
| Arena `/portfolios` `/comparison` | 真 stub（`# TODO` 返假空数据），前端无依赖 | → **501** |
| API Stats `/api-stats` | 真 stub（硬编码 `99.8% success_rate`），前端 settings.ts:446 有依赖 | → **保留结构 + implemented:false** |
| User Groups `/user-groups` | **已接线**（L786-788 处理双版本兼容 #6227 + count_all_members #5675），body 报 Failed 为陈旧服务误判 | 不动 |
| Notification Recipients | **已接线**（L1495 调 service.list_all()，完整 try/except），非 stub | 不动 |
| API Keys | 种子数据内容（DB），非代码 stub | 不在代码范围 |

### 修复

**Arena**（`api/api/arena.py`）：2 端点原返 `ok(data={"items": []})` 假装成功 → 改 `raise HTTPException(501)`。前端 grep 无 arena 调用（webui 重构范围），零破坏。消除「竞技场无数据」误判为「功能可用但空」。

**API Stats**（`api/api/settings.py:1829`）：原返硬编码 `{today_calls:15234, success_rate:99.8, ...}` → 改 `{implemented:False, 各值归零}`。保留字段结构（前端依赖），但假数据归零 + `implemented:false` 标记，消除 `99.8% success_rate` 误导用户以为系统健康。

**为何 API Stats 不做真实统计**：rate_limit 中间件仅做 IP 维度限流（内存 dict），无全局调用计数/成功率/响应时间基础设施。真实统计需新建统计中间件 + 存储，超 P3 chore 范围。诚实标记是 AC 接受的方案（"标记为 mock / alpha"）。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml`）全绿：
- **L1 py_compile**：src + api 全量语法 ✅
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29）✅
- **L3 变更相关**：新 `test_stub_endpoints_honest_5861`（3）— Arena 2 端点返 501 + API Stats implemented:false 且保留 today_calls 字段 ✅
- **回归检查**：grep 既有测试无依赖 Arena 返空 / API Stats 固定值，零回归 ✅

**TDD**：3 测试先 RED（DID NOT RAISE / KeyError implemented）→ 实现 Arena 501 + API Stats 标记 → GREEN。

Closes #5861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
