### PR TITLE
fix: Account 响应字段 account_uuid 统一为 uuid (#5633)

### DIFF
--- a/src/ginkgo/data/services/live_account_service.py
+++ b/src/ginkgo/data/services/live_account_service.py
@@ -69,7 +69,7 @@ class LiveAccountService(BaseService):
         Returns:
             Dict: {
                 "success": bool,
-                "data": {"account_uuid": str} or None,
+                "data": {"uuid": str} or None,
                 "message": str,
                 "error": str
             }
@@ -142,7 +142,7 @@ class LiveAccountService(BaseService):
             return {
                 "success": True,
                 "data": {
-                    "account_uuid": account.uuid,
+                    "uuid": account.uuid,
                     "validation_result": validation_result
                 },
                 "message": "Live account created successfully"
@@ -573,7 +573,7 @@ class LiveAccountService(BaseService):
                 "success": True,
                 "message": f"Account status updated to {status}",
                 "data": {
-                    "account_uuid": updated_account.uuid,
+                    "uuid": updated_account.uuid,
                     "status": updated_account.status
                 }
             }

--- a/tests/integration/test_okx_integration.py
+++ b/tests/integration/test_okx_integration.py
@@ -207,7 +207,7 @@ class TestLiveAccountServiceIntegration:
         result = live_account_service.create_account(**sample_account_data)
 
         assert result["success"] is True
-        account_uuid = result["data"]["account_uuid"]
+        account_uuid = result["data"]["uuid"]
 
         # 2. 获取账号
         result = live_account_service.get_account_by_uuid(account_uuid)

--- a/tests/unit/data/test_live_account_service_existing.py
+++ b/tests/unit/data/test_live_account_service_existing.py
@@ -51,7 +51,7 @@ class TestLiveAccountServiceCreation:
         )
 
         assert result["success"] is True
-        assert result["data"]["account_uuid"] == "test-account-uuid"
+        assert result["data"]["uuid"] == "test-account-uuid"
         assert result["data"]["validation_result"] is None
 
     def test_create_account_missing_user_id(self, live_account_service):
@@ -160,7 +160,7 @@ class TestLiveAccountServiceCreation:
         )
 
         assert result["success"] is True
-        assert result["data"]["account_uuid"] == "test-account-uuid"
+        assert result["data"]["uuid"] == "test-account-uuid"
         assert result["data"]["validation_result"]["success"] is True
         # 验证validate_account被调用过
         mock_validate.assert_called_once()
@@ -462,6 +462,8 @@ class TestAccountStatusManagement:
         )
 
         assert result["success"] is True
+        assert "uuid" in result["data"]  # #5633: response key 统一为 uuid（非 account_uuid）
+        assert "account_uuid" not in result["data"]
         assert result["data"]["status"] == AccountStatusType.ENABLED
 
     def test_update_account_status_to_disabled(self, live_account_service):


### PR DESCRIPTION
## Summary

#5633 [P2 bug] Account API 响应字段不一致 — `account_uuid` 而非 `uuid`。

Account 创建/状态更新接口返回 `{"data":{"account_uuid":"xxx"}}`，而其他所有模块（Portfolio / Component / Backtest / Paper Trading）统一使用 `uuid`。前端需针对 Account 模块写特殊处理。

## 根因

`LiveAccountService` 在 `create_account` (L145) 和 `update_account_status` (L576) **手动构造** response dict 时用了 `account_uuid` key，与同模块其他路径不一致：

| 路径 | 实现 | key |
|---|---|---|
| 创建 | `create_account` 手动 dict (L145) | `account_uuid` ❌ |
| 状态 | `update_account_status` 手动 dict (L576) | `account_uuid` ❌ |
| 查询 | `get_account_by_uuid` → `account.to_dict()` (model L140) | `uuid` ✅ |
| 对照 | `portfolio_service` (L144) | `uuid` ✅ |

查询路径走 model `to_dict()`（已输出 `uuid`），故异类仅 **2 处手动 dict** + 1 处 docstring。值均为 `.uuid`，仅 key 名差异。

## 修复

`src/ginkgo/data/services/live_account_service.py`：
- L145 `"account_uuid": account.uuid` → `"uuid": account.uuid`（create_account）
- L576 `"account_uuid": updated_account.uuid` → `"uuid": updated_account.uuid`（update_account_status）
- L72 docstring `{"account_uuid": str}` → `{"uuid": str}`

model 不动（`to_dict` 已 `uuid`），与 #6395（model schema alias，不同层）零文件重叠。

## 调用链

```
POST /api/v1/accounts/ → api create_account (accounts.py:79)
  → LiveAccountService.create_account (service:43)
  → return {"data":{"uuid": account.uuid}} (service:145)   ← 原 account_uuid
  → api ok(data=result["data"]) 透传
PUT /api/v1/accounts/{id}/status → update_account_status (service:537)
  → return {"data":{"uuid": updated_account.uuid}} (service:576)   ← 原 account_uuid
GET  /api/v1/accounts/{id} → get_account_by_uuid (service:1019)
  → account.to_dict() (model:140) → {"uuid": ...}  ✅ 已正确
```

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全部通过：

- **L1 py_compile**：`src` + `api` 全量编译通过
- **L2 启动路径**：`test_user_crud_mock` + `test_containers` + `test_user_cli` — 29 passed
- **L3 service unit**：`test_live_account_service_existing.py` — 37 passed
  - `test_create_account_success_without_validation` / `test_create_account_with_validation_success`：断言 `result["data"]["uuid"]`
  - `test_update_account_status_to_enabled`：断言 `"uuid" in data` 且 `"account_uuid" not in data`

TDD 2 vertical slice（create RED→GREEN，update_status RED→GREEN）。

Closes #5633

🤖 Generated with [Claude Code](https://claude.com/claude-code)
