### PR TITLE
feat: SubscribableMixin 事件订阅契约 (ADR-017)

### DIFF
--- a/docs/adrs/ADR-017-event-subscription-contract.md
+++ b/docs/adrs/ADR-017-event-subscription-contract.md
@@ -1,0 +1,46 @@
+# 事件订阅契约归组件（@subscribes + __init_subclass__）
+
+**Status**: Accepted
+**Date**: 2026-06-23
+**Related**: ADR-003（引擎二态）、S4 issue #6296
+
+## Context
+
+引擎按 `component.__class__.__name__` 字符串查表注册事件订阅（`time_controlled_engine.py:798` `component_event_mapping`，另 `:728` `hook_event_mapping` 管 Analyzers），订阅真相散落在 5 个站点（2 个 engine dict + `engine_assembly_service` / `infrastructure_factory` / `task_engine_builder` 共 7 处手动 `engine.register`）。
+
+根因症状：
+- `PortfolioLive`（真实类，`portfolio_live.py:51`）类名不匹配 dict key `"PortfolioT1Backtest"`，永远进不了 auto-register，被逼出 `_convert_to_backtest_portfolio`（`task_engine_builder.py:158`）克隆成 T1Backtest 的 hack——手抄 `_strategies/_sizer/_risk_managers` 私有属性，Live 多一个订阅方法/状态就漏。
+- ORDERFILLED / INTERESTUPDATE 双重注册靠 `register` 的 dedup（`event_engine.py:478` 按 handler 对象去重）静默吞掉，改 handler 指向时埋重复调用 bug。
+- `PortfolioLive.on_order_filled`（`:383`）是"一方法多 event"的转发壳（签名收 `EventOrderPartiallyFilled`，转发给 `on_order_partially_filled`）——旧模型不支持一方法多 event 的 workaround。
+
+根因：`EngineBindableMixin.bind_engine` 只绑了出方向（`_engine_put = engine.put`），入方向（订阅）无落点，引擎只好反过来按类名猜。
+
+## Decision
+
+订阅真相归组件。引入 `@subscribes(*events)` 装饰器 + `SubscribableMixin.__init_subclass__`，在类创建期把声明合并进类属性 `_subscriptions: Dict[Event, str]`（event→方法名）；`bind_engine` 调 `register_handlers(engine)` 遍历 `_subscriptions`，按 `getattr(self, 方法名)` 解析 bound method（MRO 自然返回子类 override）。
+
+- **契约在基类**：`PortfolioBase` 的抽象 handler（`raise NotImplementedError`）标 `@subscribes` 声明类族订阅契约；子类 override 同名方法不重标即继承。
+- **合并规则**：子类声明覆盖父类同 event 的方法名 → 换映射免费（无需 unsubscribe）。
+- **一方法多 event**：`@subscribes(E1, E2)` → registry 多键同值。
+- **append / replace**：`__subscriptions_reset__ = True` 时丢弃父类全部，仅本类声明为唯一真相；默认 append。
+- **reset 局部性**：reset 标志用 `vars(cls)` 读取（不沿 MRO 继承），否则后代意外继承祖先的 reset。
+
+## Rationale
+
+选数据化契约（`@subscribes` + registry dict）而非命令式 `register_handlers(self, engine)` 方法：
+
+- **数据化可独立断言**：registry 是 `Dict[Event, str]`，测试直接断言映射，不起引擎；命令式要 mock `engine.register`。
+- **换映射免费**：声明式合并在类创建期算出最终 registry，子类声明覆盖父类同 event；命令式 `super().register_handlers()` 执行后改不回，换 handler 要 `unregister` 补丁，且 `register` 的 dedup 按 handler 对象去重抓不住不同 handler → 双注册陷阱。
+- **删 hack**：`PortfolioLive` 自带订阅直接进引擎，`_convert_to_backtest_portfolio` 可删；`on_order_filled` 转发壳被 `@subscribes(ORDERFILLED, ORDERPARTIALLYFILLED)` 取代。
+
+## Considered Options
+
+- **① `register_handlers(self, engine)` 命令式方法**：集中视图，最灵活。否决——改映射要 `unregister` 补丁 + dedup 双注册陷阱；测试要 mock engine；契约靠约定非声明。
+- **收敛单一 dict（engine 侧 key 从 `__class__.__name__` 改 isinstance）**：治标——能让 PortfolioLive 注册，但 `_convert` hack 仍要留，新组件家族仍要动 engine。开闭原则差。
+
+## Consequences
+
+- 删 engine 双 dict（`component_event_mapping` + `hook_event_mapping`）+ 7 处手动 `engine.register`。
+- `@unsubscribe(E)` 作为逐 event 负声明（部分移除），与 `__subscriptions_reset__` 全量清空互补；Portfolio 场景暂不发生，列为逃生舱。
+- engine 自注册 TIME_ADVANCE / COMPONENT_TIME_ADVANCE（`tce:471`）合法，不迁。
+- 迁移顺序：Portfolio 契约 → PortfolioT1Backtest 实现 → PortfolioLive（删 _convert + 转发壳）→ BacktestFeeder / TradeGateway → Analyzers。

--- a/src/ginkgo/trading/mixins/subscribable_mixin.py
+++ b/src/ginkgo/trading/mixins/subscribable_mixin.py
@@ -1,0 +1,87 @@
+# Upstream: 任何需向引擎订阅事件的组件（Portfolio / Feeder / Gateway / Analyzer）
+# Downstream: BaseEngine.register（事件入方向落点）
+# Role: 声明式事件订阅契约，类创建期合并 @subscribes 声明进 _subscriptions，
+#       register_handlers 遍历该映射完成入方向绑定。详见 ADR-017。
+
+"""
+事件订阅契约归组件（ADR-017）
+
+引擎绑定分两个方向：
+  - 出方向：组件 → 引擎（publish_event，由 EngineBindableMixin.bind_engine 设 _engine_put）
+  - 入方向：引擎 → 组件（事件回调，本 Mixin 负责）
+
+本 Mixin 补入方向落点：组件在类创建期用 @subscribes 声明订阅，__init_subclass__
+合并进类属性 _subscriptions: Dict[Event, str]，register_handlers 遍历该映射注册。
+
+合并规则（见 ADR-017 Decision）：
+  - 默认 append：继承最近父类的 _subscriptions
+  - 子类声明覆盖父类同 event 的方法名 → 换映射免费（无需 unsubscribe）
+  - __subscriptions_reset__ = True → 丢弃父类全部，仅本类声明为唯一真相
+    （reset 标志用 vars(cls) 读取，不沿 MRO 继承，否则后代意外继承祖先的 reset）
+  - 一方法多 event：@subscribes(E1, E2) → 多键同方法名
+"""
+
+from typing import Any, Dict, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ginkgo.trading.engines.base_engine import BaseEngine
+
+
+def subscribes(*events: Any):
+    """声明被装饰方法订阅哪些事件。
+
+    可叠加（多个 @subscribes 装饰器）也可单次多事件（@subscribes(E1, E2)）。
+    在函数对象上累积 ``__subscribes__`` 元组，由 SubscribableMixin.__init_subclass__
+    在类创建期读取合并。返回原函数，非 wrapper。
+
+    Args:
+        *events: 订阅的事件键（通常是 Event 枚举值）。
+    """
+
+    def decorator(func):
+        func.__subscribes__ = (*getattr(func, "__subscribes__", ()), *events)
+        return func
+
+    return decorator
+
+
+class SubscribableMixin:
+    """事件订阅契约归组件（ADR-017）。
+
+    子类在类创建期经 @subscribes 声明订阅，合并规则把声明并入 ``_subscriptions``。
+    bind_engine 时调用 register_handlers 完成入方向绑定。
+
+    类属性:
+        _subscriptions: Dict[Event, str] —— 事件键 → 处理方法名（由 __init_subclass__ 维护）。
+        __subscriptions_reset__: bool —— 子类设 True 表示丢弃父类全部订阅，仅留本类。
+            用 vars(cls) 读取，不沿 MRO 继承。
+    """
+
+    _subscriptions: Dict[Any, str] = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        own = vars(cls)
+        # reset 用 vars(cls) 读取：仅当前类命名空间，不沿 MRO 继承。
+        # 若用 getattr，孙类会沿 MRO 命中祖先的 reset=True，意外清空继承链。
+        if own.get("__subscriptions_reset__", False):
+            merged: Dict[Any, str] = {}
+        else:
+            # append：继承最近父类的 _subscriptions（getattr 沿 MRO 取最近定义）
+            merged = dict(getattr(cls, "_subscriptions", {}))
+        for name, member in own.items():
+            for ev in getattr(member, "__subscribes__", ()):
+                merged[ev] = name
+        cls._subscriptions = merged
+
+    def register_handlers(self, engine: "BaseEngine") -> None:
+        """遍历 _subscriptions，按方法名解析 bound method 注册到引擎。
+
+        getattr(self, method_name) 经 MRO 解析，子类 override 同名方法自然返回子类版本。
+        与 EngineBindableMixin.bind_engine（出方向）对称，构成本 Mixin 的入方向落点。
+
+        Args:
+            engine: 目标引擎，需提供 register(event, handler) 接口。
+        """
+        for event, method_name in self._subscriptions.items():
+            engine.register(event, getattr(self, method_name))

--- a/tests/unit/trading/test_subscribable_mixin.py
+++ b/tests/unit/trading/test_subscribable_mixin.py
@@ -1,0 +1,291 @@
+"""
+SubscribableMixin + @subscribes 单元测试
+
+验证 ADR-017（事件订阅契约归组件）的 6 项契约：
+  ① append 默认继承父类 _subscriptions
+  ② 子类声明覆盖父类同 event → 换映射免费（无需 unsubscribe）
+  ③ 一方法多 event（@subscribes(E1, E2) → 多键同值）
+  ④ 装饰器叠加累积（@subscribes(E1) @subscribes(E2)）
+  ⑤ __subscriptions_reset__=True 清空父类仅留本类
+  ⑥ reset 用 vars 读取不沿 MRO（孙类默认 append，不继承祖先 reset）— 关键 bug 防护
+  ⑦ register_handlers 遍历 registry 调 engine.register(E, bound_method)
+  ⑧ register_handlers 经 getattr 解析返回子类 override 版本（MRO bound method）
+
+测试隔离：每个 test 内重新定义类族，__init_subclass__ 每次重新触发，无跨测试状态污染。
+事件键用模块级 object() sentinel —— mixin 契约是 Dict[Any, str]，键类型泛型，零真实 Event 耦合。
+"""
+
+import pytest
+from unittest.mock import Mock
+
+from ginkgo.trading.mixins.subscribable_mixin import SubscribableMixin, subscribes
+
+# 事件 sentinel —— 不关心键类型，只关心映射
+E1, E2, E3 = object(), object(), object()
+
+
+# ============================================================================
+# @subscribes 装饰器
+# ============================================================================
+
+
+class TestSubscribesDecorator:
+    """装饰器本身：标记函数 + 累积 + 原样返回"""
+
+    def test_decorator_marks_function(self):
+        @subscribes(E1)
+        def handler(self):
+            pass
+
+        assert handler.__subscribes__ == (E1,)
+
+    def test_decorator_stacks_across_multiple_decorators(self):
+        @subscribes(E1)
+        @subscribes(E2)
+        def handler(self):
+            pass
+
+        # 顺序无关，集合相等即可
+        assert set(handler.__subscribes__) == {E1, E2}
+
+    def test_decorator_multi_events_in_one_call(self):
+        @subscribes(E1, E2, E3)
+        def handler(self):
+            pass
+
+        assert set(handler.__subscribes__) == {E1, E2, E3}
+
+    def test_decorator_preserves_function_identity(self):
+        def handler(self):
+            pass
+
+        wrapped = subscribes(E1)(handler)
+        assert wrapped is handler  # 原函数对象，非 wrapper
+
+
+# ============================================================================
+# __init_subclass__ 合并规则
+# ============================================================================
+
+
+class TestSubscriptionMerge:
+    """类创建期把声明合并进 _subscriptions"""
+
+    def test_append_inherits_parent_subscriptions(self):
+        """① 默认 append：子类不声明 → 继承父类全部"""
+
+        class Parent(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                return "parent"
+
+        class Child(Parent):
+            pass
+
+        assert Parent._subscriptions == {E1: "on_e1"}
+        assert Child._subscriptions == {E1: "on_e1"}
+
+    def test_child_override_remaps_for_free(self):
+        """② 子类声明覆盖父类同 event → 换映射免费（不需 unsubscribe）"""
+
+        class Parent(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                return "parent"
+
+        class Child(Parent):
+            @subscribes(E1)  # 同 event，不同方法名
+            def on_e1_v2(self):
+                return "child"
+
+        assert Parent._subscriptions[E1] == "on_e1"
+        assert Child._subscriptions[E1] == "on_e1_v2"  # 映射换到子类实现
+
+    def test_one_method_many_events(self):
+        """③ @subscribes(E1, E2) 标同一方法 → 多键同值"""
+
+        class Component(SubscribableMixin):
+            @subscribes(E1, E2)
+            def on_multi(self):
+                return "shared"
+
+        assert Component._subscriptions == {E1: "on_multi", E2: "on_multi"}
+
+    def test_grandchild_accumulates_across_chain(self):
+        """链式 append：三级各自声明 → 孙类含全部三个 event"""
+
+        class L1(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                pass
+
+        class L2(L1):
+            @subscribes(E2)
+            def on_e2(self):
+                pass
+
+        class L3(L2):
+            @subscribes(E3)
+            def on_e3(self):
+                pass
+
+        assert set(L3._subscriptions.keys()) == {E1, E2, E3}
+
+
+# ============================================================================
+# __subscriptions_reset__ 全量清空 + MRO 隔离（关键 bug 防护）
+# ============================================================================
+
+
+class TestResetSemantics:
+    """reset：全量清空父类 + vars 读取不沿 MRO"""
+
+    def test_reset_clears_parent_subscriptions(self):
+        """⑤ __subscriptions_reset__=True → 丢弃父类全部，仅留本类声明"""
+
+        class Parent(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                pass
+
+            @subscribes(E2)
+            def on_e2(self):
+                pass
+
+        class Child(Parent):
+            __subscriptions_reset__ = True
+
+            @subscribes(E3)
+            def on_e3(self):
+                pass
+
+        assert Parent._subscriptions == {E1: "on_e1", E2: "on_e2"}
+        # Child 清空父类 E1/E2，仅留本类 E3
+        assert Child._subscriptions == {E3: "on_e3"}
+
+    def test_reset_mro_isolation_grandchild_does_not_inherit_reset(self):
+        """⑥ 关键：reset 用 vars 读取，孙类不继承祖先 reset
+
+        链：Parent(声明 E1) → Child(reset=True, 声明 E2) → GrandChild(无声明)
+
+        正确（vars 实现）：
+          Child reset → {E2}
+          GrandChild own 无 reset → append，继承 Child 的 {E2}
+
+        Bug（getattr 实现）：
+          GrandChild getattr 沿 MRO 找到 Child 的 reset=True
+          → merged 从 {} 开始 → GrandChild._subscriptions == {}（丢失 E2）
+        """
+
+        class Parent(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                pass
+
+        class Child(Parent):
+            __subscriptions_reset__ = True
+
+            @subscribes(E2)
+            def on_e2(self):
+                pass
+
+        class GrandChild(Child):
+            pass  # 无 reset 声明，应 append 继承 Child
+
+        assert Child._subscriptions == {E2: "on_e2"}
+        # GrandChild 必须继承 Child 的 E2，而非被祖先 reset 清空
+        assert GrandChild._subscriptions == {E2: "on_e2"}
+
+    def test_reset_only_affects_own_class_not_siblings(self):
+        """reset 只影响该类自身命名空间，不影响兄弟类"""
+
+        class Parent(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                pass
+
+        class ResettingChild(Parent):
+            __subscriptions_reset__ = True
+
+            @subscribes(E2)
+            def on_e2(self):
+                pass
+
+        class AppendingChild(Parent):
+            @subscribes(E3)
+            def on_e3(self):
+                pass
+
+        assert ResettingChild._subscriptions == {E2: "on_e2"}
+        # 兄弟类不受 reset 影响，正常 append 父类 E1
+        assert AppendingChild._subscriptions == {E1: "on_e1", E3: "on_e3"}
+
+
+# ============================================================================
+# register_handlers —— bind_engine 入方向落点
+# ============================================================================
+
+
+class TestRegisterHandlers:
+    """register_handlers 遍历 _subscriptions 调 engine.register"""
+
+    def test_register_calls_engine_for_each_subscription(self):
+        """⑦ 每个 (event, 方法名) → engine.register(event, bound_method)"""
+
+        class Component(SubscribableMixin):
+            @subscribes(E1)
+            def on_e1(self):
+                return "e1"
+
+            @subscribes(E2)
+            def on_e2(self):
+                return "e2"
+
+        engine = Mock()
+        component = Component()
+        component.register_handlers(engine)
+
+        # 断言注册了两个 event
+        registered_events = {call.args[0] for call in engine.register.call_args_list}
+        assert registered_events == {E1, E2}
+
+        # 第二参数是 bound method（getattr(self, mname)），可调用且绑定到实例
+        for call in engine.register.call_args_list:
+            bound_method = call.args[1]
+            assert callable(bound_method)
+
+    def test_register_resolves_subclass_override_via_getattr(self):
+        """⑧ register 传 getattr(self, mname) → 子类 override 版本（MRO bound method）
+
+        Parent 声明 @subscribes(E1) on handle；Child override handle 不重标。
+        register_handlers 传的应是 Child 的 bound method，调用返回 'child'。
+        """
+
+        class Parent(SubscribableMixin):
+            @subscribes(E1)
+            def handle(self):
+                return "parent"
+
+        class Child(Parent):
+            def handle(self):  # override，不标装饰器
+                return "child"
+
+        engine = Mock()
+        child = Child()
+        child.register_handlers(engine)
+
+        assert engine.register.call_count == 1
+        event_arg, method_arg = engine.register.call_args.args
+        assert event_arg is E1
+        # 传的是 child 的 bound method，调用得 'child' 而非 'parent'
+        assert method_arg() == "child"
+
+    def test_register_handles_empty_subscriptions(self):
+        """无声明组件 register_handlers 不报错、不调 register"""
+
+        class Bare(SubscribableMixin):
+            pass
+
+        engine = Mock()
+        Bare().register_handlers(engine)
+        engine.register.assert_not_called()


### PR DESCRIPTION
## Summary
S4（#6296）架构重构**基础设施切片**：新增 `SubscribableMixin` + `@subscribes` 装饰器，把**事件订阅契约归组件**（类创建期声明式合并进 `_subscriptions`），取代引擎按 `__class__.__name__` 字符串猜注册。

## 解决的问题（详见 ADR-017）
订阅真相散落 5 站点（engine 双 dict + 7 处手动 `engine.register`）；`PortfolioLive` 类名不匹配 dict key 致 `_convert_to_backtest_portfolio` 克隆 hack；ORDERFILLED/INTERESTUPDATE 双注册靠 dedup 静默吞；一方法多 event 靠 `on_order_filled` 转发壳 workaround。

## 本 PR 范围（基础设施，未接线）
- `src/ginkgo/trading/mixins/subscribable_mixin.py`：`@subscribes(*events)` + `__init_subclass__` 声明合并 + `register_handlers(engine)` 按 `getattr` 解析 bound method（MRO 自然返回子类 override）
- 合并规则：子类覆盖父类同 event 换映射免费；`@subscribes(E1,E2)` 一方法多 event；`__subscriptions_reset__=True` 全量清空；reset 用 `vars(cls)` 局部不沿 MRO 继承
- `tests/unit/trading/test_subscribable_mixin.py`：**14 测试全绿**（装饰器叠加/继承累积/子类覆盖/reset MRO 隔离/register handler 解析）
- `docs/adrs/ADR-017-event-subscription-contract.md`：设计决策（数据化契约 vs 命令式 register 的取舍）

## 后续切片（迁移顺序，本 PR 不含）
Portfolio 契约 → PortfolioT1Backtest → PortfolioLive（删 `_convert` + 转发壳）→ BacktestFeeder / TradeGateway → Analyzers。

## 关联
ADR-003（引擎二态）· ADR-017 · #6296（S4）
