### PR TITLE
fix(#5567): node_graph 端点 500 响应 detail 脱敏（不泄露 str(e)）

### DIFF
--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -82,7 +82,7 @@ async def list_node_graphs(
         logger.error(f"Error listing node graphs: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error listing node graphs: {str(e)}"
+            detail="Error listing node graphs"
         )
 
 
@@ -127,7 +127,7 @@ async def get_node_graph(
         logger.error(f"Error getting node graph {graph_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting node graph: {str(e)}"
+            detail="Error getting node graph"
         )
 
 
@@ -176,7 +176,7 @@ async def create_node_graph(
         logger.error(f"Error creating node graph: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error creating node graph: {str(e)}"
+            detail="Error creating node graph"
         )
 
 
@@ -212,7 +212,7 @@ async def update_node_graph(
         logger.error(f"Error updating node graph {graph_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error updating node graph: {str(e)}"
+            detail="Error updating node graph"
         )
 
 
@@ -235,7 +235,7 @@ async def delete_node_graph(
         logger.error(f"Error deleting node graph {graph_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error deleting node graph: {str(e)}"
+            detail="Error deleting node graph"
         )
 
 
@@ -259,7 +259,7 @@ async def duplicate_node_graph(
         logger.error(f"Error duplicating node graph {graph_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error duplicating node graph: {str(e)}"
+            detail="Error duplicating node graph"
         )
 
 
@@ -311,7 +311,7 @@ async def validate_node_graph(
         logger.error(f"Error validating node graph {graph_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error validating node graph: {str(e)}"
+            detail="Error validating node graph"
         )
 
 
@@ -350,7 +350,7 @@ async def compile_node_graph(
         logger.error(f"Error compiling node graph {graph_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error compiling node graph: {str(e)}"
+            detail="Error compiling node graph"
         )
 
 
@@ -373,7 +373,7 @@ async def create_from_backtest(
         logger.error(f"Error creating from backtest {backtest_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error creating from backtest: {str(e)}"
+            detail="Error creating from backtest"
         )
 
 
@@ -412,7 +412,7 @@ async def get_portfolio_mappings(
         logger.error(f"Error getting portfolio mappings {portfolio_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error getting portfolio mappings: {str(e)}"
+            detail="Error getting portfolio mappings"
         )
 
 
@@ -464,7 +464,7 @@ async def add_file_to_portfolio(
         logger.error(f"Error adding file to portfolio {portfolio_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error adding file: {str(e)}"
+            detail="Error adding file"
         )
 
 
@@ -495,5 +495,5 @@ async def remove_file_from_portfolio(
         logger.error(f"Error removing file from portfolio {portfolio_uuid}: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error removing file: {str(e)}"
+            detail="Error removing file"
         )

--- a/tests/api/test_node_graph_error_sanitization.py
+++ b/tests/api/test_node_graph_error_sanitization.py
@@ -1,0 +1,155 @@
+"""#5567: node_graph 端点 500 响应不泄露 str(e) 内部细节。
+
+接续 PR #6421（components.py 切片），同根因同修复模式：
+`raise HTTPException(500, detail=f"...{str(e)}")` → `detail="..."`，
+异常详情已在紧邻的 `logger.error(f"...: {str(e)}")` 记录，诊断不丢。
+
+参考 [[arch_global_error_handler_trace_id]]：FastAPI 默认 HTTPException handler
+精确匹配优先于全局 Exception handler，global_error_handler 的
+isinstance(HTTPException) 分支是死代码，端点须自行脱敏。
+
+覆盖 7 个 service-backed 可达端点。delete/duplicate/create_from_backtest
+的 `except Exception` 不可达（try 体只 raise HTTPException 被
+`except HTTPException: raise` 重抛），脱敏是防御性，不测死代码。
+validate/compile 为纯逻辑/内部 import，service mock 不触发其 except。
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# node_graph.py 行39 `from ._file_type import` 是相对导入，需保持包上下文。
+# 自行 insert /repo/api/ 使 `api` 包可导入，node_graph 作为 api.node_graph，
+# 相对导入 from ._file_type → api._file_type 正确解析（对齐
+# [[arch_api_test_import_collapse]] 折叠约定；components 切片用 from components
+# 顶层导入是因为 components.py 无相对导入，node_graph 不同）。
+_api_dir = str(Path(__file__).parent.parent.parent / "api")
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+# config.py 全局 Settings() 需合法 SECRET_KEY
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-jwt-security-tests")
+
+from api.node_graph import (  # noqa: E402
+    add_file_to_portfolio,
+    create_node_graph,
+    get_node_graph,
+    get_portfolio_mappings,
+    list_node_graphs,
+    remove_file_from_portfolio,
+    update_node_graph,
+)
+
+# 模拟内部异常细节（SQL/表名/连接串/IP）——这些绝不应出现在 500 响应里
+SENSITIVE = "SQL: SELECT * FROM secret_internal_table; conn=postgres://u:p@10.0.0.1/db"
+
+
+def _raise_sensitive(*_a, **_kw):
+    raise RuntimeError(SENSITIVE)
+
+
+def _assert_sanitized(exc, expected_detail):
+    """断言 500 响应不含敏感细节，detail 为 generic。"""
+    assert exc.value.status_code == 500
+    assert "SQL" not in exc.value.detail
+    assert "secret_internal_table" not in exc.value.detail
+    assert "postgres" not in exc.value.detail
+    assert "10.0.0.1" not in exc.value.detail
+    assert exc.value.detail == expected_detail
+
+
+class TestListNodeGraphsSanitization:
+    """list_node_graphs 500 响应 detail 不含异常内部细节。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get_portfolio_graph.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                # 传 portfolio_uuid 才会走 service.get_portfolio_graph 调用
+                asyncio.run(list_node_graphs(portfolio_uuid="some-uuid"))
+
+        _assert_sanitized(exc, "Error listing node graphs")
+
+
+class TestGetNodeGraphSanitization:
+    """get_node_graph 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get_portfolio_graph.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_node_graph("some-uuid"))
+
+        _assert_sanitized(exc, "Error getting node graph")
+
+
+class TestCreateNodeGraphSanitization:
+    """create_node_graph 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.create_from_graph_editor.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(create_node_graph(data=MagicMock()))
+
+        _assert_sanitized(exc, "Error creating node graph")
+
+
+class TestUpdateNodeGraphSanitization:
+    """update_node_graph 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.update_from_graph_editor.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(update_node_graph("some-uuid", data=MagicMock()))
+
+        _assert_sanitized(exc, "Error updating node graph")
+
+
+class TestGetPortfolioMappingsSanitization:
+    """get_portfolio_mappings 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get_portfolio_mappings.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_portfolio_mappings("some-uuid"))
+
+        _assert_sanitized(exc, "Error getting portfolio mappings")
+
+
+class TestAddFileToPortfolioSanitization:
+    """add_file_to_portfolio 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.add_file.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                # file_type="strategy" 合法，_resolve_file_type 不抛，进 service.add_file
+                asyncio.run(add_file_to_portfolio("some-uuid", "file-id", "strategy"))
+
+        _assert_sanitized(exc, "Error adding file")
+
+
+class TestRemoveFileFromPortfolioSanitization:
+    """remove_file_from_portfolio 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.remove_file.side_effect = _raise_sensitive
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(remove_file_from_portfolio("some-uuid", "file-id"))
+
+        _assert_sanitized(exc, "Error removing file")


### PR DESCRIPTION
## Summary

#5567 第 2 切片：`node_graph.py` 12 处 `HTTPException(500, detail=f"Error X: {str(e)}")` 泄露点脱敏。接续 PR #6421（components.py）。

### 问题

同 #6421 根因：`raise HTTPException(500, detail=f"...{str(e)}")` 把异常 `str(e)`（SQL / traceback / 连接串 / 内部表名）通过 500 响应返回客户端。FastAPI 默认 HTTPException handler 精确匹配优先于全局 Exception handler，`global_error_handler` 的 `isinstance(HTTPException)` 分支是死代码（[[arch_global_error_handler_trace_id]]），端点须自行脱敏。

### 修复

12 处 `detail=f"Error X: {str(e)}"` → `detail="Error X"`，异常详情已在紧邻的 `logger.error(f"...: {str(e)}")` 记录，诊断不丢。

| 行号 | 端点 |
|---|---|
| 85 | `list_node_graphs` |
| 130 | `get_node_graph` |
| 179 | `create_node_graph` |
| 215 | `update_node_graph` |
| 238 | `delete_node_graph`（防御性，见下）|
| 262 | `duplicate_node_graph`（防御性）|
| 314 | `validate_node_graph` |
| 353 | `compile_node_graph` |
| 376 | `create_from_backtest`（防御性）|
| 415 | `get_portfolio_mappings` |
| 467 | `add_file_to_portfolio` |
| 498 | `remove_file_from_portfolio` |

**防御性脱敏**：`delete_node_graph` / `duplicate_node_graph` / `create_from_backtest` 的 try 体只 `raise HTTPException(501)`，被 `except HTTPException: raise` 重抛，`except Exception` 不可达。脱敏仍正确（防未来加 service 调用）。不测死代码（TDD 测真实行为）。

**404 业务错误保留**：行 105/401 的 `detail=f"...{uuid} not found"` 含用户输入 uuid（非 str(e) 泄露），合法保留。

### 测试导入约定

`node_graph.py` 行 39 `from ._file_type import` 是相对导入，测试需保持包上下文：`from api.node_graph import`（非 `from node_graph`），patch 字符串 `api.node_graph.xxx`。与 components 切片（无相对导入，用 `from components`）不同，参考 [[arch_api_test_import_collapse]] 折叠约定。

### 后续 slice

`data.py`（9 处）/ `settings.py`（4 处）留后续 PR 接力，issue 保持 open。与 #5481（PR #6409 dashboard/system）/ #6421（components）不同文件，零 hunk 重叠。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全部通过：

- **L1 py_compile**：`src` + `api` 全量编译通过
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli` — 29 passed
- **L3 node_graph api**：`test_node_graph_error_sanitization.py`（新，7 passed，每端点断言 `SQL` / `secret_internal_table` / `postgres` / `10.0.0.1` 不在 detail 中且 detail == generic）+ `test_node_graph_file_type.py`（既有 12 passed，无回归）— 19 passed

TDD 7 vertical slice（service-backed 可达端点，RED→GREEN）。

Refs #5567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
