### PR TITLE
docs(#6203): 同步 debug 命令文档（system config→debug，CLAUDE.md + ADR-004/013）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 - ClickHouse=时序 | MySQL=关系 | Redis=缓存 | MongoDB=文档
 
 ### Debug 模式
-数据库操作前必须开启：`ginkgo system config set --debug on`
+数据库操作前必须开启：`ginkgo debug on`
 
 ### 基础组件
 **禁止擅自修改 Base 类**（BaseCRUD、BaseService 等），在具体实现层处理
@@ -47,7 +47,7 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 ## Key Commands
 ```bash
 ginkgo version / status                       # 版本/状态
-ginkgo system config set --debug on           # 开启 debug（必须）
+ginkgo debug on                               # 开启 debug（必须）
 ginkgo serve api                              # API 服务器 (:8000)
 ginkgo serve webui                            # Web UI (:5173)
 ginkgo serve worker-backtest -id test2        # 回测 Worker
@@ -91,6 +91,9 @@ ginkgo backtest cat <backtest_id>
 ```
 
 ### 可用组件
+
+> **实际命名**：DB 组件名多为 `<name>_<type>` 格式（如 `fixed_selector`/`atr_sizer`/`fixed_sizer`），部分带描述前缀（如 `qr_momentum_selector`/`sharpe_ratio`）。`bind-component` 前用 `ginkgo component list` 查实际 `file_id` 与名称；下表为短名速查。
+
 - **Strategy**: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor, social_signal, game_theory, random_choice
 - **Selector**: fixed, cn_all, momentum, popularity, multi_params
 - **Sizer**: fixed, atr, ratio

--- a/docs/adrs/ADR-004-dual-db-debug.md
+++ b/docs/adrs/ADR-004-dual-db-debug.md
@@ -19,7 +19,7 @@ Docker 部署两套数据库（ClickHouse + MySQL），用端口前缀区分：
 - Debug 模式下 `GCONF.CLICKPORT` 端口首位 +1（8123 → 18123），自动指向 test 实例。
 - `.env` 默认 `GINKGO_CLICKHOUSE_HOST=clickhouse-test`。
 - Vector 默认连 `clickhouse-test`，与 Worker/API 保持一致。
-- 开启 Debug：`ginkgo system config set --debug on`。
+- 开启 Debug：`ginkgo debug on`。
 
 ## Rationale
 

--- a/docs/adrs/ADR-013-debug-retry-backoff.md
+++ b/docs/adrs/ADR-013-debug-retry-backoff.md
@@ -31,7 +31,7 @@ else:
 ## Rationale
 
 - **为何保留语义不改装饰器**：`@retry` 被 ~160 处使用（实测 `src/ginkgo` 下 163 处装饰器应用，覆盖 `tick_service`/`ginkgo_kafka`/`stockinfo`/`param`/`adjustfactor`/`tushare` 及各 driver/crud …），改 debug 分支牵动全系统；且 debug 下跳过退避是刻意的测试加速设计。
-- **为何用纪律而非代码强制**：debug 是开发者手动开关（`ginkgo system config set --debug on`），批量同步也是手动操作；在装饰器层探测"是否批量远端调用"会引入运行时判断复杂度，得不偿失。
+- **为何用纪律而非代码强制**：debug 是开发者手动开关（`ginkgo debug on`），批量同步也是手动操作；在装饰器层探测"是否批量远端调用"会引入运行时判断复杂度，得不偿失。
 - **已排除 A：debug 下也退避**——单测/集成测试会卡 `30s × N`，破坏 debug 加速反馈的初衷。
 - **已排除 B：装饰器加"远端 API 识别"自动限流**——跨切面耦合（装饰器要知道被调函数是否打远端），违背单一职责。
 


### PR DESCRIPTION
## Summary

同步 `CLAUDE.md` 与 ADR 中的 debug 命令文档，使其与 ginkgo 0.8.1 实际 CLI 一致（#6203）。

### 背景

CLI 重构后 `debug` 提升为顶层命令（`ginkgo debug on|off`），旧的 `ginkgo system config set --debug on` 子命令路径已移除。`README.md:223` 与 `docs/cli-quant-research-report-2026-06-12.md:21` 已修正，但 **AI 面向文档（CLAUDE.md）+ 两个 ADR** 仍写旧命令，新会话/用户照文档执行会失败（`No such command system`）。

验证：
- `ginkgo debug --help` → `Usage: debug MODE:{on|off}`（顶层命令 ✅）
- `ginkgo system config set --debug on` → `Error: No such command system`（旧路径失效 ✅）

## 改动

| 文件 | 改动 |
|---|---|
| `CLAUDE.md` L42/L50 | `ginkgo system config set --debug on` → `ginkgo debug on` |
| `CLAUDE.md` 可用组件段 | 加 `<name>_<type>` 实际命名说明 + `component list` 引导（DB 实际名 `fixed_selector`/`atr_sizer`/`qr_momentum_selector` 等，非短名） |
| `docs/adrs/ADR-004-dual-db-debug.md` L22 | 连带同步 debug 命令（操作步骤示例，不改决策语义） |
| `docs/adrs/ADR-013-debug-retry-backoff.md` L34 | 连带同步 debug 命令（Rationale 引用，不改决策语义） |

**不改**：`docs/superpowers/plans/2026-06-13-*.md`（历史规划快照，存档性质）。

## 组件名范围说明

实际组件命名不统一（`fixed_sizer`/`ratio_sizer`/`momentum_selector`/`qr_momentum_selector`/`sharpe_ratio`），逐个列全会触发组件数量口径争议（`project_component_count_pending`）。本 PR 采用 **映射说明 + `component list` 引导**（issue AC 第二选项："明确说明短名映射到 `<name>_<type>`"），保留短名速查表同时引导查实际名。

## AC

- [x] debug 命令改为 `ginkgo debug on|off` — CLAUDE.md L42/L50 + ADR-004/013 连带
- [x] 组件清单说明短名映射（引导 `component list` 查实际名）
- [x] 用户照文档操作能直接成功（`ginkgo debug on` 可执行）

## Test plan

- [x] grep 验收：3 文件旧命令 `system config set --debug` 残留 = 0
- [x] grep 验收：新命令 `ginkgo debug on` 存在（CLAUDE.md ×2 + ADR-004 ×1 + ADR-013 ×1）
- [x] L1 py_compile：src+api 全量通过（无 .py 变更，环境确认）
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed ✅
- [x] 实际执行 `ginkgo debug --help` 确认顶层命令存在

docs 类变更无对应代码测试（8.2.1 覆盖率豁免：纯文档，无 .py 行为变更）。

Closes #6203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
