### PR TITLE
fix(#5595): settings 假数据桩端点改诚实 501 + type 筛选接 channels

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -656,13 +656,13 @@ async def test_user_contact(contact_uuid: str, data: UserContactTest):
 
         # 根据联系方式类型发送测试通知
         if contact_type == CONTACT_TYPES.EMAIL:
-            # TODO: 实现邮件发送
-            logger.info(f"Email test sent to: {data.address}")
-            return ok(data={
-                "detail": "Email sending not implemented yet"
-            }, message=f"Test email sent to {data.address}")
+            # #5595: 邮件发送未实现——诚实返 501，不假装发送成功
+            raise HTTPException(
+                status_code=status.HTTP_501_NOT_IMPLEMENTED,
+                detail="Email sending is not implemented"
+            )
         elif contact_type == CONTACT_TYPES.WEBHOOK:
-            # TODO: 实现Webhook调用
+            # Webhook 已实现（下方 requests.post 实发），原 TODO 注释为过期残留（#5595）
             import requests
             try:
                 response = requests.post(
@@ -1328,10 +1328,11 @@ async def test_notification_template(uuid: str):
                 detail="Notification template not found"
             )
 
-        # TODO: 实现真实的测试发送
-        logger.info(f"Test notification template: {uuid}")
-
-        return ok(message="Test notification sent")
+        # #5595: 真实测试发送未实现——诚实返 501，不假装发送成功
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Notification template test send is not implemented"
+        )
 
     except HTTPException:
         raise
@@ -1386,7 +1387,9 @@ async def list_notification_history(
 
         # 构建查询条件
         filters = {"is_del": False}
-        # TODO: 添加类型筛选支持
+        # #5595: type 筛选接入 channels 字段（email/webhook/wechat/discord 等通知渠道）
+        if type is not None:
+            filters["channels"] = type
 
         result = notification_service.list_records(
             filters=filters,
@@ -1799,40 +1802,28 @@ class APIStats(BaseModel):
 @router.get("/api-keys")
 async def list_api_keys():
     """获取API密钥列表"""
-    # TODO: 从数据库获取API密钥
-    return ok(data=[
-        {
-            "key_id": "key-1",
-            "name": "生产环境密钥",
-            "masked_key": "ginkgo_sk_****",
-            "status": "active",
-            "expires_at": "2025-01-31T00:00:00Z",
-            "last_used": "2024-01-30T15:30:00Z"
-        }
-    ])
+    # #5595: API 密钥库未实现——诚实返 501，不返回硬编码假列表
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="API key management is not implemented"
+    )
 
 
 @router.post("/api-keys", status_code=201)
 async def create_api_key(data: dict):
     """创建API密钥"""
-    # TODO: 创建API密钥
-    return ok(data={
-        "key_id": "new-key",
-        "name": data.get("name"),
-        "masked_key": "ginkgo_sk_****",
-        "status": "active",
-        "expires_at": None,
-        "last_used": None
-    })
+    # #5595: API 密钥创建未实现——诚实返 501
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="API key creation is not implemented"
+    )
 
 
 @router.get("/api-stats")
 async def get_api_stats():
     """获取API统计"""
-    # TODO: 获取实际统计数据
-    return ok(data={
-        "today_calls": 15234,
-        "month_calls": 456789,
-        "success_rate": 99.8,
-        "avg_response_time": 85.0
-    })
+    # #5595: API 统计采集未实现——诚实返 501，不返回硬编码假统计
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="API stats collection is not implemented"
+    )

--- a/tests/api/test_settings_todo_stubs_501.py
+++ b/tests/api/test_settings_todo_stubs_501.py
@@ -1,0 +1,94 @@
+"""#5595: settings.py 7 个 TODO 桩——假成功/假数据端点改诚实 501，type 筛选接 channels。
+
+延迟导入（conftest api_modules fixture 临时把 api/ 入 sys.path，见 #3849/#4080）。
+"""
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_contact(contact_type):
+    """构造 mock 联系方式对象，get_contact_type_enum() 返回指定类型。"""
+    contact = Mock()
+    contact.get_contact_type_enum.return_value = contact_type
+    return contact
+
+
+# ---------- 1. EMAIL 测试联系方式：应返 501，非假成功 ----------
+def test_email_contact_test_returns_501_not_fake_success(api_modules):
+    from ginkgo.enums import CONTACT_TYPES
+    from api.settings import test_user_contact, UserContactTest
+
+    fake_contact = _make_contact(CONTACT_TYPES.EMAIL)
+    user_svc = Mock()
+    user_svc.get_contact.return_value = Mock(success=True, data=fake_contact)
+
+    with patch("api.settings.get_user_service", return_value=user_svc):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(test_user_contact(
+                "contact-uuid",
+                UserContactTest(address="a@b.c"),
+            ))
+    assert exc.value.status_code == 501
+    assert "not implemented" in exc.value.detail.lower()
+
+
+# ---------- 2. 通知模板测试发送：应返 501 ----------
+def test_notification_template_test_returns_501(api_modules):
+    from api.settings import test_notification_template
+
+    notif_svc = Mock()
+    notif_svc.template_exists.return_value = True
+
+    with patch("api.settings.get_notification_service", return_value=notif_svc):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(test_notification_template("tpl-uuid"))
+    assert exc.value.status_code == 501
+
+
+# ---------- 3. list_api_keys：应返 501，非硬编码假列表 ----------
+def test_list_api_keys_returns_501(api_modules):
+    from api.settings import list_api_keys
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(list_api_keys())
+    assert exc.value.status_code == 501
+
+
+# ---------- 4. create_api_key：应返 501，非假密钥 ----------
+def test_create_api_key_returns_501(api_modules):
+    from api.settings import create_api_key
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(create_api_key({"name": "test"}))
+    assert exc.value.status_code == 501
+
+
+# ---------- 5. get_api_stats：应返 501，非硬编码假统计 ----------
+def test_get_api_stats_returns_501(api_modules):
+    from api.settings import get_api_stats
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(get_api_stats())
+    assert exc.value.status_code == 501
+
+
+# ---------- 6. notification history type 筛选应接入 channels 字段 ----------
+def test_notification_history_type_filter_wired_to_channels(api_modules):
+    from api.settings import list_notification_history
+
+    captured = {}
+
+    def fake_list_records(filters=None, limit=None, offset=None, sort=None):
+        captured["filters"] = filters
+        return Mock(success=True, data=[])
+
+    notif_svc = Mock()
+    notif_svc.list_records.side_effect = fake_list_records
+
+    with patch("api.settings.get_notification_service", return_value=notif_svc):
+        asyncio.run(list_notification_history(type="email", page=1, page_size=20))
+
+    assert captured["filters"].get("channels") == "email"


### PR DESCRIPTION
## Summary

修复 #5595：`api/api/settings.py` 中 7 个 TODO 桩端点返回**假装成功的假数据**。按 AC「每个 TODO 要么实现真实逻辑，要么端点返回 501，不返回假数据」处理。

### 改动

| TODO | 端点 | 原状 | 处理 |
|---|---|---|---|
| L659 | `test_user_contact` EMAIL 分支 | 只 log 却 `ok("Test email sent")` | **501**（邮件发送未实现） |
| L665 | `test_user_contact` WEBHOOK 分支 | `requests.post` 已实发，注释过期 | 删过期 TODO 注释（行为不变） |
| L1331 | `test_notification_template` | 只 log 却 `ok("Test notification sent")` | **501**（真实测试发送未实现） |
| L1389 | `list_notification_history` | `type` 参数收了但被静默忽略 | **真实现**：`type` 接入 `channels` 字段（email/webhook/wechat/discord 通知渠道） |
| L1802 | `list_api_keys` | 硬编码假列表 `[{"key_id":"key-1",...}]` | **501**（API 密钥库未实现） |
| L1818 | `create_api_key` | 假密钥 `{"key_id":"new-key",...}` | **501** |
| L1832 | `get_api_stats` | 硬编码假统计 `{today_calls:15234,...}` | **501**（统计采集未实现） |

### 设计要点

- **诚实优先**：未实现的外部系统（邮件发送、API 密钥库、统计采集）返 501 Not Implemented，而非假数据冒充成功。调用方能据实降级，不会被"成功"误导。
- **复用现有模式**：`HTTPException` + `status.HTTP_501_NOT_IMPLEMENTED`，文件已大量使用同型异常，无新依赖。
- **L1389 type 筛选接 `channels`**：`MNotificationRecord.channels: List[str]`（email/discord/kafka 等）即用户视角的"通知类型"，MongoDB 查询 `filters["channels"] = type` 语义正确。`type=None` 时不过滤（兼容原行为）。
- **L665 webhook 不动行为**：代码本就 `requests.post` 实发，仅 TODO 注释为过期残留，删注释即可。（SSRF 风险属 #5469 另题，不在本 PR 范围。）

### AC

- [x] 每个 TODO 要么实现真实逻辑（L1389），要么端点返回 501（L659/L1331/L1802/L1818/L1832），或确认为过期注释（L665）
- [x] 不返回假装成功的假数据

## Test plan

TDD 红-绿循环（`tests/api/test_settings_todo_stubs_501.py`，6 测试）：
- [x] EMAIL 联系方式测试 → 501（非假成功）
- [x] 通知模板测试发送 → 501
- [x] list_api_keys / create_api_key / get_api_stats → 各自 501
- [x] list_notification_history(type="email") → filters 含 `channels:"email"`
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud/containers/user_cli）29 passed
- [x] L3 现有 settings api 回归（n_plus_1 / user_groups）零回归，合计 17 passed

Closes #5595

🤖 Generated with [Claude Code](https://claude.com/claude-code)
