### PR TITLE
fix: webhook test 端点 SSRF 防护（URL scheme + 私有段校验）

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -6,6 +6,9 @@ from fastapi import APIRouter, HTTPException, status, Request, Query
 from pydantic import BaseModel, ConfigDict, Field
 from typing import List, Optional
 from datetime import datetime
+import ipaddress
+import socket
+from urllib.parse import urlparse
 import bcrypt
 
 from ginkgo.data.containers import container
@@ -21,6 +24,72 @@ router = APIRouter()
 
 
 # ==================== 通用函数 ====================
+
+# #5469: SSRF 防护——webhook test 服务端直发用户可控 URL，须拦内网/云元数据。
+# 显式网络表（版本无关，精确对齐 AC：10/172.16-31/192.168/127/169.254 + IPv6 等价段）。
+_BLOCKED_NETWORKS = (
+    ipaddress.ip_network("127.0.0.0/8"),       # IPv4 loopback
+    ipaddress.ip_network("10.0.0.0/8"),        # RFC1918 私有
+    ipaddress.ip_network("172.16.0.0/12"),     # RFC1918 私有（172.16-31）
+    ipaddress.ip_network("192.168.0.0/16"),    # RFC1918 私有
+    ipaddress.ip_network("169.254.0.0/16"),    # link-local（含云元数据 169.254.169.254）
+    ipaddress.ip_network("0.0.0.0/8"),         # unspecified / current-network
+    ipaddress.ip_network("::1/128"),           # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),          # IPv6 unique-local
+    ipaddress.ip_network("fe80::/10"),         # IPv6 link-local
+    ipaddress.ip_network("::/128"),            # IPv6 unspecified
+)
+
+
+def _assert_safe_webhook_url(address: str) -> None:
+    """#5469: 校验 webhook test 目标 URL 防 SSRF，不安全则 HTTPException(400)。
+
+    校验三道：
+    1. scheme 限 http/https（拦 file:///、gopher:// 等）；
+    2. hostname 经 getaddrinfo 解析为 IP——拦域名直写私有段，亦防 DNS rebinding
+       （域名解析期公网、请求期内网）；
+    3. 解析所得 IP 命中 _BLOCKED_NETWORKS 即拒。
+
+    raise HTTPException（非 BusinessError）以穿透端点既有 ``except HTTPException: raise``
+    链（BusinessError 会被 ``except Exception`` 吞成 500，见 arch_httpexception_caught_by_except）。
+    DNS 解析失败 fail-closed（按不安全处理）。
+    """
+    try:
+        parsed = urlparse(address)
+    except Exception as e:
+        logger.warning(f"#5469 SSRF block: malformed URL: {address!r} ({e})")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid webhook URL")
+
+    if parsed.scheme not in ("http", "https"):
+        logger.warning(f"#5469 SSRF block: bad scheme {parsed.scheme!r}: {address!r}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Webhook URL scheme must be http or https")
+
+    hostname = parsed.hostname
+    if not hostname:
+        logger.warning(f"#5469 SSRF block: no hostname: {address!r}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Webhook URL missing hostname")
+
+    # 解析全部 IP（getaddrinfo 可能返回多条；含 v6）。解析失败 fail-closed。
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as e:
+        logger.warning(f"#5469 SSRF block: DNS resolve failed for {hostname!r}: {e}")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Webhook hostname could not be resolved")
+
+    ips = {info[4][0] for info in infos}
+    for ip_str in ips:
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        for net in _BLOCKED_NETWORKS:
+            if ip in net:
+                logger.warning(f"#5469 SSRF block: {hostname!r} resolves to blocked {ip} ({net})")
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Webhook URL targets a blocked internal or private network range",
+                )
+
 
 def get_user_service():
     """获取UserService实例"""
@@ -705,6 +774,8 @@ async def test_user_contact(contact_uuid: str, data: UserContactTest):
             )
         elif contact_type == CONTACT_TYPES.WEBHOOK:
             # Webhook 已实现（下方 requests.post 实发），原 TODO 注释为过期残留（#5595）
+            # #5469: 发送前校验目标 URL 防 SSRF（拦内网/云元数据/scheme），不安全抛 400。
+            _assert_safe_webhook_url(data.address)
             import requests
             try:
                 response = requests.post(
@@ -1761,6 +1832,8 @@ async def test_notification_recipient(uuid: str):
             try:
                 if contact_type in ["DISCORD", "WEBHOOK"]:
                     # 使用 requests 直接发送 Discord Webhook
+                    # #5469: 发送前校验目标 URL 防 SSRF（address 来自 DB contact，用户自设仍可控）。
+                    _assert_safe_webhook_url(address)
                     import requests
                     payload = {
                         "content": test_content.replace("\n", " ").replace("\r", ""),
@@ -1796,6 +1869,10 @@ async def test_notification_recipient(uuid: str):
                     failed_count += 1
                     results.append(f"{contact_type}: 未知类型")
 
+            except HTTPException:
+                # #5469: SSRF 守卫抛的 400 须穿透内层兜底，否则被下方 except Exception
+                # 吞成 "failed"（返 200）。不安全 URL 直接拒整批请求。
+                raise
             except Exception as e:
                 err_name = type(e).__name__
                 if "Timeout" in err_name:

--- a/tests/api/test_settings_webhook_ssrf.py
+++ b/tests/api/test_settings_webhook_ssrf.py
@@ -1,0 +1,142 @@
+"""#5469: webhook test 端点 SSRF 防护——_assert_safe_webhook_url 校验。
+
+服务端 test_user_contact 对用户可控 address 直发 requests.post，可探内网/云元数据
+(169.254.169.254)。修复：发送前校验 URL（scheme 白名单 + 解析后 IP 拦私有段 +
+getaddrinfo 防 DNS rebinding），不安全则 HTTPException(400)。
+
+延迟导入（conftest api_modules fixture 临时把 api/ 入 sys.path，对齐
+test_settings_todo_stubs_501.py 模式）。
+"""
+import asyncio
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_webhook_contact():
+    """构造 mock webhook 联系方式对象。"""
+    from ginkgo.enums import CONTACT_TYPES
+
+    contact = Mock()
+    contact.get_contact_type_enum.return_value = CONTACT_TYPES.WEBHOOK
+    return contact
+
+
+# ---------- 1. tracer：loopback 必拦 ----------
+def test_webhook_blocks_loopback(api_modules):
+    from api.settings import _assert_safe_webhook_url
+
+    with pytest.raises(HTTPException) as exc:
+        _assert_safe_webhook_url("http://127.0.0.1/x")
+    assert exc.value.status_code == 400
+
+
+# ---------- 2. RFC1918 私有段全拦 ----------
+@pytest.mark.parametrize("url", [
+    "http://10.0.0.1/x",
+    "http://172.16.5.4/x",
+    "http://172.31.255.255/x",
+    "http://192.168.1.1/x",
+])
+def test_webhook_blocks_rfc1918(api_modules, url):
+    from api.settings import _assert_safe_webhook_url
+
+    with pytest.raises(HTTPException) as exc:
+        _assert_safe_webhook_url(url)
+    assert exc.value.status_code == 400
+
+
+# ---------- 3. link-local / 云元数据（#5469 头条 AC） ----------
+def test_webhook_blocks_cloud_metadata(api_modules):
+    from api.settings import _assert_safe_webhook_url
+
+    with pytest.raises(HTTPException) as exc:
+        _assert_safe_webhook_url("http://169.254.169.254/latest/meta-data/")
+    assert exc.value.status_code == 400
+
+
+# ---------- 4. 非 http/https scheme 必拦 ----------
+@pytest.mark.parametrize("url", ["file:///etc/passwd", "gopher://127.0.0.1/x", "ftp://example.com/x"])
+def test_webhook_blocks_bad_scheme(api_modules, url):
+    from api.settings import _assert_safe_webhook_url
+
+    with pytest.raises(HTTPException) as exc:
+        _assert_safe_webhook_url(url)
+    assert exc.value.status_code == 400
+
+
+# ---------- 5. DNS rebinding：域名解析到私有段亦拦 ----------
+def test_webhook_blocks_dns_rebinding(api_modules):
+    from api.settings import _assert_safe_webhook_url
+
+    # benign 域名经 mock 解析到 10.0.0.1（私有），应被拦
+    fake_info = [(2, 1, 6, "", ("10.0.0.1", 0))]
+    with patch("api.settings.socket.getaddrinfo", return_value=fake_info):
+        with pytest.raises(HTTPException) as exc:
+            _assert_safe_webhook_url("https://internal.evil.example.com/hook")
+    assert exc.value.status_code == 400
+
+
+# ---------- 6. 公网 URL 放行 ----------
+def test_webhook_allows_public(api_modules):
+    from api.settings import _assert_safe_webhook_url
+
+    # example.com 经 mock 解析到公网 IP（93.184.216.34），应放行不抛
+    fake_info = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    with patch("api.settings.socket.getaddrinfo", return_value=fake_info):
+        _assert_safe_webhook_url("https://example.com/hook")  # 不抛即通过
+
+
+# ---------- 7. DNS 解析失败 fail-closed ----------
+def test_webhook_dns_failure_fail_closed(api_modules):
+    from api.settings import _assert_safe_webhook_url
+    import socket
+
+    with patch("api.settings.socket.getaddrinfo", side_effect=socket.gaierror("dns fail")):
+        with pytest.raises(HTTPException) as exc:
+            _assert_safe_webhook_url("https://nonexistent.invalid/x")
+    assert exc.value.status_code == 400
+
+
+# ---------- 8. 端点集成：test_user_contact 拦内网 URL（guard 在 requests 导入前抛 400） ----------
+def test_user_contact_blocks_internal_webhook(api_modules):
+    from ginkgo.enums import CONTACT_TYPES
+    from api.settings import test_user_contact, UserContactTest
+
+    fake_contact = _make_webhook_contact()
+    user_svc = Mock()
+    user_svc.get_contact.return_value = Mock(success=True, data=fake_contact)
+
+    with patch("api.settings.get_user_service", return_value=user_svc):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(test_user_contact(
+                "contact-uuid",
+                UserContactTest(address="http://169.254.169.254/latest/meta-data/"),
+            ))
+    assert exc.value.status_code == 400
+
+
+# ---------- 9. 第二 sink：test_notification_recipient 内网 webhook block 穿透内层 except ----------
+def test_notification_recipient_blocks_internal_webhook(api_modules):
+    """#5469: test_notification_recipient 的 DISCORD/WEBHOOK 分支同型 SSRF。
+
+    内层 ``except Exception`` 会吞 HTTPException；修复加 ``except HTTPException: raise``
+    使 block 一致返 400（非 200 failed）。
+    """
+    from api.settings import test_notification_recipient
+
+    svc = Mock()
+    contacts_result = Mock()
+    contacts_result.is_success.return_value = True
+    contacts_result.data = {
+        "contacts": [{"type": "WEBHOOK", "address": "http://10.0.0.1/exfil"}],
+        "recipient_name": "alice",
+        "recipient_type": "USER",
+    }
+    svc.get_recipient_contacts.return_value = contacts_result
+
+    with patch("api.settings.get_notification_recipient_service", return_value=svc):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(test_notification_recipient("recipient-uuid"))
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Summary

`api/api/settings.py` 两处 webhook/discord **test** 端点对用户可控 `address` 直发 `requests.post`，无任何 URL 校验——可探内网服务、云元数据（`http://169.254.169.254/latest/meta-data/` 泄 IAM 凭证）、Redis/MySQL 等。

加 `_assert_safe_webhook_url` 守卫，发送前拦截不安全目标。

## 根因

- **表象**：webhook test 服务端按用户给的 URL 直发 HTTP。
- **调用链**：`test_user_contact` (settings.py:775) WEBHOOK 分支 → `requests.post(data.address)` 无校验 → 💥 SSRF sink。同型第二 sink：`test_notification_recipient` (settings.py:1833) DISCORD/WEBHOOK 分支。
- **根因**：发送前缺 scheme/网络段校验。
- **修复点**：两处 sink 发送前调 `_assert_safe_webhook_url`（非 service/CRUD/Base，纯 API 层输入校验）。

## 修改

`api/api/settings.py`：
- 新增 `_assert_safe_webhook_url(address)`：三道校验
  1. scheme 限 `http`/`https`（拦 `file:///`、`gopher://` 等）
  2. hostname 经 `socket.getaddrinfo` 解析为 IP——拦域名直写私有段，亦防 DNS rebinding（解析期公网、请求期内网）
  3. 解析所得 IP 命中 `_BLOCKED_NETWORKS`（显式表：`10/8`、`172.16/12`、`192.168/16`、`127/8`、`169.254/16` link-local 含云元数据、`0.0.0.0/8`、IPv6 `::1`/`fc00::/7`/`fe80::/10`/`::/128`）即拒
  - DNS 解析失败 fail-closed（按不安全处理）；拦截记 WARNING 日志（AC4 安全监控）
  - raise `HTTPException(400)`（非 `BusinessError`）以穿透端点既有 `except HTTPException: raise` 链——`BusinessError` 会被 `except Exception` 吞成 500（见 arch_httpexception_caught_by_except）
- `test_user_contact` WEBHOOK 分支：`requests.post` 前调用守卫
- `test_notification_recipient` DISCORD/WEBHOOK 分支：同上；并补 `except HTTPException: raise`（内层 `except Exception` 会吞 400 成 "failed" 返 200，补透传使 block 一致返 400；任一 contact URL 不安全即拒整批，安全语义正确）

## Test plan

TDD RED→GREEN（`tests/api/test_settings_webhook_ssrf.py`，14 测试）：
- `test_webhook_blocks_loopback`（tracer）
- `test_webhook_blocks_rfc1918`（参数化 10/172.16/172.31/192.168）
- `test_webhook_blocks_cloud_metadata`（169.254.169.254，#5469 头条 AC）
- `test_webhook_blocks_bad_scheme`（参数化 file/gopher/ftp）
- `test_webhook_blocks_dns_rebinding`（mock getaddrinfo→10.0.0.1）
- `test_webhook_allows_public`（mock getaddrinfo→93.184.216.34，放行不抛）
- `test_webhook_dns_failure_fail_closed`（mock gaierror→400）
- `test_user_contact_blocks_internal_webhook`（端点集成，169.254→400）
- `test_notification_recipient_blocks_internal_webhook`（第二 sink 端点集成，10.0.0.1→400，验证内层 except 穿透）

三层冒烟全绿：
- L1 py_compile (src+api) ✅
- L2 启动路径 (user_crud_mock + containers + user_cli) 29 passed ✅
- L3 变更相关 15 passed ✅
  - 注：`test_settings_todo_stubs_501.py` 有 3 个 api_keys/api_stats 501 测试在 master 即预存失败（#5595 桩已被后续 PR 实现真实端点，测试过期），与本 PR 无关——已 `git show origin/master` 验证 `list_api_keys` 在干净 master 已是 `return ok(...)` 实现。

Closes #5469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
