### PR TITLE
fix(#5567): settings.py 端点 500 响应 detail 脱敏（不泄露 str(e)）

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -681,7 +681,7 @@ async def test_user_contact(contact_uuid: str, data: UserContactTest):
                 logger.error(f"Webhook test failed: {e}")
                 raise HTTPException(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail=f"Webhook test failed: {str(e)}"
+                    detail="Webhook test failed"
                 )
         else:
             raise HTTPException(
@@ -1547,7 +1547,7 @@ async def create_notification_recipient(data: NotificationRecipientCreate):
         logger.error(f"Error creating notification recipient: {e}\nTraceback: {traceback.format_exc()}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to create notification recipient: {str(e)}"
+            detail="Failed to create notification recipient"
         )
 
 
@@ -1772,7 +1772,7 @@ async def test_notification_recipient(uuid: str):
         logger.error(f"Error testing notification recipient {uuid}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to test notification recipient: {str(e)}"
+            detail="Failed to test notification recipient"
         )
 
 

--- a/tests/api/test_settings_error_sanitization.py
+++ b/tests/api/test_settings_error_sanitization.py
@@ -1,0 +1,113 @@
+"""#5567: settings.py 端点 500 响应不泄露 str(e) 内部细节。
+
+收尾切片（#5567 第 4 切片）。接续 PR #6421（components）/ #6422（node_graph）/ #6423（data），
+同根因同修复模式：HTTPException(500, detail=f"...{str(e)}") → detail="..."，
+异常详情已在 logger.error 记录，诊断不丢。
+
+参考 [[arch_global_error_handler_trace_id]]：FastAPI 默认 HTTPException handler 精确匹配
+优先于全局 Exception handler，global_error_handler 的 isinstance(HTTPException) 分支是
+死代码，端点须自行脱敏。
+
+覆盖 3 处泄露点：
+- 683 test_user_contact WEBHOOK 分支（requests.post 抛异常）
+- 1559 create_notification_recipient（service.add_recipient 抛）
+- 1784 test_notification_recipient（service.get_recipient_contacts 抛）
+
+688 Unsupported contact type（400，contact_type 用户输入枚举）合法保留不脱敏。
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+# settings.py 无相对导入，但 worktree/api/ 双层结构（api/api/settings.py），
+# 测试用 from api.settings import（包上下文），patch api.settings.xxx。
+# 对齐 data 切片（PR #6423）双层约定。
+_api_dir = str(Path(__file__).parent.parent.parent / "api")
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+
+# config.py 全局 Settings() 需合法 SECRET_KEY
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-jwt-security-tests")
+
+# 注意：端点函数 test_user_contact / test_notification_recipient 以 test_ 开头，
+# 直接导入会被 pytest 误收集成测试函数（报 fixture 'contact_uuid' not found）。
+# 别名导入（_xxx_endpoint）使其不以 test_ 开头，规避收集。
+from api.settings import (  # noqa: E402
+    UserContactTest,
+    create_notification_recipient,
+    test_notification_recipient as _test_notification_recipient_endpoint,
+    test_user_contact as _test_user_contact_endpoint,
+)
+
+# 模拟内部异常细节（URL/连接串/内部主机名）——这些绝不应出现在 500 响应里
+SENSITIVE = "Connection failed: postgres://u:p@10.0.0.1/db; host=secret-internal-host"
+
+
+def _raise_sensitive(*_a, **_kw):
+    raise RuntimeError(SENSITIVE)
+
+
+def _assert_sanitized(exc, expected_detail):
+    """断言 500 响应不含敏感细节，detail 为 generic。"""
+    assert exc.value.status_code == 500
+    assert "postgres" not in exc.value.detail
+    assert "10.0.0.1" not in exc.value.detail
+    assert "secret-internal-host" not in exc.value.detail
+    assert exc.value.detail == expected_detail
+
+
+class TestTestUserContactSanitization:
+    """test_user_contact WEBHOOK 分支 500 响应不泄露 requests 异常细节。"""
+
+    def test_webhook_500_detail_excludes_exception_internals(self):
+        from ginkgo.enums import CONTACT_TYPES
+
+        # 构造 get_contact 返回 WEBHOOK 类型联系方式
+        mock_contact = MagicMock()
+        mock_contact.get_contact_type_enum.return_value = CONTACT_TYPES.WEBHOOK
+        mock_contact_result = MagicMock()
+        mock_contact_result.success = True  # 647 not success → False，跳过 404
+        mock_contact_result.data = mock_contact
+        mock_user_svc = MagicMock()
+        mock_user_svc.get_contact.return_value = mock_contact_result
+
+        with patch("api.settings.get_user_service", return_value=mock_user_svc), \
+             patch("requests.post", side_effect=_raise_sensitive):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(_test_user_contact_endpoint(
+                    "contact-uuid",
+                    UserContactTest(address="https://example.com/webhook")
+                ))
+
+        _assert_sanitized(exc, "Webhook test failed")
+
+
+class TestCreateNotificationRecipientSanitization:
+    """create_notification_recipient 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.add_recipient.side_effect = _raise_sensitive
+        with patch("api.settings.get_notification_recipient_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(create_notification_recipient(data=MagicMock()))
+
+        _assert_sanitized(exc, "Failed to create notification recipient")
+
+
+class TestTestNotificationRecipientSanitization:
+    """test_notification_recipient 500 响应不泄露。"""
+
+    def test_500_detail_excludes_exception_internals(self):
+        mock_svc = MagicMock()
+        mock_svc.get_recipient_contacts.side_effect = _raise_sensitive
+        with patch("api.settings.get_notification_recipient_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                asyncio.run(_test_notification_recipient_endpoint("recipient-uuid"))
+
+        _assert_sanitized(exc, "Failed to test notification recipient")


### PR DESCRIPTION
## Summary

#5567 第 4 切片（收尾）：`settings.py` 3 处 `HTTPException(500, detail=f"...{str(e)}")` 泄露点脱敏。接续 PR #6421（components）/ #6422（node_graph）/ #6423（data）。

### 问题

同 #6421/#6422/#6423 根因：`raise HTTPException(500, detail=f"...{str(e)}")` 把异常 `str(e)`（SQL / traceback / 连接串 / 内部主机名）通过 500 响应返回客户端。FastAPI 默认 HTTPException handler 精确匹配优先于全局 Exception handler，`global_error_handler` 的 `isinstance(HTTPException)` 分支是死代码，端点须自行脱敏。

### 修复

3 处 `detail=f"...{str(e)}"` → `detail="..."`，异常详情已在紧邻的 `logger.error` 记录，诊断不丢。

| 行号 | 端点 |
|---|---|
| 684 | `test_user_contact` WEBHOOK 分支（requests.post 抛）|
| 1550 | `create_notification_recipient`（service.add_recipient 抛）|
| 1775 | `test_notification_recipient`（service.get_recipient_contacts 抛）|

**合法保留**：行 689 `detail=f"Unsupported contact type: {contact_type}"`（400，contact_type 用户输入枚举，非 str(e) 泄露）。

### 关键区分：响应路径 vs 诊断路径

- `logger.error(f"...: {e}")` — 服务端日志诊断，保留完整异常
- `detail=f"...{str(e)}"` — HTTP 500 响应，外部泄露，脱敏

### 测试约定

- settings.py 无相对导入，`worktree/api/` 双层结构（`api/api/settings.py`），测试用 `from api.settings import`（包上下文），patch `api.settings.xxx`。对齐 data 切片（PR #6423）。
- 端点名 `test_user_contact` / `test_notification_recipient` 以 `test_` 开头，直接导入会被 pytest 误收集（报 fixture not found）。别名导入 `as _xxx_endpoint` 规避，不改源码端点名（API 契约）。

### 后续

settings.py 是 #5567 最后文件（grep 全 api 确认：剩余泄露文件 components/data/node_graph 正是前序 3 PR 覆盖）。4 PR 全合并后 issue 可关闭。本 PR 用 `Refs` 保持 open，等前序合并。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全部通过：

- **L1 py_compile**：`src` + `api` 全量编译通过
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli` — 29 passed
- **L3 settings api**：`test_settings_error_sanitization.py`（新，3 passed，每端点断言 `postgres` / `10.0.0.1` / `secret-internal-host` 不在 detail 中且 detail == generic）

TDD 3 vertical slice（RED→GREEN，3 service-backed 端点）。

Refs #5567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
