### PR TITLE
fix: rate limiter 仅信任可信代理的 X-Forwarded-For (#5475)

### DIFF
--- a/api/middleware/rate_limit.py
+++ b/api/middleware/rate_limit.py
@@ -5,6 +5,7 @@
 from fastapi import Request, HTTPException, status
 from starlette.middleware.base import BaseHTTPMiddleware
 from typing import Dict
+import os
 import time
 
 from core.logging import logger
@@ -14,15 +15,36 @@ _MAX_IPS = 10000
 _FULL_CLEANUP_INTERVAL = 1000
 
 
+def _load_trusted_proxies() -> set:
+    """#5475: 从 TRUSTED_PROXIES 环境变量加载可信反向代理 IP（逗号分隔）。
+
+    部署在 nginx/反向代理后时配置，例如 TRUSTED_PROXIES=10.0.0.1,10.0.0.2。
+    空（默认）= fail-closed，不信任任何 X-Forwarded-For，只用 TCP 直连 IP。
+    """
+    raw = os.environ.get("TRUSTED_PROXIES", "")
+    return {p.strip() for p in raw.split(",") if p.strip()}
+
+
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """基于内存的请求限流中间件（开发环境）"""
 
-    def __init__(self, app, max_requests: int = 100, window_seconds: int = 60):
+    def __init__(
+        self,
+        app,
+        max_requests: int = 100,
+        window_seconds: int = 60,
+        trusted_proxies=None,
+    ):
         super().__init__(app)
         self.max_requests = max_requests
         self.window_seconds = window_seconds
         self.requests: Dict[str, list] = {}
         self._request_count = 0
+        # #5475: 仅直连 IP 属于此集合时才采信 X-Forwarded-For（防伪造绕过限流）。
+        # 默认从 TRUSTED_PROXIES 环境变量读；显式传入（测试）优先。
+        if trusted_proxies is None:
+            trusted_proxies = _load_trusted_proxies()
+        self.trusted_proxies = set(trusted_proxies)
 
     async def dispatch(self, request: Request, call_next):
         client_ip = self.get_client_ip(request)
@@ -44,17 +66,18 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
     def get_client_ip(self, request: Request) -> str:
-        forwarded = request.headers.get("X-Forwarded-For")
-        if forwarded:
-            return forwarded.split(",")[0].strip()
-
-        real_ip = request.headers.get("X-Real-IP")
-        if real_ip:
-            return real_ip
-
-        if request.client:
-            return request.client.host
-
+        # #5475: 先取 TCP 直连 IP，仅当它来自可信反向代理时才采信 XFF/X-Real-IP
+        # 头（这些头可被任意客户端伪造）；否则用直连 IP（fail-closed，不可伪造）。
+        direct_ip = request.client.host if request.client else None
+        if direct_ip and direct_ip in self.trusted_proxies:
+            forwarded = request.headers.get("X-Forwarded-For")
+            if forwarded:
+                return forwarded.split(",")[0].strip()
+            real_ip = request.headers.get("X-Real-IP")
+            if real_ip:
+                return real_ip.strip()
+        if direct_ip:
+            return direct_ip
         return "unknown"
 
     def is_rate_limited(self, client_ip: str) -> bool:

--- a/tests/api/test_rate_limit_xff_5475.py
+++ b/tests/api/test_rate_limit_xff_5475.py
@@ -1,0 +1,100 @@
+# Issue: #5475
+# Upstream: middleware.rate_limit (RateLimitMiddleware.get_client_ip)
+# Role: rate limiter X-Forwarded-For 信任校验测试——仅可信代理直连才采信 XFF
+
+"""
+rate limiter X-Forwarded-For 信任校验测试 (#5475)。
+
+#5475 根因：middleware/rate_limit.py get_client_ip 无条件信任 X-Forwarded-For /
+X-Real-IP 头，不校验 request.client.host（TCP 直连 IP）是否可信反向代理。
+攻击者轮换伪造 XFF 头绕过限流（每伪造 IP 独立配额）。
+
+修复：__init__ 加 trusted_proxies 参数（默认从 TRUSTED_PROXIES 环境变量读，
+逗号分隔）。get_client_ip 仅当直连 IP ∈ trusted_proxies 才采信 XFF/X-Real-IP，
+否则用直连 IP（fail-closed，不可伪造）。
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _make_request(xff=None, x_real_ip=None, client_host=None):
+    """构造 Request mock：headers + client.host（TCP 直连 IP）。"""
+    headers = {}
+    if xff is not None:
+        headers["X-Forwarded-For"] = xff
+    if x_real_ip is not None:
+        headers["X-Real-IP"] = x_real_ip
+    client = SimpleNamespace(host=client_host) if client_host else None
+    return SimpleNamespace(headers=headers, client=client)
+
+
+def _make_middleware(trusted_proxies=None):
+    """构造 RateLimitMiddleware 实例（app 用 mock，不触发 dispatch）。"""
+    from middleware.rate_limit import RateLimitMiddleware
+
+    return RateLimitMiddleware(app=MagicMock(), trusted_proxies=trusted_proxies)
+
+
+class TestGetClientIpXffTrust:
+    """#5475: get_client_ip 仅在直连来自可信代理时才采信 XFF。"""
+
+    def test_direct_ip_used_when_no_trusted_proxies(self, api_modules):
+        """无可信代理（默认空）→ XFF 被忽略，用直连 IP（fail-closed）。"""
+        m = _make_middleware(trusted_proxies=set())
+        req = _make_request(xff="1.2.3.4", client_host="10.0.0.5")
+        assert m.get_client_ip(req) == "10.0.0.5"
+
+    def test_xff_trusted_when_from_trusted_proxy(self, api_modules):
+        """直连来自可信代理 → XFF 被采信（取最左客户端 IP）。"""
+        m = _make_middleware(trusted_proxies={"10.0.0.1"})
+        req = _make_request(xff="203.0.113.5", client_host="10.0.0.1")
+        assert m.get_client_ip(req) == "203.0.113.5"
+
+    def test_xff_ignored_when_from_untrusted(self, api_modules):
+        """直连非可信代理 → XFF 被忽略，用直连 IP（防伪造绕过）。"""
+        m = _make_middleware(trusted_proxies={"10.0.0.1"})
+        req = _make_request(xff="1.2.3.4", client_host="203.0.113.9")
+        assert m.get_client_ip(req) == "203.0.113.9"
+
+    def test_x_real_ip_trusted_when_from_trusted_proxy(self, api_modules):
+        """直连可信代理 + 无 XFF 有 X-Real-IP → 采信 X-Real-IP。"""
+        m = _make_middleware(trusted_proxies={"10.0.0.1"})
+        req = _make_request(x_real_ip="203.0.113.7", client_host="10.0.0.1")
+        assert m.get_client_ip(req) == "203.0.113.7"
+
+    def test_unknown_when_no_client(self, api_modules):
+        """无 client（无直连信息）→ 'unknown'。"""
+        m = _make_middleware(trusted_proxies=set())
+        req = _make_request(xff="1.2.3.4", client_host=None)
+        assert m.get_client_ip(req) == "unknown"
+
+    def test_xff_first_ip_taken_from_chain(self, api_modules):
+        """XFF 多跳链 'client, proxy1' → 取最左（真实客户端）。"""
+        m = _make_middleware(trusted_proxies={"10.0.0.1"})
+        req = _make_request(xff="203.0.113.5, 10.0.0.2", client_host="10.0.0.1")
+        assert m.get_client_ip(req) == "203.0.113.5"
+
+
+class TestLoadTrustedProxies:
+    """#5475: TRUSTED_PROXIES 环境变量解析。"""
+
+    def test_parses_comma_separated_env(self, api_modules, monkeypatch):
+        """逗号分隔的 env → set（去空白、去空段）。"""
+        monkeypatch.setenv("TRUSTED_PROXIES", "10.0.0.1, 10.0.0.2 ,10.0.0.3")
+        from middleware.rate_limit import _load_trusted_proxies
+
+        assert _load_trusted_proxies() == {"10.0.0.1", "10.0.0.2", "10.0.0.3"}
+
+    def test_empty_env_returns_empty_set(self, api_modules, monkeypatch):
+        """env 未设/空 → 空 set（fail-closed）。"""
+        monkeypatch.delenv("TRUSTED_PROXIES", raising=False)
+        from middleware.rate_limit import _load_trusted_proxies
+
+        assert _load_trusted_proxies() == set()
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

修复 #5475：rate limiter 的 `get_client_ip` 无条件信任 `X-Forwarded-For` / `X-Real-IP` 头，不校验请求是否来自可信反向代理。攻击者轮换伪造 XFF 头（`X-Forwarded-For: 1.2.3.{N}`）即可绕过限流——每个伪造 IP 获得独立配额。

### 根因（调用链分析）

**表象**：攻击者发 200 请求/60s，每次带不同 `X-Forwarded-For: 1.2.3.{N}`，全部通过（每个伪造 IP 独立 100req/60s 桶）。

**调用链**：
```
request → RateLimitMiddleware.dispatch
  → get_client_ip(request)
    → 无条件 headers["X-Forwarded-For"].split(",")[0]  # 💥 不校验来源
    → 返回伪造 IP
  → record_request(伪造 IP)  # 独立桶，配额独立
```

**根因**：`get_client_ip`（`api/middleware/rate_limit.py`）不校验 `request.client.host`（TCP 直连 IP，socket 层不可伪造）是否可信反向代理，无条件信任任何客户端可伪造的 HTTP 头。

**修复点**：仅当 TCP 直连 IP ∈ `TRUSTED_PROXIES` 时才采信 XFF/X-Real-IP，否则用直连 IP（fail-closed）。

### 改动

| 文件 | 改动 |
|---|---|
| `api/middleware/rate_limit.py` | 加 `import os` + `_load_trusted_proxies()` 模块函数；`__init__` 加 `trusted_proxies` 参数（默认从 `TRUSTED_PROXIES` env 读，逗号分隔）；`get_client_ip` 改 fail-closed 逻辑 |
| `tests/api/test_rate_limit_xff_5475.py` | 新建 8 测试（2 类）：`get_client_ip` 6 分支 + `_load_trusted_proxies` env 解析 2 测试 |

### 设计要点

- **fail-closed 默认**：`trusted_proxies` 默认空集 = 永不信任 XFF，永远用 TCP 直连 IP。单机开发环境（无反向代理）直连 IP == 客户端 IP，行为等价；部署到 nginx 后才需配 `TRUSTED_PROXIES=nginx_ip` 显式信任。空 set 而非 `None`，避免 `in` 操作 TypeError。
- **TCP 直连 IP 不可伪造**：`request.client.host` 是 socket 层对端地址（TCP 三次握手建立），攻击者无法在 HTTP 层伪造。XFF 是应用层 header，任意 curl 可加。校验顺序：先信直连，仅对可信代理降级信 XFF。
- **XFF 多跳链**：`X-Forwarded-For: client, proxy1, proxy2` 取最左（真实客户端声明值），单层反向代理下正确。
- **环境变量配置**（非 pydantic settings）：部署友好（docker `-e`）+ 规避 core/config 模块级实例化 import 风险 + 最小改动面。
- **向后兼容**：`__init__` 加可选参数 `trusted_proxies=None`，`main.py:95 add_middleware(RateLimitMiddleware)` 无参数调用仍工作（L2 启动路径 smoke 验证）。

### AC

- [x] 加 TRUSTED_PROXIES 配置（环境变量，逗号分隔）
- [x] 仅可信代理时读 X-Forwarded-For
- [x] 直连 IP 用作 fallback（fail-closed）
- [x] 文档代理配置要求（`_load_trusted_proxies` docstring 说明部署用法）

## Test plan

TDD 红-绿循环（`tests/api/test_rate_limit_xff_5475.py`）：

**`get_client_ip` 分支**：
- [x] test_direct_ip_used_when_no_trusted_proxies — 默认空，XFF 忽略用直连
- [x] test_xff_trusted_when_from_trusted_proxy — 直连可信代理，XFF 采信
- [x] test_xff_ignored_when_from_untrusted — 直连非可信，XFF 忽略用直连
- [x] test_x_real_ip_trusted_when_from_trusted_proxy — 直连可信，无 XFF 用 X-Real-IP
- [x] test_unknown_when_no_client — 无 client → "unknown"
- [x] test_xff_first_ip_taken_from_chain — 多跳链取最左客户端

**`_load_trusted_proxies` env 解析**：
- [x] test_parses_comma_separated_env — 逗号分隔去空白
- [x] test_empty_env_returns_empty_set — 空 env → 空 set

**三层冒烟（对齐 `.github/workflows/ci.yml`）**：
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud_mock + containers + user_cli）29 passed（验证 main.py 无参数挂载兼容）
- [x] L3 test_rate_limit_xff_5475 8 passed

Closes #5475

🤖 Generated with [Claude Code](https://claude.com/claude-code)
