### PR TITLE
fix(#3859): 流式查询 value 参数化防 SQL 注入

### DIFF
--- a/src/ginkgo/data/crud/mixins/_streaming.py
+++ b/src/ginkgo/data/crud/mixins/_streaming.py
@@ -5,7 +5,7 @@
 """
 
 import time
-from typing import Any, Dict, Optional, List, Callable
+from typing import Any, Dict, Optional, List, Callable, Tuple
 
 from ginkgo.libs import GLOG, time_logger
 
@@ -131,12 +131,13 @@ class _Streaming:
             # 获取流式查询引擎
             engine = self._get_streaming_engine()
 
-            # 构建基础查询
-            base_query = self._build_streaming_query(filters, order_by, desc_order)
+            # 构建基础查询（参数化，防 SQL 注入 #3859）
+            base_query, params = self._build_streaming_query(filters, order_by, desc_order)
 
-            # 执行流式查询
+            # 执行流式查询（params 绑定 value）
             return engine.execute_stream(
                 query=base_query,
+                params=params,
                 filters=filters or {},
                 batch_size=batch_size
             )
@@ -228,13 +229,22 @@ class _Streaming:
     def _build_streaming_query(self,
                               filters: Optional[Dict[str, Any]] = None,
                               order_by: Optional[str] = None,
-                              desc_order: bool = False) -> str:
-        """构建流式查询SQL语句"""
+                              desc_order: bool = False) -> Tuple[str, Dict[str, Any]]:
+        """构建流式查询SQL语句（value 参数化绑定，防 SQL 注入 #3859）。
+
+        列名经 ``hasattr`` 白名单保护（不可注入）；value 经 ``%(name)s`` 命名占位符
+        绑定（MySQL PyMySQL/mysqlclient 与 ClickHouse clickhouse-driver 均支持
+        named paramstyle + dict params）。
+
+        Returns:
+            (query, params): query 含占位符模板，params 为绑定值字典。
+        """
         # 基础SELECT语句
         table_name = self.model_class.__tablename__
         query = f"SELECT * FROM {table_name}"
+        params: Dict[str, Any] = {}
 
-        # 添加WHERE条件
+        # 添加WHERE条件（value 参数化，len(params) 作索引保证占位符 key 唯一）
         if filters:
             where_conditions = []
             for key, value in filters.items():
@@ -242,33 +252,53 @@ class _Streaming:
                     field, operator = key.split("__", 1)
                     if hasattr(self.model_class, field):
                         if operator == "gte":
-                            where_conditions.append(f"{field} >= '{value}'")
+                            pk = f"flt_{field}_gte_{len(params)}"
+                            where_conditions.append(f"{field} >= %({pk})s")
+                            params[pk] = value
                         elif operator == "lte":
-                            where_conditions.append(f"{field} <= '{value}'")
+                            pk = f"flt_{field}_lte_{len(params)}"
+                            where_conditions.append(f"{field} <= %({pk})s")
+                            params[pk] = value
                         elif operator == "gt":
-                            where_conditions.append(f"{field} > '{value}'")
+                            pk = f"flt_{field}_gt_{len(params)}"
+                            where_conditions.append(f"{field} > %({pk})s")
+                            params[pk] = value
                         elif operator == "lt":
-                            where_conditions.append(f"{field} < '{value}'")
+                            pk = f"flt_{field}_lt_{len(params)}"
+                            where_conditions.append(f"{field} < %({pk})s")
+                            params[pk] = value
                         elif operator == "in":
                             if isinstance(value, (list, tuple)):
-                                value_str = "', '".join(str(v) for v in value)
-                                where_conditions.append(f"{field} IN ('{value_str}')")
+                                placeholders = []
+                                for v in value:
+                                    pk = f"flt_{field}_in_{len(params)}"
+                                    placeholders.append(f"%({pk})s")
+                                    params[pk] = v
+                                where_conditions.append(
+                                    f"{field} IN ({', '.join(placeholders)})"
+                                )
                         elif operator == "like":
-                            where_conditions.append(f"{field} LIKE '%{value}%'")
+                            pk = f"flt_{field}_like_{len(params)}"
+                            where_conditions.append(f"{field} LIKE %({pk})s")
+                            # % 放 Python 值侧，SQL 模板不留裸 %（PyMySQL
+                            # string-formatting 会把裸 % 误当占位符）
+                            params[pk] = f"%{value}%"
                 else:
                     if hasattr(self.model_class, key):
-                        where_conditions.append(f"{key} = '{value}'")
+                        pk = f"flt_{key}_eq_{len(params)}"
+                        where_conditions.append(f"{key} = %({pk})s")
+                        params[pk] = value
 
             if where_conditions:
                 query += f" WHERE {' AND '.join(where_conditions)}"
 
-        # 添加ORDER BY
+        # 添加ORDER BY（列名白名单保护，非用户 value）
         if order_by and hasattr(self.model_class, order_by):
             query += f" ORDER BY {order_by}"
             if desc_order:
                 query += " DESC"
 
-        return query
+        return query, params
 
     def _fallback_to_traditional_query(self,
                                      filters: Optional[Dict[str, Any]] = None,
@@ -345,8 +375,11 @@ class _Streaming:
                 GLOG.INFO(f"Resuming from checkpoint: {checkpoint_id}")
             elif auto_checkpoint:
                 # 创建新断点
+                # query_text 带占位符模板；params 不存——执行路径 resumable→stream_find
+                # 重建查询，checkpoint.query_text 仅参与 hash + 人类可读（#3859）
+                query_text, _params = self._build_streaming_query(filters, order_by, desc_order)
                 checkpoint_id = checkpoint_manager.create_checkpoint(
-                    query=self._build_streaming_query(filters, order_by, desc_order),
+                    query=query_text,
                     filters=filters or {},
                     batch_size=batch_size or 1000,
                     database_type=getattr(self.driver, '_db_type', 'unknown'),

--- a/tests/unit/data/crud/test_streaming_sql_injection_3859.py
+++ b/tests/unit/data/crud/test_streaming_sql_injection_3859.py
@@ -1,0 +1,220 @@
+"""
+#3859 — 流式查询 SQL 注入修复 characterization tests
+
+`_build_streaming_query` 历史 f-string 拼接 filter value（列名有 hasattr
+白名单保护，但值无防护）。本测试验证 value 经参数化占位符绑定，注入字符串
+被当字面值而非 SQL 片段。
+
+Related: #3859
+"""
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _import_or_skip(module_path: str, name: str):
+    """Import a name from a module, skip test if import fails."""
+    import importlib
+    try:
+        mod = importlib.import_module(module_path)
+        return getattr(mod, name)
+    except (ImportError, AttributeError, ModuleNotFoundError) as exc:
+        pytest.skip(f"Cannot import {name} from {module_path}: {exc}")
+
+
+def _make_crud():
+    """构造最小 CRUD 实例，跳过 driver/session init。
+
+    `_build_streaming_query` 只读 `self.model_class`（__tablename__ + hasattr 列
+    检查），不碰其他实例状态，故 `object.__new__` 跳 `__init__` 后手动设
+    `model_class` 即可。
+
+    用真实 `StockInfoCRUD`（已 override `_model_class` 通过 `__init_subclass__`
+    验证）而非自造假子类——`__init_subclass__` 强制 `_model_class` 继承
+    MClickBase/MMysqlBase，假 model 无法绕过。
+    """
+    StockInfoCRUD = _import_or_skip(
+        "ginkgo.data.crud.stock_info_crud", "StockInfoCRUD"
+    )
+    MStockInfo = _import_or_skip(
+        "ginkgo.data.models.model_stock_info", "MStockInfo"
+    )
+    crud = object.__new__(StockInfoCRUD)
+    crud.model_class = MStockInfo
+    return crud
+
+
+# ===========================================================================
+# Slice 1 — tracer: equal 操作符 value 参数化（注入防护核心语义）
+# ===========================================================================
+
+class TestEqualOperatorParameterized:
+    """filter value 经 %(name)s 占位符绑定，不拼进 SQL 字符串。"""
+
+    def test_value_in_params_not_in_query(self):
+        """注入字符串必须进 params dict，不出现在 SQL 模板里。"""
+        crud = _make_crud()
+        injection = "'; DROP TABLE fake_table; --"
+
+        result = crud._build_streaming_query(filters={"code": injection})
+
+        assert isinstance(result, tuple) and len(result) == 2, (
+            "_build_streaming_query 必须返回 (query, params) 元组"
+        )
+        query, params = result
+
+        # 注入字符串不应出现在 SQL 模板（当字面值被绑定）
+        assert injection not in query
+        assert "DROP TABLE" not in query.upper()
+        # 注入字符串应在 params dict（参数化绑定）
+        assert injection in list(params.values())
+
+    def test_query_uses_named_placeholder(self):
+        """SQL 模板用 %(name)s 命名占位符，value 不裸露。"""
+        crud = _make_crud()
+
+        query, params = crud._build_streaming_query(filters={"code": "000001"})
+
+        assert "code = %(" in query, f"应用命名占位符: {query}"
+        assert "000001" not in query
+        assert "000001" in list(params.values())
+
+
+# ===========================================================================
+# Slice 2 — in 操作符：多值绑定多个独立占位符
+# ===========================================================================
+
+class TestInOperatorParameterized:
+    def test_in_values_each_get_own_placeholder(self):
+        crud = _make_crud()
+        injection_in_list = "evil'); DROP TABLE t; --"
+        values = ["000001", injection_in_list, "000002"]
+
+        query, params = crud._build_streaming_query(filters={"code__in": values})
+
+        # 注入字符串不进 SQL 模板
+        assert "DROP" not in query.upper()
+        assert "evil" not in query
+        # 每个值在 params 里
+        for v in values:
+            assert v in list(params.values())
+        # 三个独立占位符
+        assert query.count("%(") == 3
+
+    def test_in_non_iterable_skipped(self):
+        """in 操作符 value 非 list/tuple 时静默跳过（保留原行为）。"""
+        crud = _make_crud()
+
+        query, params = crud._build_streaming_query(filters={"code__in": "000001"})
+
+        assert "WHERE" not in query
+        assert params == {}
+
+
+# ===========================================================================
+# Slice 3 — like 操作符：% 在 Python 值侧，SQL 模板无裸 %
+# ===========================================================================
+
+class TestLikeOperatorParameterized:
+    def test_like_percent_in_value_not_in_template(self):
+        crud = _make_crud()
+
+        query, params = crud._build_streaming_query(filters={"code__like": "000"})
+
+        assert "LIKE %(" in query
+        assert "000" not in query  # value 不裸露
+        bound = list(params.values())[0]
+        assert bound == "%000%"  # % 包在绑定值侧
+        # SQL 模板不应有裸 %（除 %(name)s 占位符语法）
+        import re
+        bare_pct = re.findall(r"%(?!\()", query)
+        assert bare_pct == [], f"SQL 模板有裸 %: {bare_pct}"
+
+
+# ===========================================================================
+# Slice 4 — 比较操作符 gte/lte/gt/lt
+# ===========================================================================
+
+class TestComparisonOperatorsParameterized:
+    @pytest.mark.parametrize("op,sql_op", [
+        ("gte", ">="), ("lte", "<="), ("gt", ">"), ("lt", "<"),
+    ])
+    def test_comparison_value_bound_not_concatenated(self, op, sql_op):
+        crud = _make_crud()
+        injection = "1 OR 1=1"
+
+        query, params = crud._build_streaming_query(
+            filters={f"code__{op}": injection}
+        )
+
+        assert sql_op in query
+        assert "%(" in query
+        assert "1 OR 1=1" not in query
+        assert injection in list(params.values())
+
+
+# ===========================================================================
+# Slice 5 — 边界：无 filters / 多条件 AND 唯一 key
+# ===========================================================================
+
+class TestEdgeCases:
+    def test_no_filters_returns_plain_select(self):
+        crud = _make_crud()
+
+        query, params = crud._build_streaming_query(filters=None)
+
+        assert query == "SELECT * FROM stock_info"
+        assert params == {}
+
+    def test_multiple_conditions_unique_param_keys(self):
+        crud = _make_crud()
+
+        query, params = crud._build_streaming_query(
+            filters={"code": "000001", "code_name": "平安银行"}
+        )
+
+        assert query.count("%(") == 2
+        assert len(params) == 2
+        assert "000001" not in query
+        assert "平安银行" not in query
+        assert "000001" in list(params.values())
+        assert "平安银行" in list(params.values())
+
+    def test_order_by_unchanged(self):
+        """order_by 列名白名单保护（非用户 value），行为不变。"""
+        crud = _make_crud()
+
+        query, params = crud._build_streaming_query(
+            filters={"code": "000001"}, order_by="code", desc_order=True
+        )
+
+        assert query.endswith("ORDER BY code DESC")
+        assert params == {"flt_code_eq_0": "000001"}
+
+
+# ===========================================================================
+# Slice 6 — stream_find 接线：params 流到 execute_stream（端到端）
+# ===========================================================================
+
+class TestStreamFindPassesParams:
+    def test_stream_find_binds_params_to_execute_stream(self):
+        """stream_find 必须把 _build_streaming_query 的 params 传给 execute_stream。"""
+        from unittest.mock import MagicMock
+
+        crud = _make_crud()
+        fake_engine = MagicMock()
+        fake_engine.execute_stream.return_value = iter([])
+        crud._get_streaming_engine = lambda: fake_engine
+        crud._streaming_config = None  # 避免降级分支
+
+        injection = "'; DROP TABLE stock_info; --"
+        list(crud.stream_find(filters={"code": injection}, batch_size=10))
+
+        fake_engine.execute_stream.assert_called_once()
+        kwargs = fake_engine.execute_stream.call_args.kwargs
+        assert "params" in kwargs, "stream_find 未传 params 给 execute_stream"
+        assert injection in list(kwargs["params"].values())
+        assert "DROP" not in kwargs["query"].upper()


### PR DESCRIPTION
## Summary

修复 #3859：`_build_streaming_query` 的 6 操作符（gte/lte/gt/lt/in/like/=）filter value 用 f-string 拼接进 SQL 字符串。列名有 `hasattr` 白名单保护，但 value 裸奔，恶意 filter value 可注入 SQL。

### 注入复现（修复前）

```python
_build_streaming_query(filters={"code": "'; DROP TABLE t; --"})
```
生成：
```sql
SELECT * FROM stock_info WHERE code = ''; DROP TABLE t; --'
```
`DROP TABLE` 直接进入 SQL 字符串——经典注入穿透，value 路径零防护。

### 根因调用链

- **表象**：filter value 可注入 SQL
- **调用链**：`stream_find(filters)` → `_build_streaming_query(filters)` f-string 拼 value → `execute_stream(query=拼接SQL)` → `cursor.execute(拼接SQL)` 💥
- **根因**：value 未走参数化占位符。**engine 层已支持 `params`**（`execute_stream(params=)` / `_create_streaming_cursor(query, params)` 在 mysql:103、clickhouse:125 均 `cursor.execute(query, params)`），mixin 层只是没产生 params

### 改动

| 文件 | 改动 |
|---|---|
| `src/ginkgo/data/crud/mixins/_streaming.py` | `_build_streaming_query` 返回 `(query, params)` 元组，value 经 `%(name)s` 命名占位符绑定；6 操作符全部参数化 |
| 同上 `stream_find` (L135) | 拆包 `(query, params)` + 传 `params` 给 `execute_stream` |
| 同上 `stream_find_resumable` (L380) | `checkpoint.query_text` 存占位符模板（params 不存；执行路径 resumable→stream_find 重建查询，query_text 仅参与 hash + 人类可读） |
| `tests/unit/data/crud/test_streaming_sql_injection_3859.py` | 新建 13 测试 |

### 设计要点

- **`%(name)s` 跨驱动兼容**：MySQL（PyMySQL/mysqlclient）+ ClickHouse（clickhouse-driver）均支持 named paramstyle + dict params，一套格式适配两种 engine，无需分支。
- **LIKE 的 `%` 在 Python 值侧**（`params[key]="%{value}%"`）：SQL 模板不留裸 `%`，避免 PyMySQL string-formatting 把裸 `%` 误当占位符。
- **列名白名单 vs value 参数化正交**：`hasattr(self.model_class, field)` 保护列名（不可注入），value 走参数化（不可注入），两者独立——修复只动 value 路径，列名保护保持不变。
- **checkpoint.query_text 不影响功能**：执行路径（resumable→stream_find）永远重建查询，query_text 只参与 `_generate_query_hash` + 人类可读，参数化对断点续传零语义影响。
- **降级路径隔离**：`_fallback_to_traditional_query` 用 `self.find()`（SQLAlchemy ORM），不走 `_build_streaming_query`，不受影响。

### AC

- [x] filter value 经参数化绑定，注入字符串被当字面值（AC1）
- [x] 6 操作符（gte/lte/gt/lt/in/like/=）语义不回归（AC2）
- [x] `stream_find` 把 `params` 传到 `execute_stream`（端到端接线）

## Test plan

TDD 红-绿循环（vertical slice，13 测试）：
- [x] RED：`_build_streaming_query(filters={"code": "'; DROP TABLE t; --"})` 返回 str 含 `DROP TABLE`（注入成功复现）
- [x] GREEN：返回 `(query, params)`，注入字符串进 params 不进 query
- [x] L1 py_compile 全量 src+api 通过
- [x] L2 启动路径 smoke（user_crud_mock + containers + user_cli）通过
- [x] L3 变更相关：13 新测试 + `test_base_crud_mixin_composition`（结构契约）+ streaming engine（mysql/ch）全绿，**127 passed 零回归**

Closes #3859

🤖 Generated with [Claude Code](https://claude.com/claude-code)
