### PR TITLE
fix(#5866): bars sync 支持 codes=['all'] 一键展开 stockinfo 全表批量同步

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -629,6 +629,22 @@ async def sync_data(request: DataUpdateRequest):
 
         elif request.type == "bars":
             codes = request.codes or []
+            # #5866: codes=["all"] 展开为 stockinfo 全表 code（一键批量同步）
+            if len(codes) == 1 and codes[0].lower() == "all":
+                stockinfo_svc = get_stockinfo_service()
+                codes_result = stockinfo_svc.list_all_codes()
+                if not codes_result.is_success():
+                    raise HTTPException(
+                        status_code=500,
+                        detail="Failed to list stockinfo codes for batch sync",
+                    )
+                codes = codes_result.data or []
+                if not codes:
+                    raise HTTPException(
+                        status_code=400,
+                        detail="No stockinfo records to sync; run stockinfo sync first "
+                               "(POST /api/v1/data/sync {\"type\":\"stockinfo\"})",
+                    )
             if not codes:
                 raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for bars update")
 

--- a/src/ginkgo/data/services/stockinfo_service.py
+++ b/src/ginkgo/data/services/stockinfo_service.py
@@ -424,6 +424,21 @@ class StockinfoService(BaseService):
         )
         return self._crud_repo.find(filters=filters, **query_params)
 
+    def list_all_codes(self) -> ServiceResult:
+        """列出 stockinfo 表所有股票 code。
+
+        #5866: 供 bars sync 端点 codes=["all"] 展开为全表 code 列表，
+        一键批量同步所有已登记股票的 K 线数据，避免用户逐只手动 sync。
+        """
+        try:
+            model_list = self._find_modellist()
+            if not model_list:
+                return ServiceResult.success(data=[])
+            codes = [info.code for info in model_list if getattr(info, "code", None)]
+            return ServiceResult.success(data=codes)
+        except Exception as e:
+            return ServiceResult.error(f"Failed to list stockinfo codes: {e}")
+
     # ===== ADR-010 Phase 4.2：类型即契约多出口 =====
 
     def get_stockinfos_df(self, code: str = None, name: str = None, exchange: str = None,

--- a/tests/api/test_data_sync_bars_all.py
+++ b/tests/api/test_data_sync_bars_all.py
@@ -1,0 +1,102 @@
+# Upstream: api.api.data.sync_data (POST /api/v1/data/sync)
+# Downstream: StockinfoService.list_all_codes, BarService.sync_smart, DataSyncRecordService
+# Role: 验证 bars sync codes=['all'] 展开为 stockinfo 全表批量同步 (#5866 AC1)
+"""
+sync_data bars codes=['all'] 展开测试
+
+#5866: bars sync 端点只接受显式 codes 数组，缺一键同步全表机制。
+用户须逐只 POST {"type":"bars","codes":["000002.SZ"]}，50 只股票 62% 无数据。
+本测试锁定：codes=["all"] 展开为 stockinfo 全表 code，逐个 sync_smart。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+from fastapi import HTTPException
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_ok_result():
+    r = MagicMock()
+    r.is_success.return_value = True
+    r.success = True
+    r.message = "ok"
+    r.data = None
+    r.metadata = {}
+    return r
+
+
+def make_sync_record_mock():
+    svc = MagicMock()
+    rec = MagicMock()
+    rec.is_success.return_value = True
+    rec.data = {"uuid": "rec-uuid-1"}
+    svc.record_start.return_value = rec
+    return svc
+
+
+def make_codes_result(codes):
+    """构造 list_all_codes 的 ServiceResult 替身"""
+    r = MagicMock()
+    r.is_success.return_value = True
+    r.success = True
+    r.data = codes
+    return r
+
+
+class TestSyncBarsCodesAll:
+    """#5866 AC1: bars sync codes=['all'] 展开为 stockinfo 全表"""
+
+    @pytest.mark.unit
+    def test_codes_all_expands_to_all_stockinfo_codes(self):
+        """codes=['all'] 展开为 stockinfo 全表，对每个 code 调一次 sync_smart
+
+        RED: 当前 codes=['all'] 当字面 'all' 传 sync_smart('all')，
+        不会展开为 stockinfo 全表 code 列表。
+        """
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_bar_svc = MagicMock()
+        mock_bar_svc.sync_smart.return_value = make_ok_result()
+
+        mock_stockinfo_svc = MagicMock()
+        mock_stockinfo_svc.list_all_codes.return_value = make_codes_result(
+            ["000001.SZ", "000002.SZ", "000026.SZ"]
+        )
+
+        request = DataUpdateRequest(type="bars", codes=["all"])
+
+        with patch("api.data.get_bar_service", return_value=mock_bar_svc), \
+                patch("api.data.get_stockinfo_service", return_value=mock_stockinfo_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            try:
+                run_async(sync_data(request))
+            except HTTPException as e:
+                pytest.fail(f"codes=['all'] 应展开并路由成功，却抛 HTTPException: {e.detail}")
+
+        assert mock_bar_svc.sync_smart.call_count == 3
+        called_codes = [call.args[0] for call in mock_bar_svc.sync_smart.call_args_list]
+        assert called_codes == ["000001.SZ", "000002.SZ", "000026.SZ"]
+
+    @pytest.mark.unit
+    def test_codes_all_empty_stockinfo_raises_helpful_error(self):
+        """codes=['all'] 但 stockinfo 表空时报 400，提示先 sync stockinfo"""
+        from api.data import sync_data, DataUpdateRequest
+
+        mock_stockinfo_svc = MagicMock()
+        mock_stockinfo_svc.list_all_codes.return_value = make_codes_result([])
+
+        request = DataUpdateRequest(type="bars", codes=["all"])
+
+        with patch("api.data.get_bar_service"), \
+                patch("api.data.get_stockinfo_service", return_value=mock_stockinfo_svc), \
+                patch("api.data.get_sync_record_service", return_value=make_sync_record_mock()):
+            with pytest.raises(HTTPException) as exc:
+                run_async(sync_data(request))
+
+        assert exc.value.status_code == 400
+        assert "stockinfo" in str(exc.value.detail).lower()

--- a/tests/unit/data/services/test_stockinfo_list_codes.py
+++ b/tests/unit/data/services/test_stockinfo_list_codes.py
@@ -1,0 +1,77 @@
+"""
+#5866: StockinfoService.list_all_codes 单元测试（Mock 依赖）
+
+bars sync 端点 codes=["all"] 需展开为 stockinfo 全表 code 列表，
+此方法提供该展开能力的 service 层入口。
+"""
+
+import sys
+import os
+import pytest
+from unittest.mock import patch, MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path in sys.path:
+    pass
+else:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.stockinfo_service import StockinfoService
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.data.crud.model_conversion import ModelList
+
+
+@pytest.fixture
+def mock_deps():
+    return {
+        "crud_repo": MagicMock(),
+        "data_source": MagicMock(),
+    }
+
+
+@pytest.fixture
+def service(mock_deps):
+    with patch("ginkgo.libs.GLOG"):
+        return StockinfoService(
+            crud_repo=mock_deps["crud_repo"],
+            data_source=mock_deps["data_source"],
+        )
+
+
+class TestListAllCodes:
+    """#5866: list_all_codes 列出 stockinfo 全表 code（供 bars sync codes=['all'] 展开）"""
+
+    @pytest.mark.unit
+    def test_returns_codes_from_all_stockinfo(self, service, mock_deps):
+        """无过滤时返回所有 stockinfo 的 code 列表"""
+        from types import SimpleNamespace
+        # _find_modellist 返回可迭代的 model 列表；list_all_codes 遍历提取 .code
+        mock_deps["crud_repo"].find.return_value = [
+            SimpleNamespace(code="000001.SZ"),
+            SimpleNamespace(code="000002.SZ"),
+            SimpleNamespace(code="000026.SZ"),
+        ]
+
+        result = service.list_all_codes()
+
+        assert result.success is True
+        assert result.data == ["000001.SZ", "000002.SZ", "000026.SZ"]
+
+    @pytest.mark.unit
+    def test_returns_empty_list_when_no_stockinfo(self, service, mock_deps):
+        """stockinfo 表空时返回空列表（非 error），调用方可据此判空"""
+        mock_deps["crud_repo"].find.return_value = []
+
+        result = service.list_all_codes()
+
+        assert result.success is True
+        assert result.data == []
+
+    @pytest.mark.unit
+    def test_returns_error_when_crud_fails(self, service, mock_deps):
+        """crud 异常时返回 ServiceResult.error（不向上抛）"""
+        mock_deps["crud_repo"].find.side_effect = RuntimeError("DB down")
+
+        result = service.list_all_codes()
+
+        assert result.success is False


### PR DESCRIPTION
## Summary

修复 #5866 AC1：bars sync 端点新增 `codes=["all"]` 一键展开为 stockinfo 全表 code，逐个 `sync_smart` 批量同步 K 线。

### 背景

#5866：StockInfo 有 50 只股票，62%（31 只）无 K 线数据。bars sync 端点只接受显式 codes 数组，用户须逐只 `POST {"type":"bars","codes":["000002.SZ"]}`，缺批量机制 → Selector 选中无数据股票时回测失败/零交易。

### 改动

| 文件 | 改动 |
|---|---|
| `stockinfo_service.py` | +`list_all_codes()`：service 层列出 stockinfo 全表 code 入口（基于 `_find_modellist`，空表返空列表，异常返 `ServiceResult.error`） |
| `api/api/data.py` | bars 分支：`codes=["all"]` 展开为 stockinfo 全表 code 后逐个 `sync_smart`；空表报 400 提示先 sync stockinfo |

### 设计要点

- **sentinel 复用**：`codes=["all"]` 复用既有 codes 数组语义，对齐 stockinfo 分支早用 `code="ALL"` 惯例，前端零迁移；比新增 `/sync-all` 端点更内聚
- **分层守恒**：API→Service→CRUD，端点委托 `stockinfo_service.list_all_codes()`，不接触 ORM ModelList（TDD mock 链验证）
- **根因导向报错**：stockinfo 空表时 400 提示「先 sync stockinfo」，把根因（stockinfo 未导入）而非表象（bars 失败）返给用户
- **封禁边界**：逐个 `sync_smart` 复用既有重试 + debug 退避机制（arch_debug_mode_vs_retry_backoff），代码层只提供机制

### AC 范围

- [x] AC1：提供批量 sync 端点（`codes=["all"]` 一键同步所有 stockinfo 股票数据）
- [ ] AC2：StockInfo API 返回数据覆盖状态 — 范围外（运行时 bars 覆盖查询，后续 issue）
- [ ] AC3：ginkgo init 预加载主流指数成分股 — 范围外（init 流程改动，后续 issue）
- [ ] AC4：回测选到无数据股票给明确错误 — 范围外（回测引擎错误处理，后续 issue）

本 PR 聚焦 AC1（用户最痛点批量同步入口），AC2-4 涉及多模块建议拆分后续 issue。

## Test plan

TDD 红-绿循环：
- [x] service 层 `list_all_codes`：返回全表 code / 空表返空 / crud 异常返 error（3 passed）
- [x] 端点 `codes=["all"]` 展开：3 code 各调一次 sync_smart / 空表报 400 含 stockinfo 提示（2 passed）
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud/containers/user_cli）29 passed
- [x] L3a api 组（#5784 回归 + 新）5 passed
- [x] L3b unit 组（stockinfo_service 既有回归 + 新）42 passed 零回归

Closes #5866

🤖 Generated with [Claude Code](https://claude.com/claude-code)
