### PR TITLE
fix(#6048): trading total_pnl 从净资产计算

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -209,6 +209,7 @@ async def list_paper_accounts():
             initial_capital = float(getattr(p, 'initial_capital', 100000) or 100000)
             cash = float(getattr(p, 'cash', initial_capital) or initial_capital)
             position_value = _compute_position_value(_query_positions(p.uuid))
+            total_asset = cash + position_value
 
             accounts.append({
                 "uuid": p.uuid,
@@ -216,9 +217,9 @@ async def list_paper_accounts():
                 "initial_capital": initial_capital,
                 "available_cash": cash,
                 "position_value": position_value,
-                "total_asset": cash + position_value,
-                "today_pnl": 0,
-                "total_pnl": 0,
+                "total_asset": total_asset,
+                "today_pnl": 0,  # TODO(#6048): 需历史 position_record 按日对比（独立 slice）
+                "total_pnl": _compute_total_pnl(total_asset, initial_capital),
                 "status": _map_pt_status(p),
                 "created_at": _format_datetime(getattr(p, 'create_at', None)),
             })
@@ -318,6 +319,7 @@ async def get_paper_account(account_id: str):
         # 查询当前持仓
         positions = _query_positions(account_id)
         position_value = _compute_position_value(positions)
+        total_asset = cash + position_value
 
         # 查询活跃订单（pending 状态）
         orders = _query_orders(account_id, status_filter=["pending"])
@@ -329,9 +331,9 @@ async def get_paper_account(account_id: str):
                 "initial_capital": initial_capital,
                 "available_cash": cash,
                 "position_value": position_value,
-                "total_asset": cash + position_value,
-                "today_pnl": 0,
-                "total_pnl": 0,
+                "total_asset": total_asset,
+                "today_pnl": 0,  # TODO(#6048): 需历史 position_record 按日对比（独立 slice）
+                "total_pnl": _compute_total_pnl(total_asset, initial_capital),
                 "status": _map_pt_status(p),
                 "created_at": _format_datetime(getattr(p, 'create_at', None)),
                 "positions": positions,
@@ -620,6 +622,19 @@ def _compute_position_value(positions: list) -> float:
             sum(float(p.get("market_value", 0) or 0) for p in (positions or [])),
             2,
         )
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _compute_total_pnl(total_asset: float, initial_capital: float) -> float:
+    """计算总盈亏 = 当前净资产 − 初始资金（#6048）。
+
+    含已实现盈亏（体现在 cash 变化）+ 未实现盈亏（体现在持仓市值）。
+    用于 ``list_paper_accounts`` / ``get_paper_account`` 的 ``total_pnl``
+    字段（替代硬编码 0）。非数值入参安全降级为 0.0（不崩）。
+    """
+    try:
+        return round(float(total_asset) - float(initial_capital), 2)
     except (TypeError, ValueError):
         return 0.0
 

--- a/tests/api/test_trading_total_pnl.py
+++ b/tests/api/test_trading_total_pnl.py
@@ -1,0 +1,125 @@
+# Issue #6048: trading API total_pnl 从净资产计算（接力 PR#6420 的下一切片）
+# Upstream: api.api.trading._compute_total_pnl (new helper)
+# Downstream: api.api.trading.list_paper_accounts / get_paper_account
+# Role: 验证 total_pnl = total_asset - initial_capital（含已实现+未实现盈亏）。
+
+"""
+#6048 子集测试：trading 端点 total_pnl 硬编码零值。
+
+``list_paper_accounts`` (trading.py:188) 和 ``get_paper_account`` (trading.py:280) 的
+``total_pnl`` 字段是 TODO 桩（固定 0）。PR#6420 已接线 ``position_value`` /
+``total_asset``，``initial_capital`` 已现成 —— ``total_pnl = total_asset -
+initial_capital`` 数据全具备，无需 result_service/analyzer，规避模拟盘（PAPER
+portfolio）无回测 task_id 的陷阱。
+
+本测试验证 ``_compute_total_pnl`` helper 与端点接线：
+- ``total_pnl`` = total_asset - initial_capital（盈利为正、亏损为负、持平为 0）
+
+``today_pnl`` 留后续 slice（需历史 position_record 按日对比，独立数据源）。
+"""
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(autouse=True)
+def _ensure_debug():
+    GCONF.set_debug(True)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+class TestComputeTotalPnl:
+    """_compute_total_pnl = total_asset - initial_capital（#6048）。"""
+
+    def test_profit_when_total_asset_exceeds_initial(self):
+        """净资产 > 初始资金 → 正盈亏。"""
+        from api.trading import _compute_total_pnl
+
+        assert _compute_total_pnl(110000.0, 100000.0) == 10000.0
+
+    def test_loss_when_total_asset_below_initial(self):
+        """净资产 < 初始资金 → 负盈亏（亏损为负）。"""
+        from api.trading import _compute_total_pnl
+
+        assert _compute_total_pnl(95000.0, 100000.0) == -5000.0
+
+    def test_zero_when_equal(self):
+        """净资产 == 初始资金 → 0（持平）。"""
+        from api.trading import _compute_total_pnl
+
+        assert _compute_total_pnl(100000.0, 100000.0) == 0.0
+
+    def test_non_numeric_safe_zero(self):
+        """非数值入参安全降级为 0.0（容错，不崩）。"""
+        from api.trading import _compute_total_pnl
+
+        assert _compute_total_pnl("abc", 100000.0) == 0.0
+        assert _compute_total_pnl(100000.0, None) == 0.0
+
+
+class TestGetPaperAccountTotalPnl:
+    """get_paper_account total_pnl = total_asset - initial_capital（#6048）。"""
+
+    def test_total_pnl_is_total_asset_minus_initial_capital(self):
+        """total_pnl = (cash + position_value) - initial_capital。"""
+        from api.trading import get_paper_account
+
+        portfolio = SimpleNamespace(
+            uuid="acc-1", name="test", initial_capital=100000,
+            cash=80000, create_at=None,
+        )
+        positions = [
+            {"code": "000001", "market_value": 1500.0},
+            {"code": "600000", "market_value": 2300.0},
+        ]
+
+        with patch("api.trading._require_portfolio", return_value=[portfolio]), \
+             patch("api.trading._query_positions", return_value=positions), \
+             patch("api.trading._query_orders", return_value=[]):
+            result = run_async(get_paper_account("acc-1"))
+
+        data = result["data"]
+        # total_asset = 80000 + 3800 = 83800; total_pnl = 83800 - 100000 = -16200
+        assert data["total_asset"] == 83800.0
+        assert data["total_pnl"] == -16200.0
+
+
+class TestListPaperAccountsTotalPnl:
+    """list_paper_accounts 每个账户 total_pnl 独立计算（#6048）。"""
+
+    def test_each_account_total_pnl_from_its_net_asset(self):
+        """多账户各自 total_pnl = (cash + position_value) - initial_capital。"""
+        from api.trading import list_paper_accounts
+        from ginkgo.data.services.base_service import ServiceResult
+
+        p1 = SimpleNamespace(uuid="acc-1", name="a", initial_capital=100000,
+                             cash=90000, create_at=None)
+        p2 = SimpleNamespace(uuid="acc-2", name="b", initial_capital=200000,
+                             cash=150000, create_at=None)
+
+        positions_map = {
+            "acc-1": [{"code": "000001", "market_value": 1000.0}],
+            "acc-2": [{"code": "600000", "market_value": 2000.0},
+                      {"code": "000002", "market_value": 500.0}],
+        }
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=[p1, p2])
+
+        with patch("api.trading._get_portfolio_service", return_value=mock_service), \
+             patch("api.trading._query_positions",
+                   side_effect=lambda aid: positions_map.get(aid, [])):
+            result = run_async(list_paper_accounts())
+
+        accounts = result["data"]
+        # acc-1: total_asset = 90000 + 1000 = 91000; total_pnl = 91000 - 100000 = -9000
+        assert accounts[0]["total_pnl"] == -9000.0
+        # acc-2: total_asset = 150000 + 2500 = 152500; total_pnl = 152500 - 200000 = -47500
+        assert accounts[1]["total_pnl"] == -47500.0


### PR DESCRIPTION
## Summary

接力 PR#6420（position_value/total_asset）+ PR#6363（name）的下一切片，推进 #6048（trading API 盈亏字段硬编码零值）。

### 问题

`list_paper_accounts`(L188) / `get_paper_account`(L280) 的 `total_pnl` 是 TODO 桩（固定 0），模拟盘面板总盈亏恒零。

### 修复

`total_pnl = total_asset - initial_capital`（= 现金+持仓市值 − 初始资金，含已实现+未实现盈亏）。`total_asset` / `initial_capital` 已由 PR#6420 接线现成，无需 result_service/analyzer，规避模拟盘（PAPER portfolio）无回测 task_id 的陷阱。

- 新增 `_compute_total_pnl(total_asset, initial_capital)` helper（`round` 2 位 + `try/except (TypeError, ValueError)` 容错，对齐 `_compute_position_value` 风格）
- `list_paper_accounts` / `get_paper_account` 接线（提 `total_asset` 为局部变量复用）

### 未做（留后续 slice）

- `today_pnl`：需历史 position_record 按日对比（独立数据源，已留 TODO 标注）
- `status` 反映实际运行状态
- `daily_return`

各需独立数据源 + 陷阱处理，保持本 slice 最小独立。

### 与 #6363 / PR#6420 的关系

零 hunk 重叠：#6363 改 `_query_positions`/`_query_orders`（name），PR#6420 改 position_value/total_asset，本 PR 改 total_pnl（同 list/get 函数不同字段，base master，git 三方合并可自动处理）。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全绿：
- **L1 py_compile**：trading.py + test 文件
- **L2 启动路径**：test_user_crud_mock + test_containers + test_user_cli（29 passed）
- **L3 api**：test_trading_total_pnl（6 passed）+ test_trading_position_value 回归（7 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
