### PR TITLE
fix: node-graph 读一致性（add_file 去重 / graph 选图优先级 / GET files 端点）

### DIFF
--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -448,6 +448,44 @@ async def get_portfolio_mappings(
         )
 
 
+@router.get("/{portfolio_uuid}/files")
+async def get_portfolio_files(portfolio_uuid: str):
+    """
+    获取投资组合已绑定的文件列表 (#5806)
+
+    委托 service.get_portfolio_mappings 返回文件级视图。
+    与 GET /{portfolio_uuid}/mappings 同源；本端点 URL 语义更直白
+    （RESTful /files），供前端「列文件」场景免带参数负载。
+    """
+    try:
+        service = get_portfolio_mapping_service()
+
+        result = service.get_portfolio_mappings(
+            portfolio_uuid=portfolio_uuid,
+            include_params=False,
+        )
+
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Portfolio {portfolio_uuid} not found"
+            )
+
+        return ok(data={
+            "portfolio_uuid": portfolio_uuid,
+            "files": result.data,
+            "total": len(result.data),
+        })
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting portfolio files {portfolio_uuid}: {str(e)}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error getting portfolio files"
+        )
+
+
 @router.post("/{portfolio_uuid}/files")
 async def add_file_to_portfolio(
     portfolio_uuid: str,

--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -280,6 +280,17 @@ class PortfolioMappingService(BaseService):
                     f"cannot bind as {file_type.name}"
                 )
 
+            # #5808: 去重 — 同 (portfolio_uuid, file_id) 已绑定时幂等返回，不创建重复 mapping
+            existing_mappings = self._mapping_crud.find_by_portfolio(portfolio_uuid)
+            for _existing in existing_mappings:
+                if getattr(_existing, "file_id", None) == file_id:
+                    GLOG.INFO(f"文件已绑定，幂等返回: {portfolio_uuid} -> {file_id}")
+                    return ServiceResult.success(data={
+                        "file_id": file_id,
+                        "mapping_id": _existing.uuid,
+                        "already_existed": True,
+                    })
+
             # 1. 创建 MySQL Mapping
             mapping = MPortfolioFileMapping(
                 portfolio_id=portfolio_uuid,

--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -492,11 +492,12 @@ class PortfolioMappingService(BaseService):
         try:
             collection = self._mongo_driver.get_collection("portfolio_graph_data")
 
-            # 查找现有图数据（优先 GRAPH_EDITOR 来源的）
-            graph_doc = collection.find_one(
-                {"portfolio_uuid": portfolio_uuid},
-                sort=[("metadata.source", 1), ("created_at", -1)]
-            )
+            # 查找现有图数据，按应用层优先级选图：
+            #   #5742 — 原先 find_one(sort by source asc) 让 AUTO_GENERATED 空图
+            #   抢占 GRAPH_EDITOR 非空图（"A" < "G"）。改为取全部后按
+            #   「非空优先 + GRAPH_EDITOR 优先」选最佳文档。
+            all_docs = list(collection.find({"portfolio_uuid": portfolio_uuid}))
+            graph_doc = self._select_best_graph_doc(all_docs)
 
             if graph_doc:
                 return ServiceResult.success(data={
@@ -511,7 +512,8 @@ class PortfolioMappingService(BaseService):
             self._sync_graph_from_mappings(portfolio_uuid)
 
             # 再次查询
-            graph_doc = collection.find_one({"portfolio_uuid": portfolio_uuid})
+            all_docs = list(collection.find({"portfolio_uuid": portfolio_uuid}))
+            graph_doc = self._select_best_graph_doc(all_docs)
             return ServiceResult.success(data={
                 "graph_data": graph_doc["graph_data"] if graph_doc else {"nodes": [], "edges": []},
                 "metadata": graph_doc.get("metadata", {}) if graph_doc else {},
@@ -521,6 +523,39 @@ class PortfolioMappingService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"获取图数据失败: {e}")
             return ServiceResult.error(f"获取图数据失败: {str(e)}")
+
+    def _select_best_graph_doc(self, docs):
+        """
+        按优先级选最佳图文档 (#5742)
+
+        规则：
+          1. 非空图（有 nodes）优先于空图 —— 空图不得抢占非空图
+          2. 非空图中 GRAPH_EDITOR（用户手动编辑）优先于 AUTO_GENERATED
+          3. 全部为空图时返回第一个（保持旧行为兼容）
+
+        Args:
+            docs: 同 portfolio 的全部图文档列表
+
+        Returns:
+            最佳图文档，或 None（列表为空）
+        """
+        if not docs:
+            return None
+
+        def _has_nodes(doc):
+            return bool(doc.get("graph_data", {}).get("nodes"))
+
+        non_empty = [d for d in docs if _has_nodes(d)]
+        if non_empty:
+            editor = next(
+                (d for d in non_empty
+                 if d.get("metadata", {}).get("source") == "GRAPH_EDITOR"),
+                None,
+            )
+            return editor or non_empty[0]
+
+        # 全部为空图，保持旧行为返回第一个
+        return docs[0]
 
     def get_portfolio_mappings(
         self,

--- a/tests/api/test_node_graph_files_get.py
+++ b/tests/api/test_node_graph_files_get.py
@@ -1,0 +1,51 @@
+"""
+#5806 — GET /node-graphs/{portfolio_uuid}/files 端点
+
+表象：前端列出 portfolio 已绑定文件时，只有 POST/DELETE files，无 GET files，
+      只能退而调 GET /mappings（含参数，重）。缺一个语义直白的文件列表端点。
+契约：
+  - GET /{portfolio_uuid}/files 委托 service.get_portfolio_mappings
+  - 返回 {portfolio_uuid, files:[...], total}
+  - service 失败时 404（与 mappings 端点一致）
+风格对齐 tests/api/test_node_graph_lifecycle.py（函数内 import + mock + await）。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from fastapi import HTTPException
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+class TestGetPortfolioFiles:
+    """GET /{portfolio_uuid}/files → 返已绑定文件列表 (#5806)"""
+
+    @pytest.mark.asyncio
+    async def test_returns_bound_files_list(self):
+        """成功时委托 service 并返文件列表 + total"""
+        from api.node_graph import get_portfolio_files
+
+        mock_svc = MagicMock()
+        mock_svc.get_portfolio_mappings.return_value = ServiceResult.success(data=[
+            {"file_id": "f1", "type": "STRATEGY"},
+            {"file_id": "f2", "type": "SELECTOR"},
+        ])
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            result = await get_portfolio_files("p1")
+
+        mock_svc.get_portfolio_mappings.assert_called_once()
+        assert result["data"]["portfolio_uuid"] == "p1"
+        assert result["data"]["total"] == 2
+        assert len(result["data"]["files"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_service_failure_raises_404(self):
+        """service 失败抛 404（与 mappings 端点一致）"""
+        from api.node_graph import get_portfolio_files
+
+        mock_svc = MagicMock()
+        mock_svc.get_portfolio_mappings.return_value = ServiceResult.error("not found")
+        with patch("api.node_graph.get_portfolio_mapping_service", return_value=mock_svc):
+            with pytest.raises(HTTPException) as exc:
+                await get_portfolio_files("p1")
+
+        assert exc.value.status_code == 404

--- a/tests/unit/data/services/test_portfolio_mapping_add_file_dedup.py
+++ b/tests/unit/data/services/test_portfolio_mapping_add_file_dedup.py
@@ -1,0 +1,90 @@
+"""
+#5808 — add_file 重复绑定去重
+
+表象：POST /node-graphs/{uuid}/files 同一组件多次绑定，mappings 出现重复 auto_binding 条目。
+根因：portfolio_mapping_service.add_file 类型校验后直接落库 MPortfolioFileMapping，
+      不检查同 (portfolio_uuid, file_id) 是否已存在绑定。
+契约：
+  - 同 (portfolio, file_id) 已绑定时，add_file 幂等返回已存在 mapping，不创建重复条目
+  - 返回 data 标记 already_existed=True，供调用方区分新绑定 vs 已存在
+  - 未绑定时正常创建（已由 test_portfolio_mapping_add_file_type_validation 覆盖）
+"""
+from unittest.mock import MagicMock
+
+from ginkgo.enums import FILE_TYPES
+from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_svc():
+    mock_mapping = MagicMock()
+    mock_param = MagicMock()
+    mock_mongo = MagicMock()
+    mock_file = MagicMock()
+    svc = PortfolioMappingService(
+        mapping_crud=mock_mapping,
+        param_service=mock_param,
+        mongo_driver=mock_mongo,
+        file_service=mock_file,
+    )
+    return svc, mock_mapping, mock_file
+
+
+def _file_found(type_int: int, name: str = "fake_component"):
+    fake_file = MagicMock()
+    fake_file.type = type_int
+    fake_file.name = name
+    return ServiceResult.success(data={"file": fake_file})
+
+
+class TestAddFileDedup:
+    """add_file 重复绑定时必须幂等，不产生重复 mapping (#5808)"""
+
+    def test_already_bound_returns_existing_no_duplicate(self):
+        """同 (portfolio, file_id) 已绑定 → 返已存在 mapping，不新增"""
+        svc, mock_mapping, mock_file = _make_svc()
+        mock_file.get_by_uuid.return_value = _file_found(FILE_TYPES.STRATEGY.value)
+
+        existing = MagicMock()
+        existing.uuid = "existing-mapping"
+        existing.file_id = "f1"
+        existing.type = FILE_TYPES.STRATEGY
+        mock_mapping.find_by_portfolio.return_value = [existing]
+
+        result = svc.add_file(
+            portfolio_uuid="p1",
+            file_id="f1",
+            file_type=FILE_TYPES.STRATEGY,
+        )
+
+        assert result.success, "已绑定时应幂等返回 success，而非报错或重复创建"
+        assert result.data["mapping_id"] == "existing-mapping", "应返回已存在 mapping 的 id"
+        assert result.data.get("already_existed") is True, "应标记 already_existed 供调用方区分"
+        # 关键：不创建重复 mapping
+        mock_mapping.add.assert_not_called()
+
+    def test_different_file_still_creates(self):
+        """portfolio 已绑定 f1，再绑 f2 → f2 正常创建（去重不影响新绑定）"""
+        svc, mock_mapping, mock_file = _make_svc()
+        mock_file.get_by_uuid.return_value = _file_found(FILE_TYPES.STRATEGY.value)
+
+        existing = MagicMock()
+        existing.uuid = "m1"
+        existing.file_id = "f1"  # 已绑定的是 f1，不是 f2
+        existing.type = FILE_TYPES.STRATEGY
+        mock_mapping.find_by_portfolio.return_value = [existing]
+
+        new_mapping = MagicMock()
+        new_mapping.uuid = "m2"
+        mock_mapping.add.return_value = new_mapping
+
+        result = svc.add_file(
+            portfolio_uuid="p1",
+            file_id="f2",
+            file_type=FILE_TYPES.STRATEGY,
+        )
+
+        assert result.success
+        assert result.data["mapping_id"] == "m2"
+        assert result.data.get("already_existed") is not True, "新绑定不应标记 already_existed"
+        mock_mapping.add.assert_called_once()

--- a/tests/unit/services/test_portfolio_mapping_graph_read_priority.py
+++ b/tests/unit/services/test_portfolio_mapping_graph_read_priority.py
@@ -1,0 +1,89 @@
+"""
+#5742 / #5734 — get_portfolio_graph 读优先级
+
+表象：GET /node-graphs/{pid} 返回 {nodes:[], edges:[]}，但同 portfolio 的
+      mappings 端点返回 4 条绑定记录。
+根因：get_portfolio_graph 用 find_one(sort=[("metadata.source",1), ...])
+      不限 source 升序取第一个。"AUTO_GENERATED"(A) 排在 "GRAPH_EDITOR"(G) 前
+      被命中，而 portfolio 初建无 mappings 时 _sync 存的正是 AUTO 空图
+      ({nodes:[],edges:[]}, source=AUTO_GENERATED)。后续即使有 GRAPH_EDITOR
+      非空图，排序仍让 AUTO 空图抢占。
+契约：
+  - 存在非空图时必须返回非空图（空图不得抢占）
+  - 多个非空图时 GRAPH_EDITOR（用户手动编辑）优先于 AUTO_GENERATED
+  - 无任何图文档时仍 fallback 到 _sync（不破坏原行为）
+"""
+from unittest.mock import MagicMock
+
+from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+
+
+def _make_svc():
+    mock_mapping = MagicMock()
+    mock_param = MagicMock()
+    mock_mongo = MagicMock()
+    mock_file = MagicMock()
+    svc = PortfolioMappingService(
+        mapping_crud=mock_mapping,
+        param_service=mock_param,
+        mongo_driver=mock_mongo,
+        file_service=mock_file,
+    )
+    mock_collection = MagicMock()
+    mock_mongo.get_collection.return_value = mock_collection
+    return svc, mock_mapping, mock_mongo, mock_collection
+
+
+def _doc(source: str, nodes: list, _id: str = "x"):
+    return {
+        "_id": _id,
+        "portfolio_uuid": "p1",
+        "graph_data": {"nodes": nodes, "edges": []},
+        "metadata": {"source": source},
+    }
+
+
+class TestGetPortfolioGraphReadPriority:
+    """get_portfolio_graph 必须按非空 + GRAPH_EDITOR 优先选图 (#5742)"""
+
+    def test_non_empty_graph_preferred_over_empty_auto(self):
+        """AUTO 空图 + GRAPH_EDITOR 非空图共存 → 返 GRAPH_EDITOR 非空"""
+        svc, _, _, mock_collection = _make_svc()
+        auto_empty = _doc("AUTO_GENERATED", nodes=[], _id="a1")
+        editor_full = _doc("GRAPH_EDITOR", nodes=[{"id": "n1"}], _id="e1")
+        # 模拟当前 sort 命中空图的行为 + find 取所有
+        mock_collection.find_one.return_value = auto_empty
+        mock_collection.find.return_value = [auto_empty, editor_full]
+
+        result = svc.get_portfolio_graph("p1")
+
+        assert result.is_success(), f"应成功: {getattr(result, 'error', None)}"
+        nodes = result.data["graph_data"]["nodes"]
+        assert len(nodes) == 1, "应返回非空图（GRAPH_EDITOR），空图不得抢占"
+
+    def test_graph_editor_preferred_among_non_empty(self):
+        """两个非空图 → GRAPH_EDITOR 优先于其他 source"""
+        svc, _, _, mock_collection = _make_svc()
+        auto_full = _doc("AUTO_GENERATED", nodes=[{"id": "auto_n"}], _id="a1")
+        editor_full = _doc("GRAPH_EDITOR", nodes=[{"id": "editor_n"}], _id="e1")
+        mock_collection.find.return_value = [auto_full, editor_full]  # AUTO 在前
+
+        result = svc.get_portfolio_graph("p1")
+
+        assert result.is_success()
+        nodes = result.data["graph_data"]["nodes"]
+        assert nodes[0]["id"] == "editor_n", "非空图中 GRAPH_EDITOR 应优先"
+
+    def test_no_docs_falls_back_to_sync(self):
+        """Mongo 无任何图文档 → 触发 _sync_graph_from_mappings（不破坏原行为）"""
+        svc, mock_mapping, _, mock_collection = _make_svc()
+        mock_collection.find.return_value = []
+        # sync 后再查返一个生成图
+        synced = _doc("AUTO_GENERATED", nodes=[{"id": "synced_n"}], _id="s1")
+        mock_collection.find_one.return_value = synced
+
+        result = svc.get_portfolio_graph("p1")
+
+        assert result.is_success()
+        # fallback 触发了 sync（查了 mappings）
+        mock_mapping.find_by_portfolio.assert_called()


### PR DESCRIPTION
## Summary

修复 #6085 父问题框架下 4 个 node-graph 读一致性 bug。这 4 个 issue 曾于 2026-06-10 关闭但无关联 PR/commit，bug 在 master 仍存在（已验证），本 PR 实际修复。**父问题 #6085 保持开放**，待框架内其余子问题处理。

- **#5808 add_file 重复绑定去重**：同 (portfolio, file_id) 已绑定时幂等返回已存在 mapping，不创建重复条目；返回 `already_existed=True` 供调用方区分。
- **#5742 get_portfolio_graph 读优先级**：原 `find_one(sort=[("metadata.source",1)])` 让 `AUTO_GENERATED`(A) 空图抢占 `GRAPH_EDITOR`(G) 非空图——portfolio 初建无 mappings 时 `_sync` 存的就是 AUTO 空图，后续即使有 GRAPH_EDITOR 非空图，排序仍让空图被命中，GET /node-graphs 返空图但 mappings 非空。改 `find()` 取全部 + `_select_best_graph_doc` helper 按「非空优先、GRAPH_EDITOR 优先」选图，全空时保持旧行为返第一个。
- **#5734** 与 #5742 同根源（双源缓存 AUTO 空图与 GRAPH_EDITOR 共存时排序抢占），随 #5742 一并修复。
- **#5806 新增 GET /node-graphs/{portfolio_uuid}/files 端点**：前端列已绑定文件只有 POST/DELETE files，缺 GET；退而调 /mappings 带参数负载。新增 GET files 委托 `get_portfolio_mappings` 返文件级视图 `{portfolio_uuid, files, total}`，service 失败 404（与 mappings 端点一致）。GET/POST/DELETE files 三端点聚簇。

## Test plan

TDD 红-绿循环，每个 issue 单独测试 + 提交：

- [x] Layer 1 — `py_compile`（src + api 全量）✅
- [x] Layer 2 — 启动路径 smoke：`test_user_crud_mock` / `test_containers` / `test_user_cli`（29 passed）✅
- [x] Layer 3a — unit：`test_portfolio_mapping_graph_read_priority`（3 新增）+ `test_portfolio_mapping_graph_lifecycle` + `test_portfolio_mapping_add_file_dedup`（2 新增）+ `test_portfolio_mapping_add_file_type_validation`（11 passed）✅
- [x] Layer 3b — api：node_graph 全簇 6 文件含 `test_node_graph_files_get`（2 新增）（35 passed）✅

Closes #5806
Closes #5808
Closes #5742
Closes #5734
