### PR TITLE
fix(#5574): tests bare except → except Exception 放行系统退出信号 (子项1 1/5)

### DIFF
--- a/tests/integration/backtest/test_event_engine.py
+++ b/tests/integration/backtest/test_event_engine.py
@@ -25,7 +25,7 @@ def event_engine():
     if hasattr(engine, 'stop'):
         try:
             engine.stop()
-        except:
+        except Exception:
             pass
 
 

--- a/tests/integration/data/services/test_bar_service.py
+++ b/tests/integration/data/services/test_bar_service.py
@@ -101,7 +101,7 @@ class TestBarServiceGetBars:
             # 清理旧的测试数据
             try:
                 stockinfo_crud.remove({"code__in": ["000001.SZ", "000002.SZ"]})
-            except:
+            except Exception:
                 pass
 
             # 添加测试需要的股票信息
@@ -1129,7 +1129,7 @@ class TestBarServiceErrorHandling:
                         assert hasattr(result, 'data')
                         assert hasattr(result, 'message')
                         assert hasattr(result, 'error')
-                except:
+                except Exception:
                     # 某些错误可能抛出异常，这也是可以接受的
                     pass
 

--- a/tests/integration/test_execution_event_flow.py
+++ b/tests/integration/test_execution_event_flow.py
@@ -170,7 +170,7 @@ def test_execution_event_flow():
                 print(f"   方向: {order.direction.name}")
                 print(f"   数量: {order.volume}")
                 print(f"   限价: {order.limit_price}")
-        except:
+        except Exception:
             break
 
     # ============================================================

--- a/tests/integration/test_execution_event_flow_with_strategy.py
+++ b/tests/integration/test_execution_event_flow_with_strategy.py
@@ -216,7 +216,7 @@ def test_execution_with_strategy():
                 print(f"   数量: {order.volume}")
                 print(f"   限价: {order.limit_price}")
                 print(f"   状态: {order.status.name}")
-        except:
+        except Exception:
             break
 
     # ============================================================

--- a/tests/integration/trading/engines/test_engine_integration.py
+++ b/tests/integration/trading/engines/test_engine_integration.py
@@ -1044,7 +1044,7 @@ class TestTimeControlledEngineIntegration:
             from ginkgo.trading.events import EventPriceUpdate
             engine3.register(EventPriceUpdate, price_update_handler)
             price_handler_registered = True
-        except:
+        except Exception:
             price_handler_registered = False
 
         engine3.start()

--- a/tests/integration/trading/engines/test_time_controlled_engine_integration.py
+++ b/tests/integration/trading/engines/test_time_controlled_engine_integration.py
@@ -48,7 +48,7 @@ def safe_get_event(engine, timeout=0.1):
     """安全获取事件，从内部队列直接读取（仅用于测试验证）"""
     try:
         return engine._event_queue.get(timeout=timeout)
-    except:
+    except Exception:
         return None
 
 

--- a/tests/unit/backtest/test_historic_engine.py
+++ b/tests/unit/backtest/test_historic_engine.py
@@ -25,7 +25,7 @@ class HistoricEngineTest(unittest.TestCase):
         if hasattr(self.engine, 'stop'):
             try:
                 self.engine.stop()
-            except:
+            except Exception:
                 pass
 
     def test_HistoricEngine_Init(self):

--- a/tests/unit/data/services/test_bar_service.py
+++ b/tests/unit/data/services/test_bar_service.py
@@ -99,7 +99,7 @@ class TestBarServiceGetBars:
             # 清理旧的测试数据
             try:
                 stockinfo_crud.remove({"code__in": ["000001.SZ", "000002.SZ"]})
-            except:
+            except Exception:
                 pass
 
             # 添加测试需要的股票信息
@@ -1127,7 +1127,7 @@ class TestBarServiceErrorHandling:
                         assert hasattr(result, 'data')
                         assert hasattr(result, 'message')
                         assert hasattr(result, 'error')
-                except:
+                except Exception:
                     # 某些错误可能抛出异常，这也是可以接受的
                     pass
 

--- a/tests/unit/trading/engines/test_engine_mode_management.py
+++ b/tests/unit/trading/engines/test_engine_mode_management.py
@@ -2665,7 +2665,7 @@ class TestBacktestModeManagerCore:
         while not engine._event_queue.empty():
             try:
                 safe_get_event(engine, timeout=0.01)
-            except:
+            except Exception:
                 break
 
         # 创建乱序提交但期望按FIFO处理的事件
@@ -2947,7 +2947,7 @@ class TestBacktestModeManagerCore:
         while not engine._event_queue.empty():
             try:
                 safe_get_event(engine, timeout=0.01)
-            except:
+            except Exception:
                 break
 
         # 投递新的事件批次
@@ -2985,7 +2985,7 @@ class TestBacktestModeManagerCore:
         while not engine._event_queue.empty():
             try:
                 safe_get_event(engine, timeout=0.01)
-            except:
+            except Exception:
                 break
 
         # 投递更多事件

--- a/tests/unit/trading/engines/test_time_controlled_engine_advanced.py
+++ b/tests/unit/trading/engines/test_time_controlled_engine_advanced.py
@@ -48,7 +48,7 @@ def safe_get_event(engine, timeout=0.1):
     """安全获取事件，避免阻塞"""
     try:
         return engine._event_queue.get(timeout=timeout)
-    except:
+    except Exception:
         return None
 
 
@@ -769,7 +769,7 @@ class TestBacktestModeManagerCore:
         while not engine._event_queue.empty():
             try:
                 safe_get_event(engine, timeout=0.01)
-            except:
+            except Exception:
                 break
 
         # 创建乱序提交但期望按FIFO处理的事件

--- a/tests/unit/trading/engines/test_time_controlled_engine_core.py
+++ b/tests/unit/trading/engines/test_time_controlled_engine_core.py
@@ -807,7 +807,7 @@ class TestEventQueueOperations:
                     if event:
                         with operation_lock:
                             dequeue_count += 1
-                except:
+                except Exception:
                     # 超时或其他异常是正常的
                     pass
 


### PR DESCRIPTION
## Summary

#5574 子项1（bare except 清理），5 子项中的 1/5。

测试 cleanup/teardown/event-consume 中的 bare `except:` 会吞掉 `KeyboardInterrupt` / `SystemExit` / `GeneratorExit`（它们继承自 `BaseException` 而非 `Exception`），使 hang 住的测试在 Ctrl-C 后「假装通过」——这正是 bare except 在测试代码里的真实危害。

改为 `except Exception:` 后，BaseException 子类（系统退出信号）得以放行，hang 时能真正中断，不再被静默吞掉。

### 变更范围

11 个测试文件，16 处 `except:` → `except Exception:`：

- `tests/unit/backtest/test_historic_engine.py` (1)
- `tests/unit/data/services/test_bar_service.py` (2)
- `tests/unit/trading/engines/test_time_controlled_engine_core.py` (1)
- `tests/unit/trading/engines/test_time_controlled_engine_advanced.py` (2)
- `tests/unit/trading/engines/test_engine_mode_management.py` (3)
- `tests/integration/test_execution_event_flow.py` (1)
- `tests/integration/test_execution_event_flow_with_strategy.py` (1)
- `tests/integration/backtest/test_event_engine.py` (1)
- `tests/integration/data/services/test_bar_service.py` (2)
- `tests/integration/trading/engines/test_engine_integration.py` (1)
- `tests/integration/trading/engines/test_time_controlled_engine_integration.py` (1)

**未触及**：`src/ginkgo/libs/data/source/baostock/*.py` 中 10 处 `# except:` 为注释示例（docstring/注释内的 bare except 示例文本），保持原样。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全部通过：

- **L1 py_compile**：`src` + `api` 全量编译通过
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli` — 29 passed
- **L3 代表测试**：`test_historic_engine.py`（unit，无 DB）— 9 passed

静态验证：11 文件 active `except:` 16 → 0（baostock 注释 10 处未动）。

Refs #5574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
