### PR TITLE
fix: TradingTimeRisk 补开盘/收盘保护窗口检查 (AC1+AC2 切片)

### DIFF
--- a/src/ginkgo/trading/risk_management/trading_time_risk.py
+++ b/src/ginkgo/trading/risk_management/trading_time_risk.py
@@ -42,6 +42,17 @@ class TradingTimeRisk(BaseRiskManagement):
         from datetime import time as dt_time
         if hasattr(current_time, "hour"):
             h, m = current_time.hour, current_time.minute
+            minutes = h * 60 + m
+            # 开盘保护窗口 [9:30, 9:30+open_minutes_after)，0 表示不限制
+            if self._open_minutes_after > 0:
+                open_start = 9 * 60 + 30
+                if open_start <= minutes < open_start + self._open_minutes_after:
+                    return False
+            # 收盘保护窗口 [15:00-close_minutes_before, 15:00]，0 表示不限制
+            if self._close_minutes_before > 0:
+                close_end = 15 * 60
+                if close_end - self._close_minutes_before <= minutes <= close_end:
+                    return False
             if h == self._lunch_start_hour and m >= self._lunch_start_minute:
                 return False
             if h == self._lunch_end_hour and m < self._lunch_end_minute:

--- a/tests/unit/trading/strategy/risk_managements/test_trading_time_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_trading_time_risk.py
@@ -79,12 +79,12 @@ class TestTradingTimeRiskMarketHoursControl:
     def test_market_opening_time_control(self):
         r = TradingTimeRisk()
         now = datetime(2024, 1, 1, 9, 30)
-        assert r.is_trading_allowed(now) is True
+        assert r.is_trading_allowed(now) is False
 
     def test_market_closing_time_control(self):
         r = TradingTimeRisk()
         now = datetime(2024, 1, 1, 14, 55)
-        assert r.is_trading_allowed(now) is True
+        assert r.is_trading_allowed(now) is False
 
     def test_lunch_break_management(self):
         r = TradingTimeRisk(lunch_start_hour=11, lunch_start_minute=30,
@@ -211,7 +211,7 @@ class TestTradingTimeRiskOrderProcessing:
     def test_optimal_time_order_scheduling(self):
         r = TradingTimeRisk()
         for hour in [9, 10, 13, 14]:
-            now = datetime(2024, 1, 1, hour, 30)
+            now = datetime(2024, 1, 1, hour, 40)
             assert r.is_trading_allowed(now) is True
 
 
@@ -314,3 +314,63 @@ class TestTradingTimeRiskPerformance:
             r.cal(_make_portfolio_info(now=datetime(2024, 1, 1, 10, 30)), _make_order())
         elapsed = time.time() - start
         assert elapsed < 5.0
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
+@pytest.mark.critical
+class TestTradingTimeRiskOpenCloseBoundaries:
+    """开盘/收盘保护窗口边界语义固化（AC1 open_minutes_after + AC2 close_minutes_before）。"""
+
+    def test_open_window_blocks_from_open(self):
+        # 默认 open=5：[9:30, 9:35) 阻塞，9:30 起即拦截
+        r = TradingTimeRisk()
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 9, 30)) is False
+
+    def test_open_window_last_blocked_minute(self):
+        # 9:34 仍在窗口内（半开右端 9:35 不含）
+        r = TradingTimeRisk()
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 9, 34)) is False
+
+    def test_open_window_releases_at_boundary(self):
+        # 9:35 恰好出窗口，立即放行
+        r = TradingTimeRisk()
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 9, 35)) is True
+
+    def test_open_window_disabled_when_zero(self):
+        # open=0 表示无开盘保护，9:30 放行
+        r = TradingTimeRisk(open_minutes_after=0)
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 9, 30)) is True
+
+    def test_open_window_custom_size(self):
+        # open=10：9:39 仍在窗口，9:40 出窗口
+        r = TradingTimeRisk(open_minutes_after=10)
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 9, 39)) is False
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 9, 40)) is True
+
+    def test_close_window_blocks_until_close(self):
+        # 默认 close=5：[14:55, 15:00] 阻塞
+        r = TradingTimeRisk()
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 14, 55)) is False
+
+    def test_close_window_last_allowed_minute(self):
+        # 14:54 在窗口外，放行（闭区间左端 14:55 含）
+        r = TradingTimeRisk()
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 14, 54)) is True
+
+    def test_close_window_blocks_last_minute(self):
+        # 14:59 仍在窗口内（含收盘点 15:00）
+        r = TradingTimeRisk()
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 14, 59)) is False
+
+    def test_close_window_disabled_when_zero(self):
+        # close=0 表示无收盘保护，14:59 放行
+        r = TradingTimeRisk(close_minutes_before=0)
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 14, 59)) is True
+
+    def test_close_window_custom_size(self):
+        # close=10：14:50 起阻塞（15:00-10=14:50），14:49 放行
+        r = TradingTimeRisk(close_minutes_before=10)
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 14, 50)) is False
+        assert r.is_trading_allowed(datetime(2024, 1, 1, 14, 49)) is True


### PR DESCRIPTION
## Summary

推进 #6041（TradingTimeRisk 交易时段风控 P2 bug）的 **AC1 + AC2 切片**。

### 问题

`TradingTimeRisk.is_trading_allowed()` 原仅检查午休时段，**漏读** `_open_minutes_after` / `_close_minutes_before` 两个参数——开盘保护、收盘保护完全失效。构造函数接受参数、`set_name` 把它们拼进名字（`_open5m_close5m`），但方法体从不引用，参数形同虚设。

`cal()` 已调用 `is_trading_allowed()`（前序已修），本轮补**方法体**。

### 修复

补两段窗口检查（A 股 9:30 开盘 / 15:00 收盘为基准点）：

| 窗口 | 语义（默认 open=5/close=5） | 边界 |
|---|---|---|
| 开盘保护 | `[9:30, 9:35)` 半开（9:35 立即放行） | `open=0` 跳过 |
| 收盘保护 | `[14:55, 15:00]` 闭区间（含收盘点） | `close=0` 跳过 |

午休逻辑**保持原样**（最小切片）。

### 不完全关闭 #6041（重要）

triage brief 含 AC3（非交易时段拦截，如盘前 / 15:00 后）。本切片仅 AC1+AC2，AC3 推迟原因：
- feeder 按数据时间驱动订单，非交易时段是否真会触发 `cal()` 需先确认
- 硬编码 9:30/15:00 基准对 A 股成立，若后续支持其他市场需参数化

### 顺带发现的 pre-existing bug（不在本切片）

午休检查 `h == lunch_start_hour` 单小时匹配，**12:00-12:59（h==12）被放过**；且 `lunch_end_minute=0` 使 `m < 0` 永假成死代码。本切片未动午休逻辑，建议另开 issue。

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）全绿：
- **L1 py_compile**：src+api 全量 ✅
- **L2 启动路径**：test_user_crud_mock + test_containers + test_user_cli（29 passed）✅
- **L3 变更相关**：test_trading_time_risk（47 passed，含 10 个新增边界用例）+ risk_managements 全目录回归（551 passed, 2 skipped）✅

TDD：翻转 2 处 encode-bug 断言（9:30→False、14:55→False）→ RED → 实现 → GREEN；新增 `TestTradingTimeRiskOpenCloseBoundaries` 10 用例固化半开/闭区间/0 跳过语义。

Refs #6041

🤖 Generated with [Claude Code](https://claude.com/claude-code)
