### PR TITLE
fix: CLI mapping 死调用改走 mapping_service._df 出口（ADR-010）

### DIFF
--- a/src/ginkgo/client/backtest_result_cli.py
+++ b/src/ginkgo/client/backtest_result_cli.py
@@ -76,6 +76,8 @@ def show(
     """
     from ginkgo.data.containers import container
     from ginkgo.enums import FILE_TYPES
+    import pandas as pd
+    from ginkgo.libs.utils.display import display_dataframe
 
     # 新方式：按 task_id 查询
     if task_id is not None:
@@ -109,14 +111,12 @@ def show(
         )
         return
     if portfolio is None:
-        # 使用新的Service API获取引擎-投资组合映射
-        engine_service = container.engine_service()
-        mappings_result = engine_service.get_engine_portfolio_mappings(engine)
+        # 使用 mapping_service._df 出口获取引擎-投资组合映射（#6136: data 即 DataFrame）
+        mapping_service = container.mapping_service()
+        mappings_result = mapping_service.get_engine_portfolio_mappings_df(engine_uuid=engine)
 
         if mappings_result.success:
             mappings_df = mappings_result.data
-            if hasattr(mappings_df, 'to_dataframe'):
-                mappings_df = mappings_df.to_dataframe()
         else:
             console.print(f":x: Failed to get engine-portfolio mappings: {mappings_result.error}")
             mappings_df = pd.DataFrame()  # 空DataFrame作为fallback

--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -7,6 +7,7 @@
 
 
 
+import pandas as pd
 from rich.console import Console
 from rich.tree import Tree
 from typing import Optional
@@ -39,10 +40,10 @@ def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filt
     """添加Portfolio的组件到树节点"""
     from ginkgo.data.containers import container
     
-    # 获取portfolio的文件映射
-    portfolio_service = container.portfolio_service()
-    mappings_df = portfolio_service.get_portfolio_file_mappings().to_dataframe()
-    portfolio_files = mappings_df[mappings_df["portfolio_id"] == portfolio_id]
+    # 获取portfolio的文件映射（#6136: 走 mapping_service._df 出口，data 即 DataFrame）
+    mapping_service = container.mapping_service()
+    mappings_result = mapping_service.get_portfolio_file_mappings_df(portfolio_uuid=portfolio_id)
+    portfolio_files = mappings_result.data if mappings_result.success else pd.DataFrame()
     
     if portfolio_files.shape[0] == 0:
         parent_node.add("[dim]No components bound to this portfolio[/dim]")
@@ -129,10 +130,10 @@ def _show_engine_tree(engine_row, detail: bool, filter_type: Optional[FILE_TYPES
     
     tree = Tree(f"[bold blue]Engine:[/bold blue] {engine_row['name']} ([cyan]{engine_row['uuid']}[/cyan])")
     
-    # 获取engine关联的portfolios
-    engine_service = container.engine_service()
-    mappings_df = engine_service.get_engine_portfolio_mappings().to_dataframe()
-    engine_portfolios = mappings_df[mappings_df["engine_id"] == engine_row["uuid"]]
+    # 获取engine关联的portfolios（#6136: 走 mapping_service._df 出口，data 即 DataFrame）
+    mapping_service = container.mapping_service()
+    mappings_result = mapping_service.get_engine_portfolio_mappings_df(engine_uuid=engine_row["uuid"])
+    engine_portfolios = mappings_result.data if mappings_result.success else pd.DataFrame()
     
     if engine_portfolios.shape[0] == 0:
         tree.add("[dim]No portfolios bound to this engine[/dim]")

--- a/src/ginkgo/data/services/mapping_service.py
+++ b/src/ginkgo/data/services/mapping_service.py
@@ -19,6 +19,7 @@ Mapping Service - 统一管理所有映射关系
 提供统一的接口和业务逻辑，避免在各个地方直接操作CRUD。
 """
 
+import pandas as pd
 from typing import List, Dict, Any, Optional
 from ginkgo.libs import GLOG, retry
 from ginkgo.data.services.base_service import BaseService, ServiceResult
@@ -336,6 +337,44 @@ class MappingService(BaseService):
 
         except Exception as e:
             return ServiceResult.error(f"获取Engine-Portfolio映射失败: {str(e)}")
+
+    def get_engine_portfolio_mappings_df(self, engine_uuid: str = None) -> ServiceResult:
+        """出口：data 是 pandas.DataFrame（类型即契约）。ADR-010 _df 范式（#6136）。
+
+        消除调用方 ``result.data.to_dataframe()`` 反模式与对不存在复数方法的死调用。
+        """
+        try:
+            filters = {}
+            if engine_uuid:
+                filters["engine_id"] = engine_uuid
+            model_list = self._engine_portfolio_mapping_crud.find(filters=filters)
+            df = model_list.to_dataframe() if model_list else pd.DataFrame()
+            return ServiceResult.success(
+                data=df,
+                message=f"Retrieved {len(df)} engine-portfolio mappings (DataFrame)",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"查询engine-portfolio映射(df)失败: {str(e)}")
+            return ServiceResult.error(f"查询engine-portfolio映射(df)失败: {str(e)}")
+
+    def get_portfolio_file_mappings_df(self, portfolio_uuid: str = None) -> ServiceResult:
+        """出口：data 是 pandas.DataFrame（类型即契约）。ADR-010 _df 范式（#6136）。
+
+        消除调用方 ``result.data.to_dataframe()`` 反模式与对不存在方法的死调用。
+        """
+        try:
+            filters = {}
+            if portfolio_uuid:
+                filters["portfolio_id"] = portfolio_uuid
+            model_list = self._portfolio_file_mapping_crud.find(filters=filters)
+            df = model_list.to_dataframe() if model_list else pd.DataFrame()
+            return ServiceResult.success(
+                data=df,
+                message=f"Retrieved {len(df)} portfolio-file mappings (DataFrame)",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"查询portfolio-file映射(df)失败: {str(e)}")
+            return ServiceResult.error(f"查询portfolio-file映射(df)失败: {str(e)}")
 
     @retry(max_try=3)
     def delete_engine_portfolio_mapping(self, engine_uuid: str, portfolio_uuid: str) -> ServiceResult:

--- a/tests/unit/client/test_backtest_result_cli_show.py
+++ b/tests/unit/client/test_backtest_result_cli_show.py
@@ -1,0 +1,67 @@
+"""#6136: backtest_result_cli show() 选 portfolio 分支走 mapping_service._df 出口。
+
+验证 ``--engine`` 给定、``--portfolio`` 缺省时调用
+``mapping_service.get_engine_portfolio_mappings_df``（修复前的死调用
+``engine_service.get_engine_portfolio_mappings`` 不再触发）。
+
+注：show() 旧方式分支顶部 ``from ginkgo.data.operations import ...`` 指向的模块
+当前 master 全仓缺失（预存、独立于 #6136），此处注入 sys.modules 桩隔离之，
+聚焦验证 #6136 的 mapping _df 出口契约，端到端可达性留待 operations 补齐。
+"""
+
+import os
+import sys
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+# 隔离预存的 operations 缺失（非 #6136 范围）：注入桩使 show() 顶部 import 不崩，
+# 聚焦验证 L114 死调用已改走 mapping_service._df 出口。
+sys.modules.setdefault("ginkgo.data.operations", MagicMock())
+
+from ginkgo.client import backtest_result_cli
+
+
+def _make_service_result(df: pd.DataFrame, success: bool = True) -> MagicMock:
+    """模拟 ServiceResult：.success + .data(DataFrame)，对齐 _df 出口契约。"""
+    result = MagicMock()
+    result.success = success
+    result.data = df
+    return result
+
+
+def test_show_portfolio_branch_uses_mapping_service_df():
+    """#6136：engine 给定 + portfolio 缺省 → 走 mapping_service._df，不崩且展示。"""
+    mock_mapping = MagicMock()
+    mock_mapping.get_engine_portfolio_mappings_df.return_value = _make_service_result(
+        pd.DataFrame([{"engine_id": "eng-1", "portfolio_id": "pf-1", "portfolio_name": "P1"}])
+    )
+    with patch("ginkgo.data.containers.container") as mock_container, \
+         patch("ginkgo.libs.utils.display.display_dataframe") as mock_display, \
+         patch.object(backtest_result_cli.console, "print"):
+        mock_container.mapping_service.return_value = mock_mapping
+        # portfolio 默认 None → 进入"选 portfolio"分支（call site 3）
+        backtest_result_cli.show(engine="eng-1")
+
+    mock_mapping.get_engine_portfolio_mappings_df.assert_called_once_with(engine_uuid="eng-1")
+    # 非空映射 → 调 display_dataframe 展示
+    assert mock_display.called
+
+
+def test_show_portfolio_branch_empty_mappings_does_not_crash():
+    """#6136：空映射 → 打印提示，不崩（_df 出口 data 即空 DataFrame）。"""
+    mock_mapping = MagicMock()
+    mock_mapping.get_engine_portfolio_mappings_df.return_value = _make_service_result(
+        pd.DataFrame(columns=["engine_id", "portfolio_id"])
+    )
+    with patch("ginkgo.data.containers.container") as mock_container, \
+         patch("ginkgo.libs.utils.display.display_dataframe") as mock_display, \
+         patch.object(backtest_result_cli.console, "print"):
+        mock_container.mapping_service.return_value = mock_mapping
+        backtest_result_cli.show(engine="eng-1")
+
+    mock_mapping.get_engine_portfolio_mappings_df.assert_called_once_with(engine_uuid="eng-1")
+    # 空映射 → 不调 display_dataframe（走 "No portfolios found" 提示分支）
+    assert not mock_display.called

--- a/tests/unit/client/test_cli_utils.py
+++ b/tests/unit/client/test_cli_utils.py
@@ -27,11 +27,13 @@ from ginkgo.client import cli_utils
 from ginkgo.enums import FILE_TYPES
 
 
-def _make_mock_model_list(df: pd.DataFrame) -> MagicMock:
-    """创建模拟 ModelList 的 mock，支持 .to_dataframe() 返回 DataFrame。"""
-    mock_ml = MagicMock()
-    mock_ml.to_dataframe.return_value = df
-    return mock_ml
+def _make_service_result(df: pd.DataFrame, success: bool = True) -> MagicMock:
+    """模拟 ServiceResult：.success + .data(pandas.DataFrame)。
+    #6136 后调用方走 mapping_service._df 出口，data 即 DataFrame（类型即契约）。"""
+    result = MagicMock()
+    result.success = success
+    result.data = df
+    return result
 
 
 # ============================================================================
@@ -84,26 +86,26 @@ class TestAddPortfolioComponents:
     """Tests for _add_portfolio_components tree builder."""
 
     def test_no_components_shows_message(self):
-        mock_service = MagicMock()
-        mock_service.get_portfolio_file_mappings.return_value = _make_mock_model_list(
+        mock_mapping = MagicMock()
+        mock_mapping.get_portfolio_file_mappings_df.return_value = _make_service_result(
             pd.DataFrame(columns=["portfolio_id", "type", "name", "file_id", "uuid"])
         )
         parent = MagicMock()
         with patch("ginkgo.data.containers.container") as mock_container:
-            mock_container.portfolio_service.return_value = mock_service
+            mock_container.mapping_service.return_value = mock_mapping
             cli_utils._add_portfolio_components(parent, "portfolio-1", False, None)
         parent.add.assert_called_once()
         assert "No components bound" in parent.add.call_args[0][0]
 
     def test_components_added_to_tree(self):
-        mock_service = MagicMock()
-        mock_service.get_portfolio_file_mappings.return_value = _make_mock_model_list(pd.DataFrame([
+        mock_mapping = MagicMock()
+        mock_mapping.get_portfolio_file_mappings_df.return_value = _make_service_result(pd.DataFrame([
             {"portfolio_id": "portfolio-1", "type": FILE_TYPES.STRATEGY.value,
              "name": "MyStrategy", "file_id": "file-1", "uuid": "mapping-1"}
         ]))
         parent = MagicMock()
         with patch("ginkgo.data.containers.container") as mock_container:
-            mock_container.portfolio_service.return_value = mock_service
+            mock_container.mapping_service.return_value = mock_mapping
             cli_utils._add_portfolio_components(parent, "portfolio-1", False, None)
         # Should have added a section node via parent.add
         assert parent.add.call_count >= 1
@@ -123,24 +125,24 @@ class TestShowTree:
 
     def test_show_portfolio_tree(self):
         portfolio_row = {"name": "TestPortfolio", "uuid": "p-1"}
-        mock_service = MagicMock()
-        mock_service.get_portfolio_file_mappings.return_value = _make_mock_model_list(
+        mock_mapping = MagicMock()
+        mock_mapping.get_portfolio_file_mappings_df.return_value = _make_service_result(
             pd.DataFrame(columns=["portfolio_id", "type", "name", "file_id", "uuid"])
         )
         with patch("ginkgo.data.containers.container") as mock_container, \
              patch.object(cli_utils.console, "print") as mock_print:
-            mock_container.portfolio_service.return_value = mock_service
+            mock_container.mapping_service.return_value = mock_mapping
             cli_utils._show_portfolio_tree(portfolio_row, False, None)
         mock_print.assert_called_once()
 
     def test_show_engine_tree_no_portfolios(self):
         engine_row = {"name": "TestEngine", "uuid": "e-1"}
-        mock_engine_service = MagicMock()
-        mock_engine_service.get_engine_portfolio_mappings.return_value = _make_mock_model_list(
+        mock_mapping = MagicMock()
+        mock_mapping.get_engine_portfolio_mappings_df.return_value = _make_service_result(
             pd.DataFrame(columns=["engine_id", "portfolio_id"])
         )
         with patch("ginkgo.data.containers.container") as mock_container, \
              patch.object(cli_utils.console, "print") as mock_print:
-            mock_container.engine_service.return_value = mock_engine_service
+            mock_container.mapping_service.return_value = mock_mapping
             cli_utils._show_engine_tree(engine_row, False, None)
         mock_print.assert_called_once()

--- a/tests/unit/data/services/test_mapping_service_df.py
+++ b/tests/unit/data/services/test_mapping_service_df.py
@@ -1,0 +1,105 @@
+"""#6136: MappingService _df 出口契约测试（ADR-010 多出口范式）。
+
+补 get_engine_portfolio_mappings_df / get_portfolio_file_mappings_df：data 是
+pandas.DataFrame（类型即契约），消除 cli_utils/backtest_result_cli 调用方对
+不存在方法的死调用 + result.data.to_dataframe() 反模式。
+
+消费点：
+- cli_utils._add_portfolio_components → get_portfolio_file_mappings_df
+- cli_utils._show_engine_tree          → get_engine_portfolio_mappings_df
+- backtest_result_cli 选 portfolio 分支 → get_engine_portfolio_mappings_df
+"""
+
+import sys
+import os
+
+import pandas as pd
+from unittest.mock import MagicMock, patch
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.crud.model_conversion import ModelList
+from ginkgo.data.services.mapping_service import MappingService
+
+
+# ===== 桩工厂（参照 test_signal_order_position_multiexit）=====
+
+
+def _make_engine_portfolio_modellist() -> ModelList:
+    from ginkgo.data.models import MEnginePortfolioMapping
+
+    model = MEnginePortfolioMapping()
+    crud_stub = MagicMock()
+    crud_stub._convert_models_to_dataframe.return_value = pd.DataFrame(
+        [{"engine_id": "eng-1", "portfolio_id": "pf-1",
+          "engine_name": "E1", "portfolio_name": "P1"}]
+    )
+    return ModelList([model], crud_stub)
+
+
+def _make_portfolio_file_modellist() -> ModelList:
+    from ginkgo.data.models import MPortfolioFileMapping
+
+    model = MPortfolioFileMapping()
+    crud_stub = MagicMock()
+    crud_stub._convert_models_to_dataframe.return_value = pd.DataFrame(
+        [{"portfolio_id": "pf-1", "file_id": "f-1", "name": "strat", "type": 6}]
+    )
+    return ModelList([model], crud_stub)
+
+
+def _make_mapping_service(ep_find=None, pf_find=None) -> MappingService:
+    with patch("ginkgo.libs.GLOG"):
+        ep = MagicMock()
+        ep.find.return_value = ep_find
+        pf = MagicMock()
+        pf.find.return_value = pf_find
+        svc = MappingService(ep, pf, MagicMock(), MagicMock())
+    return svc
+
+
+# ===== Slice 1: get_engine_portfolio_mappings_df =====
+
+
+def test_get_engine_portfolio_mappings_df_returns_dataframe_filtered_by_engine():
+    """#6136 tracer：_df 出口 data 是 DataFrame（类型即契约），engine 过滤透传 CRUD。"""
+    svc = _make_mapping_service(ep_find=_make_engine_portfolio_modellist())
+    result = svc.get_engine_portfolio_mappings_df(engine_uuid="eng-1")
+
+    assert result.success
+    assert isinstance(result.data, pd.DataFrame)
+    assert "engine_id" in result.data.columns
+    assert len(result.data) == 1
+    svc._engine_portfolio_mapping_crud.find.assert_called_once_with(
+        filters={"engine_id": "eng-1"}
+    )
+
+
+# ===== Slice 2: get_portfolio_file_mappings_df =====
+
+
+def test_get_portfolio_file_mappings_df_returns_dataframe_filtered_by_portfolio():
+    """#6136：portfolio-file 映射 _df 出口，portfolio 过滤透传 CRUD。"""
+    svc = _make_mapping_service(pf_find=_make_portfolio_file_modellist())
+    result = svc.get_portfolio_file_mappings_df(portfolio_uuid="pf-1")
+
+    assert result.success
+    assert isinstance(result.data, pd.DataFrame)
+    assert "portfolio_id" in result.data.columns
+    assert len(result.data) == 1
+    svc._portfolio_file_mapping_crud.find.assert_called_once_with(
+        filters={"portfolio_id": "pf-1"}
+    )
+
+
+def test_get_engine_portfolio_mappings_df_empty_when_find_returns_none():
+    """#6136：find 返 None 时出口给空 DataFrame（不崩）。"""
+    svc = _make_mapping_service(ep_find=None)
+    result = svc.get_engine_portfolio_mappings_df(engine_uuid="eng-x")
+
+    assert result.success
+    assert isinstance(result.data, pd.DataFrame)
+    assert len(result.data) == 0
+


### PR DESCRIPTION
## Summary

#6136 列出的 3 个 CLI mapping 死调用（活函数内部调用不存在的 service 方法，运行即 AttributeError），全部改走 MappingService 的 `_df` 出口（ADR-010 多出口范式）。

| 站点 | 修复前（死调用） | 修复后 |
|---|---|---|
| `cli_utils.py:44` `_add_portfolio_components` | `portfolio_service.get_portfolio_file_mappings()` | `mapping_service.get_portfolio_file_mappings_df()` |
| `cli_utils.py:134` `_show_engine_tree` | `engine_service.get_engine_portfolio_mappings()` | `mapping_service.get_engine_portfolio_mappings_df()` |
| `backtest_result_cli.py:114` `show` 选 portfolio 分支 | `engine_service.get_engine_portfolio_mappings(engine)` | `mapping_service.get_engine_portfolio_mappings_df(engine_uuid=engine)` |

新增 `MappingService` 两个出口方法，遵循 ADR-010：`data` 即 `pandas.DataFrame`（类型即契约），消除调用方 `result.data.to_dataframe()` 反模式。

### 附带修复（show() 潜伏 NameError）
backtest_result_cli.show() 在 L104/L133/L155/L189 使用 `display_dataframe`、L120 使用 `pd`，但模块级无 import（`pd` 仅 TYPE_CHECKING）。原死调用崩在 L114 前，使这层 NameError 潜伏。补 show() 顶部局部 import（与文件既有函数内局部 import 风格一致）。

### 范围说明（诚实）
backtest_result_cli.show() 旧方式分支（`--engine` 不带 `--task-id`）顶部 `from ginkgo.data.operations import ...` 指向的模块当前 master 全仓缺失（预存、独立于本 issue）。本 PR 消除该分支的 mapping 死调用（满足 #6136 站点 3 字面 AC），但该分支端到端可达性受 operations 缺失阻挠，需另开 issue 补 operations 模块。`--task-id` 新方式分支不受影响。cli_utils 的两个站点（portfolio/engine 树命令）路径可达，为真实修复。

## Test plan

三层 smoke（对齐 CI #6015）：
- [x] Layer1 py_compile（src+api 全量）
- [x] Layer2 启动路径：test_user_crud_mock + test_containers + test_user_cli（29 passed）
- [x] Layer3 变更相关：
  - `tests/unit/data/services/test_mapping_service_df.py`（_df 出口契约，3 passed）
  - `tests/unit/services/smoke/test_mapping_service_smoke.py`（5 passed）
  - `tests/unit/client/test_cli_utils.py`（7 passed，mock 改走 _df）
  - `tests/unit/client/test_backtest_result_cli_show.py`（2 passed，选 portfolio 分支契约，sys.modules 隔离 operations 预存缺失）

Closes #6136
