### PR TITLE
fix: system /workers/{type} 分类 filter 端点

### DIFF
--- a/api/api/system.py
+++ b/api/api/system.py
@@ -2,7 +2,7 @@
 系统状态和Worker管理API路由
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
 
 from core.config import settings
@@ -10,6 +10,15 @@ from core.response import ok
 from core.logging import logger
 
 router = APIRouter()
+
+# #5878 Worker Management 切片：前端期望的分类端点路径 → 后端 worker.type（system_service.py:107-153）
+WORKER_TYPE_MAP: Dict[str, str] = {
+    "backtest": "backtest_worker",
+    "data": "data_worker",
+    "execution": "execution_node",
+    "scheduler": "scheduler",
+    "timer": "task_timer",
+}
 
 
 def _get_system_service():
@@ -39,3 +48,23 @@ async def get_workers():
     except Exception as e:
         logger.error(f"Failed to get workers status: {e}")
         return ok(data={"data": [], "components": {}})
+
+
+@router.get("/workers/{worker_type}")
+async def get_workers_by_type(worker_type: str):
+    """#5878: 按类型获取 Worker 状态（前端 /workers/backtest|data|execution|scheduler|timer 分类端点）。"""
+    target = WORKER_TYPE_MAP.get(worker_type)
+    if target is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown worker type: {worker_type}. Valid: {list(WORKER_TYPE_MAP)}",
+        )
+    try:
+        svc = _get_system_service()
+        result = svc.get_workers_status()
+        workers = result.get("data", []) if isinstance(result, dict) else []
+        filtered = [w for w in workers if w.get("type") == target]
+        return ok(data={"type": target, "workers": filtered, "count": len(filtered)})
+    except Exception as e:
+        logger.error(f"Failed to get workers by type {worker_type}: {e}")
+        return ok(data={"type": target, "workers": [], "count": 0})

--- a/tests/api/test_system_workers_by_type.py
+++ b/tests/api/test_system_workers_by_type.py
@@ -1,0 +1,119 @@
+# Issue #5878: Worker Management 切片 — GET /workers/{type} 分类 filter
+# Upstream: api.system.get_workers_by_type (new endpoint)
+# Downstream: WebUI Worker 管理页（/workers/backtest|data|execution|scheduler|timer）
+# Role: 前端调 5 个分类端点，后端按 worker.type filter 聚合数据。
+
+"""
+#5878 Worker Management 切片测试。
+
+前端调 ``GET /api/v1/system/workers/{backtest|data|execution|scheduler|timer}`` 5 个分类
+端点均 404（后端仅有聚合 ``GET /workers``，#5878 body 列举）。``get_workers_status`` 已返回
+带 ``type`` 字段（``backtest_worker``/``data_worker``/``execution_node``/``scheduler``/
+``task_timer``，见 system_service.py:107-153）的 worker 列表，但无按 type filter 的子端点。
+
+本切片补 ``GET /workers/{worker_type}``，复用聚合按 ``worker.type`` 归类。满足 AC 第 5 条
+「Worker 管理端点返回各 Worker 真实状态」。不关闭 #5878（22+ 端点跨 7 模块，本切片仅
+Worker Management 1 模块）。
+"""
+import asyncio
+
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi import HTTPException
+
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(autouse=True)
+def _ensure_debug():
+    GCONF.set_debug(True)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+class TestWorkersByType:
+    """GET /workers/{worker_type} 按 worker.type filter（#5878）。"""
+
+    def test_unknown_type_raises_404(self):
+        """未知 type → HTTPException 404（防静默返回空，前端能区分 type 错误 vs 真无 worker）。"""
+        from api.system import get_workers_by_type
+
+        with pytest.raises(HTTPException) as exc:
+            run_async(get_workers_by_type("unknown_type"))
+        assert exc.value.status_code == 404
+
+    def test_backtest_filters_backtest_worker(self):
+        """backtest type → 只返回 backtest_worker（复用聚合 filter）。"""
+        from api.system import get_workers_by_type
+
+        mock_svc = MagicMock()
+        mock_svc.get_workers_status.return_value = {
+            "data": [
+                {"id": "w1", "type": "backtest_worker", "status": "running"},
+                {"id": "w2", "type": "data_worker", "status": "running"},
+                {"id": "w3", "type": "backtest_worker", "status": "idle"},
+            ],
+            "components": {},
+        }
+        with patch("api.system._get_system_service", return_value=mock_svc):
+            result = run_async(get_workers_by_type("backtest"))
+
+        data = result["data"]
+        assert data["type"] == "backtest_worker"
+        assert data["count"] == 2
+        assert all(w["type"] == "backtest_worker" for w in data["workers"])
+
+    @pytest.mark.parametrize("path,target", [
+        ("backtest", "backtest_worker"),
+        ("data", "data_worker"),
+        ("execution", "execution_node"),
+        ("scheduler", "scheduler"),
+        ("timer", "task_timer"),
+    ])
+    def test_each_path_maps_to_correct_worker_type(self, path, target):
+        """5 个前端路径 → 对应后端 worker.type（#5878 body 列举的 5 端点全覆盖）。"""
+        from api.system import get_workers_by_type
+
+        mock_svc = MagicMock()
+        mock_svc.get_workers_status.return_value = {
+            "data": [{"id": "x", "type": target}],
+            "components": {},
+        }
+        with patch("api.system._get_system_service", return_value=mock_svc):
+            result = run_async(get_workers_by_type(path))
+
+        data = result["data"]
+        assert data["type"] == target
+        assert data["count"] == 1
+
+    def test_valid_type_with_no_matching_workers_returns_empty(self):
+        """type 有效但聚合无该类型 worker → count=0 不崩（前端显示「无运行实例」）。"""
+        from api.system import get_workers_by_type
+
+        mock_svc = MagicMock()
+        mock_svc.get_workers_status.return_value = {
+            "data": [{"id": "x", "type": "data_worker"}],
+            "components": {},
+        }
+        with patch("api.system._get_system_service", return_value=mock_svc):
+            result = run_async(get_workers_by_type("backtest"))
+
+        data = result["data"]
+        assert data["type"] == "backtest_worker"
+        assert data["count"] == 0
+        assert data["workers"] == []
+
+    def test_service_exception_degrades_to_empty_not_crash(self):
+        """get_workers_status 抛异常 → 降级 count=0（端点不崩，与聚合 /workers 一致）。"""
+        from api.system import get_workers_by_type
+
+        mock_svc = MagicMock()
+        mock_svc.get_workers_status.side_effect = RuntimeError("redis down")
+        with patch("api.system._get_system_service", return_value=mock_svc):
+            result = run_async(get_workers_by_type("backtest"))
+
+        data = result["data"]
+        assert data["type"] == "backtest_worker"
+        assert data["count"] == 0


### PR DESCRIPTION
## Summary

推进 #5878（WebUI 面板调用的后端端点大面积缺失）的 **Worker Management 切片**。

### 问题

#5878 body 列举前端调 5 个分类端点均 404：
- `GET /api/v1/system/workers/backtest`
- `GET /api/v1/system/workers/data`
- `GET /api/v1/system/workers/execution`
- `GET /api/v1/system/workers/scheduler`
- `GET /api/v1/system/workers/timer`

后端仅有聚合 `GET /workers`。`system_service.get_workers_status` 已返回带 `type` 字段（`backtest_worker`/`data_worker`/`execution_node`/`scheduler`/`task_timer`）的 worker 列表，但无按 type filter 的子端点。

### 修复

新增 `GET /workers/{worker_type}`，复用聚合按 `worker.type` filter：

- `WORKER_TYPE_MAP`：前端路径 → 后端 worker.type（`system_service._format_workers`）
- 未知 type → `HTTPException 404`（前端能区分「type 拼错」vs「真无运行实例」）
- service 异常 → 降级 `count=0`（与聚合 `/workers` 一致，端点不崩）

### 不关闭 #5878（重要）

#5878 涉及 22+ 端点跨 7 模块（Auth/Trading/Portfolio/Worker/Backtest/Alert/DI），本 PR 仅 Worker Management 1 模块（AC 第 5 条）。后续切片：
- Auth 子模块
- Trading 盈亏字段（PR#6420 / #6363 / #6427 已推进 total_pnl 等）
- Portfolio / Backtest / Alert / DI 端点补全

各切片最小独立，零 hunk 重叠，便于分别 review。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全绿：
- **L1 py_compile**：system.py + test 文件 ✅
- **L2 启动路径**：test_user_crud_mock + test_containers + test_user_cli + system_service 回归（53 passed）✅
- **L3 api**：test_system_workers_by_type（9 passed）— 未知 type 404 / 5 type 参数化映射 / 空匹配 / 异常降级 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
