### PR TITLE
fix(#5567): data.py 端点 500 响应 detail 脱敏（不泄露 str(e)）

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -178,7 +178,7 @@ async def get_data_stats():
         logger.error(f"Error getting data stats: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get data stats: {str(e)}"
+            detail="Failed to get data stats"
         )
 
 async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: int = 10) -> Dict[str, Any]:
@@ -230,8 +230,7 @@ async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: in
             "stocks_with_tick_data": 0,
             "sample_size": sample_size,
             "total_sampled_ticks": 0,
-            "top_stocks": [],
-            "error": str(e)
+            "top_stocks": []
         }
 
 
@@ -304,7 +303,7 @@ async def get_stockinfo(
         logger.error(f"Error getting stockinfo: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get stock info: {str(e)}"
+            detail="Failed to get stock info"
         )
 
 
@@ -380,7 +379,7 @@ async def get_bars(
         logger.error(f"Error getting bars: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get bars: {str(e)}"
+            detail="Failed to get bars"
         )
 
 
@@ -466,7 +465,7 @@ async def get_ticks(
         logger.error(f"Error getting ticks: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get ticks: {str(e)}"
+            detail="Failed to get ticks"
         )
 
 
@@ -534,7 +533,7 @@ async def get_adjust_factors(
         logger.error(f"Error getting adjust factors: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get adjust factors: {str(e)}"
+            detail="Failed to get adjust factors"
         )
 
 
@@ -721,7 +720,7 @@ async def sync_data(request: DataUpdateRequest):
         raise
     except Exception as e:
         logger.error(f"Error updating data: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to update data: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to update data")
 
 
 @router.get("/sync/history")
@@ -748,7 +747,7 @@ async def get_sync_history(
         return paginated(items=items, total=total, page=page, page_size=page_size)
     except Exception as e:
         logger.error(f"Error getting sync history: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to get sync history: {str(e)}")
+        raise HTTPException(status_code=500, detail="Failed to get sync history")
 
 
 @router.get("/sources")
@@ -789,5 +788,5 @@ async def get_data_sources():
         logger.error(f"Error getting data sources: {e}")
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to get data sources: {str(e)}"
+            detail="Failed to get data sources"
         )

--- a/tests/api/test_data_error_sanitization.py
+++ b/tests/api/test_data_error_sanitization.py
@@ -1,0 +1,174 @@
+"""#5567: data.py 端点 500 响应不泄露 str(e) 内部细节。
+
+接续 PR #6421（components.py）/ #6422（node_graph.py）切片，同根因同修复模式：
+- HTTPException(500, detail=f"...{str(e)}") → detail="..."，异常详情已在紧邻的
+  logger.error 记录，诊断不丢。
+- helper get_tick_data_summary 的降级 dict 移除 "error": str(e) 字段（200 body 泄露）。
+
+参考 [[arch_global_error_handler_trace_id]]：FastAPI 默认 HTTPException handler 精确匹配
+优先于全局 Exception handler，global_error_handler 的 isinstance(HTTPException) 分支是
+死代码，端点须自行脱敏。
+
+覆盖 8 个可测泄露点。get_data_sources（792）try 体纯静态 dict 无 service 调用，
+except 不可达，脱敏是防御性，不测死代码。
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# data.py 无相对导入（grep ^from \. 为空），用顶层 from data import。
+# 自行 insert /repo/api/ 使 `data` 顶层模块可导入（_API_DIR = api/，core 作为 api/core）。
+# 对齐 components 切片（PR #6421）顶层导入约定。
+_api_dir = str(Path(__file__).parent.parent.parent / "api")
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+# config.py 全局 Settings() 需合法 SECRET_KEY
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-jwt-security-tests")
+
+from api.data import (  # noqa: E402
+    DataUpdateRequest,
+    get_adjust_factors,
+    get_bars,
+    get_data_stats,
+    get_stockinfo,
+    get_sync_history,
+    get_tick_data_summary,
+    get_ticks,
+    sync_data,
+)
+
+# 模拟内部异常细节（SQL/表名/连接串/IP）——这些绝不应出现在 500 响应里
+SENSITIVE = "SQL: SELECT * FROM secret_internal_table; conn=postgres://u:p@10.0.0.1/db"
+
+
+def _raise_sensitive(*_a, **_kw):
+    raise RuntimeError(SENSITIVE)
+
+
+def _assert_sanitized(exc, expected_detail):
+    """断言 500 响应不含敏感细节，detail 为 generic。"""
+    assert exc.value.status_code == 500
+    assert "SQL" not in exc.value.detail
+    assert "secret_internal_table" not in exc.value.detail
+    assert "postgres" not in exc.value.detail
+    assert "10.0.0.1" not in exc.value.detail
+    assert exc.value.detail == expected_detail
+
+
+class TestGetDataStatsSanitization:
+    """get_data_stats 500 响应 detail 不含异常内部细节。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.count.side_effect = _raise_sensitive
+        with patch("api.data.get_stockinfo_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_data_stats())
+
+        _assert_sanitized(exc, "Failed to get data stats")
+
+
+class TestGetTickDataSummarySanitization:
+    """get_tick_data_summary helper 降级 dict 不含 error 字段（200 body 泄露）。"""
+
+    def test_fallback_dict_excludes_error_field(self):
+        # helper 接收 service 参数（不经 getter），stockinfo_service.get 抛 → except → 降级 dict
+        mock_stockinfo = MagicMock()
+        mock_stockinfo.get.side_effect = _raise_sensitive
+        mock_tick = MagicMock()
+
+        result = asyncio.run(get_tick_data_summary(mock_stockinfo, mock_tick, sample_size=10))
+
+        # 降级 dict 仍含统计字段（零值），但绝不泄露异常文本
+        assert "error" not in result
+        assert "SQL" not in str(result)
+        assert "secret_internal_table" not in str(result)
+        assert "postgres" not in str(result)
+        assert "10.0.0.1" not in str(result)
+        assert result["stocks_with_tick_data"] == 0
+
+
+class TestGetStockinfoSanitization:
+    """get_stockinfo 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.search.side_effect = _raise_sensitive
+        with patch("api.data.get_stockinfo_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                # search 触发 service.search 调用路径
+                asyncio.run(get_stockinfo(search="600"))
+
+        _assert_sanitized(exc, "Failed to get stock info")
+
+
+class TestGetBarsSanitization:
+    """get_bars 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get.side_effect = _raise_sensitive
+        with patch("api.data.get_bar_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_bars())
+
+        _assert_sanitized(exc, "Failed to get bars")
+
+
+class TestGetTicksSanitization:
+    """get_ticks 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        # get_tick_service() 抛在 try 首行（code 校验之前），不传 code 即可触发
+        with patch("api.data.get_tick_service", side_effect=_raise_sensitive):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_ticks())
+
+        _assert_sanitized(exc, "Failed to get ticks")
+
+
+class TestGetAdjustFactorsSanitization:
+    """get_adjust_factors 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get.side_effect = _raise_sensitive
+        with patch("api.data.get_adjustfactor_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_adjust_factors())
+
+        _assert_sanitized(exc, "Failed to get adjust factors")
+
+
+class TestSyncDataSanitization:
+    """sync_data 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        # record_start 在内层 try 之前（行 614），抛异常直达外层 except → 724 泄露点
+        mock_svc = MagicMock()
+        mock_svc.record_start.side_effect = _raise_sensitive
+        with patch("api.data.get_sync_record_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(sync_data(DataUpdateRequest(type="stockinfo")))
+
+        _assert_sanitized(exc, "Failed to update data")
+
+
+class TestGetSyncHistorySanitization:
+    """get_sync_history 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get_history.side_effect = _raise_sensitive
+        with patch("api.data.get_sync_record_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(get_sync_history())
+
+        _assert_sanitized(exc, "Failed to get sync history")


### PR DESCRIPTION
## Summary

#5567 第 3 切片：`data.py` 8 处 `HTTPException(500, detail=f"...{str(e)}")` + 1 处 helper 降级 dict `"error": str(e)` 泄露点脱敏。接续 PR #6421（components）/ #6422（node_graph）。

### 问题

同 #6421/#6422 根因：`raise HTTPException(500, detail=f"...{str(e)}")` 把异常 `str(e)`（SQL / traceback / 连接串 / 内部表名）通过 500 响应返回客户端。FastAPI 默认 HTTPException handler 精确匹配优先于全局 Exception handler，`global_error_handler` 的 `isinstance(HTTPException)` 分支是死代码（[[arch_global_error_handler_trace_id]]），端点须自行脱敏。

### 修复

**8 处 HTTPException(500) detail 脱敏**（`detail=f"...{str(e)}"` → `detail="..."`）：

| 行号 | 端点 |
|---|---|
| 181 | `get_data_stats` |
| 307 | `get_stockinfo` |
| 383 | `get_bars` |
| 469 | `get_ticks` |
| 537 | `get_adjust_factors` |
| 724 | `sync_data` |
| 751 | `get_sync_history` |
| 792 | `get_data_sources`（防御性，见下）|

**1 处 helper body 泄露**（`get_tick_data_summary` 行 234）：降级 dict 移除 `"error": str(e)` 字段。该 helper 不是端点，被 `get_data_stats` 调用，降级 dict 作为 `tick_data_summary` 字段进 200 响应 body —— 这是 #5567 修复中最隐蔽的变体（非 HTTPException，走 200 body）。

### 关键区分：响应路径 vs 诊断路径

data.py 有两类 `str(e)`：
- `record_fail(error_message=str(e))`（行 626 / 644 / 669 ...）— **写库诊断**，内部记录同步失败原因，便于排查，**保留**
- `detail=f"...{str(e)}"` / `"error": str(e)` — **HTTP 响应**，外部泄露，**脱敏**

脱敏只针对响应路径。logger.error 仍记录完整异常（诊断不丢）。

### 不测点

- `get_data_sources`（792）：try 体纯静态 dict 无 service 调用，`except Exception` 不可达，脱敏是防御性，不测死代码（TDD 测真实行为）
- 行 717 `detail=f"Unsupported data type: {request.type}"`（400）：用户输入 `request.type`，业务校验，合法保留（类似 404 uuid）

### 测试导入约定

data.py 无相对导入，但 `worktree/api/` 是双层结构（`api/api/data.py`），测试用 `from api.data import`（包上下文），patch `api.data.xxx`。对齐 node_graph 切片（PR #6422）双层约定。

### 后续 slice

`settings.py`（4 处）留后续 PR 接力，issue 保持 open。与前序切片不同文件，零 hunk 重叠。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全部通过：

- **L1 py_compile**：`src` + `api` 全量编译通过
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli` — 29 passed
- **L3 data api**：`test_data_error_sanitization.py`（新，8 passed：7 HTTPException detail 断言 `SQL` / `secret_internal_table` / `postgres` / `10.0.0.1` 不在 detail 中且 detail == generic + 1 helper 断言 `"error" not in result`）+ 既有 `test_data_bars_500_fix` / `test_data_pagination` / `test_data_sync_status` / `test_data_sync_codes_field` / `test_data_sync_adjustfactor`（23 passed，无回归）— 31 passed

TDD 8 vertical slice（RED→GREEN，7 service-backed 端点 + 1 helper）。

Refs #5567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
