### PR TITLE
fix: VolatilityRisk 缓存随价格更新失效，cal() 用最新波动率 (#6037)

### DIFF
--- a/src/ginkgo/trading/risk_management/volatility_risk.py
+++ b/src/ginkgo/trading/risk_management/volatility_risk.py
@@ -186,6 +186,9 @@ class VolatilityRisk(BaseRiskManagement):
         if len(self._price_history[code]) > self._lookback_period:
             self._price_history[code] = self._price_history[code][-self._lookback_period:]
 
+        # 价格历史已变，失效该 code 的波动率缓存，下次 _get_stock_volatility 重算（#6037）
+        self._volatility_cache.pop(code, None)
+
     def _calculate_volatility(self, code: str) -> float:
         """计算指定股票的波动率"""
         if code not in self._price_history or len(self._price_history[code]) < 2:

--- a/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
@@ -245,6 +245,35 @@ class TestVolatilityRiskEdgeCases:
 @pytest.mark.tdd
 @pytest.mark.risk
 @pytest.mark.financial
+class TestVolatilityRiskCacheInvalidation:
+    def test_cache_invalidated_after_price_update(self):
+        r = VolatilityRisk(lookback_period=20, volatility_window=5)
+        # 低波动序列填充价格历史 + 首次计算并缓存
+        for p in [10.0, 10.01, 9.99, 10.02, 9.98, 10.0, 10.01, 9.99, 10.0, 10.01]:
+            r._update_price_history("000001.SZ", p)
+        vol_low = r._get_stock_volatility("000001.SZ")
+        assert "000001.SZ" in r._volatility_cache
+        assert vol_low >= 0
+        # 喂高波动序列更新价格历史
+        for p in [10.0, 12.0, 8.0, 12.5, 7.5, 13.0, 7.0, 12.0, 8.0, 12.0]:
+            r._update_price_history("000001.SZ", p)
+        # 修复后：cache 在 _update_price_history 失效 → 重算应反映高波动
+        vol_refreshed = r._get_stock_volatility("000001.SZ")
+        assert vol_refreshed > vol_low
+
+    def test_cache_hit_without_price_update(self):
+        r = VolatilityRisk()
+        for p in [10.0, 10.5, 11.0, 10.5]:
+            r._update_price_history("000001.SZ", p)
+        v1 = r._get_stock_volatility("000001.SZ")
+        # 无 _update_price_history 间隔：连续查询命中缓存（不退化为每 tick 全重算）
+        v2 = r._get_stock_volatility("000001.SZ")
+        assert v1 == v2
+
+
+@pytest.mark.tdd
+@pytest.mark.risk
+@pytest.mark.financial
 @pytest.mark.performance
 class TestVolatilityRiskPerformance:
     def test_calculation_performance(self):


### PR DESCRIPTION
## Summary

#6037 — `VolatilityRisk._volatility_cache` 首次计算后**永不失效**：`generate_signals()` 通过 `_update_price_history()` 每 bar 追加价格（数据源持续更新），但 `_get_stock_volatility()` 一旦写入缓存就只读不弃。整个回测期间 `cal()` 用**首根 bar 算出的波动率**缩放订单——高波动期保护失效 = 资金风险。

### 根因（调用链）

`generate_signals`(L125) → `_update_price_history`(L145/177) 每 bar append 价格 + 截断 → **但 `_volatility_cache` 无 pop/del/clear** → `cal`(L86) → `_get_stock_volatility`(L222) L225 命中首次缓存值 → `reduction_factor = (max / stale_vol)²` 偏大 → 高波动期订单未充分缩减。

数据更新点（`_update_price_history`）与缓存失效点错位 = stale cache。

### 修复

`_update_price_history` 末尾加 `self._volatility_cache.pop(code, None)` —— 该 code 价格历史已变，失效其波动率缓存，下次 `_get_stock_volatility` 基于最新历史重算。per-bar pop 是**精确失效**（只弃被更新 code，未更新 code 命中保留）。

### 范围说明（诚实 / 窄切片）

- **单行修复**（+注释共 3 行），遵循 agent brief out-of-scope：
  - 不改缓存结构（`dict` 足够，无需 TTL/LRU——per-bar pop 已精确失效）
  - 不改 `_calculate_volatility` 算法
- **性能**：per-bar pop + 下次 cal 重算 `O(lookback)` std（lookback 通常 20-60），可接受；`get_portfolio_volatility`(L261) 循环内同 code 不重复计算（循环内无 `_update_price_history`，缓存命中保留）。
- **关联 #6038**（PR #6443）：同文件 `volatility_risk.py` 的 lot 对齐修复，独立 PR，改不同方法（`_update_price_history` vs `cal`），git 层面无冲突。
- **非 Base 类修改**（VolatilityRisk 继承 RiskBase，改在具体实现层，未触碰基类）。

## Test plan

三层 smoke（对齐 CI #6015）：
- [x] Layer1 py_compile（src+api 全量）✅
- [x] Layer2 启动路径：test_user_crud_mock + test_containers + test_user_cli（29 passed）✅
- [x] Layer3 变更相关：`test_volatility_risk.py`（28 passed，含新增 `TestVolatilityRiskCacheInvalidation` 2 用例：① 低波动缓存后喂高波动，`_get_stock_volatility` 重算返回更高值（2.06 → 反映高波动）；② 无价格更新间隔连续查询命中缓存，不退化为每 tick 全重算）

Closes #6037
