### PR TITLE
fix(#5481): dashboard/system 端点异常响应脱敏（生产不泄露 str(e)）

### DIFF
--- a/api/api/dashboard.py
+++ b/api/api/dashboard.py
@@ -3,6 +3,7 @@
 """
 
 from fastapi import APIRouter, Request
+from core.config import settings
 from core.logging import logger
 from core.response import ok
 from models.dashboard import DashboardStats, SystemHealthItem
@@ -14,6 +15,15 @@ ginkgo_path = Path(__file__).parent.parent.parent / "src"
 sys.path.insert(0, str(ginkgo_path))
 
 router = APIRouter()
+
+
+def _safe_detail(e: Exception) -> str:
+    """#5481: 生产环境响应体不泄露内部异常细节（DB 连接串/堆栈）；
+    DEBUG 模式才附 str(e) 便于本地排查。完整异常始终由 logger 记录服务端。
+    """
+    if settings.DEBUG:
+        return str(e)
+    return "service unavailable (see server logs)"
 
 
 def _check_health() -> list[SystemHealthItem]:
@@ -37,7 +47,7 @@ def _check_health() -> list[SystemHealthItem]:
             ))
     except Exception as e:
         health_items.append(SystemHealthItem(
-            name="MySQL", status="OFFLINE", detail=str(e)
+            name="MySQL", status="OFFLINE", detail=_safe_detail(e)
         ))
 
     # Redis 检查
@@ -58,7 +68,7 @@ def _check_health() -> list[SystemHealthItem]:
             ))
     except Exception as e:
         health_items.append(SystemHealthItem(
-            name="Redis", status="OFFLINE", detail=str(e)
+            name="Redis", status="OFFLINE", detail=_safe_detail(e)
         ))
 
     return health_items
@@ -135,7 +145,7 @@ async def get_dashboard_stats(request: Request):
             running_strategies=0,
             system_status="WARNING",
             health_checks=[SystemHealthItem(
-                name="System", status="WARNING", detail=str(e)
+                name="System", status="WARNING", detail=_safe_detail(e)
             )],
         )
         return ok(data=stats.model_dump(), message="Dashboard stats retrieved with degraded data")

--- a/api/api/system.py
+++ b/api/api/system.py
@@ -5,6 +5,7 @@
 from fastapi import APIRouter
 from typing import Dict, Any
 
+from core.config import settings
 from core.response import ok
 from core.logging import logger
 
@@ -24,7 +25,9 @@ async def get_system_status():
         return ok(data=svc.get_system_status())
     except Exception as e:
         logger.error(f"Failed to get system status: {e}")
-        return ok(data={"status": "error", "version": "unknown", "error": str(e)})
+        # #5481: 生产环境 error 字段不泄露内部异常细节；DEBUG 才附 str(e)
+        _err = str(e) if settings.DEBUG else "internal error (see server logs)"
+        return ok(data={"status": "error", "version": "unknown", "error": _err})
 
 
 @router.get("/workers")

--- a/tests/api/test_dashboard_system_sanitization.py
+++ b/tests/api/test_dashboard_system_sanitization.py
@@ -1,0 +1,92 @@
+# Issue: #5481 dashboard/system 端点异常响应泄露内部错误细节
+# Upstream: api.api.dashboard._safe_detail, api.api.system
+# Downstream: core.config.settings (DEBUG 守卫)
+# Role: 验证生产环境异常响应脱敏，DEBUG 模式才附 str(e)
+
+"""
+#5481: dashboard/system 端点异常响应脱敏测试
+
+验证基础设施下线时，响应体不泄露内部细节（DB 连接串/堆栈片段）。
+生产模式返 generic message，DEBUG 模式才附完整异常信息。
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestSafeDetail:
+    """_safe_detail: 生产脱敏 + DEBUG 详查"""
+
+    def test_debug_off_strips_internal_exception_detail(self):
+        """生产模式：_safe_detail 不泄露异常里的内部地址/端口"""
+        from api.dashboard import _safe_detail
+        from core.config import settings
+
+        sensitive = RuntimeError("DB connection to 10.0.0.1:3306 failed: Access denied")
+        with patch.object(settings, "DEBUG", False):
+            result = _safe_detail(sensitive)
+
+        # 内部细节被剥离
+        assert "10.0.0.1" not in result, f"泄露内部地址: {result}"
+        assert "3306" not in result, f"泄露端口: {result}"
+        assert "Access denied" not in result, f"泄露异常细节: {result}"
+        # 仍是可读字符串（generic message）
+        assert isinstance(result, str) and len(result) > 0
+
+    def test_debug_on_returns_full_detail(self):
+        """DEBUG 模式：_safe_detail 附完整异常信息（便于本地排查）"""
+        from api.dashboard import _safe_detail
+        from core.config import settings
+
+        sensitive = RuntimeError("DB connection to 10.0.0.1:3306 failed")
+        with patch.object(settings, "DEBUG", True):
+            result = _safe_detail(sensitive)
+
+        assert "10.0.0.1" in result, f"DEBUG 模式应附详情: {result}"
+
+
+class TestEndpointSanitization:
+    """端点异常路径响应脱敏：_check_health / system status 下线时不泄露内部细节"""
+
+    def test_check_health_mysql_offline_detail_sanitized(self):
+        """_check_health MySQL 下线时 detail 不泄露 DB 连接串/端口"""
+        from api.dashboard import _check_health
+        from core.config import settings
+
+        mock_container = MagicMock()
+        # MySQL 下线：portfolio_service().count() 抛含敏感信息的异常
+        mock_container.portfolio_service.return_value.count.side_effect = RuntimeError(
+            "DB connection to 10.0.0.1:3306 failed: Access denied for root"
+        )
+        # Redis 也下线，避免 _check_health 在 Redis 块因 mock 不全而崩
+        mock_container.redis_service.return_value.ping.side_effect = RuntimeError("redis down")
+
+        with patch.object(settings, "DEBUG", False), \
+             patch("ginkgo.data.containers.container", mock_container):
+            health = _check_health()
+
+        mysql = next(h for h in health if h.name == "MySQL")
+        assert mysql.status == "OFFLINE"
+        assert "10.0.0.1" not in mysql.detail, f"泄露内部地址: {mysql.detail}"
+        assert "3306" not in mysql.detail, f"泄露端口: {mysql.detail}"
+        assert "Access denied" not in mysql.detail, f"泄露异常细节: {mysql.detail}"
+
+    def test_system_status_exception_error_sanitized(self):
+        """/system/status 异常时 error 字段不泄露 DB 连接串"""
+        import asyncio
+        from api.system import get_system_status
+        from core.config import settings
+
+        sensitive = RuntimeError("DB connection to 10.0.0.1:3306 failed: Access denied")
+        with patch.object(settings, "DEBUG", False), \
+             patch("api.system._get_system_service", side_effect=sensitive):
+            resp = asyncio.run(get_system_status())
+
+        # resp = ok(data={"status":"error","version":"unknown","error":...})
+        payload = resp.body if hasattr(resp, "body") else resp
+        if isinstance(payload, (bytes, bytearray)):
+            import json
+            payload = json.loads(payload)
+        error_text = payload.get("data", {}).get("error", "") if isinstance(payload, dict) else ""
+        assert "10.0.0.1" not in error_text, f"泄露内部地址: {error_text}"
+        assert "Access denied" not in error_text, f"泄露异常细节: {error_text}"


### PR DESCRIPTION
## Summary

修复 #5481：dashboard/system 端点基础设施下线时，响应体 `detail`/`error` 字段直接塞 `str(e)`，泄露内部细节（DB 连接串 `10.0.0.1:3306`、堆栈片段、`Access denied` 等）。

### 根因

4 处 except 分支把异常字符串直接写入 API 响应：
- `api/api/dashboard.py:40` MySQL OFFLINE `detail=str(e)`
- `api/api/dashboard.py:61` Redis OFFLINE `detail=str(e)`
- `api/api/dashboard.py:138` System WARNING `detail=str(e)`
- `api/api/system.py:27` status error `error=str(e)`

`logger.error`/`logger.warning` 已正确记录服务端（保留不动）。

### 改动

| 文件 | 改动 |
|---|---|
| `dashboard.py` | +`_safe_detail(e)` helper（`settings.DEBUG` 返 `str(e)` else generic），3 处 `detail=str(e)` → `detail=_safe_detail(e)` |
| `system.py` | +`from core.config import settings`，单处 `error=str(e)` → DEBUG 守卫脱敏（inline） |

### 设计要点

- **生产脱敏 + DEBUG 详查**：响应体守 generic message，DEBUG 模式附 `str(e)` 便于本地排查；完整异常始终 `logger.error` 服务端（可观测性不变）
- **dashboard 用 helper（3 处复用），system inline（1 处最小化）**：避免过度抽象
- **不改 logger**：服务端日志保留完整异常，只脱敏客户端响应通道（信息分流而非删除）

### AC

- [x] 错误响应用 generic message（生产）
- [x] 完整异常仅服务端 logger（现有 logger 不动）
- [x] DEBUG 模式才显细节

## Test plan

TDD 红-绿循环：
- [x] helper `_safe_detail`：生产脱敏（不含内部地址/端口）/ DEBUG 附详情（2 passed）
- [x] 端点接线：_check_health MySQL 下线 detail 脱敏 / system status 异常 error 脱敏（2 passed）
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud/containers/user_cli）29 passed
- [x] L3 既有 dashboard 聚合回归 + 新脱敏测试 6 passed 零回归

Closes #5481

🤖 Generated with [Claude Code](https://claude.com/claude-code)
