### PR TITLE
feat(#5779): 新增 DELETE /engines/stale 僵尸引擎清理端点

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -307,6 +307,32 @@ async def list_backtest_engines(
         raise BusinessError(f"Error listing engines: {str(e)}")
 
 
+@router.delete("/engines/stale")
+async def cleanup_stale_engines(
+    is_live: bool = Query(False, description="清理范围 False=回测引擎(默认)"),
+    dry_run: bool = Query(True, description="试运行 True=仅统计不删除(默认安全)"),
+):
+    """清理从未运行的僵尸引擎（#5779）。
+
+    僵尸判据：backtest_start_date + backtest_end_date 双空（创建后从未启动）。
+    默认 dry_run=True 安全模式仅统计；显式 dry_run=false 执行软删除（可恢复）。
+    """
+    try:
+        engine_service = get_engine_service()
+        result = engine_service.cleanup_stale_engines(
+            is_live=0 if not is_live else 1, dry_run=dry_run
+        )
+        if not result.is_success():
+            raise BusinessError(f"清理僵尸引擎失败: {result.message}")
+        return ok(data=result.data, message=result.message)
+
+    except BusinessError:
+        raise
+    except Exception as e:
+        logger.error(f"Error cleaning stale engines: {str(e)}")
+        raise BusinessError(f"Error cleaning stale engines: {str(e)}")
+
+
 @router.get("/analyzers")
 async def list_analyzers():
     """

--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -635,6 +635,57 @@ class EngineService(BaseService):
             GLOG.ERROR(f"批量删除引擎失败: {str(e)}")
             return ServiceResult.error(f"批量删除引擎失败: {str(e)}")
 
+    def cleanup_stale_engines(self, is_live=None, dry_run=True) -> ServiceResult:
+        """
+        清理从未运行的僵尸引擎（#5779）。
+
+        僵尸判据：backtest_start_date 与 backtest_end_date 均空 = 创建后从未启动。
+        判据与引擎命名解耦：生产引擎启动后 start_date 必非空，不会误伤；
+        遗留 test_engine_* 等历史残留同样满足双空条件被纳入清理。
+
+        Args:
+            is_live: 引擎类型过滤（None=全部 / 0=回测 / 1=实盘）
+            dry_run: True=仅统计不删除（默认安全），False=执行删除
+
+        Returns:
+            ServiceResult: dry_run 返回 {stale_count, stale_uuids, dry_run}；
+                          实删返回 delete_batch 统计（软删除，可恢复）。
+        """
+        try:
+            result = self.get(is_live=is_live)
+            if not result.is_success():
+                return ServiceResult.error(f"获取引擎失败: {result.message}")
+
+            stale_uuids = []
+            for engine in (result.data or []):
+                start = getattr(engine, 'backtest_start_date', None)
+                end = getattr(engine, 'backtest_end_date', None)
+                if start is None and end is None:
+                    uid = getattr(engine, 'uuid', None)
+                    if uid:
+                        stale_uuids.append(uid)
+
+            if dry_run:
+                return ServiceResult.success(
+                    data={
+                        "stale_count": len(stale_uuids),
+                        "stale_uuids": stale_uuids,
+                        "dry_run": True,
+                    },
+                    message=f"DRY RUN: 发现 {len(stale_uuids)} 个僵尸引擎"
+                )
+
+            if not stale_uuids:
+                return ServiceResult.success(
+                    data={"stale_count": 0, "successful_deletions": 0},
+                    message="无僵尸引擎需清理"
+                )
+
+            return self.delete_batch(stale_uuids)
+        except Exception as e:
+            GLOG.ERROR(f"清理僵尸引擎失败: {str(e)}")
+            return ServiceResult.error(f"清理僵尸引擎失败: {str(e)}")
+
     # 注意：重复的查询方法已删除
 # - get_engines: 使用标准 get 方法替代
 # - get_engine: 使用标准 get 方法替代

--- a/tests/api/test_backtest_engine_cleanup.py
+++ b/tests/api/test_backtest_engine_cleanup.py
@@ -1,0 +1,44 @@
+"""
+#5779: DELETE /engines/stale 僵尸引擎清理端点测试。
+
+直调端点函数（避开 app 启动 / root main.py 遮蔽），
+patch get_engine_service 注入 mock。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.data.services.base_service import ServiceResult
+from core.exceptions import BusinessError
+
+
+class TestCleanupStaleEnginesEndpoint:
+    """DELETE /engines/stale 端点契约。"""
+
+    def test_dry_run_returns_count_and_wires_is_live(self):
+        """dry_run=True 透传 service，is_live=False 映射 0（回测）。"""
+        from api.backtest import cleanup_stale_engines
+
+        mock_service = MagicMock()
+        mock_service.cleanup_stale_engines.return_value = ServiceResult.success(
+            data={"stale_count": 5, "stale_uuids": ["z1", "z2"], "dry_run": True},
+            message="DRY RUN: 5",
+        )
+        with patch("api.backtest.get_engine_service", return_value=mock_service):
+            result = asyncio.run(cleanup_stale_engines(is_live=False, dry_run=True))
+
+        mock_service.cleanup_stale_engines.assert_called_once_with(is_live=0, dry_run=True)
+        assert result["code"] == 0
+        assert result["data"]["stale_count"] == 5
+        assert result["data"]["dry_run"] is True
+
+    def test_service_error_raises_business_error(self):
+        """service 返回 error 时端点抛 BusinessError（不静默吞）。"""
+        from api.backtest import cleanup_stale_engines
+
+        mock_service = MagicMock()
+        mock_service.cleanup_stale_engines.return_value = ServiceResult.error("DB down")
+        with patch("api.backtest.get_engine_service", return_value=mock_service):
+            with pytest.raises(BusinessError):
+                asyncio.run(cleanup_stale_engines(is_live=False, dry_run=False))

--- a/tests/unit/data/services/test_engine_service_cleanup.py
+++ b/tests/unit/data/services/test_engine_service_cleanup.py
@@ -1,0 +1,95 @@
+"""
+EngineService 僵尸引擎清理单元测试（Mock 依赖）
+
+覆盖 #5779：cleanup_stale_engines 识别并清理从未运行的引擎
+（backtest_start_date 与 backtest_end_date 均空 = 创建后未启动）。
+"""
+
+import sys
+import os
+import datetime
+import pytest
+from unittest.mock import patch, MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.engine_service import EngineService
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.enums import ENGINESTATUS_TYPES
+
+
+@pytest.fixture
+def mock_deps():
+    return {
+        "crud_repo": MagicMock(),
+        "engine_portfolio_mapping_crud": MagicMock(),
+        "param_crud": MagicMock(),
+    }
+
+
+@pytest.fixture
+def service(mock_deps):
+    with patch("ginkgo.libs.GLOG"):
+        return EngineService(
+            crud_repo=mock_deps["crud_repo"],
+            engine_portfolio_mapping_crud=mock_deps["engine_portfolio_mapping_crud"],
+            param_crud=mock_deps["param_crud"],
+        )
+
+
+def _make_engine(uuid, start=None, end=None):
+    """构造引擎 mock。start/end 默认 None（僵尸）。"""
+    e = MagicMock()
+    e.uuid = uuid
+    e.name = f"engine-{uuid}"
+    e.backtest_start_date = start
+    e.backtest_end_date = end
+    return e
+
+
+class TestCleanupStaleEngines:
+    """#5779: 僵尸引擎（从未运行）批量清理。"""
+
+    def test_dry_run_identifies_zombies_by_null_dates(self, service, mock_deps):
+        """dry_run=True 仅识别不删除：start+end 双空才算僵尸。"""
+        run_engine = _make_engine("ran-1", start=datetime.datetime(2026, 1, 1),
+                                   end=datetime.datetime(2026, 6, 1))
+        zombie_a = _make_engine("zombie-1")  # 双空
+        zombie_b = _make_engine("zombie-2")  # 双空
+        mock_deps["crud_repo"].find.return_value = [run_engine, zombie_a, zombie_b]
+
+        result = service.cleanup_stale_engines(is_live=0, dry_run=True)
+
+        assert result.is_success()
+        assert result.data["dry_run"] is True
+        assert result.data["stale_count"] == 2
+        assert set(result.data["stale_uuids"]) == {"zombie-1", "zombie-2"}
+
+    def test_real_delete_calls_delete_batch_with_zombie_uuids(self, service, mock_deps):
+        """dry_run=False 调 delete_batch 仅传僵尸 uuid，运行过的引擎不传入。"""
+        run_engine = _make_engine("ran-1", start=datetime.datetime(2026, 1, 1))
+        zombie = _make_engine("zombie-9")
+        mock_deps["crud_repo"].find.return_value = [run_engine, zombie]
+
+        captured = ServiceResult.success(data={"successful_deletions": 1}, message="ok")
+        service.delete_batch = MagicMock(return_value=captured)
+
+        result = service.cleanup_stale_engines(is_live=0, dry_run=False)
+
+        assert result.is_success()
+        service.delete_batch.assert_called_once_with(["zombie-9"])
+
+    def test_no_zombies_skips_delete(self, service, mock_deps):
+        """无僵尸时不调 delete_batch，返回 stale_count=0。"""
+        run_only = _make_engine("ran-1", start=datetime.datetime(2026, 1, 1),
+                                 end=datetime.datetime(2026, 6, 1))
+        mock_deps["crud_repo"].find.return_value = [run_only]
+        service.delete_batch = MagicMock()
+
+        result = service.cleanup_stale_engines(is_live=0, dry_run=False)
+
+        assert result.is_success()
+        assert result.data["stale_count"] == 0
+        service.delete_batch.assert_not_called()


### PR DESCRIPTION
## Summary

修复 #5779：`GET /api/v1/backtests/engines` 返回大量从未运行的僵尸引擎记录（`backtest_start_date`/`backtest_end_date` 均空），无清理机制。新增 admin 端点批量清理。

### 背景

引擎在装配期（`_perform_backtest_engine_assembly`）即创建记录，若回测从未派发/启动，`backtest_start_date` 永远为空 → 僵尸积累。生产引擎命名 `BacktestEngine_{uuid8}`，issue 中的 `test_engine_*` 是遗留测试残留——两者均满足「双空」条件。

### 改动

| 文件 | 改动 |
|---|---|
| `engine_service.py` | +`cleanup_stale_engines(is_live, dry_run)`：按「从未运行」语义识别僵尸（start+end 双空），委托既有 `delete_batch`（软删除可恢复 + 自动清 engine_portfolio_mapping，不碰 portfolio 本体） |
| `api/api/backtest.py` | +`DELETE /engines/stale` 端点，`dry_run` 默认 `True`（安全模式仅统计），显式 `false` 才执行删除 |

### 设计要点

- **僵尸判据按语义不按名称**：`start_date + end_date` 双空 = 从未启动。生产引擎启动后 start_date 必非空，不会误伤；命名无关避免漏新僵尸或误删。
- **dry_run 默认 True**：DELETE 端点默认只统计，必须显式 `dry_run=false` 才删除——契合不可逆操作先确认原则。
- **软删除 + 事务**：`delete_batch` → `soft_remove`（is_del=True，可恢复），且 `get()` 已过滤 is_del，清理后僵尸不再出现在引擎列表。
- **`except BusinessError: raise`**：防自抛的 BusinessError 被外层 `except Exception` 改写丢 message（[[arch_httpexception_caught_by_except]] 同型陷阱）。

### AC

- [x] 提供 admin 端点批量清理僵尸引擎（`DELETE /engines/stale`，双空判据）
- [x] 默认安全模式（dry_run=True 仅统计）

## Test plan

TDD 红-绿循环：
- [x] service 层：dry_run 识别双空僵尸 / 实删委托 delete_batch 仅传僵尸 uuid / 无僵尸跳过删除（3 passed）
- [x] 端点：dry_run 透传 + is_live 映射 / service error 抛 BusinessError（2 passed）
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke + 既有 engine_service 回归 72 passed 零回归
- [x] L3 端点测试 2 passed

Closes #5779
Closes #5639
Closes #5596

> #5639 / #5596 为 #5779 同症重复（均「379 条引擎 start_date/end_date 全 None，名称 test_engine_*」），本 PR 的双空判据清理端点一并解决。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
