### PR TITLE
fix: Paper Trading start 端点废弃为 410 Gone + 迁移指引 (#5860)

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -291,44 +291,20 @@ async def get_paper_account(account_id: str):
         raise BusinessError(f"Error getting paper account: {str(e)}")
 
 
-@router.post("/{account_id}/start", deprecated=True)
+@router.post("/{account_id}/start", deprecated=True, status_code=410)
 async def start_paper_trading(account_id: str, data: StartPaperTradingRequest = None):
-    """[DEPRECATED] Use POST /api/v1/portfolios/{uuid}/start instead"""
-    try:
-        from ginkgo.messages.control_command import ControlCommand
-        from ginkgo.interfaces.kafka_topics import KafkaTopics
+    """[DEPRECATED] 此端点已废弃，请使用 POST /api/v1/portfolios/{uuid}/start
 
-        # 验证 portfolio 存在
-        portfolio = _require_portfolio(account_id)
-        # #6095 review: _require_portfolio 经 PortfolioService.get → _crud_repo.find 返回 list，
-        # 与 get_paper_account(L258) 一致地解包取首元素，否则 _map_pt_status 收到 list → 恒为 "error"
-        if isinstance(portfolio, list):
-            portfolio = portfolio[0]
-
-        # 发送 Kafka deploy 命令
-        producer = _get_kafka_producer()
-        cmd = ControlCommand.deploy(account_id)
-        success = producer.send(KafkaTopics.CONTROL_COMMANDS, cmd.to_dict())
-
-        if not success:
-            raise BusinessError("Failed to send deploy command via Kafka")
-
-        logger.info(f"Start paper trading command sent for {account_id}")
-
-        # #5401: 即发即忘——Kafka 命令已投递，但 worker 异步处理，状态不会立即变
-        # RUNNING。返回当前真实状态 + 诚实消息，避免前端误以为已启动。
-        return ok(
-            data={"success": True, "current_status": _map_pt_status(portfolio)},
-            message="Deploy command sent. Worker starts asynchronously; status will update shortly."
-        )
-
-    except NotFoundError:
-        raise
-    except BusinessError:
-        raise
-    except Exception as e:
-        logger.error(f"Error starting paper trading {account_id}: {str(e)}")
-        raise BusinessError(f"Error starting paper trading: {str(e)}")
+    原 Kafka ControlCommand.deploy 投递到 CONTROL_COMMANDS topic，但 worker 只消费
+    DATA_COMMANDS（worker.py:31 数据采集专用），topic 不匹配无消费者，命令发出后无人
+    处理，账户状态永不变。改返回 410 Gone + 迁移指引（#5860 A 方案）。「真启动引擎」
+    需 worker 改消费 CONTROL_COMMANDS，属基础设施改造，新旧端点同受影响，超本端点范围。
+    """
+    raise BusinessError(
+        "POST /api/v1/paper-trading/{account_id}/start is deprecated and no longer functional. "
+        "Use POST /api/v1/portfolios/{uuid}/start instead.",
+        code=410,
+    )
 
 
 @router.post("/{account_id}/stop", deprecated=True)

--- a/tests/api/test_paper_trading_start_deprecated_5860.py
+++ b/tests/api/test_paper_trading_start_deprecated_5860.py
@@ -1,0 +1,48 @@
+# Issue: #5860
+# Upstream: api.api.trading, api.core.exceptions
+# Downstream: pytest
+# Role: Paper Trading start 端点废弃治理 — 410 Gone + 迁移指引 + 移除无效 Kafka 投递
+
+"""
+Paper Trading start 端点废弃测试
+
+根因：POST /api/v1/paper-trading/{account_id}/start 标 @deprecated 仍暴露 OpenAPI，
+发 Kafka ControlCommand.deploy 到 CONTROL_COMMANDS topic，但 worker.py:31 只消费
+DATA_COMMANDS（数据采集专用），topic 不匹配无消费者 → 命令发出后无人处理，账户状态
+永不变。端点返回 200/{success:true} 误导用户。
+
+修复（A 方案，#5860 验收）：废弃端点改 raise BusinessError(code=410)，移除无效 Kafka
+投递，message 含迁移指引（POST /api/v1/portfolios/{uuid}/start）。「真启动引擎」需
+worker 改消费 CONTROL_COMMANDS（基础设施改造，新旧端点同受影响，超本端点范围）。
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+@pytest.mark.asyncio
+async def test_start_is_deprecated_returns_410_no_kafka_with_migration(monkeypatch):
+    """#5860 AC1+AC2: 废弃 start 端点必须 (1) 返 410 Gone 非 200/success:true,
+    (2) 不再发无效 Kafka 投递（CONTROL_COMMANDS 无消费者）, (3) message 含迁移指引。
+    """
+    from api.trading import start_paper_trading
+    from core.exceptions import BusinessError
+
+    # 即便 _get_kafka_producer 被调用（废弃后不应被调用），也注入 mock 以断言不发
+    fake_producer = MagicMock()
+    monkeypatch.setattr("api.trading._get_kafka_producer", lambda: fake_producer)
+
+    with pytest.raises(BusinessError) as exc_info:
+        await start_paper_trading("acct-deprecated-1")
+
+    # AC1: 410 Gone（不再 200/success:true 误导）
+    assert exc_info.value.code == 410
+    assert exc_info.value.status_code == 410
+
+    # 废弃端点不再发无效 Kafka 投递（CONTROL_COMMANDS 无 worker 消费）
+    fake_producer.send.assert_not_called()
+
+    # AC2: message 含迁移指引（新端点路径）
+    msg = str(exc_info.value.message)
+    assert "/portfolios/" in msg, "410 响应必须指向新端点 /portfolios/{uuid}/start"
+    assert "start" in msg

--- a/tests/api/test_paper_trading_status.py
+++ b/tests/api/test_paper_trading_status.py
@@ -64,39 +64,6 @@ class TestMapPtStatus:
         assert _map_pt_status(SimpleNamespace(state=running_int)) == "running"
 
 
-class TestStartReturnsCurrentStatus:
-    """#5401: start 即发即忘，返回必须含当前真实状态，避免前端误判已启动"""
-
-    def test_start_returns_current_status_not_running(self, monkeypatch):
-        """worker 尚未处理 deploy，state 仍 INITIALIZED；返回应诚实反映 stopped，而非假装 running"""
-        import asyncio
-        from api import trading
-        from ginkgo.enums import PORTFOLIO_RUNSTATE_TYPES
-
-        portfolio = SimpleNamespace(uuid="acc-1",
-                                    state=PORTFOLIO_RUNSTATE_TYPES.INITIALIZED)
-
-        # #6095 review: 真实 PortfolioService.get 经 _crud_repo.find 返回的是 list，
-        # FakeResult.data 必须是 list 形状，否则测试退化成"测 mock"而非"测生产契约"。
-        # 旧实现 FakeResult.data = portfolio（单对象）掩盖了 start 端点未解包 list 的 bug。
-        class FakeResult:
-            data = [portfolio]
-            def is_success(self): return True
-
-        class FakeSvc:
-            def get(self, portfolio_id): return FakeResult()
-
-        class FakeProducer:
-            def send(self, *a, **k): return True
-
-        monkeypatch.setattr(trading, "_get_portfolio_service", lambda: FakeSvc())
-        monkeypatch.setattr(trading, "_get_kafka_producer", lambda: FakeProducer())
-
-        resp = asyncio.run(trading.start_paper_trading("acc-1", None))
-
-        assert resp["code"] == 0
-        assert resp["data"]["success"] is True
-        # 关键：current_status 反映 DB 真实状态（INITIALIZED→stopped），非误导性 "running"
-        assert resp["data"]["current_status"] == "stopped"
-        # 消息必须诚实说明异步性，不再宣称"已启动"
-        assert "asynchronously" in resp["message"].lower()
+# #5860 取代 #5401 对 start 端点的处理：端点废弃为 410 Gone（原 success+current_status
+# 返回行为已移除）。start 废弃语义测试迁移至 test_paper_trading_start_deprecated_5860.py。
+# TestMapPtStatus（_map_pt_status 映射）保留——仍用于 get/list 端点（#5392 未受 #5860 影响）。


### PR DESCRIPTION
## Summary

修复 #5860：Paper Trading `POST /api/v1/paper-trading/{account_id}/start` 端点标记 `@deprecated` 仍暴露 OpenAPI，调用后返回 `{success: true}` 但账户状态永不变。

### 根因调用链

**表象**：start 返回 success:true，但账户 status 始终 stopped。
**调用链**：`start_paper_trading` → `producer.send(KafkaTopics.CONTROL_COMMANDS, deploy)` → ⚠️ **无 worker 消费**
**根因**：`worker.py:31` 的 `CONTROL_COMMANDS_TOPIC = KafkaTopics.DATA_COMMANDS`（数据采集专用），worker 只消费 `DATA_COMMANDS`，**与 start/stop 端点投递的 `CONTROL_COMMANDS` topic 不匹配**，命令发出后无消费者处理，账户状态永不变。端点返回 `200/{success:true}` 误导用户以为已启动。
**影响范围**：新旧端点同受影响——`POST /portfolios/{uuid}/start`（portfolio.py:507）同样投递 `CONTROL_COMMANDS`，也依赖未接线的消费者。这是基础设施缺口（worker topic 接线），非单端点能修。

### 改动（A 方案：废弃 → 410 Gone）

issue 验收给了两个方案，「真启动引擎」需 worker 改消费 `CONTROL_COMMANDS`（基础设施改造，可能触实盘交易链路安全阀），超本端点范围。选 **A 方案**——废弃旧端点为 410 Gone + 迁移指引：

| 文件 | 改动 |
|---|---|
| `api/api/trading.py` | `start_paper_trading` 改 `raise BusinessError(code=410)` + 迁移指引 message（指向 `POST /api/v1/portfolios/{uuid}/start`）；移除无效 Kafka 投递（`_require_portfolio`/`_get_kafka_producer`/`ControlCommand.deploy`）；`@router.post(..., status_code=410)` 声明 OpenAPI 410 |
| `tests/api/test_paper_trading_start_deprecated_5860.py` | 新建，1 测试覆盖完整废弃语义（410 code/status + 不调 producer.send + message 含迁移路径） |
| `tests/api/test_paper_trading_status.py` | 删除 `TestStartReturnsCurrentStatus`（#5401 测的 success+current_status 返回行为已被废弃移除）；保留 `TestMapPtStatus`（`_map_pt_status` 仍用于 get/list 端点，#5392 未受影响） |

### 设计要点

- **`BusinessError(code=410)` 而非 `HTTPException(410)`**：`APIError.__init__` 的 `status_code = status_code or code` 短路映射 410→HTTP 410；BusinessError 是 APIError 子类，端点既有 `except BusinessError: raise` 链零改动穿透，不会被 `except Exception` 吞成 400（[[arch_httpexception_caught_by_except]]）。
- **保留 `data: StartPaperTradingRequest = None` 参数签名**：维护 OpenAPI 请求体契约兼容旧 client（FastAPI body 可选，废弃端点不强制 body）。
- **移除无效副作用**：废弃端点的核心是停止执行无效 Kafka 投递（到无消费者 topic）+ 返回明确语义码，而非保留无效逻辑 + 标 deprecated。

### AC

- [x] start 端点返回 410 Gone（不再 200/success:true 误导）（AC1）
- [x] OpenAPI 标 deprecated（既有 `deprecated=True`）+ status_code=410 + 迁移指引 message（AC2）
- [x] 不再发无效 Kafka 投递（CONTROL_COMMANDS 无消费者）

## Test plan

TDD 红-绿循环（vertical slice，1 测试覆盖完整废弃语义）：
- [x] RED：当前端点走 `_require_portfolio` → NotFoundError（非 BusinessError(410)）
- [x] GREEN：端点改 raise BusinessError(code=410) + 迁移指引 + 不调 producer.send
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud_mock + containers + user_cli）29 passed
- [x] L3 trading 相关测试 6 passed（新建废弃测试 1 + TestMapPtStatus 5 防回归）

Closes #5860

🤖 Generated with [Claude Code](https://claude.com/claude-code)
