### PR TITLE
refactor: data sync 三分支汇总格式统一 (SyncStats)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -40,6 +40,36 @@ def _normalize_stock_code(code: str) -> str:
     return code
 
 
+class SyncStats:
+    """#6054: data sync 三态计数器 + 统一汇总格式。
+
+    day/tick/adjustfactor 三分支共用，避免每分支独立维护 success/error[/skipped]
+    计数与拼接字符串导致格式漂移（day 加 skipped_count 时 tick/adjustfactor 未同步，
+    adjustfactor 的 no-data 情况漏计数——均是不抽象的代价）。
+    """
+
+    def __init__(self) -> None:
+        self.success = 0
+        self.skipped = 0
+        self.errors = 0
+
+    def record_success(self) -> None:
+        self.success += 1
+
+    def record_skipped(self) -> None:
+        self.skipped += 1
+
+    def record_error(self) -> None:
+        self.errors += 1
+
+    def summary(self, type_name: str) -> str:
+        """统一汇总行：``{Type} sync completed. Success: N, Skipped: S, Errors: M``。"""
+        return (
+            f"{type_name} sync completed. "
+            f"Success: {self.success}, Skipped: {self.skipped}, Errors: {self.errors}"
+        )
+
+
 @app.command()
 def get(
     data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick/adjustfactor/sources) \\[planned: calendar]"),
@@ -591,9 +621,7 @@ def sync(
                     raise typer.Exit(1)
 
             try:
-                success_count = 0
-                error_count = 0
-                skipped_count = 0
+                stats = SyncStats()
 
                 for current_code in codes:
                     try:
@@ -621,22 +649,22 @@ def sync(
                             except (AttributeError, TypeError, ValueError):
                                 records_added = 0
                             if records_added > 0:
-                                success_count += 1
+                                stats.record_success()
                                 console.print(f":white_check_mark: {current_code} sync completed ({records_added} records)")
                             else:
-                                skipped_count += 1
+                                stats.record_skipped()
                                 console.print(f":warning: {current_code} — no data available from source")
                         else:
-                            error_count += 1
+                            stats.record_error()
                             error_msg = result.message if hasattr(result, 'message') else str(result.error) if hasattr(result, 'error') else 'Unknown error'
                             console.print(f":x: {current_code} sync failed: {error_msg}")
 
                     except Exception as e:
-                        error_count += 1
+                        stats.record_error()
                         console.print(f":x: Error syncing {current_code}: {str(e)}")
                         continue
 
-                console.print(f":information: Day sync completed. Success: {success_count}, Skipped: {skipped_count}, Errors: {error_count}")
+                console.print(f":information: {stats.summary('Day')}")
 
             except Exception as e:
                 console.print(f":x: Error in day sync process: {e}")
@@ -666,8 +694,7 @@ def sync(
                     raise typer.Exit(1)
 
             try:
-                success_count = 0
-                error_count = 0
+                stats = SyncStats()
 
                 for current_code in codes:
                     try:
@@ -689,19 +716,19 @@ def sync(
                             result = tick_service.sync_smart(current_code)
 
                         if result and result.is_success():
-                            success_count += 1
+                            stats.record_success()
                             console.print(f":white_check_mark: {current_code} sync completed")
                         else:
-                            error_count += 1
+                            stats.record_error()
                             error_msg = result.message if hasattr(result, 'message') else str(result.error) if hasattr(result, 'error') else 'Unknown error'
                             console.print(f":x: {current_code} sync failed: {error_msg}")
 
                     except Exception as e:
-                        error_count += 1
+                        stats.record_error()
                         console.print(f":x: Error syncing {current_code}: {str(e)}")
                         continue
 
-                console.print(f":information: Tick sync completed. Success: {success_count}, Errors: {error_count}")
+                console.print(f":information: {stats.summary('Tick')}")
 
             except Exception as e:
                 console.print(f":x: Error in tick sync process: {e}")
@@ -730,8 +757,7 @@ def sync(
                     raise typer.Exit(1)
 
             try:
-                success_count = 0
-                error_count = 0
+                stats = SyncStats()
 
                 for current_code in codes:
                     try:
@@ -770,10 +796,11 @@ def sync(
                             except (AttributeError, TypeError, ValueError):
                                 records_added = 0
                             if records_added > 0:
-                                success_count += 1
+                                stats.record_success()
                                 console.print(f":white_check_mark: {current_code} sync completed ({records_added} records)")
                             else:
-                                # service.sync 成功但源端无数据：不算成功计数，避免误导（#6053）
+                                # service.sync 成功但源端无数据：计 skipped（#6053/#6054 统一三态）
+                                stats.record_skipped()
                                 console.print(f":warning: {current_code} — no adjustfactor data available from source")
 
                             # 同步完成后立即计算该股票的复权因子
@@ -786,7 +813,7 @@ def sync(
                                 if hasattr(calc_result, 'error') and calc_result.error:
                                     console.print(f"   Error: {calc_result.error}")
                         else:
-                            error_count += 1
+                            stats.record_error()
                             console.print(f":x: {current_code} sync failed")
                             if hasattr(result, 'error') and result.error:
                                 console.print(f"   Error: {result.error}")
@@ -794,11 +821,11 @@ def sync(
                                 console.print(f"   Message: {result.message}")
 
                     except Exception as e:
-                        error_count += 1
+                        stats.record_error()
                         console.print(f":x: Error syncing {current_code}: {str(e)}")
                         continue
 
-                console.print(f":information: Adjustfactor sync completed. Success: {success_count}, Errors: {error_count}")
+                console.print(f":information: {stats.summary('Adjustfactor')}")
 
             except Exception as e:
                 console.print(f":x: Error in adjustfactor sync process: {e}")

--- a/tests/unit/client/test_data_cli_syncstats.py
+++ b/tests/unit/client/test_data_cli_syncstats.py
@@ -1,0 +1,44 @@
+"""#6054: SyncStats 三态计数器 + 统一汇总格式。
+
+data_cli.sync 的 day/tick/adjustfactor 三分支各自维护 success_count/error_count
+（day 另有 skipped_count），汇总格式不一致（day 三态 vs tick/adjustfactor 二态），
+且 adjustfactor 的 no-data 情况漏计数。SyncStats 收敛「三态计数 + 格式化」到一处，
+三分支共用，杜绝漂移（见 issue #6054 简报）。
+"""
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+
+from ginkgo.client.data_cli import SyncStats
+
+
+class TestSyncStats:
+    """SyncStats 纯逻辑：三态计数 + 统一 summary 格式。"""
+
+    def test_empty_summary_format(self):
+        """零计数 → ``{Type} sync completed. Success: 0, Skipped: 0, Errors: 0``。"""
+        stats = SyncStats()
+        assert stats.summary("Day") == (
+            "Day sync completed. Success: 0, Skipped: 0, Errors: 0"
+        )
+
+    def test_three_state_counts(self):
+        """record_success/skipped/error 累加 → summary 反映正确计数。"""
+        stats = SyncStats()
+        stats.record_success()
+        stats.record_success()
+        stats.record_skipped()
+        stats.record_error()
+        stats.record_error()
+        stats.record_error()
+        assert stats.summary("Tick") == (
+            "Tick sync completed. Success: 2, Skipped: 1, Errors: 3"
+        )
+
+    def test_type_name_interpolated(self):
+        """type_name 原样插到汇总行开头（day/tick/adjustfactor 三分支复用）。"""
+        stats = SyncStats()
+        stats.record_success()
+        assert stats.summary("Adjustfactor").startswith("Adjustfactor sync completed.")


### PR DESCRIPTION
## Summary

推进 #6054（data sync 三分支汇总格式不统一 refactor）。

### 问题

`data_cli.sync` 的 day/tick/adjustfactor 三分支各自维护 `success_count`/`error_count`（day 另有 `skipped_count`），汇总字符串独立拼接，导致：

- **格式漂移**：day 加 `Skipped` 计数时，tick/adjustfactor 未同步（仍二态）
- **漏计数**：adjustfactor 的 `records_added=0`（no-data）分支只 warn 不计数，day 同情况计 skipped

### 修复

抽取 **SyncStats** 三态计数器（`success`/`skipped`/`errors`）+ 统一 `summary()` 格式，三分支共用：

- `record_success()` / `record_skipped()` / `record_error()` 累加
- `summary(type_name)` 统一输出：`{Type} sync completed. Success: N, Skipped: S, Errors: M`
- adjustfactor no-data 分支补计 skipped（对齐 day 语义）

未来加第 4 态只改 SyncStats 一处，杜绝漂移。

### 变更

- `src/ginkgo/client/data_cli.py`：新增 `SyncStats` 类 + day/tick/adjustfactor 三分支接线
- `tests/unit/client/test_data_cli_syncstats.py`：3 测试覆盖三态计数 + 格式

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全绿：
- **L1 py_compile**：src+api 全量 ✅
- **L2 启动路径**：test_user_crud_mock + test_containers + test_user_cli（29 passed）✅
- **L3 变更相关**：test_data_cli + test_data_cli_syncstats + test_data_cli_adjustfactor（56 passed，含既有 adjustfactor wiring 回归 + no-data 契约）✅

Closes #6054

🤖 Generated with [Claude Code](https://claude.com/claude-code)
