### PR TITLE
fix(#6029): _handle_deploy 魔法数字 0 改用 PORTFOLIO_MODE_TYPES.BACKTEST.value

### DIFF
--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -876,7 +876,7 @@ class PaperTradingWorker:
 
             # Mode 校验：只接受 PAPER 或 LIVE
             portfolio_mode = getattr(db_portfolio, 'mode', -1)
-            if portfolio_mode == 0:  # BACKTEST
+            if portfolio_mode == PORTFOLIO_MODE_TYPES.BACKTEST.value:
                 GLOG.ERROR(
                     f"[PAPER-WORKER] Cannot deploy BACKTEST portfolio {portfolio_id}. "
                     "Deploy first via DeploymentService.deploy()."

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -560,6 +560,31 @@ class TestDeploy:
         result = worker._handle_deploy({"portfolio_id": "p-001"})
         assert result is False
 
+    def test_deploy_backtest_mode_rejected(self):
+        """BACKTEST 模式 portfolio 不应被 PaperTradingWorker deploy (#6029)
+
+        锁定 _handle_deploy 的模式判断行为：portfolio.mode == BACKTEST 时拒绝部署。
+        #6029 将魔法数字 0 替换为 PORTFOLIO_MODE_TYPES.BACKTEST.value，行为不变。
+        """
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+        from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+        worker = PaperTradingWorker(worker_id="test-1")
+        worker._engine = MagicMock()  # 引擎就绪，排除 engine 检查干扰
+
+        mock_db_portfolio = MagicMock()
+        mock_db_portfolio.mode = PORTFOLIO_MODE_TYPES.BACKTEST.value  # 0
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = [mock_db_portfolio]
+        mock_container = MagicMock()
+        mock_container.cruds.portfolio.return_value = mock_crud
+
+        with patch("ginkgo.services", create=True) as mock_services:
+            mock_services.data.container = mock_container
+            result = worker._handle_deploy({"portfolio_id": "p-backtest-001"})
+
+        assert result is False
+
 
 class TestUnload:
     """unload 命令处理测试"""


### PR DESCRIPTION
## Summary

#6029 PaperTradingWorker `_handle_deploy` 魔法数字 `0` 改用 `PORTFOLIO_MODE_TYPES.BACKTEST.value` 枚举。

### 问题

`paper_trading_worker.py:879` 用魔法数字 `0` 判断 BACKTEST 模式拒绝部署：

```python
portfolio_mode = getattr(db_portfolio, 'mode', -1)
if portfolio_mode == 0:  # BACKTEST
    GLOG.ERROR(...)
    return False
```

同文件 L117 已用 `PORTFOLIO_MODE_TYPES.PAPER.value` 枚举示范，L879 却回退到魔法数字，不一致且易腐化。

### 修复

```python
if portfolio_mode == PORTFOLIO_MODE_TYPES.BACKTEST.value:
```

`BACKTEST.value == 0`（已验证：PAPER=1, LIVE=2），语义完全等价。`PORTFOLIO_MODE_TYPES` 已在 L23 import（本 PR 未动 import 行）。

### AC2 核对

全文 `grep` 仅此一处 portfolio mode 魔法数字（`== 0.*# BACKTEST`），无残留。

## 测试

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全部通过：

- **L1 py_compile**:`src` + `api` 全量编译通过
- **L2 启动路径**:`test_user_crud_mock` + `test_containers` + `test_user_cli` — 29 passed
- **L3 worker unit**:`tests/unit/workers/test_paper_trading_worker.py::TestDeploy` — 3 passed
  - 新增 `test_deploy_backtest_mode_rejected` characterization test 锁定 BACKTEST 拒绝行为（L879 分支此前未覆盖）
  - 重构前后均 3 passed（行为不变）

纯可读性修复（魔法数字→枚举值，行为不变），无 TDD RED；先加特征测试锁定既有行为 → GREEN → 重构实现 → 仍 GREEN。

Closes #6029

🤖 Generated with [Claude Code](https://claude.com/claude-code)
