### PR TITLE
fix(#5476): account _get_user_id 读 user_uuid + fail-closed 抛 401

### DIFF
--- a/api/api/accounts.py
+++ b/api/api/accounts.py
@@ -4,7 +4,7 @@ Live Account 相关API路由
 实盘账号管理接口，对应前端 web-ui/src/api/modules/live.ts
 """
 
-from fastapi import APIRouter, Query, Request, status
+from fastapi import APIRouter, Query, Request, status, HTTPException
 from typing import Optional
 import asyncio
 from core.logging import logger
@@ -36,11 +36,16 @@ def get_live_account_service():
 
 
 def _get_user_id(request: Request) -> str:
-    """从 request.state 获取 user_id"""
-    try:
-        return request.state.user_id
-    except AttributeError:
-        return "default_user"
+    """从 request.state 获取 user_uuid（auth 中间件注入字段）。
+
+    #5476: 之前读 user_id（中间件从不设置）+ fallback "default_user"，
+    致所有 account 操作恒落 default_user。现对齐 user_uuid + fail-closed 抛 401。
+    """
+    user_uuid = getattr(request.state, "user_uuid", None)
+    if not user_uuid:
+        logger.warning("#5476: user_uuid missing on request.state — auth middleware may be absent")
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user_uuid
 
 
 @router.get("/")

--- a/tests/api/test_accounts_api_5476.py
+++ b/tests/api/test_accounts_api_5476.py
@@ -1,0 +1,53 @@
+"""
+#5476: _get_user_id 应读 auth 中间件注入的 user_uuid，缺失时 fail-closed 抛 401
+
+表象: _get_user_id fallback 到 "default_user"。
+根因: auth 中间件注入 request.state.user_uuid（auth.py:128），
+      但 _get_user_id 读 request.state.user_id 字段名不匹配，
+      致所有 account 操作恒落 default_user。
+契约: 缺失 user_uuid → HTTPException(401)；存在 → 返回该 uuid。
+
+注: api/ 非 Python 包（无 __init__.py），经 tests/api/conftest 的 api_modules
+    fixture 临时加入 sys.path，故 import 延迟到测试函数内。
+"""
+
+from unittest.mock import Mock
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_get_user_id_raises_401_when_user_uuid_missing(api_modules):
+    """缺失 user_uuid 时必须 fail-closed 抛 401，不得 fallback default_user。"""
+    from api import accounts as accounts_api
+    from fastapi import HTTPException
+
+    req = Mock()
+    req.state = object()  # 无 user_uuid 属性 → AttributeError
+
+    with pytest.raises(HTTPException) as exc:
+        accounts_api._get_user_id(req)
+    assert exc.value.status_code == 401
+
+
+def test_get_user_id_returns_user_uuid_when_present(api_modules):
+    """存在 user_uuid 时返回该值（与 auth 中间件注入字段对齐）。"""
+    from api import accounts as accounts_api
+
+    req = Mock()
+    req.state = SimpleNamespace(user_uuid="user-abc-123")
+
+    assert accounts_api._get_user_id(req) == "user-abc-123"
+
+
+def test_get_user_id_never_returns_default_user(api_modules):
+    """回归守护：任何缺失场景都不得静默 fallback 到 default_user。"""
+    from api import accounts as accounts_api
+    from fastapi import HTTPException
+
+    req = Mock()
+    req.state = object()  # 无任何用户标识
+
+    # 必须抛 401 而非返回 default_user
+    with pytest.raises(HTTPException):
+        accounts_api._get_user_id(req)


### PR DESCRIPTION
## Summary

修复 #5476：`_get_user_id`（accounts.py）fallback 到 `"default_user"` 而非拒绝请求。

### 根因（比 issue body 描述更严重）

auth 中间件注入 `request.state.user_uuid`（`auth.py:128`），但 `_get_user_id`（`accounts.py:41`）读 `request.state.user_id` —— **字段名不匹配**。中间件从不设 `user_id`，故 `request.state.user_id` **恒** AttributeError → **所有** account 操作 100% 落 `default_user`（非 body 说的「中间件失效时」偶发）。

两层掩盖：(1) 字段名错 (2) AttributeError 被静默 catch 成 `default_user`。

### 改动

| 文件 | 改动 |
|---|---|
| `api/api/accounts.py` | `_get_user_id` 改读 `user_uuid`（与中间件对齐）+ 缺失时 fail-closed 抛 `HTTPException(401)` + 记 warning；补 `HTTPException` import |

### 设计要点

- **字段名对齐**：读 `user_uuid`（中间件 `auth.py:128` 实际注入字段），非 `user_id`。`settings.py:68/336` 已是正确 pattern（`getattr(req.state, "user_uuid", None)`），`accounts.py` 是全仓唯一错配。
- **fail-closed**：缺失身份 → 401 拒绝，不静默 fallback。契合认证原则（身份缺失必须拒绝，不可猜测/默认身份）。
- **audit（AC3）**：全仓 grep `default_user` / `_get_user_id` / `request.state.user_id`，仅 `accounts.py` 一处错配，无其他 `default_user` fallback。

### AC

- [x] Replace `"default_user"` fallback with `HTTPException(status_code=401)`
- [x] Log warning when `user_uuid` not found on `request.state`
- [x] Audit all similar fallback patterns（仅 accounts.py 一处）

## Test plan

TDD 红-绿循环（3 测试 RED→GREEN）：
- [x] 缺失 `user_uuid` → `HTTPException(401)`（不再返 `default_user`）
- [x] 存在 `user_uuid` → 返回该值（与中间件注入对齐）
- [x] 回归守护：任何缺失场景永不返 `default_user`
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud + containers + user_cli）29 passed
- [x] L3 auth 契约（`test_auth_security_batch` + `test_jwt_security`）+ accounts 端到端（`#5789` / `#5782`）42 passed 零回归

Closes #5476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
