### PR TITLE
fix: CI smoke 补 --extra dev 装 pytest-timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,14 +71,17 @@ jobs:
         # pip 不读 override-dependencies 致 ResolutionImpossible（首版 CI 实跑 failure）。
         # uv sync --frozen 按 uv.lock 锁定版本装，不解析、不报 drift——
         # master uv.lock 存在 pre-existing drift（滞后 pyproject），--locked 会立即报红；
-        # smoke tests 不依赖 drift 包，--frozen 可跑通。lock 修正另作独立维护。
+        # --frozen 只按 lock 现状装，不校验 lock↔pyproject 一致，故 drift 不阻断。
+        # --extra dev：pyproject required_plugins=["pytest-cov","pytest-timeout"]，
+        # pytest-timeout 只在 [project.optional-dependencies].dev；主依赖仅 pytest-cov
+        # （传递拉入 pytest 本体）。缺 --extra dev 则 pytest-timeout 缺失致 pytest exit 4。
         # astral-sh/setup-uv 未发布 v8 major rolling tag（仅 v8.0.0/v8.1.0/v8.2.0），
         # @v8 解析失败；用具体版本 v8.2.0 可复现。
         uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      - name: Sync deps (frozen, from uv.lock)
-        run: uv sync --frozen --python 3.12
+      - name: Sync deps (frozen, +dev for pytest plugins)
+        run: uv sync --frozen --extra dev --python 3.12
       - name: user_crud mock tests (#6015 点名)
         run: |
           uv run python -m pytest tests/unit/data/crud/test_user_crud_mock.py \


### PR DESCRIPTION
## 问题

所有 PR 的 `Smoke tests (mock + import)` check 报红（如 #6436 合并前）：

```
ERROR: Missing required plugins: pytest-timeout
```

## 根因

`ci.yml` 用 `uv sync --frozen --python 3.12`（无 `--extra dev`），默认只装主依赖，不装 `[project.optional-dependencies].dev`。

`pyproject.toml`：
- `required_plugins = ["pytest-cov", "pytest-timeout"]` 强制两者
- `pytest-cov` 在主依赖 → 传递拉入 `pytest` 本体（故 pytest 能启动）
- `pytest-timeout` **只在 dev extra**，无人传递 → 缺失 → pytest `required_plugins` 检查失败 → exit 4

与代码无关的 CI 环境配置问题，master 既有，任何 PR 触发。

## 修复

`ci.yml` sync 加 `--extra dev`，并纠正过时注释（原误判「--frozen 可跑通」）。

`--frozen` 仍安全：lock 完整支持 dev extra 包树，按 lock 现状装不报 drift（drift 校验是 `--locked` 职责）。

## 验证（TDD，本地隔离 venv）

- **RED**：`uv sync --frozen`（无 extra）→ smoke 报 `Missing required plugins: pytest-timeout`，复现 CI
- **GREEN**：`uv sync --frozen --extra dev` → exit 0，smoke **11 passed**
