### PR TITLE
fix(#5468): 实盘账户 get/update/delete 端点加 ownership 校验防越权

### DIFF
--- a/api/api/accounts.py
+++ b/api/api/accounts.py
@@ -43,6 +43,19 @@ def _get_user_id(request: Request) -> str:
         return "default_user"
 
 
+def _require_account_ownership(account_data: dict, user_id: str) -> None:
+    """#5468: 校验实盘账户归属，非 owner 抛 BusinessError(code=403)。
+
+    防止任意登录用户读/改/删他人实盘账户。account_data 来自
+    service.get_account_by_uuid 的 to_dict()（含 user_id，已脱敏无 api_secret）。
+    用 BusinessError(code=403) 而非 HTTPException——status_code 经
+    APIError ``status_code = status_code or code`` 自动映射 403，穿透端点既有
+    ``except (NotFoundError, BusinessError): raise`` 链（见 arch_httpexception_caught_by_except）。
+    """
+    if not isinstance(account_data, dict) or account_data.get("user_id") != user_id:
+        raise BusinessError("无权访问该实盘账户", code=403)
+
+
 @router.get("/")
 async def list_accounts(
     request: Request,
@@ -106,17 +119,19 @@ async def create_account(request: Request, data: CreateLiveAccountRequest):
 
 
 @router.get("/{account_id}")
-async def get_account(account_id: str):
+async def get_account(account_id: str, request: Request):
     """获取实盘账号详情"""
     try:
         service = get_live_account_service()
         result = service.get_account_by_uuid(account_id)
 
-        if not result["success"]:
+        if not result["success"] or not result.get("data"):
             raise NotFoundError("Account", account_id)
 
+        _require_account_ownership(result["data"], _get_user_id(request))
+
         return ok(data=result["data"], message="Account retrieved successfully")
-    except NotFoundError:
+    except (NotFoundError, BusinessError):
         raise
     except Exception as e:
         logger.error(f"Error getting account {account_id}: {e}")
@@ -124,10 +139,16 @@ async def get_account(account_id: str):
 
 
 @router.put("/{account_id}")
-async def update_account(account_id: str, data: UpdateLiveAccountRequest):
+async def update_account(account_id: str, data: UpdateLiveAccountRequest, request: Request):
     """更新实盘账号信息"""
     try:
         service = get_live_account_service()
+
+        # #5468: ownership 前置——非 owner 改他人实盘账户 → BusinessError(403)
+        existing = service.get_account_by_uuid(account_id)
+        if not existing["success"] or not existing.get("data"):
+            raise NotFoundError("Account", account_id)
+        _require_account_ownership(existing["data"], _get_user_id(request))
 
         result = service.update_account(
             account_uuid=account_id,
@@ -151,17 +172,24 @@ async def update_account(account_id: str, data: UpdateLiveAccountRequest):
 
 
 @router.delete("/{account_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_account(account_id: str):
+async def delete_account(account_id: str, request: Request):
     """删除实盘账号（软删除）"""
     try:
         service = get_live_account_service()
+
+        # #5468: ownership 前置——非 owner 删他人实盘账户 → BusinessError(403)
+        existing = service.get_account_by_uuid(account_id)
+        if not existing["success"] or not existing.get("data"):
+            raise NotFoundError("Account", account_id)
+        _require_account_ownership(existing["data"], _get_user_id(request))
+
         result = service.delete_account(account_id)
 
         if not result["success"]:
             raise NotFoundError("Account", account_id)
 
         logger.info(f"Account {account_id} deleted successfully")
-    except NotFoundError:
+    except (NotFoundError, BusinessError):
         raise
     except Exception as e:
         logger.error(f"Error deleting account {account_id}: {e}")

--- a/tests/api/test_accounts_api_5789.py
+++ b/tests/api/test_accounts_api_5789.py
@@ -10,6 +10,7 @@ fixture 临时加入 sys.path, 故 import 须延迟到测试函数内。
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -22,6 +23,11 @@ def test_put_account_handler_passes_status(api_modules, monkeypatch):
     from models.accounts import UpdateLiveAccountRequest, AccountStatus
 
     mock_service = Mock()
+    # #5468: ownership 前置校验先经 get_account_by_uuid 查归属
+    mock_service.get_account_by_uuid.return_value = {
+        "success": True,
+        "data": {"uuid": "test-uuid", "user_id": "test-user"},
+    }
     mock_service.update_account.return_value = {
         "success": True,
         "data": {"uuid": "test-uuid"},
@@ -31,7 +37,9 @@ def test_put_account_handler_passes_status(api_modules, monkeypatch):
 
     # model 必须接受 status 字段（#5789 修复后）
     data = UpdateLiveAccountRequest(status=AccountStatus.ENABLED)
-    asyncio.run(accounts_api.update_account("test-uuid", data))
+    # #5468: 端点新增 request 参数（ownership 校验需 request.state.user_id）
+    req = SimpleNamespace(state=SimpleNamespace(user_id="test-user"))
+    asyncio.run(accounts_api.update_account("test-uuid", data, req))
 
     # handler 必须把 status 透传给 service
     mock_service.update_account.assert_called_once()

--- a/tests/api/test_accounts_ownership_5468.py
+++ b/tests/api/test_accounts_ownership_5468.py
@@ -1,0 +1,129 @@
+"""#5468: 实盘账户 CRUD 端点 ownership 校验。
+
+get_account/update_account/delete_account 三端点此前按 UUID 直接操作，
+任意登录用户可读/改/删他人实盘账户（含脱敏前可能接触的凭据）。
+本测试验证端点层 ownership 校验：非 owner → BusinessError(403)，owner 正常。
+
+绕过 TestClient（arch_api_test_root_main_shadow）：直接 asyncio.run 端点，
+req 用 SimpleNamespace 模拟 JWT 中间件注入 request.state.user_id。
+"""
+import asyncio
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from api.accounts import (
+    get_account,
+    update_account,
+    delete_account,
+    _require_account_ownership,
+)
+from core.exceptions import BusinessError
+
+
+def _make_req(user_id):
+    """模拟 JWT 中间件注入的 request.state.user_id（accounts 模块语义）。"""
+    return SimpleNamespace(state=SimpleNamespace(user_id=user_id))
+
+
+def _mock_account_data(owner_id, uuid="acc-1"):
+    """service.get_account_by_uuid 返回 result['data']（to_dict，含 user_id）。"""
+    return {
+        "uuid": uuid,
+        "user_id": owner_id,
+        "exchange": "SIM",
+        "name": "test-account",
+        "status": "ACTIVE",
+    }
+
+
+def _patch_service(get_data=None, update_data=None, delete_success=True):
+    """配置 mock live_account_service。
+
+    get_data: get_account_by_uuid 返回的 data（None=not found）
+    update_data: update_account 返回的 data
+    delete_success: delete_account 是否成功
+
+    用 @contextmanager yield svc，使 ``with _patch_service(...) as svc:`` 绑定
+    端点实际调用的 service mock（而非 get_live_account_service 工厂 mock），
+    断言 svc.xxx 才对应端点内 ``service.xxx`` 调用。
+    """
+    svc = MagicMock()
+    get_result = {"success": bool(get_data), "data": get_data}
+    update_result = {"success": bool(update_data), "data": update_data}
+    delete_result = {"success": delete_success, "data": None}
+    svc.get_account_by_uuid.return_value = get_result
+    svc.update_account.return_value = update_result
+    svc.delete_account.return_value = delete_result
+
+    @contextmanager
+    def _cm():
+        with patch("api.accounts.get_live_account_service", return_value=svc):
+            yield svc
+
+    return _cm()
+
+
+class TestRequireAccountOwnership:
+    """#5468 helper: 校验 account 归属。"""
+
+    def test_non_owner_raises_business_error_403(self):
+        """非 owner → BusinessError(code=403, status_code=403)。"""
+        account = _mock_account_data(owner_id="owner-x")
+        with pytest.raises(BusinessError) as exc:
+            _require_account_ownership(account, "attacker-y")
+        assert exc.value.status_code == 403
+
+    def test_owner_passes_without_raising(self):
+        """owner → 不抛。"""
+        account = _mock_account_data(owner_id="owner-x")
+        _require_account_ownership(account, "owner-x")  # 不抛即通过
+
+
+class TestGetAccountEndpointOwnership:
+    """get_account 端点接线 ownership 校验（#5468 AC1/AC2）。"""
+
+    def test_non_owner_forbidden(self):
+        """非 owner 请求他人账户 → BusinessError(403)，不返回数据。"""
+        account = _mock_account_data(owner_id="owner-x")
+        with _patch_service(get_data=account):
+            with pytest.raises(BusinessError) as exc:
+                asyncio.run(get_account("acc-1", _make_req("attacker-y")))
+        assert exc.value.status_code == 403
+
+    def test_owner_retrieves_account(self):
+        """owner → 不抛 403，正常返回。"""
+        account = _mock_account_data(owner_id="owner-x")
+        with _patch_service(get_data=account) as svc:
+            resp = asyncio.run(get_account("acc-1", _make_req("owner-x")))
+        svc.get_account_by_uuid.assert_called_once_with("acc-1")
+        assert resp is not None
+
+
+class TestUpdateAccountEndpointOwnership:
+    """update_account 端点接线 ownership 校验（#5468 AC1/AC2）。"""
+
+    def test_non_owner_forbidden_no_mutation(self):
+        """非 owner 改他人账户 → 403，且 service.update_account 不被调用。"""
+        account = _mock_account_data(owner_id="owner-x")
+        data = MagicMock(name="UpdateLiveAccountRequest")
+        with _patch_service(get_data=account) as svc:
+            with pytest.raises(BusinessError) as exc:
+                asyncio.run(update_account("acc-1", data, _make_req("attacker-y")))
+        assert exc.value.status_code == 403
+        svc.update_account.assert_not_called()
+
+
+class TestDeleteAccountEndpointOwnership:
+    """delete_account 端点接线 ownership 校验（#5468 AC1/AC2）。"""
+
+    def test_non_owner_forbidden_no_deletion(self):
+        """非 owner 删他人账户 → 403，且 service.delete_account 不被调用。"""
+        account = _mock_account_data(owner_id="owner-x")
+        with _patch_service(get_data=account) as svc:
+            with pytest.raises(BusinessError) as exc:
+                asyncio.run(delete_account("acc-1", _make_req("attacker-y")))
+        assert exc.value.status_code == 403
+        svc.delete_account.assert_not_called()


### PR DESCRIPTION
## Summary

修复 #5468：实盘账户 CRUD 的 `get_account`/`update_account`/`delete_account` 三端点按 UUID 直接操作，不校验请求者归属，任意登录用户可读/改/删他人实盘账户（含 API 凭证接触面）。

### 根因调用链

**表象**：三端点接受任意 `account_id` 直接操作。
**调用链**（`api/api/accounts.py`）：
- `list_accounts(request)` → `_get_user_id(request)` → `service.get_user_accounts(user_id=...)` ✅ 已过滤
- `create_account(request, data)` → `_get_user_id(request)` → `service.create_account(user_id=...)` ✅ 已绑定
- `get_account(account_id)` → `service.get_account_by_uuid(account_id)` ❌ 无 user_id 校验
- `update_account(account_id, data)` → `service.update_account(account_uuid=...)` ❌
- `delete_account(account_id)` → `service.delete_account(account_id)` ❌

**根因**：list/create 端点已用 `_get_user_id(request)` 辅助（:38）并传 user_id 给 service 过滤，模式已确立；但 get/update/delete 三端点签名无 `request: Request`，直接按 UUID 操作。`ModelLiveAccount.user_id`（model_live_account.py:50，`nullable=False`）是 ownership 判定依据，前提成立。

### 改动

| 文件 | 改动 |
|---|---|
| `api/api/accounts.py` | 新增 `_require_account_ownership(account_data, user_id)` helper（:46，非 owner → `BusinessError(code=403)`）；`get_account`/`update_account`/`delete_account` 三端点签名加 `request: Request` + 调用前置 ownership 校验；`delete_account` 的 except 链补 `BusinessError` 透传 |
| `tests/api/test_accounts_ownership_5468.py` | 新建，6 测试（helper 2 + get/update/delete 端点接线 4） |
| `tests/api/test_accounts_api_5789.py` | 适配新签名（补 `request` 参数 + `get_account_by_uuid` mock 配合 ownership 前置），核心断言（status 透传）不变 |

### 设计要点

- **`BusinessError(code=403)` 而非 `HTTPException(403)`**：`APIError.status_code = status_code or code`（api/core/exceptions.py:31）短路求值，只传 code 即自动映射 HTTP 403；BusinessError 是 APIError 子类，端点既有 `except (NotFoundError, BusinessError): raise` 链零改动即可穿透 403。对比 `HTTPException` 会被 `except Exception` 吞成 500（arch_httpexception_caught_by_except），本方案更干净。
- **校验在端点层**：`service.get_account_by_uuid` 通用（balance/positions/validate 等多处调用），端点层 ownership 聚焦 HTTP 访问控制，不污染 service/CRUD（守分层边界）。
- **AC3 数据层已满足**：`MLiveAccount.to_dict()`（model_live_account.py:132-152）仅返回 uuid/user_id/exchange/name/status 等非敏感字段，**不含** `api_key`/`api_secret`/`passphrase`；叠加非 owner 403 拦截，keys 永不泄露给非 owner（owner 自己也只拿脱敏数据）。
- **`_get_user_id(request)` 取 `request.state.user_id`**：accounts 模块用 user_id 语义（与 ModelLiveAccount.user_id 字段一致），非 settings 模块的 user_uuid；复用既有 helper，零新依赖。

### AC

- [x] get/update/delete 三端点校验 ownership（`account.user_id == 请求者 user_id`）
- [x] 非 owner → 403（`BusinessError(code=403)` → HTTP 403）
- [x] API keys/secrets 不返回给非 owner（to_dict 已脱敏 + 非 owner 403 前置拦截）

## Test plan

TDD 红-绿循环（vertical slices，6 测试）：
- [x] helper 非 owner → BusinessError(403)（status_code 断言）
- [x] helper owner → 不抛
- [x] get_account 非 owner → 403
- [x] get_account owner → 正常返回
- [x] update_account 非 owner → 403 + `service.update_account` 不被调用
- [x] delete_account 非 owner → 403 + `service.delete_account` 不被调用
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud_mock + containers + user_cli）29 passed
- [x] L3 accounts 端点测试 11 passed（新建 6 + 既有 5789/5782 适配，零回归）
- [x] 既有 `test_accounts_api_5789.py::test_put_account_handler_passes_status` 适配新签名（补 request + ownership 前置 mock），status 透传断言保留

Closes #5468

🤖 Generated with [Claude Code](https://claude.com/claude-code)
