### PR TITLE
fix: 缩放型风控 A股 lot 对齐拒单(volatility/concentration/liquidity)+ 空仓 worth 投影 (#6038)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,7 @@ markers = [
     "lifecycle: 生命周期测试",
     "clickhouse: ClickHouse数据库测试",
     "mysql: MySQL数据库测试",
+    "bug: 回归 bug 守护测试(防已修 bug 复发)",
 ]
 
 # 警告过滤

--- a/src/ginkgo/entities/mixins/__init__.py
+++ b/src/ginkgo/entities/mixins/__init__.py
@@ -2,10 +2,12 @@ from .time_mixin import TimeMixin
 from .context_mixin import ContextMixin
 from .named_mixin import NamedMixin
 from .engine_bindable_mixin import EngineBindableMixin
+from .lot_alignable_mixin import LotAlignableMixin
 
 __all__ = [
     "TimeMixin",
     "ContextMixin",
     "NamedMixin",
     "EngineBindableMixin",
+    "LotAlignableMixin",
 ]

--- a/src/ginkgo/entities/mixins/lot_alignable_mixin.py
+++ b/src/ginkgo/entities/mixins/lot_alignable_mixin.py
@@ -1,0 +1,39 @@
+# Upstream: 缩放型风控(VolatilityRisk 等)/Sizer 等需对齐最小交易单位的组件
+# Downstream: 无外部依赖纯 Mixin 功能
+# Role: LotAlignableMixin 提供 lot_size 配置与 align_to_lot 对齐能力,支持不同市场最小交易单位
+
+
+
+
+"""
+最小交易单位(lot)对齐 Mixin
+
+为缩放型风控/Sizer 等组件提供成交量向下取整对齐到 lot_size 整数倍的能力。
+A 股默认 100 股/手;参数化以支持港股/美股/期货等不同最小交易单位(#6038)。
+
+混入此 Mixin 的组件需在 __init__ 中设置 self._lot_size(建议默认 100,A 股)。
+"""
+
+
+class LotAlignableMixin:
+    """最小交易单位(lot)对齐 Mixin。
+
+    为缩放型风控/Sizer 等组件提供 lot 对齐能力。组件需在 __init__ 中
+    设置 self._lot_size(建议默认 100,保持 A 股现状)。
+    """
+
+    @property
+    def lot_size(self) -> int:
+        """最小交易单位(手)。"""
+        return self._lot_size
+
+    def align_to_lot(self, volume: int) -> int:
+        """将成交量向下取整对齐到 lot_size 的整数倍。
+
+        Args:
+            volume: 原始成交量
+
+        Returns:
+            int: 对齐后的成交量(不足 1 手时返回 0,调用方据此拒单)
+        """
+        return (int(volume) // self._lot_size) * self._lot_size

--- a/src/ginkgo/trading/risk_management/concentration_risk.py
+++ b/src/ginkgo/trading/risk_management/concentration_risk.py
@@ -23,6 +23,7 @@
 from typing import List, Dict, Optional
 from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
+from ginkgo.libs import to_decimal
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
 from ginkgo.entities.mixins import LotAlignableMixin
@@ -298,11 +299,13 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
     def _project_against_worth(self, portfolio_info: Dict, order_value) -> float:
         """空组合(无持仓)时基于组合净值 worth 投影订单占比(%)(#6038 防"空仓首单误拒")。
 
-        worth 缺失或 <=0 时保守返回 100(维持旧行为)。
+        worth 缺失或 <=0 时保守返回 100(维持旧行为)。worth/order_value 统一 to_decimal
+        归一:运行时 worth 为 Decimal(portfolio_base.worth property),市价单走 prices fallback
+        时 order_value 可能为 float,float/Decimal 直接相除抛 TypeError(#6038 review 回归)。
         """
         worth = portfolio_info.get("worth", 0) or 0
         if worth > 0:
-            return float((order_value / worth) * 100)
+            return float((to_decimal(order_value) / to_decimal(worth)) * 100)
         return 100.0
 
     def _calculate_projected_ratio(self, portfolio_info: Dict, order: Order) -> float:

--- a/src/ginkgo/trading/risk_management/concentration_risk.py
+++ b/src/ginkgo/trading/risk_management/concentration_risk.py
@@ -127,10 +127,13 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
                 original_volume = order.volume
                 scaled = int(order.volume * reduction_factor)
                 # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
-                order.adjust_volume(self.align_to_lot(scaled))
-
-                min_volume = self.align_to_lot(max(1, int(original_volume * 0.1)))
-                order.adjust_volume(max(order.volume, min_volume))
+                # 缩放后不足 1 手拒单(对齐 volatility_risk 模板, 调用方对 None 软拦截)(#6038)
+                aligned = self.align_to_lot(scaled)
+                if aligned < self._lot_size:
+                    GLOG.WARN(f"ConcentrationRisk: Single position {order.code} would be {projected_ratio:.1f}% > {self._max_single_position_ratio}%, "
+                             f"scaled {original_volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                    return None
+                order.adjust_volume(aligned)
 
                 GLOG.WARN(f"ConcentrationRisk: Single position {order.code} would be {projected_ratio:.1f}% > {self._max_single_position_ratio}%, "
                          f"reducing order {original_volume} → {order.volume}")
@@ -141,12 +144,19 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
 
             if industry_ratio > self._max_industry_ratio:
                 reduction_factor = self._max_industry_ratio / industry_ratio
+                original_volume = order.volume
                 scaled = int(order.volume * reduction_factor)
                 # 行业集中度缩放同样 lot_size 对齐(LotAlignableMixin)(#6038)
-                order.adjust_volume(self.align_to_lot(scaled))
+                # 缩放后不足 1 手拒单(对齐 volatility_risk 模板)(#6038)
+                aligned = self.align_to_lot(scaled)
+                if aligned < self._lot_size:
+                    GLOG.WARN(f"ConcentrationRisk: Industry {stock_industry} would be {industry_ratio:.1f}% > {self._max_industry_ratio}%, "
+                             f"scaled {original_volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                    return None
+                order.adjust_volume(aligned)
 
                 GLOG.WARN(f"ConcentrationRisk: Industry {stock_industry} would be {industry_ratio:.1f}% > {self._max_industry_ratio}%, "
-                         f"adjusting order to {order.volume}")
+                         f"reducing order {original_volume} → {order.volume}")
 
         return order
 
@@ -285,6 +295,16 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
 
         return float((position.market_value / total_value) * 100)
 
+    def _project_against_worth(self, portfolio_info: Dict, order_value) -> float:
+        """空组合(无持仓)时基于组合净值 worth 投影订单占比(%)(#6038 防"空仓首单误拒")。
+
+        worth 缺失或 <=0 时保守返回 100(维持旧行为)。
+        """
+        worth = portfolio_info.get("worth", 0) or 0
+        if worth > 0:
+            return float((order_value / worth) * 100)
+        return 100.0
+
     def _calculate_projected_ratio(self, portfolio_info: Dict, order: Order) -> float:
         """计算下单后的预计持仓比例"""
         current_ratio = self._get_current_position_ratio(portfolio_info, order.code)
@@ -301,7 +321,7 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
         total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
 
         if total_value <= 0:
-            return 100.0  # 第一笔订单
+            return self._project_against_worth(portfolio_info, order_value)
 
         projected_total = total_value + order_value
         projected_position_value = positions.get(order.code).market_value if positions.get(order.code) else 0
@@ -314,8 +334,14 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
         positions = portfolio_info.get("positions", {})
         total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
 
+        # #3959 使用实际价格计算订单价值(提前至空组合分支前,供 worth 投影复用)
+        price = getattr(order, 'limit_price', None)
+        if not price or price <= 0:
+            price = portfolio_info.get("prices", {}).get(order.code, 100)
+        order_value = order.volume * price
+
         if total_value <= 0:
-            return 100.0
+            return self._project_against_worth(portfolio_info, order_value)
 
         # 计算当前行业价值（Decimal(0)：market_value 为 Decimal，float 初值会与 Decimal 混算抛 TypeError）
         current_industry_value = Decimal(0)
@@ -324,12 +350,6 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
                 stock_industry = self._stock_industry_map.get(code, "未知行业")
                 if stock_industry == industry:
                     current_industry_value += position.market_value
-
-        # #3959 使用实际价格计算订单价值
-        price = getattr(order, 'limit_price', None)
-        if not price or price <= 0:
-            price = portfolio_info.get("prices", {}).get(order.code, 100)
-        order_value = order.volume * price
 
         projected_industry_value = current_industry_value + order_value
         projected_total = total_value + order_value

--- a/src/ginkgo/trading/risk_management/concentration_risk.py
+++ b/src/ginkgo/trading/risk_management/concentration_risk.py
@@ -25,12 +25,13 @@ from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.trading.events.price_update import EventPriceUpdate
 from ginkgo.enums import DIRECTION_TYPES, EVENT_TYPES
 from ginkgo.libs import GLOG
 
 
-class ConcentrationRisk(BaseRiskManagement):
+class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
     """
     集中度风控模块
 
@@ -51,6 +52,7 @@ class ConcentrationRisk(BaseRiskManagement):
         warning_concept_ratio: float = 35.0,
         max_top5_ratio: float = 50.0,
         warning_top5_ratio: float = 45.0,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -74,6 +76,7 @@ class ConcentrationRisk(BaseRiskManagement):
         self._warning_concept_ratio = float(warning_concept_ratio)
         self._max_top5_ratio = float(max_top5_ratio)
         self._warning_top5_ratio = float(warning_top5_ratio)
+        self._lot_size = int(lot_size)
 
         # 存储股票的行业和概念信息
         self._stock_industry_map = {}  # code: industry_name
@@ -122,9 +125,11 @@ class ConcentrationRisk(BaseRiskManagement):
                 # 超过最大单一持仓比例，大幅减少订单
                 reduction_factor = self._max_single_position_ratio / projected_ratio
                 original_volume = order.volume
-                order.adjust_volume(int(order.volume * reduction_factor))
+                scaled = int(order.volume * reduction_factor)
+                # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
+                order.adjust_volume(self.align_to_lot(scaled))
 
-                min_volume = max(1, int(original_volume * 0.1))
+                min_volume = self.align_to_lot(max(1, int(original_volume * 0.1)))
                 order.adjust_volume(max(order.volume, min_volume))
 
                 GLOG.WARN(f"ConcentrationRisk: Single position {order.code} would be {projected_ratio:.1f}% > {self._max_single_position_ratio}%, "
@@ -136,7 +141,9 @@ class ConcentrationRisk(BaseRiskManagement):
 
             if industry_ratio > self._max_industry_ratio:
                 reduction_factor = self._max_industry_ratio / industry_ratio
-                order.adjust_volume(int(order.volume * reduction_factor))
+                scaled = int(order.volume * reduction_factor)
+                # 行业集中度缩放同样 lot_size 对齐(LotAlignableMixin)(#6038)
+                order.adjust_volume(self.align_to_lot(scaled))
 
                 GLOG.WARN(f"ConcentrationRisk: Industry {stock_industry} would be {industry_ratio:.1f}% > {self._max_industry_ratio}%, "
                          f"adjusting order to {order.volume}")

--- a/src/ginkgo/trading/risk_management/liquidity_risk.py
+++ b/src/ginkgo/trading/risk_management/liquidity_risk.py
@@ -119,18 +119,28 @@ class LiquidityRisk(LotAlignableMixin, BaseRiskManagement):
                 original_volume = order.volume
                 scaled = int(order.volume * reduction_factor)
                 # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
-                order.adjust_volume(self.align_to_lot(scaled))
-
-                min_volume = self.align_to_lot(max(1, int(original_volume * 0.1)))
-                order.adjust_volume(max(order.volume, min_volume))
+                # 缩放后不足 1 手拒单(对齐 volatility_risk 模板, 调用方对 None 软拦截)(#6038)
+                aligned = self.align_to_lot(scaled)
+                if aligned < self._lot_size:
+                    GLOG.WARN(f"LiquidityRisk: Low liquidity for {order.code}, volume ratio {avg_volume_ratio:.3f} > {self._min_avg_volume_ratio}, "
+                             f"scaled {original_volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                    return None
+                order.adjust_volume(aligned)
 
                 GLOG.WARN(f"LiquidityRisk: Low liquidity for {order.code}, volume ratio {avg_volume_ratio:.3f} > {self._min_avg_volume_ratio}, "
                          f"reducing order {original_volume} → {order.volume}")
             else:
                 # 流动性预警，适度减少订单
                 reduction_factor = 0.8  # 预警时减少20%
+                original_volume = order.volume
                 scaled = int(order.volume * reduction_factor)
-                order.adjust_volume(self.align_to_lot(scaled))  # lot_size 对齐(#6038)
+                # lot_size 对齐 + 不足 1 手拒单(对齐 volatility_risk 模板)(#6038)
+                aligned = self.align_to_lot(scaled)
+                if aligned < self._lot_size:
+                    GLOG.INFO(f"LiquidityRisk: Liquidity warning for {order.code}, volume ratio {avg_volume_ratio:.3f} > {self._warning_avg_volume_ratio}, "
+                             f"scaled {original_volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                    return None
+                order.adjust_volume(aligned)
 
                 GLOG.INFO(f"LiquidityRisk: Liquidity warning for {order.code}, volume ratio {avg_volume_ratio:.3f} > {self._warning_avg_volume_ratio}, "
                          f"adjusting order to {order.volume}")
@@ -145,7 +155,13 @@ class LiquidityRisk(LotAlignableMixin, BaseRiskManagement):
             # 价格冲击预警，减少订单
             reduction_factor = self._warning_price_impact / price_impact
             scaled = int(order.volume * reduction_factor)
-            order.adjust_volume(self.align_to_lot(scaled))  # lot_size 对齐(#6038)
+            # lot_size 对齐 + 不足 1 手拒单(对齐 volatility_risk 模板)(#6038)
+            aligned = self.align_to_lot(scaled)
+            if aligned < self._lot_size:
+                GLOG.WARN(f"LiquidityRisk: Price impact warning {price_impact:.2f}% > {self._warning_price_impact}% for {order.code}, "
+                         f"scaled {order.volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                return None
+            order.adjust_volume(aligned)
 
             GLOG.WARN(f"LiquidityRisk: Price impact warning {price_impact:.2f}% > {self._warning_price_impact}% for {order.code}, "
                      f"adjusting order to {order.volume}")
@@ -156,7 +172,13 @@ class LiquidityRisk(LotAlignableMixin, BaseRiskManagement):
             # 成交额过低，限制交易
             reduction_factor = avg_turnover / self._min_turnover_ratio
             scaled = int(order.volume * max(reduction_factor, 0.1))
-            order.adjust_volume(self.align_to_lot(scaled))  # lot_size 对齐(#6038)
+            # lot_size 对齐 + 不足 1 手拒单(对齐 volatility_risk 模板)(#6038)
+            aligned = self.align_to_lot(scaled)
+            if aligned < self._lot_size:
+                GLOG.WARN(f"LiquidityRisk: Low turnover {avg_turnover:,.0f} < {self._min_turnover_ratio:,.0f} for {order.code}, "
+                         f"scaled {order.volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                return None
+            order.adjust_volume(aligned)
 
             GLOG.WARN(f"LiquidityRisk: Low turnover {avg_turnover:,.0f} < {self._min_turnover_ratio:,.0f} for {order.code}, "
                      f"reducing order to {order.volume}")

--- a/src/ginkgo/trading/risk_management/liquidity_risk.py
+++ b/src/ginkgo/trading/risk_management/liquidity_risk.py
@@ -25,12 +25,13 @@ from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.trading.events.price_update import EventPriceUpdate
 from ginkgo.enums import DIRECTION_TYPES, EVENT_TYPES
 from ginkgo.libs import GLOG
 
 
-class LiquidityRisk(BaseRiskManagement):
+class LiquidityRisk(LotAlignableMixin, BaseRiskManagement):
     """
     流动性风控模块
 
@@ -50,6 +51,7 @@ class LiquidityRisk(BaseRiskManagement):
         min_turnover_ratio: float = 1000000,  # 最小日成交额
         warning_turnover_ratio: float = 5000000,
         liquidity_lookback_days: int = 20,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -71,6 +73,7 @@ class LiquidityRisk(BaseRiskManagement):
         self._min_turnover_ratio = float(min_turnover_ratio)
         self._warning_turnover_ratio = float(warning_turnover_ratio)
         self._liquidity_lookback_days = liquidity_lookback_days
+        self._lot_size = int(lot_size)
 
         # 存储历史流动性数据
         self._volume_history = {}  # code: [volume_list]
@@ -114,9 +117,11 @@ class LiquidityRisk(BaseRiskManagement):
                 # 流动性严重不足，大幅减少订单
                 reduction_factor = self._min_avg_volume_ratio / avg_volume_ratio
                 original_volume = order.volume
-                order.adjust_volume(int(order.volume * reduction_factor))
+                scaled = int(order.volume * reduction_factor)
+                # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
+                order.adjust_volume(self.align_to_lot(scaled))
 
-                min_volume = max(1, int(original_volume * 0.1))
+                min_volume = self.align_to_lot(max(1, int(original_volume * 0.1)))
                 order.adjust_volume(max(order.volume, min_volume))
 
                 GLOG.WARN(f"LiquidityRisk: Low liquidity for {order.code}, volume ratio {avg_volume_ratio:.3f} > {self._min_avg_volume_ratio}, "
@@ -124,7 +129,8 @@ class LiquidityRisk(BaseRiskManagement):
             else:
                 # 流动性预警，适度减少订单
                 reduction_factor = 0.8  # 预警时减少20%
-                order.adjust_volume(int(order.volume * reduction_factor))
+                scaled = int(order.volume * reduction_factor)
+                order.adjust_volume(self.align_to_lot(scaled))  # lot_size 对齐(#6038)
 
                 GLOG.INFO(f"LiquidityRisk: Liquidity warning for {order.code}, volume ratio {avg_volume_ratio:.3f} > {self._warning_avg_volume_ratio}, "
                          f"adjusting order to {order.volume}")
@@ -138,7 +144,8 @@ class LiquidityRisk(BaseRiskManagement):
         elif price_impact > self._warning_price_impact:
             # 价格冲击预警，减少订单
             reduction_factor = self._warning_price_impact / price_impact
-            order.adjust_volume(int(order.volume * reduction_factor))
+            scaled = int(order.volume * reduction_factor)
+            order.adjust_volume(self.align_to_lot(scaled))  # lot_size 对齐(#6038)
 
             GLOG.WARN(f"LiquidityRisk: Price impact warning {price_impact:.2f}% > {self._warning_price_impact}% for {order.code}, "
                      f"adjusting order to {order.volume}")
@@ -148,7 +155,8 @@ class LiquidityRisk(BaseRiskManagement):
         if avg_turnover < self._min_turnover_ratio:
             # 成交额过低，限制交易
             reduction_factor = avg_turnover / self._min_turnover_ratio
-            order.adjust_volume(int(order.volume * max(reduction_factor, 0.1)))
+            scaled = int(order.volume * max(reduction_factor, 0.1))
+            order.adjust_volume(self.align_to_lot(scaled))  # lot_size 对齐(#6038)
 
             GLOG.WARN(f"LiquidityRisk: Low turnover {avg_turnover:,.0f} < {self._min_turnover_ratio:,.0f} for {order.code}, "
                      f"reducing order to {order.volume}")

--- a/src/ginkgo/trading/risk_management/margin_risk.py
+++ b/src/ginkgo/trading/risk_management/margin_risk.py
@@ -54,7 +54,17 @@ class MarginRisk(LotAlignableMixin, BaseRiskManagement):
                         (self._max_leverage_ratio - self._forced_liquidation_ratio))
             scaled = int(order.volume * factor)
             # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
-            order.adjust_volume(self.align_to_lot(scaled))
+            # 缩放后不足 1 手拒单(对齐 volatility/concentration/liquidity/max_drawdown 模板,
+            # 调用方对 cal() 返回 None 走软拦截 ORDERBLOCKED,零侵入)(#6038)
+            aligned = self.align_to_lot(scaled)
+            if aligned < self._lot_size:
+                GLOG.WARN(f"MarginRisk: Leverage {current_leverage:.2f}x >= forced liquidation "
+                         f"{self._forced_liquidation_ratio}x, scaled {order.volume} → {scaled} "
+                         f"below 1 lot ({self._lot_size}), blocking order")
+                return None
+            order.adjust_volume(aligned)
+            GLOG.WARN(f"MarginRisk: Leverage {current_leverage:.2f}x >= forced liquidation, "
+                     f"reducing order to {order.volume}")
         return order
 
     def generate_signals(self, portfolio_info: Dict, event) -> List[Signal]:

--- a/src/ginkgo/trading/risk_management/margin_risk.py
+++ b/src/ginkgo/trading/risk_management/margin_risk.py
@@ -7,21 +7,23 @@ from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.enums import DIRECTION_TYPES, EVENT_TYPES
 from ginkgo.libs import GLOG
 
 
-class MarginRisk(BaseRiskManagement):
+class MarginRisk(LotAlignableMixin, BaseRiskManagement):
     __abstract__ = False
 
     def __init__(self, name="MarginRisk", max_leverage_ratio=2.0,
                  maintenance_margin_ratio=1.3, margin_call_warning_ratio=1.5,
-                 forced_liquidation_ratio=1.2, *args, **kwargs):
+                 forced_liquidation_ratio=1.2, lot_size: int = 100, *args, **kwargs):
         super().__init__(name, *args, **kwargs)
         self._max_leverage_ratio = float(max_leverage_ratio)
         self._maintenance_margin_ratio = float(maintenance_margin_ratio)
         self._margin_call_warning_ratio = float(margin_call_warning_ratio)
         self._forced_liquidation_ratio = float(forced_liquidation_ratio)
+        self._lot_size = int(lot_size)
         self.set_name(f"{name}_lev{self._max_leverage_ratio}x_mm{self._maintenance_margin_ratio}")
 
     @property
@@ -50,7 +52,9 @@ class MarginRisk(BaseRiskManagement):
         if current_leverage >= self._forced_liquidation_ratio:
             factor = max(0.1, (self._max_leverage_ratio - current_leverage) /
                         (self._max_leverage_ratio - self._forced_liquidation_ratio))
-            order.adjust_volume(int(order.volume * factor))
+            scaled = int(order.volume * factor)
+            # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
+            order.adjust_volume(self.align_to_lot(scaled))
         return order
 
     def generate_signals(self, portfolio_info: Dict, event) -> List[Signal]:

--- a/src/ginkgo/trading/risk_management/max_drawdown_risk.py
+++ b/src/ginkgo/trading/risk_management/max_drawdown_risk.py
@@ -126,7 +126,14 @@ class MaxDrawdownRisk(LotAlignableMixin, BaseRiskManagement):
                 reduced_order = copy.deepcopy(order)
                 scaled = int(reduced_order.volume * max(reduction_factor, 0.1))
                 # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
-                reduced_order.adjust_volume(self.align_to_lot(scaled))
+                # 缩放后不足 1 手拒单(对齐 volatility/concentration/liquidity 模板,
+                # 调用方对 cal() 返回 None 走软拦截 ORDERBLOCKED,零侵入)(#6038)
+                aligned = self.align_to_lot(scaled)
+                if aligned < self._lot_size:
+                    GLOG.WARN(f"MaxDrawdownRisk: Drawdown {current_drawdown:.1f}% > {self._max_drawdown}%, "
+                             f"scaled {reduced_order.volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
+                    return None
+                reduced_order.adjust_volume(aligned)
                 GLOG.WARN(f"MaxDrawdownRisk: Reducing position size due to drawdown {current_drawdown:.1f}%")
                 return reduced_order
 

--- a/src/ginkgo/trading/risk_management/max_drawdown_risk.py
+++ b/src/ginkgo/trading/risk_management/max_drawdown_risk.py
@@ -26,12 +26,13 @@ from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.trading.events.price_update import EventPriceUpdate
 from ginkgo.enums import DIRECTION_TYPES, EVENT_TYPES
 from ginkgo.libs import GLOG
 
 
-class MaxDrawdownRisk(BaseRiskManagement):
+class MaxDrawdownRisk(LotAlignableMixin, BaseRiskManagement):
     """
     最大回撤风控模块
 
@@ -47,6 +48,7 @@ class MaxDrawdownRisk(BaseRiskManagement):
         max_drawdown: float = 15.0,
         warning_drawdown: float = 10.0,
         critical_drawdown: float = 20.0,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -74,6 +76,7 @@ class MaxDrawdownRisk(BaseRiskManagement):
         self._max_drawdown = float(max_drawdown)
         self._warning_drawdown = float(warning_drawdown)
         self._critical_drawdown = float(critical_drawdown)
+        self._lot_size = int(lot_size)
 
         # 记录历史最高点
         self._peak_values = {}  # code: peak_value
@@ -121,7 +124,9 @@ class MaxDrawdownRisk(BaseRiskManagement):
                 reduction_factor = (self._critical_drawdown - current_drawdown) / denominator
                 # 返回副本而非原地修改 (#5495)：避免多风险链共享同一 order 引用导致过度缩减与状态污染
                 reduced_order = copy.deepcopy(order)
-                reduced_order.adjust_volume(int(reduced_order.volume * max(reduction_factor, 0.1)))
+                scaled = int(reduced_order.volume * max(reduction_factor, 0.1))
+                # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
+                reduced_order.adjust_volume(self.align_to_lot(scaled))
                 GLOG.WARN(f"MaxDrawdownRisk: Reducing position size due to drawdown {current_drawdown:.1f}%")
                 return reduced_order
 

--- a/src/ginkgo/trading/risk_management/volatility_risk.py
+++ b/src/ginkgo/trading/risk_management/volatility_risk.py
@@ -103,11 +103,15 @@ class VolatilityRisk(BaseRiskManagement):
             # 波动率过高，大幅减少订单规模
             reduction_factor = (self._max_volatility / current_volatility) ** 2
             original_volume = order.volume
-            order.adjust_volume(int(order.volume * reduction_factor))
-
-            # 确保最小订单量
-            min_volume = max(1, int(original_volume * 0.1))
-            order.adjust_volume(max(order.volume, min_volume))
+            scaled = int(order.volume * reduction_factor)
+            # A股最小交易单位 100 股/手，缩放后向下取整对齐到手（#6038）
+            aligned = (scaled // 100) * 100
+            if aligned < 100:
+                # 不足 1 手，拒单（调用方对 None 软拦截）
+                GLOG.WARN(f"VolatilityRisk: High volatility {current_volatility:.1f}% > {self._max_volatility}%, "
+                         f"scaled {original_volume} → {scaled} below 1 lot (100), blocking order")
+                return None
+            order.adjust_volume(aligned)
 
             GLOG.WARN(f"VolatilityRisk: High volatility {current_volatility:.1f}% > {self._max_volatility}%, "
                      f"reducing order {original_volume} → {order.volume}")
@@ -115,7 +119,14 @@ class VolatilityRisk(BaseRiskManagement):
         elif current_volatility > self._warning_volatility:
             # 波动率预警，适度减少订单规模
             reduction_factor = (self._max_volatility / current_volatility) ** 1.5
-            order.adjust_volume(int(order.volume * reduction_factor))
+            scaled = int(order.volume * reduction_factor)
+            # A股最小交易单位 100 股/手，缩放后向下取整对齐到手（#6038）
+            aligned = (scaled // 100) * 100
+            if aligned < 100:
+                GLOG.INFO(f"VolatilityRisk: Warning volatility {current_volatility:.1f}% > {self._warning_volatility}%, "
+                         f"scaled {order.volume} → {scaled} below 1 lot (100), blocking order")
+                return None
+            order.adjust_volume(aligned)
 
             GLOG.INFO(f"VolatilityRisk: Warning volatility {current_volatility:.1f}% > {self._warning_volatility}%, "
                      f"adjusting order to {order.volume}")

--- a/src/ginkgo/trading/risk_management/volatility_risk.py
+++ b/src/ginkgo/trading/risk_management/volatility_risk.py
@@ -25,6 +25,7 @@ from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.trading.events.price_update import EventPriceUpdate
 from ginkgo.enums import DIRECTION_TYPES, EVENT_TYPES
 from ginkgo.libs import GLOG
@@ -32,7 +33,7 @@ from ginkgo.libs import GLOG
 import math
 
 
-class VolatilityRisk(BaseRiskManagement):
+class VolatilityRisk(LotAlignableMixin, BaseRiskManagement):
     """
     波动率风控模块
 
@@ -49,6 +50,7 @@ class VolatilityRisk(BaseRiskManagement):
         warning_volatility: float = 20.0,
         lookback_period: int = 20,
         volatility_window: int = 10,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -58,12 +60,15 @@ class VolatilityRisk(BaseRiskManagement):
             warning_volatility(float): 预警波动率阈值，百分比
             lookback_period(int): 历史数据回看期，天数
             volatility_window(int): 波动率计算窗口，天数
+            lot_size(int): 最小交易单位（手），缩放后向下取整对齐。A 股默认 100 股/手；
+                参数化以支持港股/美股/期货等不同最小交易单位（#6038）。
         """
         super().__init__(name, *args, **kwargs)
         self._max_volatility = float(max_volatility)
         self._warning_volatility = float(warning_volatility)
         self._lookback_period = lookback_period
         self._volatility_window = volatility_window
+        self._lot_size = int(lot_size)
 
         # 存储历史价格数据用于波动率计算
         self._price_history = {}  # code: [price_list]
@@ -104,12 +109,12 @@ class VolatilityRisk(BaseRiskManagement):
             reduction_factor = (self._max_volatility / current_volatility) ** 2
             original_volume = order.volume
             scaled = int(order.volume * reduction_factor)
-            # A股最小交易单位 100 股/手，缩放后向下取整对齐到手（#6038）
-            aligned = (scaled // 100) * 100
-            if aligned < 100:
+            # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
+            aligned = self.align_to_lot(scaled)
+            if aligned < self._lot_size:
                 # 不足 1 手，拒单（调用方对 None 软拦截）
                 GLOG.WARN(f"VolatilityRisk: High volatility {current_volatility:.1f}% > {self._max_volatility}%, "
-                         f"scaled {original_volume} → {scaled} below 1 lot (100), blocking order")
+                         f"scaled {original_volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
                 return None
             order.adjust_volume(aligned)
 
@@ -120,11 +125,11 @@ class VolatilityRisk(BaseRiskManagement):
             # 波动率预警，适度减少订单规模
             reduction_factor = (self._max_volatility / current_volatility) ** 1.5
             scaled = int(order.volume * reduction_factor)
-            # A股最小交易单位 100 股/手，缩放后向下取整对齐到手（#6038）
-            aligned = (scaled // 100) * 100
-            if aligned < 100:
+            # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
+            aligned = self.align_to_lot(scaled)
+            if aligned < self._lot_size:
                 GLOG.INFO(f"VolatilityRisk: Warning volatility {current_volatility:.1f}% > {self._warning_volatility}%, "
-                         f"scaled {order.volume} → {scaled} below 1 lot (100), blocking order")
+                         f"scaled {order.volume} → {scaled} below 1 lot ({self._lot_size}), blocking order")
                 return None
             order.adjust_volume(aligned)
 

--- a/tests/unit/entities/test_lot_alignable_mixin.py
+++ b/tests/unit/entities/test_lot_alignable_mixin.py
@@ -1,0 +1,55 @@
+# Upstream: tests/unit/entities (实体层测试)
+# Downstream: ginkgo.entities.mixins.LotAlignableMixin
+# Role: 验证最小交易单位(lot)对齐 Mixin 的对齐能力,覆盖默认 A 股 100 与自定义 lot_size
+
+"""
+LotAlignableMixin 最小交易单位对齐能力测试
+
+框架设计不限于 A 股(100 股/手)。Mixin 提供 lot_size 配置与 align_to_lot
+对齐能力,支持港股/美股/期货等不同最小交易单位(#6038)。
+"""
+
+import pytest
+
+from ginkgo.entities.mixins import LotAlignableMixin
+
+
+class _Alignable(LotAlignableMixin):
+    """测试用宿主:Mixin 依赖 self._lot_size,由宿主 __init__ 负责初始化。"""
+
+    def __init__(self, lot_size: int = 100):
+        self._lot_size = lot_size
+
+
+@pytest.mark.tdd
+class TestLotAlignableMixin:
+    def test_lot_size_property_exposes_configured_value(self):
+        obj = _Alignable(lot_size=100)
+        assert obj.lot_size == 100
+
+    def test_align_to_default_lot_100_ashare(self):
+        """A 股默认 100 股/手:625 向下对齐到 600。"""
+        obj = _Alignable(lot_size=100)
+        assert obj.align_to_lot(625) == 600
+
+    def test_align_to_custom_lot_size(self):
+        """自定义 lot_size:lot_size=80 时 625 对齐到 560(非 600)。
+
+        证明 Mixin 不依赖硬编码 100,可适配不同市场最小交易单位。"""
+        obj = _Alignable(lot_size=80)
+        assert obj.align_to_lot(625) == 560
+
+    def test_below_one_lot_returns_zero(self):
+        """不足 1 手:62 对齐到 0(调用方据此拒单)。"""
+        obj = _Alignable(lot_size=100)
+        assert obj.align_to_lot(62) == 0
+
+    def test_exact_multiple_unchanged(self):
+        """已是 lot 整数倍时不变:600 → 600。"""
+        obj = _Alignable(lot_size=100)
+        assert obj.align_to_lot(600) == 600
+
+    def test_us_market_one_share_unit(self):
+        """美股 1 股起:lot_size=1 时任意整数不变(625 → 625)。"""
+        obj = _Alignable(lot_size=1)
+        assert obj.align_to_lot(625) == 625

--- a/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
@@ -265,6 +265,42 @@ class TestConcentrationRiskOrderProcessing:
         assert result is order
         assert order.volume == 100
 
+    def test_empty_portfolio_first_order_decimal_worth(self):
+        """空仓首单 worth 为运行时 Decimal 类型,LIMITORDER 主路径不抛异常(#6038 类型守护)。
+
+        portfolio_base.worth property 返回 Decimal。LIMITORDER 下 order.limit_price 经
+        Order.__init__ to_decimal 亦为 Decimal,order_value=Decimal,Decimal/Decimal 合法。
+        本测试守护主路径(LIMITORDER)类型契约,与下方 float-prices 边界测试互补。
+        """
+        r = ConcentrationRisk()
+        order = _make_order(volume=100, code="000001.SZ")
+        info = _make_portfolio_info(worth=Decimal("100000"))
+        result = r.cal(info, order)
+        assert result is order
+        assert order.volume == 100
+
+    def test_empty_portfolio_first_order_float_prices_decimal_worth(self):
+        """空仓首单 prices 为 float(市价单走 fallback)+ worth 为 Decimal 时不应抛 TypeError(#6038 review 回归)。
+
+        limit_price<=0(市价单/未定价)时 _calculate_projected_ratio 走 prices fallback,
+        order_value = volume(int) * prices[code](float) = float; 与 Decimal worth 相除
+        抛 TypeError(float/Decimal 不兼容)。旧实现 order_value/worth 未做类型归一,
+        调用方 None 软拦截救不了异常,整条风控链崩。本测试守护 to_decimal 归一。
+        """
+        r = ConcentrationRisk()
+        # limit_price=0 触发 _calculate_projected_ratio 的 prices fallback 分支
+        order = _make_order(volume=100, code="000001.SZ", limit_price=0)
+        info = {
+            "worth": Decimal("100000"),
+            "positions": {},
+            "prices": {"000001.SZ": 10.0},  # float → order_value 变 float,触发 float/Decimal
+            "uuid": "p1",
+            "now": datetime.now(),
+        }
+        result = r.cal(info, order)
+        assert result is order
+        assert order.volume == 100
+
 
 @pytest.mark.tdd
 @pytest.mark.risk

--- a/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
@@ -172,7 +172,8 @@ class TestConcentrationRiskIndustryAnalysis:
         pos = _make_position(code="000001.SZ", market_value=50000)
         info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
         result = r.cal(info, order)
-        assert isinstance(result, Order)
+        # 单行业 100% 极端集中 + 1 手小单:投影 100% → 缩放至 10 股 → 不足 1 手拒单(#6038)
+        assert result is None
 
     def test_multi_industry_monitoring(self):
         r = ConcentrationRisk()
@@ -250,6 +251,19 @@ class TestConcentrationRiskOrderProcessing:
         info = _make_portfolio_info()
         result = r.cal(info, order)
         assert result is order
+
+    def test_empty_portfolio_first_order_passes(self):
+        """空组合首单不误拒:投影应基于 worth(订单金额/组合净值),非硬编码 100%(#6038 回归守护)。
+
+        空 portfolio + 首笔买单 volume=100×10元=1000元,组合净值 worth=100000。
+        真实投影 1.0% < max_single 10%,首单应直通。旧代码空组合硬编码 100% → 误拒。
+        """
+        r = ConcentrationRisk()
+        order = _make_order(volume=100, code="000001.SZ")
+        info = _make_portfolio_info(worth=100000)
+        result = r.cal(info, order)
+        assert result is order
+        assert order.volume == 100
 
 
 @pytest.mark.tdd
@@ -403,7 +417,9 @@ class TestConcentrationRiskDecimalCompatibility:
         pos = _make_position(code="000001.SZ", market_value=Decimal("90000"))
         info = _make_portfolio_info(worth=100000, positions={"000001.SZ": pos})
         result = r.cal(info, order)
-        assert isinstance(result, Order)
+        # 单票 ~90% 集中 + 1 手:投影 100% > 5% → 缩放至 5 股 → 不足 1 手拒单(#6038)。
+        # 本用例守护"Decimal 混算不抛 TypeError",拒单(无异常)即达成本目的。
+        assert result is None
 
     def test_generate_signals_decimal_market_value_no_typeerror(self):
         """Decimal market_value 经 generate_signals→_calculate_concentrations 不抛。
@@ -450,3 +466,34 @@ class TestConcentrationRiskLotAlignment:
         # max(240, 0)=240(scaled>min, 保护不触发)
         assert result is order
         assert order.volume == 240
+
+    def test_single_position_scaling_not_floored_to_10pct(self):
+        """缩放后量禁止被 10% 下限抬回(#6038 同型 bug, 对齐 volatility 模板)。
+
+        volume=10000, factor=10/160=0.0625 → scaled=625 → align=600。
+        旧实现 min_volume=align(1000)=1000, max(600,1000)=1000 把 600 抬回 1000,
+        缩放形同虚设(违反 Risk 组件边界「禁止增加订单量」)。
+        """
+        r = ConcentrationRisk(max_single_position_ratio=10.0)
+        r._calculate_projected_ratio = lambda info, order: 160.0
+        r._get_current_position_ratio = lambda info, code: 0.0
+        r._calculate_projected_industry_ratio = lambda *a: 0.0
+        order = _make_order(volume=10000)
+        result = r.cal(_make_portfolio_info(), order)
+        assert result is order
+        assert order.volume == 600
+
+    def test_single_position_below_one_lot_returns_none(self):
+        """缩放后不足 1 手(align<lot_size)拒单返回 None(#6038)。
+
+        volume=1000, factor=10/200=0.05 → scaled=50 → align=0 < 100。
+        旧实现 max(0, align(100)=100)=100 仍下发 100 股(不足 1 手未拒)。
+        对齐 volatility: align<lot_size → return None(调用方对 None 软拦截)。
+        """
+        r = ConcentrationRisk(max_single_position_ratio=10.0)
+        r._calculate_projected_ratio = lambda info, order: 200.0
+        r._get_current_position_ratio = lambda info, code: 0.0
+        r._calculate_projected_industry_ratio = lambda *a: 0.0
+        order = _make_order(volume=1000)
+        result = r.cal(_make_portfolio_info(), order)
+        assert result is None

--- a/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_concentration_risk.py
@@ -419,3 +419,34 @@ class TestConcentrationRiskDecimalCompatibility:
         event = EventPriceUpdate(payload=_make_bar())
         signals = r.generate_signals(info, event)
         assert isinstance(signals, list)
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
+class TestConcentrationRiskLotAlignment:
+    def test_default_lot_size_aligns_reduced_volume(self):
+        """默认 lot_size=100:单一持仓超限缩放后向下对齐到 100 股/手(LotAlignableMixin)(#6038)。"""
+        r = ConcentrationRisk(max_single_position_ratio=10.0)
+        # mock 投影比例超限触发单一持仓缩减分支(避开复杂 helper 计算)
+        r._calculate_projected_ratio = lambda info, order: 25.0
+        r._get_current_position_ratio = lambda info, code: 0.0
+        r._calculate_projected_industry_ratio = lambda *a: 0.0  # 行业不超限
+        order = _make_order(volume=625)
+        result = r.cal(_make_portfolio_info(), order)
+        # factor=max_single/projected=10/25=0.4, scaled=int(625*0.4)=250, lot=100→200
+        assert result is order
+        assert order.volume == 200
+
+    def test_custom_lot_size_aligns_to_param(self):
+        """lot_size 参数生效:自定义手数对齐。框架不限于 A 股(#6038)。"""
+        r = ConcentrationRisk(max_single_position_ratio=10.0, lot_size=80)
+        r._calculate_projected_ratio = lambda info, order: 25.0
+        r._get_current_position_ratio = lambda info, code: 0.0
+        r._calculate_projected_industry_ratio = lambda *a: 0.0
+        order = _make_order(volume=625)
+        result = r.cal(_make_portfolio_info(), order)
+        # scaled=250, lot=80→(250//80)*80=240; min=int(625*0.1)=62→align80=0;
+        # max(240, 0)=240(scaled>min, 保护不触发)
+        assert result is order
+        assert order.volume == 240

--- a/tests/unit/trading/strategy/risk_managements/test_liquidity_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_liquidity_risk.py
@@ -383,3 +383,33 @@ class TestLiquidityRiskPerformance:
         for _ in range(10000):
             r._update_liquidity_history(event)
         assert time.perf_counter() - start < 2.0
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
+class TestLiquidityRiskLotAlignment:
+    def test_default_lot_size_aligns_reduced_volume(self):
+        """默认 lot_size=100:流动性不足缩放后向下对齐到 100 股/手(LotAlignableMixin)(#6038)。"""
+        r = LiquidityRisk(min_avg_volume_ratio=0.1, warning_avg_volume_ratio=0.2)
+        # mock 流动性指标触发大幅缩减分支(避开历史数据计算)
+        r._calculate_liquidity_metrics = lambda code: {"avg_volume": 10000, "avg_turnover": 10000000}
+        r._calculate_order_volume_ratio = lambda order, metrics: 0.5  # >warning 0.2 且 >min 0.1
+        r._calculate_price_impact = lambda order, metrics: 0.5  # <warning 3.0 不触发
+        order = _make_order(volume=625)
+        result = r.cal(_make_portfolio_info(), order)
+        # factor=min_avg/avg=0.1/0.5=0.2, scaled=int(625*0.2)=125, lot=100→100
+        assert result is order
+        assert order.volume == 100
+
+    def test_custom_lot_size_aligns_to_param(self):
+        """lot_size 参数生效:自定义手数对齐。框架不限于 A 股(#6038)。"""
+        r = LiquidityRisk(min_avg_volume_ratio=0.1, warning_avg_volume_ratio=0.2, lot_size=80)
+        r._calculate_liquidity_metrics = lambda code: {"avg_volume": 10000, "avg_turnover": 10000000}
+        r._calculate_order_volume_ratio = lambda order, metrics: 0.5
+        r._calculate_price_impact = lambda order, metrics: 0.5
+        order = _make_order(volume=625)
+        result = r.cal(_make_portfolio_info(), order)
+        # scaled=125, lot=80→(125//80)*80=80
+        assert result is order
+        assert order.volume == 80

--- a/tests/unit/trading/strategy/risk_managements/test_liquidity_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_liquidity_risk.py
@@ -413,3 +413,32 @@ class TestLiquidityRiskLotAlignment:
         # scaled=125, lot=80→(125//80)*80=80
         assert result is order
         assert order.volume == 80
+
+    def test_low_liquidity_scaling_not_floored_to_10pct(self):
+        """流动性严重不足缩放后量禁止被 10% 下限抬回(#6038 同型 bug, 对齐 volatility 模板)。
+
+        volume=10000, factor=0.1/1.6=0.0625 → scaled=625 → align=600。
+        旧实现 min_volume=align(1000)=1000, max(600,1000)=1000 抬回, 缩放失效。
+        """
+        r = LiquidityRisk(min_avg_volume_ratio=0.1, warning_avg_volume_ratio=0.2)
+        r._calculate_liquidity_metrics = lambda code: {"avg_volume": 10000, "avg_turnover": 10000000}
+        r._calculate_order_volume_ratio = lambda order, metrics: 1.6
+        r._calculate_price_impact = lambda order, metrics: 0.5
+        order = _make_order(volume=10000)
+        result = r.cal(_make_portfolio_info(), order)
+        assert result is order
+        assert order.volume == 600
+
+    def test_low_liquidity_below_one_lot_returns_none(self):
+        """缩放后不足 1 手拒单返回 None(#6038)。
+
+        volume=1000, factor=0.1/2.0=0.05 → scaled=50 → align=0 < 100。
+        对齐 volatility: align<lot_size → return None(调用方软拦截)。
+        """
+        r = LiquidityRisk(min_avg_volume_ratio=0.1, warning_avg_volume_ratio=0.2)
+        r._calculate_liquidity_metrics = lambda code: {"avg_volume": 10000, "avg_turnover": 10000000}
+        r._calculate_order_volume_ratio = lambda order, metrics: 2.0
+        r._calculate_price_impact = lambda order, metrics: 0.5
+        order = _make_order(volume=1000)
+        result = r.cal(_make_portfolio_info(), order)
+        assert result is None

--- a/tests/unit/trading/strategy/risk_managements/test_margin_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_margin_risk.py
@@ -139,7 +139,9 @@ class TestMarginRiskMaintenanceMargin:
     def test_collateral_value_assessment(self):
         r = MarginRisk()
         info = _make_portfolio_info(margin_info={"current_leverage": 1.5})
-        result = r.cal(info, _make_order(volume=100))
+        # volume=1000:缩放后 scaled=625→aligned=600≥1手,测"抵押品评估时订单经缩放对齐通过";
+        # 避免 volume=100 触发不足1手拒单(#6038 修复后该路径正确 return None)
+        result = r.cal(info, _make_order(volume=1000))
         assert isinstance(result, Order)
 
 
@@ -176,7 +178,9 @@ class TestMarginRiskMarginCall:
 
     def test_margin_call_response_strategies(self):
         r = MarginRisk(max_leverage_ratio=2.0)
-        order = _make_order()
+        # volume=1000:lev=1.8 缩放后 scaled=250→aligned=200≥1手,测"margin call 响应时订单缩放对齐通过";
+        # 避免 volume=100 触发不足1手拒单(#6038 修复后该路径正确 return None)
+        order = _make_order(volume=1000)
         info = _make_portfolio_info(margin_info={"current_leverage": 1.8})
         result = r.cal(info, order)
         assert isinstance(result, Order)
@@ -336,8 +340,11 @@ class TestMarginRiskPerformance:
         import time
         r = MarginRisk()
         start = time.perf_counter()
+        # lev=1.0 走 passthrough 监控基线(不触发缩放),测常态监控吞吐;
+        # #6038 修复后 volume=100+lev=1.5 命中不足1手拒单路径,每次打审计 WARN,
+        # 10000 次累积拖慢,非本测试关注的监控基线性能
         for _ in range(10000):
-            r.cal({"margin_info": {"current_leverage": 1.5}}, _make_order())
+            r.cal({"margin_info": {"current_leverage": 1.0}}, _make_order())
         assert time.perf_counter() - start < 2.0
 
     def test_margin_calculation_performance(self):
@@ -387,3 +394,19 @@ class TestMarginRiskLotAlignment:
         # factor=0.5, scaled=int(1000*0.5)=500, lot_size=80 → (500//80)*80=480
         assert result is order
         assert order.volume == 480
+
+    def test_scaled_below_one_lot_blocks_order(self):
+        """缩放后不足 1 手拒单(对齐 volatility/concentration/liquidity/max_drawdown 模板)(#6038)。
+
+        lev=1.6 ∈ [forced_liquidation(1.2), max_leverage(2.0)) 触发缩放分支,
+        factor=(2.0-1.6)/(2.0-1.2)=0.5, volume=150 → scaled=int(150*0.5)=75,
+        align_to_lot(75)=0 < 1 lot(100) → 应 return None(调用方走 ORDERBLOCKED 审计)。
+        与其余 4 个缩放型 Risk 拒单模板一致:本 PR 抽 LotAlignableMixin 时 MarginRisk
+        漏了不足1手拒单守卫,0量订单原走 ZERO_VOLUME 审计错配,本测试守护该一致性。
+        """
+        r = MarginRisk(max_leverage_ratio=2.0, forced_liquidation_ratio=1.2)
+        portfolio_info = _make_portfolio_info(margin_info={"current_leverage": 1.6})
+        order = _make_order(volume=150)
+        result = r.cal(portfolio_info, order)
+        # scaled=75, align_to_lot(75)=0 < lot_size(100) → blocked
+        assert result is None

--- a/tests/unit/trading/strategy/risk_managements/test_margin_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_margin_risk.py
@@ -356,3 +356,34 @@ class TestMarginRiskPerformance:
         for _ in range(10000):
             r.cal(_make_portfolio_info(), order)
         assert time.perf_counter() - start < 2.0
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
+class TestMarginRiskLotAlignment:
+    def test_default_lot_size_aligns_scaled_volume(self):
+        """默认 lot_size=100:缩放后向下对齐到 100 股/手,而非裸 int() 留下零头。
+
+        与 VolatilityRisk 对齐策略一致(LotAlignableMixin,A 股 100 股/手)(#6038)。"""
+        r = MarginRisk(max_leverage_ratio=2.0, forced_liquidation_ratio=1.2)
+        portfolio_info = _make_portfolio_info(margin_info={"current_leverage": 1.6})
+        order = _make_order(volume=1010)
+        result = r.cal(portfolio_info, order)
+        # 触发缩放分支:forced_liquidation_ratio(1.2) ≤ lev(1.6) < max_leverage_ratio(2.0)
+        # factor=(2.0-1.6)/(2.0-1.2)=0.5, scaled=int(1010*0.5)=505, lot=100 → 500
+        assert result is order
+        assert order.volume == 500
+
+    def test_custom_lot_size_aligns_to_param(self):
+        """lot_size 参数生效:自定义手数按自定义值对齐,而非硬编码 100。
+
+        框架设计不限于 A 股(100 股/手),lot_size 参数化以支持港股/美股/期货等
+        不同最小交易单位;默认 100 保持 A 股现状。"""
+        r = MarginRisk(max_leverage_ratio=2.0, forced_liquidation_ratio=1.2, lot_size=80)
+        portfolio_info = _make_portfolio_info(margin_info={"current_leverage": 1.6})
+        order = _make_order(volume=1000)
+        result = r.cal(portfolio_info, order)
+        # factor=0.5, scaled=int(1000*0.5)=500, lot_size=80 → (500//80)*80=480
+        assert result is order
+        assert order.volume == 480

--- a/tests/unit/trading/strategy/risk_managements/test_max_drawdown_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_max_drawdown_risk.py
@@ -372,3 +372,19 @@ class TestMaxDrawdownRiskLotAlignment:
         # scaled=505, lot_size=80 → (505//80)*80=480
         assert result is not None
         assert result.volume == 480
+
+    def test_reduced_below_one_lot_rejects(self):
+        """缩放后不足 1 手拒单(对齐 volatility_risk 模板)(#6038)。
+
+        drawdown=19.5%∈(15,20], factor=(20-19.5)/5=0.1 触 max(,0.1) 下限,
+        volume=800 → scaled=int(800*0.1)=80, aligned=0 < 1 lot(100) → 应 return None。
+        与 volatility/concentration/liquidity 三处拒单模板一致:本分支 5a7b3383 给 4 个
+        缩放型 Risk 混入 LotAlignableMixin 时,max_drawdown 漏了不足1手拒单守卫,本测试守护该一致性。
+        """
+        r = MaxDrawdownRisk(max_drawdown=15.0, critical_drawdown=20.0)
+        r._portfolio_peak = Decimal('100000')
+        portfolio_info = _make_portfolio_info(worth=80500)
+        order = _make_order(volume=800)
+        result = r.cal(portfolio_info, order)
+        # scaled=80, aligned=0 < lot_size(100) → blocked
+        assert result is None

--- a/tests/unit/trading/strategy/risk_managements/test_max_drawdown_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_max_drawdown_risk.py
@@ -341,3 +341,34 @@ class TestMaxDrawdownRiskPerformance:
         for i in range(10000):
             r._update_peak_values({"worth": 100000 + i, "positions": {}})
         assert len(r._peak_values) <= 10000
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.critical
+@pytest.mark.financial
+class TestMaxDrawdownRiskLotAlignment:
+    def test_default_lot_size_aligns_reduced_volume(self):
+        """默认 lot_size=100:减仓缩放后向下对齐到 100 股/手(LotAlignableMixin)(#6038)。
+
+        cal 返回 deepcopy 副本(#5495 多风险链防污染),断言用 result.volume。"""
+        r = MaxDrawdownRisk(max_drawdown=15.0, critical_drawdown=20.0)
+        r._portfolio_peak = Decimal('100000')
+        portfolio_info = _make_portfolio_info(worth=82500)
+        order = _make_order(volume=1010)
+        result = r.cal(portfolio_info, order)
+        # drawdown=(1-82500/100000)*100=17.5%∈(15,20], factor=(20-17.5)/5=0.5,
+        # scaled=int(1010*0.5)=505, lot=100 → 500
+        assert result is not None
+        assert result.volume == 500
+
+    def test_custom_lot_size_aligns_to_param(self):
+        """lot_size 参数生效:自定义手数对齐。框架不限于 A 股(#6038)。"""
+        r = MaxDrawdownRisk(max_drawdown=15.0, critical_drawdown=20.0, lot_size=80)
+        r._portfolio_peak = Decimal('100000')
+        portfolio_info = _make_portfolio_info(worth=82500)
+        order = _make_order(volume=1010)
+        result = r.cal(portfolio_info, order)
+        # scaled=505, lot_size=80 → (505//80)*80=480
+        assert result is not None
+        assert result.volume == 480

--- a/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
@@ -188,6 +188,30 @@ class TestVolatilityRiskLotAlignment:
         assert order.volume % 100 == 0
         assert order.volume > 0
 
+    def test_custom_lot_size_aligns_to_param(self):
+        """lot_size 参数生效：自定义手数按自定义值对齐，而非硬编码 100。
+
+        框架设计不限于 A 股（100 股/手）。lot_size 参数化以支持港股/美股/
+        期货等不同最小交易单位；默认 100 保持 A 股现状。"""
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0, lot_size=80)
+        r._volatility_cache["000001.SZ"] = 100.0
+        order = _make_order(volume=10000)
+        result = r.cal({}, order)
+        # factor=(25/100)^2=0.0625, scaled=625, lot_size=80 → aligned=(625//80)*80=560
+        assert result is order
+        assert order.volume == 560
+
+    def test_custom_lot_size_changes_reject_threshold(self):
+        """lot_size 参数控制拒单阈值：lot_size=200 时 scaled=150（>=100 但 <200）应拒单。
+
+        现状硬编码 100 会放行（aligned=100）；证明 lot_size 改变了不足 1 手的判定边界。"""
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0, lot_size=200)
+        r._volatility_cache["000001.SZ"] = 100.0
+        order = _make_order(volume=2400)
+        result = r.cal({}, order)
+        # factor=0.0625, scaled=150, lot_size=200 → aligned=0 < 200 → blocked
+        assert result is None
+
 
 @pytest.mark.tdd
 @pytest.mark.risk

--- a/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
@@ -160,6 +160,38 @@ class TestVolatilityRiskOrderProcessing:
 @pytest.mark.tdd
 @pytest.mark.risk
 @pytest.mark.financial
+class TestVolatilityRiskLotAlignment:
+    def test_high_volatility_scaled_aligns_to_lot(self):
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0)
+        r._volatility_cache["000001.SZ"] = 100.0
+        order = _make_order(volume=10000)
+        result = r.cal({}, order)
+        # factor=(25/100)^2=0.0625, scaled=625, aligned to 100-share lot=600
+        assert result is order
+        assert order.volume == 600
+
+    def test_high_volatility_below_lot_rejects(self):
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0)
+        r._volatility_cache["000001.SZ"] = 100.0
+        order = _make_order(volume=1000)
+        result = r.cal({}, order)
+        # factor=0.0625, scaled=62, aligned=0 < 1 lot (100) → blocked
+        assert result is None
+
+    def test_warning_level_adjusts_to_lot(self):
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=10.0)
+        r._volatility_cache["000001.SZ"] = 22.0
+        order = _make_order(volume=10000)
+        result = r.cal({}, order)
+        assert result is order
+        # 缩放后必对齐到 100 股/手
+        assert order.volume % 100 == 0
+        assert order.volume > 0
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
 class TestVolatilityRiskSignalGeneration:
     def test_extreme_volatility_signal(self):
         r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0)


### PR DESCRIPTION
## Summary

#6038 — `VolatilityRisk.cal()` 缩放后的订单量可能落在非 100 整数倍（A 股最小交易单位 = 100 股/手），且原 `min_volume = max(1, int(original_volume * 0.1))` 把最小订单量定为 **1 股**，直接违反 A 股 100 股规则。

更糟的是 L110 `order.adjust_volume(max(order.volume, min_volume))` 用 10% 下限把已缩放的量**抬回去**——缩放形同虚设：`vol=10000, factor=0.0625 → scaled=625`，但 `min_volume=1000` 把它抬回 `1000`。

### 根因

`cal(portfolio_info, order)` 高波动分支：缩放 → `max(1, 10%)` 最小量兜底 → 无 lot 对齐 → 无不足 1 手拒单。

调用方 `t1backtest.py:347` / `portfolio_live.py:163` 已正确处理 `cal()` 返回 `None`（软拦截 ORDERBLOCKED），故不足 1 手走 `return None` 复用既有拦截链，零侵入。

### 修复

两分支（高波动 / 预警）统一：
1. `scaled = int(volume * factor)`
2. `aligned = (scaled // 100) * 100`  ← 向下取整对齐 100 股/手
3. `aligned < 100` → `return None` 拒单（不足 1 手）
4. 否则 `adjust_volume(aligned)`

移除原 `max(1, 10%)` 最小量逻辑（既违反 100 股最小单位，又使缩放失效）。

### 范围说明

- **原始 AC（VolatilityRisk）**：`VolatilityRisk.cal()` 单点 lot 对齐 + 拒单。
- **同型扩展（commit 5a7b3383）**：triage（2026-06-27）指出的同型 lot 对齐问题中，**同根 bug 模式**部分本 PR 一并修（避免同模式留多个 PR 反复 review）：
  - `LiquidityRisk`：4 处缩放点同样被 `max(align(scaled), align(原量×10%))` 抬回致缩放失效 → 改为不足 1 手拒单（对齐 volatility 模板），补 2 守护测试。
  - `ConcentrationRisk`：单一持仓/行业两处缩放补 lot 对齐 + 不足 1 手拒单（对齐模板）。
  - `ConcentrationRisk` 空仓 worth 投影：空组合（无持仓）首单硬编码投影 100% → 配合拒单模板**误拒首单**。改为基于组合净值 `worth` 投影（`order_value/worth*100`），抽 `_project_against_worth` 复用。**关联 #6040**（CLOSED 2026-06-27，但其 AC②「首次建仓正确计算预计持仓比例」未真正满足——旧修复仅补 AttributeError 三元守护，空仓仍硬编码 100% 致首单误拒；本 commit 补全该漏修 AC②）+ **#3959**（price 计算前驱 CLOSED，worth 投影复用其 `order_value=volume*price`）。
  - **lot 对齐同型**：triage（2026-06-27）指出的 5 个缩放型 Risk 同型 lot 问题**未逐个开 issue**（仅在 triage 笔记），本 PR 一并修 concentration/liquidity 同根模式，避免同模式留多个 PR 反复 review。
  - **max_drawdown 守卫补全（commit 273fc181）**：5a7b3383 给 4 个缩放型 Risk 混入 LotAlignableMixin 时，max_drawdown 漏了不足 1 手拒单守卫——缩放到 0 股时返回 `volume=0` 副本（废单）而非 `None`（拒单）。本 commit 补全 `aligned < lot_size → return None`，对齐 volatility/concentration/liquidity 三处模板，复用既有软拦截链零侵入。TDD `test_reduced_below_one_lot_rejects` 守护。
- **已拆 phased issue 跟踪**（不在本 AC 范围）：
  - #6497 — 预警分支因子方向 `(max/cur)^1.5`（cur<max 时因子>1 放大仓位，应为 `(warning/cur)^1.5`）
  - #6498 — Sizer 三处硬编码 100 股/手，`lot_size` 未参数化 + 开仓/平仓零股语义未区分（涉及架构决策，ready-for-human）
- **测试基建（commit 032ba665）**：`pyproject.toml` 注册 `bug` marker（`--strict-markers` 下漏注册致 `test_position_ratio_risk.py` 等 3 文件整文件 collection 失败被静默跳过）。与 #6038 无关，顺带修以解锁全目录回归。
- **非 Base 类修改**（具体实现层，未触碰基类）。

## Test plan

三层 smoke（对齐 CI #6015）：
- [x] Layer1 py_compile（src+api 全量）✅
- [x] Layer2 启动路径：test_user_crud_mock + test_containers + test_user_cli（29 passed）✅
- [x] Layer3 变更相关：`test_volatility_risk.py`（29 passed，含新增 3 用例 `TestVolatilityRiskLotAlignment`：高波动 lot 对齐 10000→600 / 不足 1 手拒单 1000→None / 预警分支 lot 对齐）
- [x] **risk_managements 全目录回归**：`tests/unit/trading/strategy/risk_managements/`（**560 passed, 2 skipped**）—— 含 concentration 空仓首单 tracer + liquidity 缩放抬回守护 + Decimal 混算不抛 TypeError + max_drawdown 不足 1 手拒单守护（dd=19.5% → scaled=80 → aligned=0 → None）

Closes #6038
