### PR TITLE
fix: 统一 CLI 确认标志跨命令一致（-y/--yes） (#6006)

### DIFF
--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -689,7 +689,7 @@ def run(
 @app.command()
 def delete(
     engine_id: str = typer.Argument(..., help="Engine UUID"),
-    confirm: bool = typer.Option(False, "--confirm", help="Confirm deletion"),
+    confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
 ):
     """
     :wastebasket: Delete engine.
@@ -849,7 +849,7 @@ def bind_portfolio(
 def unbind_portfolio(
     engine_id: str = typer.Argument(..., help="Engine UUID or name"),
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID or name"),
-    confirm: bool = typer.Option(False, "--confirm", help="Confirm unbinding"),
+    confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
 ):
     """
     :broken_link: Unbind an engine from a portfolio.

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -429,7 +429,7 @@ def status(
 @app.command()
 def delete(
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID"),
-    confirm: bool = typer.Option(False, "--confirm", help="Confirm deletion"),
+    confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
 ):
     """
     :wastebasket: Delete portfolio.
@@ -614,7 +614,7 @@ def bind_component(
 def unbind_component(
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID or name"),
     file_id: str = typer.Argument(..., help="File UUID or name"),
-    confirm: bool = typer.Option(False, "--confirm", help="Confirm unbinding"),
+    confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
 ):
     """
     :broken_link: Unbind a component from a portfolio.

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -494,6 +494,18 @@ class TestDelete:
 
     @pytest.mark.unit
     @pytest.mark.cli
+    def test_delete_with_yes_short_flag(self, cli_runner):
+        """-y 短标志成功删除（#6006: 统一确认标志跨命令一致）"""
+        svc = _mock_engine_service(delete=ServiceResult.success(data=None))
+
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(engine_cli.app, ["delete", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "-y"])
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.output
+        svc.delete.assert_called_once_with("aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa")
+
+    @pytest.mark.unit
+    @pytest.mark.cli
     def test_delete_missing_confirm(self, cli_runner):
         result = cli_runner.invoke(engine_cli.app, ["delete", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 1
@@ -638,6 +650,39 @@ class TestUnbindPortfolio:
             )
         assert result.exit_code == 0
         assert "deleted successfully" in result.output.lower()
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_unbind_with_yes_short_flag(self, cli_runner):
+        """-y 短标志成功解绑（#6006: 统一确认标志跨命令一致）"""
+        mock_portfolio = MagicMock()
+        mock_portfolio.uuid = "port-uuid"
+        mock_portfolio.name = "TestPortfolio"
+
+        port_model_list = MagicMock()
+        port_model_list.__len__ = MagicMock(return_value=1)
+        port_model_list.__getitem__ = MagicMock(return_value=mock_portfolio)
+
+        portfolio_svc = MagicMock()
+        portfolio_svc.get.return_value = ServiceResult.success(data=port_model_list)
+
+        mapping_svc = MagicMock()
+        mapping_svc.delete_engine_portfolio_mapping.return_value = ServiceResult.success(data=None)
+
+        container = _mock_container(
+            portfolio_service=portfolio_svc,
+            mapping_service=mapping_svc,
+        )
+
+        with patch("ginkgo.data.containers.container", container), \
+             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+            result = cli_runner.invoke(
+                engine_cli.app,
+                ["unbind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid", "-y"],
+            )
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.output.lower()
+        mapping_svc.delete_engine_portfolio_mapping.assert_called_once()
 
     @pytest.mark.unit
     @pytest.mark.cli

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -420,6 +420,20 @@ class TestPortfolioDelete:
         assert result.exit_code == 1
         assert "Failed to delete portfolio" in result.output
 
+    @patch("ginkgo.data.containers.container")
+    def test_delete_with_yes_short_flag(self, mock_container, cli_runner):
+        """使用 -y 短标志成功删除（#6006: 统一确认标志跨命令一致）"""
+        mock_service = MagicMock()
+        mock_service.delete.return_value = ServiceResult.success(data=None)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "delete", "portfolio-uuid-001", "-y"
+        ])
+        assert result.exit_code == 0
+        assert "deleted successfully" in result.output
+        mock_service.delete.assert_called_once_with("portfolio-uuid-001")
+
 
 # ============================================================================
 # 6. Bind/Unbind 测试
@@ -599,6 +613,33 @@ class TestPortfolioUnbindComponent:
         ])
         assert result.exit_code == 0
         assert "binding deleted successfully" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_unbind_with_yes_short_flag(self, mock_container, cli_runner, mock_portfolio):
+        """使用 -y 短标志成功解绑（#6006: 统一确认标志跨命令一致）"""
+        mock_pf_service = MagicMock()
+        mock_pf_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
+
+        mock_file = MagicMock()
+        mock_file.uuid = "file-uuid-001"
+        mock_file.name = "MyStrategy"
+
+        mock_file_service = MagicMock()
+        mock_file_service.get_by_uuid.return_value = ServiceResult.success(data=mock_file)
+
+        mock_mapping_service = MagicMock()
+        mock_mapping_service.delete_portfolio_file_binding.return_value = ServiceResult.success(data=None)
+
+        mock_container.portfolio_service.return_value = mock_pf_service
+        mock_container.file_service.return_value = mock_file_service
+        mock_container.mapping_service.return_value = mock_mapping_service
+
+        result = cli_runner.invoke(portfolio_cli.app, [
+            "unbind-component", "TestPortfolio", "MyStrategy", "-y"
+        ])
+        assert result.exit_code == 0
+        assert "binding deleted successfully" in result.output
+        mock_mapping_service.delete_portfolio_file_binding.assert_called_once()
 
     def test_unbind_missing_confirm(self, cli_runner):
         """缺少 --confirm 时拒绝解绑"""


### PR DESCRIPTION
## Summary

修复 #6006：CLI 确认标志跨命令不一致——4 处命令（portfolio `delete`/`unbind-component`、engine `delete`/`unbind-portfolio`）仅支持 `--confirm`，而 `backtest_cli`、`user_cli`、`group_cli`、`scheduler_cli` 早已统一到 `--yes`/`-y`。用户记忆的 `-y` 在这些命令上失效（typer 报 `No such option: -y`，exit 2）。

### 根因

`confirm: bool = typer.Option(False, "--confirm", ...)` 只声明了一个长名，未跟 `--yes`/`-y` 别名。与已统一的 `backtest_cli:297 typer.Option(False, "--yes", "-y", help="Skip confirmation")` 形态偏离。

### 改动

| 文件 | 命令 | 改动 |
|---|---|---|
| `src/ginkgo/client/portfolio_cli.py` | `delete` (:432) | Option 加 `--yes`/`-y` 别名 + 统一 help "Skip confirmation" |
| `src/ginkgo/client/portfolio_cli.py` | `unbind-component` (:617) | 同上 |
| `src/ginkgo/client/engine_cli.py` | `delete` (:692) | 同上 |
| `src/ginkgo/client/engine_cli.py` | `unbind-portfolio` (:852) | 同上 |

### 设计要点

- **统一形态**：`typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation")`——第一个 `--yes` 是规范名，`-y` 是短标志，`--confirm` **保留向后兼容**（AC2，既有脚本不破）。
- **不删旧标志**：`--confirm` 仍在，所有既有 `--confirm` 测试继续绿（回归守护 4 个既有 `test_*_with_confirm` + 2 个 `test_*_missing_confirm`）。
- **help 文案统一**：从碎片化的 "Confirm deletion/unbinding" 改为 "Skip confirmation"，与 backtest_cli 对齐。

> 注：#6006 body 表格称「scheduler reload 无确认选项」，实测 `scheduler_cli:397` 已有 `--force/-f`（body 滞后于代码），故本 PR 聚焦 4 处真正缺 `-y` 的命令。

### AC

- [x] portfolio/engine 的 delete / unbind 支持 `--yes` 与 `-y`
- [x] 保留 `--confirm` 向后兼容
- [x] help 文案统一为 "Skip confirmation"

## Test plan

TDD 红-绿循环（4 处各一 `-y` 测试，RED `exit_code=2 No such option` → GREEN）：
- [x] portfolio `delete -y` 跳过确认调 service.delete（:432）
- [x] portfolio `unbind-component -y` 跳过确认调 mapping.delete（:617）
- [x] engine `delete -y` 跳过确认调 engine_service.delete（:692）
- [x] engine `unbind-portfolio -y` 跳过确认调 mapping.delete（:852）
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud + containers + user_cli）29 passed
- [x] L3 test_portfolio_cli 35 passed + test_engine_cli 43 passed 零回归（既有 `--confirm`/missing/error 测试全绿）
- 注：test_portfolio_cli 内 `TestGenerateBaselinePagination::test_extracts_task_id_from_paginated_result` 1 失败为 **pre-existing**（`git stash` 回 origin/master 纯净态该测试仍红，与 confirm flag 无关），非本 PR 引入。

Closes #6006

🤖 Generated with [Claude Code](https://claude.com/claude-code)
