### PR TITLE
fix: 登录端点 brute-force 防护（progressive delay + lockout）

### DIFF
--- a/api/api/auth.py
+++ b/api/api/auth.py
@@ -61,10 +61,40 @@ def get_user_service():
     return container.user_service()
 
 
+def _check_login_throttle(username: str) -> None:
+    """#5482: 登录入口检查 per-username lockout/throttle，命中抛 429。
+    fail-open：Redis 异常时 ttl=0，不阻塞登录（可用性优先）。"""
+    rsvc = container.redis_service()
+    lockout_ttl = rsvc.get_login_lockout_ttl(username)
+    if lockout_ttl > 0:
+        logger.warning(f"#5482 login blocked for locked account {username}: {lockout_ttl}s remaining")
+        raise HTTPException(status_code=429, detail=f"Account temporarily locked. Retry in {lockout_ttl}s")
+    throttle_ttl = rsvc.get_login_throttle_ttl(username)
+    if throttle_ttl > 0:
+        raise HTTPException(status_code=429, detail=f"Too many failed attempts. Retry in {throttle_ttl}s")
+
+
+def _record_login_failure(username: str) -> None:
+    """#5482: 记录登录失败，触发 progressive delay（3/5/7/9→1/2/4/8s）与
+    lockout（10 连续失败锁 5min）。命中 lockout 阈值抛 429（取代后续 401）。"""
+    rsvc = container.redis_service()
+    count = rsvc.incr_login_failures(username)
+    if count >= 10:
+        rsvc.set_login_lockout(username, 300)
+        logger.warning(f"#5482 brute-force lockout triggered for {username} after {count} failures")
+        raise HTTPException(status_code=429, detail="Account locked for 5 minutes due to too many failed login attempts")
+    delay = {3: 1, 5: 2, 7: 4, 9: 8}.get(count, 0)
+    if delay > 0:
+        rsvc.set_login_throttle(username, delay)
+
+
 @router.post("/login")
 async def login(login_request: LoginRequest, req: Request):
     """用户登录"""
     logger.info(f"Login attempt for user: {login_request.username}")
+
+    # #5482: 入口检查 per-username brute-force 节流（lockout/throttle），命中抛 429
+    _check_login_throttle(login_request.username)
 
     user_service = get_user_service()
 
@@ -73,6 +103,7 @@ async def login(login_request: LoginRequest, req: Request):
 
     if not result.success or not result.data or not result.data.get("users"):
         logger.warning(f"Login failed for user: {login_request.username} - user not found")
+        _record_login_failure(login_request.username)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid username or password"
@@ -86,6 +117,7 @@ async def login(login_request: LoginRequest, req: Request):
 
     if not credential:
         logger.warning(f"Login failed for user: {login_request.username} - no credential found")
+        _record_login_failure(login_request.username)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid username or password"
@@ -102,6 +134,7 @@ async def login(login_request: LoginRequest, req: Request):
     # 验证密码
     if not verify_password(login_request.password, credential.password_hash):
         logger.warning(f"Login failed for user: {login_request.username} - wrong password")
+        _record_login_failure(login_request.username)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid username or password"
@@ -110,6 +143,9 @@ async def login(login_request: LoginRequest, req: Request):
     # 更新最后登录时间
     client_ip = req.client.host if req.client else ""
     user_service.update_last_login(credential.uuid, client_ip)
+
+    # #5482: 登录成功，清除该用户的失败计数/节流/锁定状态
+    container.redis_service().reset_login_state(login_request.username)
 
     # 生成JWT token
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)

--- a/src/ginkgo/data/services/redis_service.py
+++ b/src/ginkgo/data/services/redis_service.py
@@ -394,6 +394,71 @@ class RedisService(BaseService):
             self._logger.ERROR(f"Failed to check key existence: {e}")
             return ServiceResult.error(f"Failed to check key existence: {str(e)}")
 
+    # ==================================================================
+    # #5482: login brute-force 防护（per-username 失败计数 / progressive
+    # delay / lockout）。热路径方法返原始值（非 ServiceResult），fail-open：
+    # Redis 异常返安全默认（count=0 / ttl=0）不阻塞登录，与 rate_limit 的
+    # fail-open 安全网一致（见 arch_rate_limit_redis_fallback）。
+    # ==================================================================
+
+    def incr_login_failures(self, username: str, window_seconds: int = 600) -> int:
+        """#5482: 原子递增 per-username 登录失败计数（pipeline 保证 incr+expire
+        原子，避免无 TTL 计数键泄漏）。fail-open：Redis 异常返 0。"""
+        try:
+            key = f"auth:login_fail:{username}"
+            pipe = self.redis.pipeline()
+            pipe.incr(key)
+            pipe.expire(key, window_seconds)
+            count, _ = pipe.execute()
+            return int(count)
+        except Exception as e:
+            self._logger.ERROR(f"#5482 incr_login_failures failed for {username}: {e}")
+            return 0
+
+    def set_login_throttle(self, username: str, seconds: int) -> None:
+        """#5482: 设 progressive delay 节流键（3/5/7/9 失败后 1/2/4/8s）。"""
+        try:
+            self.redis.setex(f"auth:login_throttle:{username}", seconds, 1)
+        except Exception as e:
+            self._logger.ERROR(f"#5482 set_login_throttle failed for {username}: {e}")
+
+    def set_login_lockout(self, username: str, seconds: int = 300) -> None:
+        """#5482: 设账户锁定键（10 连续失败锁 5min）。"""
+        try:
+            self.redis.setex(f"auth:login_lockout:{username}", seconds, 1)
+        except Exception as e:
+            self._logger.ERROR(f"#5482 set_login_lockout failed for {username}: {e}")
+
+    def get_login_throttle_ttl(self, username: str) -> int:
+        """#5482: 返回节流键剩余秒数（0=未节流）。"""
+        try:
+            ttl = self.redis.ttl(f"auth:login_throttle:{username}")
+            return int(ttl) if ttl and ttl > 0 else 0
+        except Exception as e:
+            self._logger.ERROR(f"#5482 get_login_throttle_ttl failed for {username}: {e}")
+            return 0
+
+    def get_login_lockout_ttl(self, username: str) -> int:
+        """#5482: 返回锁定键剩余秒数（0=未锁定）。"""
+        try:
+            ttl = self.redis.ttl(f"auth:login_lockout:{username}")
+            return int(ttl) if ttl and ttl > 0 else 0
+        except Exception as e:
+            self._logger.ERROR(f"#5482 get_login_lockout_ttl failed for {username}: {e}")
+            return 0
+
+    def reset_login_state(self, username: str) -> None:
+        """#5482: 成功登录后清失败计数/节流/锁定三键。"""
+        try:
+            for key in (
+                f"auth:login_fail:{username}",
+                f"auth:login_throttle:{username}",
+                f"auth:login_lockout:{username}",
+            ):
+                self.redis.delete(key)
+        except Exception as e:
+            self._logger.ERROR(f"#5482 reset_login_state failed for {username}: {e}")
+
     def find_keys(self, pattern: str = "*") -> ServiceResult:
         """
         查找匹配 pattern 的 Redis 键列表

--- a/tests/api/test_auth_login_throttle.py
+++ b/tests/api/test_auth_login_throttle.py
@@ -1,0 +1,89 @@
+"""#5482: login 端点 brute-force 防护——auth.py helper 与端点接线测试。
+
+验证 _check_login_throttle（入口 lockout/throttle 拦截）与 _record_login_failure
+（失败计数 + progressive delay 3/5/7/9→1/2/4/8s + 10 失败 lockout 5min）。
+patch container.redis_service 隔离真 Redis。
+"""
+import pytest
+from fastapi import HTTPException
+
+
+# ---------- _check_login_throttle：入口节流检查 ----------
+
+def test_check_login_throttle_raises_429_when_locked(api_modules):
+    from unittest.mock import MagicMock, patch
+    from api.auth import _check_login_throttle
+
+    rsvc = MagicMock()
+    rsvc.get_login_lockout_ttl.return_value = 280
+    rsvc.get_login_throttle_ttl.return_value = 0
+    with patch("ginkgo.data.containers.container.redis_service", return_value=rsvc):
+        with pytest.raises(HTTPException) as exc:
+            _check_login_throttle("alice")
+    assert exc.value.status_code == 429
+    assert "locked" in exc.value.detail.lower()
+
+
+def test_check_login_throttle_raises_429_when_throttled(api_modules):
+    from unittest.mock import MagicMock, patch
+    from api.auth import _check_login_throttle
+
+    rsvc = MagicMock()
+    rsvc.get_login_lockout_ttl.return_value = 0
+    rsvc.get_login_throttle_ttl.return_value = 6
+    with patch("ginkgo.data.containers.container.redis_service", return_value=rsvc):
+        with pytest.raises(HTTPException) as exc:
+            _check_login_throttle("alice")
+    assert exc.value.status_code == 429
+
+
+def test_check_login_throttle_passes_when_clear(api_modules):
+    from unittest.mock import MagicMock, patch
+    from api.auth import _check_login_throttle
+
+    rsvc = MagicMock()
+    rsvc.get_login_lockout_ttl.return_value = 0
+    rsvc.get_login_throttle_ttl.return_value = 0
+    with patch("ginkgo.data.containers.container.redis_service", return_value=rsvc):
+        _check_login_throttle("alice")  # 不抛即通过
+
+
+# ---------- _record_login_failure：progressive delay + lockout ----------
+
+def test_record_login_failure_locks_out_at_10(api_modules):
+    from unittest.mock import MagicMock, patch
+    from api.auth import _record_login_failure
+
+    rsvc = MagicMock()
+    rsvc.incr_login_failures.return_value = 10
+    with patch("ginkgo.data.containers.container.redis_service", return_value=rsvc):
+        with pytest.raises(HTTPException) as exc:
+            _record_login_failure("alice")
+    assert exc.value.status_code == 429
+    rsvc.set_login_lockout.assert_called_once_with("alice", 300)
+
+
+def test_record_login_failure_sets_progressive_delay(api_modules):
+    from unittest.mock import MagicMock, patch
+    from api.auth import _record_login_failure
+
+    # count → delay 映射：3→1s, 5→2s, 7→4s, 9→8s
+    for count, expected_delay in [(3, 1), (5, 2), (7, 4), (9, 8)]:
+        rsvc = MagicMock()
+        rsvc.incr_login_failures.return_value = count
+        with patch("ginkgo.data.containers.container.redis_service", return_value=rsvc):
+            _record_login_failure("alice")  # 阈值内不抛
+        rsvc.set_login_throttle.assert_called_once_with("alice", expected_delay)
+        rsvc.set_login_lockout.assert_not_called()
+
+
+def test_record_login_failure_no_delay_below_threshold(api_modules):
+    from unittest.mock import MagicMock, patch
+    from api.auth import _record_login_failure
+
+    rsvc = MagicMock()
+    rsvc.incr_login_failures.return_value = 2  # 未达 3 失败阈值
+    with patch("ginkgo.data.containers.container.redis_service", return_value=rsvc):
+        _record_login_failure("alice")
+    rsvc.set_login_throttle.assert_not_called()
+    rsvc.set_login_lockout.assert_not_called()

--- a/tests/unit/data/services/test_redis_login_throttle.py
+++ b/tests/unit/data/services/test_redis_login_throttle.py
@@ -1,0 +1,103 @@
+"""#5482: login brute-force 防护——RedisService per-username 失败计数/throttle/lockout。
+
+纯 mock 测试（不依赖真 Redis），验证原子 pipeline 调用与 fail-open 语义。
+对应 auth.py login 端点的节流入口检查与失败记录。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.redis_service import RedisService
+
+
+def _make_service():
+    """构造 RedisService（跳 __init__ 避真 Redis），mock 底层 client + logger。"""
+    svc = RedisService.__new__(RedisService)
+    svc.redis = MagicMock()
+    svc._logger = MagicMock()
+    return svc
+
+
+# ---------- 1. tracer：incr 原子递增 + 设 TTL 窗口 ----------
+def test_incr_login_failures_counts_up_and_sets_window_ttl():
+    svc = _make_service()
+    pipe = MagicMock()
+    pipe.execute.return_value = (1, True)
+    svc.redis.pipeline.return_value = pipe
+
+    count = svc.incr_login_failures("alice")
+
+    assert count == 1
+    pipe.incr.assert_called_once_with("auth:login_fail:alice")
+    pipe.expire.assert_called_once_with("auth:login_fail:alice", 600)
+    svc.redis.pipeline.assert_called_once()
+
+
+def test_incr_login_failures_returns_incrementing_count():
+    svc = _make_service()
+    pipe = MagicMock()
+    pipe.execute.return_value = (5, True)
+    svc.redis.pipeline.return_value = pipe
+
+    assert svc.incr_login_failures("bob") == 5
+
+
+# ---------- 2. fail-open：Redis 异常返 0（不阻塞登录） ----------
+def test_incr_login_failures_fail_open_on_redis_error():
+    svc = _make_service()
+    svc.redis.pipeline.side_effect = Exception("redis down")
+
+    assert svc.incr_login_failures("alice") == 0  # 不抛，返安全默认
+    svc._logger.ERROR.assert_called_once()
+
+
+# ---------- 3. get/set throttle 与 lockout ----------
+def test_set_login_throttle_sets_key_with_ttl():
+    svc = _make_service()
+    svc.set_login_throttle("alice", 8)
+    svc.redis.setex.assert_called_once_with("auth:login_throttle:alice", 8, 1)
+
+
+def test_set_login_lockout_defaults_5_minutes():
+    svc = _make_service()
+    svc.set_login_lockout("alice")
+    svc.redis.setex.assert_called_once_with("auth:login_lockout:alice", 300, 1)
+
+
+# ---------- 4. TTL 查询（节流入口判断） ----------
+def test_get_login_throttle_ttl_returns_remaining_seconds():
+    svc = _make_service()
+    svc.redis.ttl.return_value = 6
+    assert svc.get_login_throttle_ttl("alice") == 6
+    svc.redis.ttl.assert_called_once_with("auth:login_throttle:alice")
+
+
+def test_get_login_throttle_ttl_zero_when_no_key():
+    svc = _make_service()
+    svc.redis.ttl.return_value = -2  # redis: key 不存在
+    assert svc.get_login_throttle_ttl("alice") == 0
+
+
+def test_get_login_lockout_ttl_returns_remaining_seconds():
+    svc = _make_service()
+    svc.redis.ttl.return_value = 280
+    assert svc.get_login_lockout_ttl("alice") == 280
+
+
+# ---------- 5. reset：成功登录清所有节流键 ----------
+def test_reset_login_state_deletes_all_three_keys():
+    svc = _make_service()
+    svc.reset_login_state("alice")
+    deleted = {call.args[0] for call in svc.redis.delete.call_args_list}
+    assert deleted == {
+        "auth:login_fail:alice",
+        "auth:login_throttle:alice",
+        "auth:login_lockout:alice",
+    }


### PR DESCRIPTION
## Summary

`api/api/auth.py` login 端点缺暴力破解防护——失败计数无上限，攻击者可无限试密码（#5482 头条 AC）。加 per-username progressive delay + lockout。

## 根因

- **表象**：login 端点对任意次数失败无节流。
- **调用链**：`POST /auth/login` (auth.py:login) → 401 失败分支直接 raise，无计数/延迟/锁定。
- **根因**：登录失败无 per-username 状态追踪。
- **修复点**：RedisService 加节流方法（非 Base 类，具体实现层）；auth.py 加 helper + 接线（纯 API 层输入校验，非 service/CRUD）。

## 修改

`src/ginkgo/data/services/redis_service.py`（在 exists() 后插入，非 Base 类）：
- `incr_login_failures`：pipeline 原子 incr+expire（600s 窗口），返计数；Redis 异常 fail-open 返 0
- `set_login_throttle` / `set_login_lockout`：setex 设节流/锁定键（lockout 默认 300s）
- `get_login_throttle_ttl` / `get_login_lockout_ttl`：返剩余秒（0=无键）
- `reset_login_state`：删失败计数/throttle/lockout 三键

`api/api/auth.py`：
- `_check_login_throttle`：入口查 lockout/throttle TTL，命中抛 429（fail-open：Redis 异常 ttl=0 不阻塞）
- `_record_login_failure`：incr 计数；≥10→set_login_lockout(300)+抛 429；{3,5,7,9}→set_login_throttle({1,2,4,8})
- login 端点接线：入口 `_check_login_throttle`；user-not-found / no-credential / wrong-password 三处 401 分支 `_record_login_failure`；成功路径 `reset_login_state`；**403 disabled 不计**（账户禁用非 brute-force 信号，记录会污染计数）

key schema：`auth:login_fail:{username}` / `auth:login_throttle:{username}` / `auth:login_lockout:{username}`

设计依据：rate_limit Redis 基础设施已存在，fail-open 安全网哲学一致（见 arch_rate_limit_redis_fallback——Redis 抖动时不自我锁定，可用性优先）。

## Test plan

TDD RED→GREEN（15 测试）：
- `tests/unit/data/services/test_redis_login_throttle.py`（9）：incr 原子计数+TTL、fail-open 返 0、set throttle/lockout、get TTL（有键/无键）、reset 三键
- `tests/api/test_auth_login_throttle.py`（6）：_check lockout(429)/throttle(429)/clear、_record lockout@10（set_login_lockout alice 300）、progressive delay（3→1,5→2,7→4,9→8）、阈值下（count=2）不设任一键

三层冒烟全绿：
- L1 py_compile (src+api) ✅
- L2 启动路径（user_crud_mock + containers + user_cli）✅
- L3 变更相关：redis service（62 passed, 11 skipped）；auth 含现有 test_jwt_security/test_auth_verify/test_auth_security_batch（49 passed），零回归

⚠️ api/unit 测试分两次跑（混跑触发 `core` 命名空间 `ModuleNotFoundError` 假阳性，非 bug，见 project_api_unit_test_namespace_pollution）。

Closes #5482

🤖 Generated with [Claude Code](https://claude.com/claude-code)
