### PR TITLE
fix(#6017): test list/run 命令补 WORKING_PATH None 守卫

### DIFF
--- a/src/ginkgo/client/test_cli.py
+++ b/src/ginkgo/client/test_cli.py
@@ -56,7 +56,9 @@ def list_tests():
     # Get project root
     from ginkgo.libs.core.config import GCONF
     
-    test_root = Path(GCONF.WORKING_PATH) / "test"
+    # WORKING_PATH 在 working_directory 配置缺失时可能为 None（同 LOGGING_PATH/COMPOSE_FILE_PATH
+    # 均有 None 守卫），fallback Path.cwd() 避免 Path(None) TypeError（#6017）
+    test_root = Path(GCONF.WORKING_PATH or Path.cwd()) / "test"
     
     console.print(":test_tube: [bold green]Ginkgo Test Suite - Modern Testing Framework[/bold green]")
     console.print()
@@ -308,7 +310,9 @@ def run(
     if debug:
         GLOG.set_level("debug")
     
-    test_root = Path(GCONF.WORKING_PATH) / "test"
+    # WORKING_PATH 在 working_directory 配置缺失时可能为 None（同 LOGGING_PATH/COMPOSE_FILE_PATH
+    # 均有 None 守卫），fallback Path.cwd() 避免 Path(None) TypeError（#6017）
+    test_root = Path(GCONF.WORKING_PATH or Path.cwd()) / "test"
     test_paths = []
     pytest_args = []
     

--- a/tests/unit/client/test_test_cli.py
+++ b/tests/unit/client/test_test_cli.py
@@ -1,0 +1,28 @@
+"""
+test_cli list_tests 命令测试。
+覆盖 #6017：WORKING_PATH=None 时不应崩溃（fallback cwd，与 COMPOSE_FILE_PATH 一致）。
+"""
+
+import pytest
+from unittest.mock import patch
+
+from ginkgo.client.test_cli import list_tests
+
+
+@pytest.mark.unit
+class TestListTestsWorkingPathGuard:
+    """list_tests 的 WORKING_PATH 防空守卫（#6017）"""
+
+    @patch("ginkgo.libs.core.config.GCONF")
+    def test_list_tests_when_working_path_none_does_not_crash(self, mock_gconf):
+        """WORKING_PATH=None 时不应抛 TypeError，应 fallback 到 cwd"""
+        # 显式设 None（MagicMock auto-truthy 会掩盖 bug，见 feedback_magicmock_method_attr_mask）
+        mock_gconf.WORKING_PATH = None
+        # 当前 Path(None) → TypeError；修复后 fallback cwd → 不崩
+        list_tests()
+
+    @patch("ginkgo.libs.core.config.GCONF")
+    def test_list_tests_when_working_path_valid_executes_cleanly(self, mock_gconf, tmp_path):
+        """WORKING_PATH 有效时正常执行（不抛异常）"""
+        mock_gconf.WORKING_PATH = str(tmp_path)
+        list_tests()


### PR DESCRIPTION
## Summary

修复 `ginkgo test list` / `ginkgo test run` 在 `working_directory` 配置缺失时崩溃的问题（#6017）。

### 背景

`src/ginkgo/client/test_cli.py` 的 `list_tests` 与 `run` 命令均裸用：

```python
test_root = Path(GCONF.WORKING_PATH) / "test"
```

`GCONF.WORKING_PATH`（`config.py:397`）返回 `self._get_config("working_directory")`，当该配置缺失时返回 **None**。`Path(None)` 抛 `TypeError: argument should be str... not NoneType`，命令直接崩溃。

**同源守卫已存在**：`config.py` 的 `LOGGING_PATH`（`if path is None: return default`）与 `COMPOSE_FILE_PATH`（`if working:`）属性都已对 `WORKING_PATH` 可空做防御——唯独 `test_cli.py` 这两个消费点漏守卫。

## 改动

| 文件 | 改动 |
|---|---|
| `src/ginkgo/client/test_cli.py` L59/L311 | 两处 `Path(GCONF.WORKING_PATH)` → `Path(GCONF.WORKING_PATH or Path.cwd())`，fallback 当前工作目录 |

### 范围说明

#6017 body 只提 `list` 命令（L59 `list_tests`），但**同文件 L311 `run` 命令是完全相同的裸用**（同根因簇）。pick-issue 步骤 3.5「同根因合并」原则下两处一并修复，避免 bug 只修一半。两处统一用 `Path.cwd()`（`Path` 已模块级 import，不依赖 `os`，跨函数作用域零依赖）。

## AC

- [x] WORKING_PATH=None 时不崩溃，fallback cwd（与 COMPOSE_FILE_PATH 同源守卫风格）
- [x] WORKING_PATH 有效时行为不变
- [x] list 与 run 两命令同根因一并修复

## Test plan

TDD 红-绿循环（`tests/unit/client/test_test_cli.py` 新建）：
- [x] RED：`test_list_tests_when_working_path_none_does_not_crash` 修复前 TypeError @ test_cli.py:59
- [x] GREEN：修复后 2 passed（None 不崩 + valid 正常）
- [x] L1 py_compile：src+api 全量通过
- [x] L2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed
- [x] L3 变更相关：`test_test_cli.py` → 2 passed

Closes #6017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
