### PR TITLE
fix(#6017): test list/run 在 WORKING_PATH 为 None 时回退当前目录

### DIFF
--- a/src/ginkgo/client/test_cli.py
+++ b/src/ginkgo/client/test_cli.py
@@ -56,7 +56,8 @@ def list_tests():
     # Get project root
     from ginkgo.libs.core.config import GCONF
     
-    test_root = Path(GCONF.WORKING_PATH) / "test"
+    # #6017: WORKING_PATH 未配置（None）时回退当前目录，避免 Path(None) 崩溃
+    test_root = Path(GCONF.WORKING_PATH or ".") / "test"
     
     console.print(":test_tube: [bold green]Ginkgo Test Suite - Modern Testing Framework[/bold green]")
     console.print()
@@ -308,7 +309,8 @@ def run(
     if debug:
         GLOG.set_level("debug")
     
-    test_root = Path(GCONF.WORKING_PATH) / "test"
+    # #6017: WORKING_PATH 未配置（None）时回退当前目录，避免 Path(None) 崩溃
+    test_root = Path(GCONF.WORKING_PATH or ".") / "test"
     test_paths = []
     pytest_args = []
     

--- a/tests/unit/client/test_test_cli_list.py
+++ b/tests/unit/client/test_test_cli_list.py
@@ -1,0 +1,40 @@
+"""
+#6017: ginkgo test list 在 GCONF.WORKING_PATH 为 None 时不应崩溃。
+
+根因：config.py WORKING_PATH property 无 None 保护，配置缺 working_directory
+键时返 None → test_cli.py Path(None) 抛 TypeError。
+
+测试策略：
+  - patch GCONF.WORKING_PATH property 为 None（PropertyMock）
+  - CliRunner.invoke catch_exceptions=True 会把异常吞进 result.exception
+    （见 feedback_test_cli_assertion_channel），故断言走 isinstance(result.exception)
+    而非 output 字面量
+"""
+from unittest.mock import PropertyMock, patch
+
+from typer.testing import CliRunner
+
+from ginkgo.client.test_cli import app
+from ginkgo.libs.core.config import GCONF
+
+
+def test_list_with_none_working_path_does_not_crash():
+    """WORKING_PATH=None 时 list 命令回退到 cwd，不抛 TypeError。"""
+    runner = CliRunner()
+    with patch.object(type(GCONF), "WORKING_PATH", new_callable=PropertyMock) as mock_wp:
+        mock_wp.return_value = None
+        result = runner.invoke(app, ["list"], catch_exceptions=True)
+    # catch_exceptions=True 吞异常进 result.exception；不抛 TypeError 是关键
+    assert not isinstance(result.exception, TypeError), (
+        f"WORKING_PATH=None 不应抛 TypeError，got: {result.exception!r}"
+    )
+    assert result.exit_code == 0
+
+
+def test_list_normal_path_displays_layers():
+    """AC2: 正常 WORKING_PATH 时 list 正常显示分层信息（不回归）。"""
+    runner = CliRunner()
+    result = runner.invoke(app, ["list"], catch_exceptions=True)
+    assert result.exit_code == 0
+    assert "Ginkgo Test Suite" in result.output
+    assert result.exception is None or not isinstance(result.exception, TypeError)


### PR DESCRIPTION
## Summary

修复 #6017：`ginkgo test list` 在 `GCONF.WORKING_PATH` 为 None 时崩溃（`TypeError: ... not 'NoneType'`）。

### 根因

`config.py:397` `WORKING_PATH` property 直接 `return self._get_config("working_directory")`，**无 None 保护**——同文件 `LOGGING_PATH`（有 `if path is None: return default`）和 `COMPOSE_FILE_PATH`（有 `if working:` 守卫）都有保护，唯独 `WORKING_PATH` 漏网。

当 `config.yml` 缺 `working_directory` 键时，`_get_config` 返 None → `test_cli.py` `Path(None)` 抛 TypeError。

### 改动

| 文件 | 改动 |
|---|---|
| `src/ginkgo/client/test_cli.py:59` | `list_tests`：`Path(GCONF.WORKING_PATH or ".") / "test"` |
| `src/ginkgo/client/test_cli.py:311` | `run`：同型 bug，一并加 fallback |
| `tests/unit/client/test_test_cli_list.py` | 新增 2 个测试（None 路径不崩溃 + 正常路径不回归） |

### 设计要点

- **消费方守卫而非改全局 property**：遵循 `COMPOSE_FILE_PATH` 既有惯例（消费方 `if working:`），不碰全局 `GCONF` property 避免影响其他 `WORKING_PATH` 消费者。
- **`or "."` 而非 `or os.getcwd()`**：字符串字面量无需额外 `import os`（`run` 命令无该 import），最小改动 + 两处一致。
- **`test_root` 仅用于计数/展示**：`layer_path.exists()` 返 False 时 count=0，回退到不存在的目录无害。
- **两处同型一并修**：`list`（issue 报告）+ `run`（同型隐患），防 issue 重报。

### AC

- [x] `WORKING_PATH` 为 None 时使用合理默认值（当前目录）
- [x] `ginkgo test list` 正常显示测试模块列表

## Test plan

TDD 红-绿循环：
- [x] RED：`WORKING_PATH=None` 时 `list` 抛 TypeError（PropertyMock patch + `isinstance(result.exception, TypeError)` 断言）
- [x] GREEN：加 fallback 后通过
- [x] AC2：正常 `WORKING_PATH` 时 `list` 正常输出分层信息
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud_mock/containers/user_cli）29 passed 零回归
- [x] L3 变更相关（新测试 + cli_utils）9 passed 零回归

Closes #6017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
