### PR TITLE
fix: frozen_volume int() 转换补全 5 处遗漏路径 (#6087)

### DIFF
--- a/src/ginkgo/data/crud/order_crud.py
+++ b/src/ginkgo/data/crud/order_crud.py
@@ -207,7 +207,7 @@ class OrderCRUD(BaseCRUD[MOrder]):
                 volume=getattr(item, 'volume', 0),
                 limit_price=to_decimal(getattr(item, 'limit_price', 0)),
                 frozen_money=to_decimal(getattr(item, 'frozen_money', 0)),
-                frozen_volume=getattr(item, 'frozen_volume', 0),
+                frozen_volume=int(getattr(item, 'frozen_volume', 0)),  # #6087: 显式 int 防御（与 #6080 L184 对称）
                 transaction_price=to_decimal(getattr(item, 'transaction_price', 0)),
                 transaction_volume=getattr(item, 'transaction_volume', 0),
                 remain=to_decimal(getattr(item, 'remain', 0)),

--- a/src/ginkgo/data/crud/order_record_crud.py
+++ b/src/ginkgo/data/crud/order_record_crud.py
@@ -182,7 +182,7 @@ class OrderRecordCRUD(BaseCRUD[MOrderRecord]):
                 volume=item.volume,
                 limit_price=item.limit_price,
                 frozen_money=item.frozen_money if hasattr(item, 'frozen_money') else 0,
-                frozen_volume=item.frozen_volume if hasattr(item, 'frozen_volume') else 0,
+                frozen_volume=int(item.frozen_volume) if hasattr(item, 'frozen_volume') else 0,  # #6087: 显式 int 防御（与 #6080 L160 对称）
                 transaction_price=item.transaction_price if hasattr(item, 'transaction_price') else 0,
                 remain=item.remain if hasattr(item, 'remain') else 0,
                 fee=item.fee if hasattr(item, 'fee') else 0,

--- a/src/ginkgo/data/models/model_order.py
+++ b/src/ginkgo/data/models/model_order.py
@@ -90,7 +90,7 @@ class MOrder(MMysqlBase, MBacktestRecordBase):
         if frozen_money is not None:
             self.frozen_money = to_decimal(frozen_money)
         if frozen_volume is not None:
-            self.frozen_volume = frozen_volume
+            self.frozen_volume = int(frozen_volume)  # #6087: 强制 int，防 float 写 Integer 列
         if transaction_price is not None:
             self.transaction_price = to_decimal(transaction_price)
         if transaction_volume is not None:
@@ -155,7 +155,7 @@ class MOrder(MMysqlBase, MBacktestRecordBase):
         if frozen_money is not None:
             self.frozen_money = to_decimal(frozen_money)
         if frozen_volume is not None:
-            self.frozen_volume = frozen_volume
+            self.frozen_volume = int(frozen_volume)  # #6087: 强制 int，防 float 写 Integer 列
         if transaction_price is not None:
             self.transaction_price = to_decimal(transaction_price)
         if transaction_volume is not None:

--- a/src/ginkgo/data/models/model_order_record.py
+++ b/src/ginkgo/data/models/model_order_record.py
@@ -90,7 +90,7 @@ class MOrderRecord(MClickBase, MBacktestRecordBase, ModelConversion):
         if frozen_money is not None:
             self.frozen_money = to_decimal(frozen_money)
         if frozen_volume is not None:
-            self.frozen_volume = frozen_volume
+            self.frozen_volume = int(frozen_volume)  # #6087: 强制 int，防 float 写 Integer 列
         if transaction_price is not None:
             self.transaction_price = to_decimal(transaction_price)
         if transaction_volume is not None:
@@ -154,6 +154,8 @@ class MOrderRecord(MClickBase, MBacktestRecordBase, ModelConversion):
         # 设置其他字段
         for key, value in kwargs.items():
             if hasattr(self, key):
+                if key == 'frozen_volume' and value is not None:
+                    value = int(value)  # #6087: 强制 int，防 float 写 Integer 列
                 setattr(self, key, value)
 
     def __repr__(self) -> str:

--- a/tests/unit/data/crud/test_order_crud_mock.py
+++ b/tests/unit/data/crud/test_order_crud_mock.py
@@ -444,3 +444,31 @@ class TestOrderCRUDFrozenVolumeIntConversion:
         )
         assert isinstance(model.frozen_volume, int)
         assert model.frozen_volume == 0
+
+
+@pytest.mark.tdd
+@pytest.mark.bug
+class TestOrderCRUDConvertInputItemFrozenVolumeInt:
+    """#6087: _convert_input_item 路径 frozen_volume 应 int() 转换（延续 #6080）。
+
+    _convert_input_item 用 getattr(item, ...) 鸭子类型读取外部输入，
+    SimpleNamespace 是该接口契约的合法替身（非掩盖：接口设计即鸭子类型）。
+    """
+
+    @pytest.mark.unit
+    def test_convert_input_item_float_frozen_volume(self, crud_instance):
+        """_convert_input_item 传入 float frozen_volume 的鸭子输入应转 int"""
+        from types import SimpleNamespace
+        item = SimpleNamespace(
+            portfolio_id="p1", engine_id="e1", task_id="t1",
+            code="000001.SZ", direction=DIRECTION_TYPES.LONG,
+            order_type=ORDER_TYPES.LIMITORDER, status=ORDERSTATUS_TYPES.NEW,
+            volume=100, limit_price=10.0, frozen_money=1000.0,
+            frozen_volume=484.03,
+            transaction_price=0, transaction_volume=0, remain=0, fee=0,
+            timestamp=None,
+        )
+        model = crud_instance._convert_input_item(item)
+        assert model is not None
+        assert isinstance(model.frozen_volume, int)
+        assert model.frozen_volume == 484

--- a/tests/unit/data/models/test_order_model_frozen_split.py
+++ b/tests/unit/data/models/test_order_model_frozen_split.py
@@ -216,3 +216,36 @@ class TestMOrderRecordUpdateSeriesFrozenMoney:
         m.update(df.iloc[0])
         assert isinstance(m.frozen_money, Decimal)
         assert m.frozen_money == Decimal("1549.50")
+
+
+class TestFrozenVolumeIntCoercionRemainingPaths:
+    """#6087: frozen_volume int() 转换遗漏路径（延续 #6080）。
+
+    #6080 修了 _create_from_params(kwargs) 与 update(Series) 路径，
+    但 __init__ 直赋值与 update(str) dispatch 分支仍直赋 float。
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.tdd
+    def test_order_init_float_coerced_int(self):
+        """MOrder(__init__) float frozen_volume 应转 int（#6087 路径1: model_order L93）"""
+        m = MOrder(frozen_volume=484.03)
+        assert isinstance(m.frozen_volume, int)
+        assert m.frozen_volume == 484
+
+    @pytest.mark.unit
+    @pytest.mark.tdd
+    def test_order_update_str_float_coerced_int(self):
+        """MOrder.update(str dispatch) float frozen_volume 应转 int（#6087 路径2: model_order L158）"""
+        m = MOrder()
+        m.update("p1", "e1", frozen_volume=150.7)
+        assert isinstance(m.frozen_volume, int)
+        assert m.frozen_volume == 150
+
+    @pytest.mark.unit
+    @pytest.mark.tdd
+    def test_record_init_float_coerced_int(self):
+        """MOrderRecord(__init__) float frozen_volume 应转 int（#6087 路径3: model_order_record L93）"""
+        m = MOrderRecord(frozen_volume=484.03)
+        assert isinstance(m.frozen_volume, int)
+        assert m.frozen_volume == 484


### PR DESCRIPTION
## Summary

#6087 — 延续 PR #6080，补全 `frozen_volume` 的 `int()` 转换在 5 处遗漏路径。#6080 修了 CRUD `_create_from_params`（kwargs）与 model `update(Series)` 路径，但以下 5 处仍直赋 float，可能将 float 写入 `Integer` 列。

### 根因（5 处分两类）

**A. model 层赋值点（4 处，真正生效）**
- `model_order.py` `__init__` L93：`self.frozen_volume = frozen_volume`（直赋 float）
- `model_order.py` `update.register(str)` dispatch 分支 L158：同上（`@singledispatchmethod` 的 str 分支，#6080 只修了 Series 分支 L184）
- `model_order_record.py` `__init__` L93：同上（**死代码** — 见下方发现）
- `model_order_record.py` L155 setattr 循环：`MOrderRecord(**kwargs)` 真正生效路径

**B. CRUD `_convert_input_item`（2 处，防御加固）**
- `order_crud.py` L210 / `order_record_crud.py` L185

### 修复

| 路径 | 修复 |
|---|---|
| `model_order.__init__` L93 | `int(frozen_volume)` |
| `model_order.update.register(str)` L158 | `int(frozen_volume)` |
| `model_order_record` L155 setattr 循环 | `key == 'frozen_volume'` 时 `int(value)` |
| `order_crud._convert_input_item` L210 | `int(getattr(...))` 显式防御 |
| `order_record_crud._convert_input_item` L185 | `int(item.frozen_volume)` 显式防御 |

### 调查中的两个发现（诚实披露）

1. **record `__init__` 死代码**：issue 指向 `model_order_record.py` `__init__` ~L93，但该类在 L134 另有 `def __init__(self, **kwargs)`，**Python 后定义胜出**，L93 的显式 `__init__` 永不被调用。`MOrderRecord(frozen_volume=...)` 实际走 L134 → L155 的通用 setattr 循环。本 PR 同时 int 化 L93（防御，若未来移除 L134 则 L93 生效）与 L155（真正生效路径）。**TDD RED 一跑即暴露**：改 L93 后测试仍 fail，定位到 L134 覆盖。

2. **CRUD 路径经下游传导已工作**：`_convert_input_item` 构造的 `MOrder/MOrderRecord` 经 model `__init__` int 化（本 PR 修复后）会自动转换 float。且 `Order` Entity 自身（`entities/order.py` L191）已有 `int(frozen_volume)`，record `_convert_input_item` 只接 Order 实例 → L185 永远收不到 float。故 CRUD 两处**无法独立 RED**（输入端已 int），但按 issue AC + 与 #6080 L184/L160 对称，仍补显式 `int()` 作第三层防御。

### 范围说明（窄切片）

- 仅修 `frozen_volume` 5 处（issue AC）。同文件 `volume` 字段也未 int 化，但**不在本 AC 范围**，不越界。
- 非基类修改（model/CRUD 均为具体实现层）。
- `@singledispatchmethod` 的 str/Series 分支同字段赋值散落是漏网根因；本次不重构 dispatch 结构。

## Test plan

三层 smoke（对齐 CI #6015）：
- [x] Layer1 py_compile（src+api 全量）✅
- [x] Layer2 启动路径：test_user_crud_mock + test_containers + test_user_cli（29 passed）✅
- [x] Layer3 变更相关：`test_order_model_frozen_split.py` + `test_order_crud_mock.py` + `test_order_record_crud_mock.py`（54 passed，含新增 `TestFrozenVolumeIntCoercionRemainingPaths` 3 用例：order `__init__` / order `update(str)` / record `__init__` float→int；及 `TestOrderCRUDConvertInputItemFrozenVolumeInt` 1 用例：CRUD 鸭子输入 float→int 端到端）

Closes #6087
