### PR TITLE
refactor: RatioSizer 经 _data_feeder 取价对齐组件边界 (#3877)

### DIFF
--- a/src/ginkgo/trading/sizers/ratio_sizer.py
+++ b/src/ginkgo/trading/sizers/ratio_sizer.py
@@ -1,5 +1,5 @@
 # Upstream: PortfolioBase, ComponentFactoryService
-# Downstream: BaseSizer, Signal, Order, DIRECTION_TYPES, container, to_decimal
+# Downstream: BaseSizer, Signal, Order, DIRECTION_TYPES, to_decimal, _data_feeder
 # Role: 比例仓位管理器，按资金比例动态计算订单仓位
 
 
@@ -13,7 +13,6 @@ from ginkgo.trading.bases.sizer_base import SizerBase as BaseSizer
 from ginkgo.entities import Order, Signal
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.libs import to_decimal, GLOG
-from ginkgo.data.containers import container
 
 
 class RatioSizer(BaseSizer):
@@ -105,14 +104,17 @@ class RatioSizer(BaseSizer):
             current_time = self.get_time_provider().now()
 
             if direction == DIRECTION_TYPES.LONG:
+                # 组件边界单向流动（Selector→Strategy→Sizer→Risk）：Sizer 不直访 data 层，
+                # 经注入的 _data_feeder 取价（对齐 FixedSizer 范式，#3877）。
+                if self._data_feeder is None:
+                    GLOG.ERROR(f"Sizer:{self.name} has no data_feeder bound")
+                    return None
                 last_month_day = current_time + datetime.timedelta(days=-30)
                 yester_day = current_time + datetime.timedelta(days=-1)
-                result = container.bar_service().get(code=code, start_date=last_month_day, end_date=yester_day)
-                if not result.success or len(result.data) == 0:
-                    GLOG.CRITICAL(f"{code} has no data from {last_month_day} to {yester_day}. {current_time}")
-                    return None
-                past_price = result.data.to_dataframe()
-                if past_price.shape[0] == 0:
+                past_price = self._data_feeder.get_historical_data(
+                    symbols=[code], start_time=last_month_day, end_time=yester_day,
+                )
+                if past_price is None or past_price.shape[0] == 0:
                     GLOG.CRITICAL(f"{code} has no data from {last_month_day} to {yester_day}. {current_time}")
                     return None
                 last_price = to_decimal(past_price.iloc[-1]["close"])

--- a/tests/unit/trading/sizers/test_ratio_sizer.py
+++ b/tests/unit/trading/sizers/test_ratio_sizer.py
@@ -1,0 +1,90 @@
+"""
+Unit tests for RatioSizer — 组件边界契约：通过 _data_feeder 取价，不直访 container。
+
+背景（#3877）：RatioSizer.cal LONG 分支曾直访 container.bar_service().get()，
+绕过注入的 _data_feeder 接口，违反组件边界单向流动（Sizer 不应直访 data 层）。
+对齐 FixedSizer 范式（tests/unit/trading/sizers/test_fixed_sizer.py）。
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.entities import Signal
+from ginkgo.trading.sizers.ratio_sizer import RatioSizer
+
+
+@pytest.fixture
+def sizer():
+    s = RatioSizer(name="TestRatioSizer", ratio="0.1")
+    # mock time provider，cal() 内 current_time = self.get_time_provider().now()
+    tp = MagicMock()
+    tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+    s._time_provider = tp
+    return s
+
+
+@pytest.fixture
+def mock_feeder():
+    return MagicMock()
+
+
+def _make_signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG):
+    s = Signal(code=code, direction=direction)
+    s._portfolio_id = "test-portfolio"
+    s._engine_id = "test-engine"
+    return s
+
+
+def _make_portfolio_info(cash=Decimal("500000"), positions=None):
+    return {
+        "cash": cash,
+        "positions": positions or {},
+    }
+
+
+class TestRatioSizerUsesDataFeeder:
+    """RatioSizer 应通过 _data_feeder 取价，不直访 container.bar_service（组件边界）。"""
+
+    def test_long_uses_data_feeder_not_container(self, sizer, mock_feeder):
+        """LONG 分支：价格经 _data_feeder.get_historical_data 获取，container.bar_service 不被调用。
+
+        双重锁区分 bug（直访 container）与修复（走 feeder）：
+        - 正向：mock_feeder.get_historical_data 被调用
+        - 反向：container.bar_service 不被调用
+        """
+        df = pd.DataFrame({"close": [10.0, 10.5, 11.0]})
+        mock_feeder.get_historical_data.return_value = df
+        sizer._data_feeder = mock_feeder
+
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=Decimal("500000"))
+
+        # 反向锁：patch container 单例源对象的 bar_service。
+        # 修复后 ratio_sizer 不再 import container，patch 单例属性对任意 import
+        # 方式都成立；若 fix 被回退（直访 container），此 spy 会被调用 → 断言失败。
+        from ginkgo.data.containers import container as _container_singleton
+        with patch.object(_container_singleton, "bar_service") as mock_bar_service:
+            order = sizer.cal(info, signal)
+
+        # 正向锁：data_feeder 被调用
+        mock_feeder.get_historical_data.assert_called_once()
+        # 反向锁：container.bar_service 不应被直访（边界违规修复后）
+        mock_bar_service.assert_not_called()
+        # 端到端：订单成功生成
+        assert order is not None
+        assert order.direction == DIRECTION_TYPES.LONG
+        assert order.volume > 0
+
+    def test_long_no_data_feeder_returns_none(self, sizer):
+        """LONG 分支：未绑定 _data_feeder 时 ERROR 返回 None，不崩。"""
+        # 不绑定 feeder
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=Decimal("500000"))
+
+        order = sizer.cal(info, signal)
+
+        assert order is None


### PR DESCRIPTION
## Summary

`RatioSizer.cal` LONG 分支直访 `container.bar_service().get()` 取历史价格，绕过注入的 `_data_feeder` 接口，违反**组件边界单向流动**（`Selector → Strategy → Sizer → Risk`，Sizer 不应直访 data 层 Service）。对齐 `FixedSizer` 范式改走 `_data_feeder.get_historical_data`。

## 根因

- **表象**：RatioSizer 直接 `container.bar_service().get(code, start_date, end_date)` 取价，而非用 SizerBase 提供的 `self._data_feeder`。
- **调用链**：`RatioSizer.cal` L110 → `container.bar_service().get(...)` → 直访 data 层 Service（绕过注入的 `_data_feeder`）。
- **根因**：RatioSizer 未对齐 `FixedSizer` 范式（`self._data_feeder.get_historical_data(symbols, start_time, end_time)`）。
- **影响**：(1) 绕过 data_feeder 的回测/实盘数据源切换；(2) 无法被 `bind_data_feeder` 注入控制；(3) 实盘拿不到回测 feeder 的缓存价格。

## 修改

`src/ginkgo/trading/sizers/ratio_sizer.py`：
- LONG 分支：`container.bar_service().get(...)` → `self._data_feeder.get_historical_data(symbols=[code], start_time=..., end_time=...)`，去掉 `result.success`/`result.data.to_dataframe()`，直接用返回的 DataFrame。
- 加 `if self._data_feeder is None: GLOG.ERROR(...); return None` 守卫（对齐 FixedSizer L115）。
- 删 `from ginkgo.data.containers import container`（修复后无引用）。

## Test plan

TDD RED→GREEN（`tests/unit/trading/sizers/test_ratio_sizer.py`，2 测试）：
- `test_long_uses_data_feeder_not_container`：双重锁——正向 `feeder.get_historical_data` 被调用 + 反向 `container.bar_service` 不被调用（patch 单例源对象属性，对任意 import 方式成立）；端到端断言订单生成。
- `test_long_no_data_feeder_returns_none`：未绑定 feeder 时 ERROR 返回 None 不崩。

三层冒烟全绿：
- L1 py_compile (src+api) ✅
- L2 启动路径 (user_crud_mock + containers + user_cli) 29 passed ✅
- L3 sizers 回归 21 passed（ratio 2 + fixed/atr/commission 19）零回归 ✅

Closes #3877

🤖 Generated with [Claude Code](https://claude.com/claude-code)
