### PR TITLE
chore(arena): /portfolios TODO stub 改 501 诚实标记未实现 (#5861)

### DIFF
--- a/api/api/arena.py
+++ b/api/api/arena.py
@@ -4,7 +4,7 @@
 
 from typing import List, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 
 from core.response import ok
@@ -70,9 +70,16 @@ def _to_date_str(raw) -> Optional[str]:
 
 @router.get("/portfolios")
 async def get_arena_portfolios():
-    """获取竞技场Portfolio列表"""
-    # TODO: 实现实际的竞技场数据获取逻辑
-    return ok(data={"items": []})
+    """获取竞技场Portfolio列表
+
+    #5861: 竞技场 portfolio 集合的业务语义未定义（哪些 portfolio 参与
+    竞技场）。在明确语义并实现前，返回 501 诚实标记未实现，不返
+    {"items": []} 空数据伪装"已实现但无数据"。AC#1 允许此回退。
+    """
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Arena portfolio listing is not implemented",
+    )
 
 
 @router.post("/comparison")

--- a/tests/api/test_arena_portfolios.py
+++ b/tests/api/test_arena_portfolios.py
@@ -1,0 +1,33 @@
+"""Arena portfolio 列表端点测试 (#5861)
+
+验证 GET /api/v1/arena/portfolios 返回 501 Not Implemented。
+
+#5861 AC#1：Arena 端点要么实现要么返回 501。竞技场 portfolio 集合的
+业务语义未定义（哪些 portfolio 参与竞技场），当前以 501 诚实标记
+未实现，不返 {"items": []} 空数据伪装"已实现但无数据"。
+"""
+import asyncio
+
+import pytest
+
+
+class TestArenaPortfoliosNotImplemented:
+    """#5861 AC#1: GET /arena/portfolios 返回 501（非空 stub 伪装）"""
+
+    def test_returns_501(self, api_modules):
+        """未实现时返回 501，不返空列表 stub 伪装已实现"""
+        from fastapi import HTTPException
+        from api.arena import get_arena_portfolios
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(get_arena_portfolios())
+        assert exc.value.status_code == 501
+
+    def test_detail_indicates_not_implemented(self, api_modules):
+        """501 detail 明确标记未实现（消费者可区分'无数据'vs'未实现'）"""
+        from fastapi import HTTPException
+        from api.arena import get_arena_portfolios
+
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(get_arena_portfolios())
+        assert "not implemented" in exc.value.detail.lower()


### PR DESCRIPTION
## Summary

`GET /api/v1/arena/portfolios` 是个 TODO stub，返回 `{"items": []}` 空数据伪装"已实现但无数据"。
竞技场 portfolio 集合的业务语义未定义（哪些 portfolio 参与竞技场、来源何处），在明确语义并实现前，
本 PR 改返 **501 Not Implemented** 诚实标记未实现，让消费者区分"无数据"与"未实现"。AC#1 允许此回退。

### 变更
- `api/api/arena.py`：`get_arena_portfolios` 由 `return ok(data={"items": []})` 改为 `raise HTTPException(501, "Arena portfolio listing is not implemented")`
- `tests/api/test_arena_portfolios.py`：新增 2 测试覆盖 501 + detail 标记

### 范围说明（issue #5861 多接收者）
#5861 列出 5 个未实现/mock 端点，本 PR 仅处理 **receiver #4（Arena portfolios stub）**：
- ✅ Arena portfolios stub → 501（本 PR）
- ⚠️ 其余 4 个 receiver 在先前 PR 已修：API Stats（ApiStatsMiddleware 实时聚合）、API Keys（#5459 持久化）、User Groups（#6235 容器统一 + #6339）、`/comparison`（#5400 实现）
- ⚠️ receiver #5（API 预设分析器/analyzer 配置）未核实，不在本 PR 范围，待单独确认

## Test plan
- [x] `tests/api/test_arena_portfolios.py` 2 passed（501 + detail "not implemented"）
- [x] `tests/api/test_arena_comparison.py` 9 passed（无回归，`/comparison` 仍工作）
- [x] L1 py_compile 通过
- [x] L2 启动路径 smoke 29 passed（user_crud_mock + containers + user_cli）

Refs #5861

🤖 Generated with [Claude Code](https://claude.com/claude-code)
