### PR TITLE
fix(#2592): cache_cli 改走 RedisService.find_keys，修复 status/list 静默失败

### DIFF
--- a/src/ginkgo/client/cache_cli.py
+++ b/src/ginkgo/client/cache_cli.py
@@ -191,6 +191,19 @@ def _clear_tick_cache(progress: Progress, code: str):
         progress.update(task, description=f"Error: {str(e)}", completed=100)
         raise
 
+
+def _keys_from_find_keys(result) -> list:
+    """从 redis_service.find_keys 的 ServiceResult 提取键列表。
+
+    #2592: crud_repo 不是 BaseService 公共属性（仅私有 _crud_repo），cache_cli 直访
+    redis_service.crud_repo.keys(...) 抛 AttributeError 被 try/except 静默吞，
+    导致 status/list 命令的缓存统计永显示错误。find_keys 失败或无 data 时返空列表。
+    """
+    if result.is_success() and result.data:
+        return result.data.get("keys") or []
+    return []
+
+
 @app.command()
 def status():
     """
@@ -229,7 +242,7 @@ def status():
         try:
             # Get function cache keys count
             from ginkgo.data.redis_schema import RedisKeyPattern
-            func_cache_keys = redis_service.crud_repo.keys(RedisKeyPattern.FUNC_CACHE_ALL)
+            func_cache_keys = _keys_from_find_keys(redis_service.find_keys(RedisKeyPattern.FUNC_CACHE_ALL))
             func_cache_count = len(func_cache_keys) if func_cache_keys else 0
             table.add_row(
                 "Function Cache",
@@ -242,7 +255,7 @@ def status():
         # Sync progress cache
         try:
             from ginkgo.data.redis_schema import RedisKeyPattern
-            sync_keys = redis_service.crud_repo.keys(RedisKeyPattern.SYNC_PROGRESS_ALL)
+            sync_keys = _keys_from_find_keys(redis_service.find_keys(RedisKeyPattern.SYNC_PROGRESS_ALL))
             sync_count = len(sync_keys) if sync_keys else 0
             table.add_row(
                 "Sync Progress",
@@ -299,7 +312,7 @@ def list(
         
         total_shown = 0
         for pattern in patterns:
-            keys = redis_service.crud_repo.keys(pattern)
+            keys = _keys_from_find_keys(redis_service.find_keys(pattern))
             if keys:
                 for key in keys[:limit - total_shown]:
                     # Determine cache type from key

--- a/src/ginkgo/data/services/redis_service.py
+++ b/src/ginkgo/data/services/redis_service.py
@@ -394,6 +394,30 @@ class RedisService(BaseService):
             self._logger.ERROR(f"Failed to check key existence: {e}")
             return ServiceResult.error(f"Failed to check key existence: {str(e)}")
 
+    def find_keys(self, pattern: str = "*") -> ServiceResult:
+        """
+        查找匹配 pattern 的 Redis 键列表
+
+        封装 _crud_repo.keys，供调用方（如 cache_cli）查询键列表，
+        避免直调 CRUD 实例（ BaseService 仅暴露私有 _crud_repo，外部直访抛
+        AttributeError 被 try/except 静默吞，见 #2592）。
+
+        Args:
+            pattern: Redis 键模式（默认 "*" 查全部）
+
+        Returns:
+            ServiceResult: data 含 keys（List[str]，空列表表示无匹配）
+        """
+        try:
+            keys = self._crud_repo.keys(pattern)
+            return ServiceResult.success(
+                data={"keys": keys or []},
+                message=f"Found {len(keys or [])} keys matching '{pattern}'"
+            )
+        except Exception as e:
+            self._logger.ERROR(f"Failed to find keys for pattern '{pattern}': {e}")
+            return ServiceResult.error(f"Failed to find keys for pattern '{pattern}': {str(e)}")
+
     # ==================== 进程管理 ====================
     
     def register_main_process(self, pid: int) -> bool:

--- a/tests/unit/client/test_cache_cli.py
+++ b/tests/unit/client/test_cache_cli.py
@@ -22,6 +22,7 @@ from typer.testing import CliRunner
 from unittest.mock import patch, MagicMock
 
 from ginkgo.client import cache_cli
+from ginkgo.data.services.base_service import ServiceResult
 
 
 @pytest.fixture
@@ -37,8 +38,8 @@ def mock_redis_service():
     m.clear_all_sync_progress.return_value = 3
     m.clear_sync_progress.return_value = 1
     m.get_redis_info.return_value = {"connected": True, "version": "7.0.0"}
-    # crud_repo 用于 keys() 查询
-    m.crud_repo.keys.return_value = []
+    # find_keys 返 ServiceResult（#2592: 走 service 非 crud_repo）
+    m.find_keys.return_value = ServiceResult.success(data={"keys": []})
     return m
 
 
@@ -187,7 +188,7 @@ class TestCacheStatus:
 
     def test_status_empty_cache(self, cli_runner, mock_container):
         """缓存为空时显示 Empty 状态"""
-        mock_container.redis_service.return_value.crud_repo.keys.return_value = []
+        mock_container.redis_service.return_value.find_keys.return_value = ServiceResult.success(data={"keys": []})
         with patch("ginkgo.data.containers.container", mock_container), \
              patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
             mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
@@ -235,7 +236,7 @@ class TestCacheList:
 
     def test_list_no_filter_empty(self, cli_runner, mock_container):
         """无过滤条件且缓存为空时显示提示"""
-        mock_container.redis_service.return_value.crud_repo.keys.return_value = []
+        mock_container.redis_service.return_value.find_keys.return_value = ServiceResult.success(data={"keys": []})
         with patch("ginkgo.data.containers.container", mock_container), \
              patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
             mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
@@ -246,9 +247,9 @@ class TestCacheList:
 
     def test_list_with_function_entries(self, cli_runner, mock_container):
         """存在函数缓存条目时正确展示"""
-        mock_container.redis_service.return_value.crud_repo.keys.return_value = [
+        mock_container.redis_service.return_value.find_keys.return_value = ServiceResult.success(data={"keys": [
             "ginkgo_func_cache_get_bars_000001.SZ",
-        ]
+        ]})
         with patch("ginkgo.data.containers.container", mock_container), \
              patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
             mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
@@ -260,9 +261,9 @@ class TestCacheList:
 
     def test_list_with_sync_entries(self, cli_runner, mock_container):
         """存在同步进度缓存条目时正确展示"""
-        mock_container.redis_service.return_value.crud_repo.keys.return_value = [
+        mock_container.redis_service.return_value.find_keys.return_value = ServiceResult.success(data={"keys": [
             "bar_update_000001.SZ",
-        ]
+        ]})
         with patch("ginkgo.data.containers.container", mock_container), \
              patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
             mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
@@ -286,9 +287,9 @@ class TestCacheList:
 
     def test_list_with_limit(self, cli_runner, mock_container):
         """--limit 参数控制返回条目数"""
-        mock_container.redis_service.return_value.crud_repo.keys.return_value = [
+        mock_container.redis_service.return_value.find_keys.return_value = ServiceResult.success(data={"keys": [
             f"ginkgo_func_cache_func_{i}" for i in range(10)
-        ]
+        ]})
         with patch("ginkgo.data.containers.container", mock_container), \
              patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
             mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
@@ -296,3 +297,53 @@ class TestCacheList:
             result = cli_runner.invoke(cache_cli.app, ["list", "--limit", "3"])
         assert result.exit_code == 0
         assert "Showing first 3" in result.output
+
+
+# ============================================================================
+# 5. #2592 封装契约：cache_cli 通过 find_keys 查询键，不直访 crud_repo
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCacheCliUsesFindKeys:
+    """#2592: cache_cli 应通过 redis_service.find_keys 查询键列表，而非直访 crud_repo。
+
+    根因：crud_repo 不是 BaseService 的公共属性（仅私有 _crud_repo），
+    直访 redis_service.crud_repo.keys(...) 抛 AttributeError，被 try/except 吞成 ":x: Error"。
+    """
+
+    def _mock_container_with_find_keys(self, keys=None):
+        """构造 find_keys 返 ServiceResult 的 container mock"""
+        keys = keys if keys is not None else []
+        mock_svc = MagicMock()
+        mock_svc.get_redis_info.return_value = {"connected": True, "version": "7.0.0"}
+        mock_svc.find_keys.return_value = ServiceResult.success(data={"keys": keys})
+        mock_container = MagicMock()
+        mock_container.redis_service.return_value = mock_svc
+        return mock_container, mock_svc
+
+    def test_status_calls_find_keys(self, cli_runner):
+        """status 命令通过 find_keys 查询缓存键（走 service 层）"""
+        mock_container, mock_svc = self._mock_container_with_find_keys()
+        with patch("ginkgo.data.containers.container", mock_container), \
+             patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
+            mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
+            mock_pattern.SYNC_PROGRESS_ALL = "*_update_*"
+            result = cli_runner.invoke(cache_cli.app, ["status"])
+        assert result.exit_code == 0
+        assert mock_svc.find_keys.called
+
+    def test_list_calls_find_keys(self, cli_runner):
+        """list 命令通过 find_keys 查询缓存键（走 service 层）"""
+        mock_container, mock_svc = self._mock_container_with_find_keys(
+            keys=["ginkgo_func_cache_get_bars_000001.SZ"]
+        )
+        with patch("ginkgo.data.containers.container", mock_container), \
+             patch("ginkgo.data.redis_schema.RedisKeyPattern") as mock_pattern:
+            mock_pattern.FUNC_CACHE_ALL = "ginkgo_func_cache_*"
+            mock_pattern.SYNC_PROGRESS_ALL = "*_update_*"
+            result = cli_runner.invoke(cache_cli.app, ["list"])
+        assert result.exit_code == 0
+        assert mock_svc.find_keys.called
+        assert "get_bars" in result.output

--- a/tests/unit/data/services/test_redis_service_find_keys.py
+++ b/tests/unit/data/services/test_redis_service_find_keys.py
@@ -1,0 +1,69 @@
+"""
+#2592: RedisService.find_keys 契约测试。
+
+根因：cache_cli 直调 redis_service.crud_repo.keys(...)，但 crud_repo 不是公共属性
+（BaseService 只暴露私有 _crud_repo），生产环境 AttributeError 被 try/except 吞。
+本测试覆盖新增的 find_keys service 方法（包装 _crud_repo.keys，返 ServiceResult）。
+
+不依赖真实 Redis：注入 mock redis_crud。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+project_root = Path(__file__).parent.parent.parent.parent
+_src = str(project_root / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from ginkgo.data.services.redis_service import RedisService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+class TestFindKeys:
+    """RedisService.find_keys 契约"""
+
+    def test_find_keys_wraps_crud_keys_and_returns_serviceresult(self):
+        """find_keys 调 _crud_repo.keys(pattern)，返 ServiceResult 含 keys 列表"""
+        mock_crud = MagicMock()
+        mock_crud.keys.return_value = ["ginkgo:func_cache:a", "ginkgo:func_cache:b"]
+        svc = RedisService(redis_crud=mock_crud)
+
+        result = svc.find_keys("ginkgo:func_cache:*")
+
+        mock_crud.keys.assert_called_once_with("ginkgo:func_cache:*")
+        assert isinstance(result, ServiceResult)
+        assert result.is_success()
+        assert result.data["keys"] == ["ginkgo:func_cache:a", "ginkgo:func_cache:b"]
+
+    def test_find_keys_default_pattern_is_star(self):
+        """无参数时默认 pattern=*（对齐 RedisCRUD.keys 签名）"""
+        mock_crud = MagicMock()
+        mock_crud.keys.return_value = []
+        svc = RedisService(redis_crud=mock_crud)
+
+        svc.find_keys()
+
+        mock_crud.keys.assert_called_once_with("*")
+
+    def test_find_keys_empty_result_still_success(self):
+        """keys 返空列表时仍 success（空缓存非错误）"""
+        mock_crud = MagicMock()
+        mock_crud.keys.return_value = []
+        svc = RedisService(redis_crud=mock_crud)
+
+        result = svc.find_keys("ginkgo:func_cache:*")
+
+        assert result.is_success()
+        assert result.data["keys"] == []
+
+    def test_find_keys_crud_error_returns_service_error(self):
+        """_crud_repo.keys 抛异常时返 ServiceResult.error，不向上传播"""
+        mock_crud = MagicMock()
+        mock_crud.keys.side_effect = RuntimeError("redis down")
+        svc = RedisService(redis_crud=mock_crud)
+
+        result = svc.find_keys("ginkgo:func_cache:*")
+
+        assert not result.is_success()
+        assert "redis down" in (result.error or "")


### PR DESCRIPTION
## Summary

#2592：`cache_cli` 3 处直调 `redis_service.crud_repo.keys(...)` 绕过 Service 层。本 PR 接通 `RedisService.find_keys` service 方法，替换 3 处直调。

**根因（验证后发现是真实 bug）**：`crud_repo` **不是** BaseService 的公共属性（仅私有 `_crud_repo`）。`redis_service.crud_repo.keys(...)` 每次抛 `AttributeError`，被各处 `try/except Exception` 静默吞成 `:x: Error`。**cache status/list 命令的 Redis 缓存统计永显示错误**——这不只是封装违规，是功能性 bug。

issue AC3「crud_repo 不作为公共属性暴露」**已自然满足**：BaseService 本就只暴露私有 `_crud_repo`。真正的缺陷是 cache_cli 访问了不存在的属性。

### 既有测试掩盖了 bug

`test_cache_cli.py` 的 fixture 与 5 处 inline mock 都设了 `m.crud_repo.keys.return_value = []`——**MagicMock 自动创建不存在的属性**，让测试通过，但生产环境 `AttributeError`。这是 mock 契约掩盖属性不存在的 CLI 变体。本 PR 同步改 mock 为 `find_keys`。

### 修复

| 文件 | 变更 |
|---|---|
| `redis_service.py` | 新增 `find_keys(pattern) -> ServiceResult`（包装 `_crud_repo.keys`，对齐 `exists`/`get_cache` 风格） |
| `cache_cli.py` | 加 `_keys_from_find_keys` helper（解包 ServiceResult，失败返空列表）；3 处（status 的 func/sync 统计 + list 的 keys 查询）改走 `find_keys` |

### AC 达成

- [x] AC1 RedisService 新增 find_keys → `redis_service.py`
- [x] AC2 cache_cli 不再直访 crud_repo → 3 处全改，grep 零残留（仅 helper docstring 根因说明含文字）
- [x] AC3 crud_repo 不公共暴露 → **已自然满足**（`hasattr(svc, 'crud_repo') == False`，BaseService 本无 `_crud_repo` 外的公共属性）

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml`）全绿：
- **L1 py_compile**：src + api 全量语法 ✅
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29）✅
- **L3 变更相关**：新 `test_redis_service_find_keys`（4：包装 keys / 默认 `*` / 空结果 / crud 异常返 error）+ 改 `test_cache_cli`（21：mock 改 find_keys + 2 新封装契约断言 status/list 调 find_keys 非 crud_repo）+ 既有 redis_service unit 零回归（11 skip 为 Redis integration 无 Redis 环境）✅

合计 74 passed / 11 skipped，零回归。

**TDD**：垂直切片——find_keys tracer bullet（包装 keys）→ 默认 pattern → error 路径 → cache_cli 契约（find_keys 被调）→ 既有 mock 同步。

Closes #2592

🤖 Generated with [Claude Code](https://claude.com/claude-code)
