### PR TITLE
docs: README/CLAUDE 组件清单口径订正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ ginkgo backtest cat <backtest_id>
 
 > **实际命名**：DB 组件名多为 `<name>_<type>` 格式（如 `fixed_selector`/`atr_sizer`/`fixed_sizer`），部分带描述前缀（如 `qr_momentum_selector`/`sharpe_ratio`）。`bind-component` 前用 `ginkgo component list` 查实际 `file_id` 与名称；下表为短名速查。
 
-- **Strategy**: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor, social_signal, game_theory, random_choice
+- **Strategy**（内置类 11）: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor；另有 DB 脚本组件（src 无类，DB component 表实例）: social_signal, game_theory, random_choice
 - **Selector**: fixed, cn_all, momentum, popularity, multi_params
 - **Sizer**: fixed, atr, ratio
 - **Risk**: no_risk, position_ratio, loss_limit, profit_target, max_drawdown, volatility, concentration, capital, liquidity, margin, market_cap, sector_rotation, correlation, currency, suspension, trading_time

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Ginkgo is a quantitative trading framework featuring event-driven backtesting, m
 ```mermaid
 graph TB
     subgraph "🖥️ Application Layer"
-        CLI["<b>CLI</b><br/>Typer + Rich<br/><i>40 commands</i>"]
-        API["<b>REST API</b><br/>FastAPI<br/><i>15 routers</i>"]
-        WEB["<b>Web UI</b><br/>Vue 3 + shadcn-vue<br/><i>19 views</i>"]
+        CLI["<b>CLI</b><br/>Typer + Rich<br/><i>35 command groups</i>"]
+        API["<b>REST API</b><br/>FastAPI<br/><i>16 routers</i>"]
+        WEB["<b>Web UI</b><br/>Vue 3 + shadcn-vue<br/><i>17 views</i>"]
     end
 
     subgraph "⚙️ Worker Layer"
@@ -41,12 +41,12 @@ graph TB
 
     subgraph "📊 Trading Engine"
         EE["EventEngine<br/><i>事件队列 + 线程分发</i>"] --> TCE["TimeControlledEngine<br/><i>回测/实盘统一</i>"]
-        EE --> FDR["Data Feeders (6)"]
+        EE --> FDR["Data Feeders (7)"]
         EE --> PTF["Portfolio<br/><i>中央编排器</i>"]
-        PTF --> STR["Strategy (15)"]
-        PTF --> RSK["Risk (18)"]
+        PTF --> STR["Strategy (11)"]
+        PTF --> RSK["Risk (16)"]
         PTF --> SIZ["Sizer (3)"]
-        PTF --> SEL2["Selector (5)"]
+        PTF --> SEL2["Selector (4)"]
     end
 
     subgraph "🔀 Gateway & Brokers"
@@ -124,22 +124,22 @@ graph LR
             engines["engines/<br/>BaseEngine → EventEngine → TimeControlled"]
             events["events/<br/>PriceUpdate · Signal · Order<br/>TimeAdvance · Portfolio"]
             bases["bases/<br/>Portfolio · Position · Order<br/>Strategy · Selector · Sizer · Risk"]
-            strat["strategies/ (15)"]
-            risk["risk_management/ (18)"]
-            sel["selectors/ (5)"]
+            strat["strategies/ (13)"]
+            risk["risk_management/ (16)"]
+            sel["selectors/ (4)"]
             sizer["sizers/ (3)"]
             brk["brokers/ (8)"]
-            fdr["feeders/ (6)"]
-            analysis["analysis/<br/>analyzers (24) · reports · plots"]
+            fdr["feeders/ (7)"]
+            analysis["analysis/<br/>analyzers (21) · reports · plots"]
             evl["evaluation/<br/>pipeline · rules · visualization"]
         end
 
         subgraph "data/"
             direction TB
             drv["drivers/<br/>ClickHouse · MySQL<br/>MongoDB · Redis · Kafka"]
-            mdl["models/ (51)"]
-            crud["crud/ (52)"]
-            svc["services/ (33)"]
+            mdl["models/ (50)"]
+            crud["crud/ (49)"]
+            svc["services/ (31)"]
             src["sources/ (5)"]
             stm["streaming/<br/>cache · checkpoint · recovery"]
         end
@@ -152,7 +152,7 @@ graph LR
         end
 
         subgraph "Supporting"
-            feat["features/<br/>definitions (17) · expression engine"]
+            feat["features/<br/>definitions (16) · expression engine"]
             ml["quant_ml/<br/>models · features · strategies"]
             res["research/<br/>IC · factor · orthogonal · decay"]
             val["validation/<br/>MonteCarlo · WalkForward · Sensitivity"]
@@ -179,13 +179,13 @@ graph LR
 
 | Category | Count | Examples |
 |----------|-------|---------|
-| **Strategies** | 15 | MA Crossover, Momentum, Mean Reversion, Dual Thrust, Scalping, ML Predictor |
-| **Risk Managers** | 18 | Position Ratio, Loss Limit, Profit Target, Max Drawdown, Volatility, Concentration |
-| **Selectors** | 5 | Fixed, CN All, Momentum, Popularity |
+| **Strategies** | 11 | MA Crossover, Momentum, Mean Reversion, Dual Thrust, Scalping, ML Predictor |
+| **Risk Managers** | 16 | Position Ratio, Loss Limit, Profit Target, Max Drawdown, Volatility, Concentration |
+| **Selectors** | 4 | Fixed, CN All, Momentum, Popularity |
 | **Sizers** | 3 | Fixed, ATR, Ratio |
 | **Brokers** | 8 | Sim, AShare, HK Stock, US Stock, Futures, OKX, Manual, Auto |
-| **Feeders** | 6 | Backtest, Live, OKX, Alpaca, EastMoney, Fushu |
-| **Analyzers** | 24 | Net Value, Max Drawdown, Sharpe, Calmar, Profit Factor, Annualized Returns |
+| **Feeders** | 7 | Backtest, Live, OKX, OKX Data, Alpaca, EastMoney, Fushu |
+| **Analyzers** | 21 | Net Value, Max Drawdown, Sharpe, Calmar, Profit Factor, Annualized Returns |
 | **Data Sources** | 5 | Tushare, AKShare, Yahoo, BaoStock, TDX |
 | **DB Drivers** | 5 | ClickHouse, MySQL, MongoDB, Redis, Kafka |
 | **Factors** | 158+ | Alpha158, Barra, Fama-French, WorldQuant Alpha101 |

--- a/src/ginkgo/trading/bases/base_trade_gateway.py
+++ b/src/ginkgo/trading/bases/base_trade_gateway.py
@@ -18,11 +18,12 @@ from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
 from ginkgo.trading.mixins.order_management_mixin import OrderManagementMixin
 from ginkgo.entities.mixins import EngineBindableMixin
+from ginkgo.trading.mixins.subscribable_mixin import SubscribableMixin
 from ginkgo.entities.base import Base
 from ginkgo.libs import GLOG
 
 
-class BaseTradeGateway(TimeMixin, ContextMixin, OrderManagementMixin, EngineBindableMixin, Base):
+class BaseTradeGateway(TimeMixin, ContextMixin, OrderManagementMixin, EngineBindableMixin, SubscribableMixin, Base):
     """
     TradeGateway基础类
 
@@ -33,6 +34,11 @@ class BaseTradeGateway(TimeMixin, ContextMixin, OrderManagementMixin, EngineBind
 
     子类继承后只需要专注于具体的路由逻辑。
     """
+
+    def bind_engine(self, engine) -> None:
+        super().bind_engine(engine)
+        # 入方向：注册组件订阅的事件处理器（ADR-017，与出方向 _engine_put 对称）
+        self.register_handlers(engine)
 
     def __init__(self, name: str = "BaseTradeGateway", *args, **kwargs):
         """

--- a/src/ginkgo/trading/bases/portfolio_base.py
+++ b/src/ginkgo/trading/bases/portfolio_base.py
@@ -36,6 +36,7 @@ from ginkgo.entities.mixins import TimeMixin
 from ginkgo.entities.mixins import ContextMixin
 from ginkgo.entities.mixins import EngineBindableMixin
 from ginkgo.entities.mixins import NamedMixin
+from ginkgo.trading.mixins.subscribable_mixin import SubscribableMixin, subscribes
 from ginkgo.trading.bases.selector_base import SelectorBase
 from ginkgo.trading.bases.risk_base import RiskBase
 from ginkgo.trading.bases.sizer_base import SizerBase
@@ -51,14 +52,14 @@ from ginkgo.trading.events.order_lifecycle_events import (
 )
 from ginkgo.entities import Position
 from ginkgo.entities import Order
-from ginkgo.enums import DIRECTION_TYPES, RECORDSTAGE_TYPES, SOURCE_TYPES, PORTFOLIO_MODE_TYPES, PORTFOLIO_RUNSTATE_TYPES, DEFAULT_ANALYZER_SET
+from ginkgo.enums import DIRECTION_TYPES, RECORDSTAGE_TYPES, SOURCE_TYPES, PORTFOLIO_MODE_TYPES, PORTFOLIO_RUNSTATE_TYPES, DEFAULT_ANALYZER_SET, EVENT_TYPES
 from ginkgo.libs import GCONF, GLOG, to_decimal
 
 
 console = Console()
 
 
-class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
+class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin, SubscribableMixin,
                    NamedMixin, Base, ABC):
     """
     投资组合组件基类
@@ -550,6 +551,8 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
 
         # 绑定引擎到portfolio自身 - ContextMixin.bind_engine在MRO中
         super().bind_engine(engine)
+        # 入方向：注册组件订阅的事件处理器（ADR-017，与出方向 _engine_put 对称）
+        self.register_handlers(engine)
 
         # 如果引擎有TimeProvider，设置给Portfolio
         if engine._time_provider is not None:
@@ -730,15 +733,21 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin,
     def get_position(self, code: str) -> Position:
         raise NotImplementedError("Portfolio must implement get_position method")
 
+    @subscribes(EVENT_TYPES.PRICEUPDATE)
     def on_price_received(self, event: EventPriceUpdate) -> None:
         raise NotImplementedError("Portfolio must implement on_price_received method")
 
+    @subscribes(EVENT_TYPES.SIGNALGENERATION)
     def on_signal(self, event: EventSignalGeneration) -> Optional[Order]:
         raise NotImplementedError("Portfolio must implement on_signal method")
 
+    # 不订阅 ORDERPARTIALLYFILLED：回测路径经 TradeGateway.on_order_partially_filled
+    # 路由器按 portfolio_id 转发调用此方法（方法调用，非引擎订阅）。直接订阅会导致
+    # 引擎触发 + Gateway 路由双重处理。抽象方法保留以约束子类实现供 Gateway 路由调用。
     def on_order_partially_filled(self, event: EventOrderPartiallyFilled) -> None:
         raise NotImplementedError("Portfolio must implement on_order_partially_filled method")
 
+    @subscribes(EVENT_TYPES.ORDERCANCELACK)
     def on_order_cancel_ack(self, event: EventOrderCancelAck) -> None:
         raise NotImplementedError("Portfolio must implement on_order_cancel_ack method")
 

--- a/src/ginkgo/trading/feeders/backtest_feeder.py
+++ b/src/ginkgo/trading/feeders/backtest_feeder.py
@@ -25,6 +25,7 @@ from rich.progress import Progress
 
 from ginkgo.trading.feeders.base_feeder import BaseFeeder
 from ginkgo.entities.mixins import EngineBindableMixin
+from ginkgo.trading.mixins.subscribable_mixin import SubscribableMixin, subscribes
 from ginkgo.trading.feeders.interfaces import (
     IBacktestDataFeeder, DataFeedStatus
 )
@@ -34,11 +35,11 @@ from ginkgo.entities.mixins import TimeMixin
 from ginkgo.trading.time.interfaces import ITimeProvider
 from ginkgo.trading.time.providers import TimeBoundaryValidator
 from ginkgo.libs import datetime_normalize, cache_with_expiration, GLOG
-from ginkgo.enums import SOURCE_TYPES
+from ginkgo.enums import SOURCE_TYPES, EVENT_TYPES
 from ginkgo.data.mappers import BarMapper
 
 
-class BacktestFeeder(EngineBindableMixin, BaseFeeder, IBacktestDataFeeder):
+class BacktestFeeder(EngineBindableMixin, SubscribableMixin, BaseFeeder, IBacktestDataFeeder):
     """
     回测数据馈送器
     
@@ -268,7 +269,13 @@ class BacktestFeeder(EngineBindableMixin, BaseFeeder, IBacktestDataFeeder):
 
         return events
 
+    def bind_engine(self, engine) -> None:
+        super().bind_engine(engine)
+        # 入方向：注册组件订阅的事件处理器（ADR-017，与出方向 _engine_put 对称）
+        self.register_handlers(engine)
+
     # === 新增：兴趣集合事件处理 ===
+    @subscribes(EVENT_TYPES.INTERESTUPDATE)
     def on_interest_update(self, event: "EventInterestUpdate") -> None:
         try:
             codes = getattr(event, 'codes', []) or []

--- a/src/ginkgo/trading/gateway/trade_gateway.py
+++ b/src/ginkgo/trading/gateway/trade_gateway.py
@@ -32,6 +32,7 @@ from ginkgo.trading.events.order_lifecycle_events import (
     EventOrderAck, EventOrderPartiallyFilled, EventOrderRejected,
     EventOrderExpired, EventOrderCancelAck
 )
+from ginkgo.trading.mixins.subscribable_mixin import subscribes
 
 
 class TradeGateway(BaseTradeGateway):
@@ -174,6 +175,7 @@ class TradeGateway(BaseTradeGateway):
         GLOG.DEBUG(f"Order {order.code} routed to {market} broker: {broker.__class__.__name__}")
         return broker
 
+    @subscribes(EVENT_TYPES.ORDERACK)
     def on_order_ack(self, event, *args, **kwargs) -> None:
         """
         统一订单确认处理 - 支持同步/异步模式
@@ -225,6 +227,7 @@ class TradeGateway(BaseTradeGateway):
             # 模拟盘/实盘：异步执行
             self._handle_async_execution(order, selected_broker, execution_mode)
 
+    @subscribes(EVENT_TYPES.PRICEUPDATE)
     def on_price_received(self, event, *args, **kwargs) -> None:
         """
         价格接收处理 - 只对回测模式传递价格
@@ -855,6 +858,7 @@ class TradeGateway(BaseTradeGateway):
             GLOG.ERROR(f"Failed to register portfolio to router: {e}")
             raise
 
+    @subscribes(EVENT_TYPES.ORDERPARTIALLYFILLED)
     def on_order_partially_filled(self, event) -> None:
         """
         处理ORDERPARTIALLYFILLED事件，按portfolio_id路由到对应的Portfolio

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -35,7 +35,9 @@ from ginkgo.enums import (
     ORDERSTATUS_TYPES,
     RECORDSTAGE_TYPES,
     PORTFOLIO_RUNSTATE_TYPES,
+    EVENT_TYPES,
 )
+from ginkgo.trading.mixins.subscribable_mixin import subscribes
 
 from ginkgo.libs import datetime_normalize, to_decimal, GLOG
 from ginkgo.libs.core.config import GCONF
@@ -187,6 +189,7 @@ class PortfolioLive(PortfolioBase):
 
         return order_event
 
+    @subscribes(EVENT_TYPES.PRICEUPDATE)
     def on_price_update(self, event: EventPriceUpdate):
         """
         处理价格更新事件（实盘交易入口）
@@ -250,6 +253,7 @@ class PortfolioLive(PortfolioBase):
 
         return events
 
+    @subscribes(EVENT_TYPES.ORDERPARTIALLYFILLED, EVENT_TYPES.ORDERFILLED)
     def on_order_partially_filled(self, event: EventOrderPartiallyFilled):
         """
         处理订单成交事件（实盘交易入口）

--- a/src/ginkgo/trading/portfolios/t1backtest.py
+++ b/src/ginkgo/trading/portfolios/t1backtest.py
@@ -44,7 +44,9 @@ from ginkgo.enums import (
     SOURCE_TYPES,
     ORDERSTATUS_TYPES,
     RECORDSTAGE_TYPES,
+    EVENT_TYPES,
 )
+from ginkgo.trading.mixins.subscribable_mixin import subscribes
 from ginkgo.data.containers import container
 
 
@@ -828,6 +830,7 @@ class PortfolioT1Backtest(PortfolioBase):
         except Exception as e:
             self.blog.log_engine_error_event(error_code="CANCEL_HANDLER_FAILED", error_message=str(e))
 
+    @subscribes(EVENT_TYPES.ORDERFILLED)
     def on_order_filled(self, event) -> None:
         """订单完全成交事件处理器 - 特殊的partially_filled (remain=0)"""
         try:

--- a/tests/unit/trading/portfolios/test_portfolio_subscription_contract.py
+++ b/tests/unit/trading/portfolios/test_portfolio_subscription_contract.py
@@ -1,0 +1,81 @@
+"""
+Portfolio 类族事件订阅契约测试（ADR-017 迁移 #12）
+
+验证三类 _subscriptions 映射，对照 tce:798-816 component_event_mapping 的旧类名注册表：
+  - PortfolioBase：4 核心抽象 handler 声明类族契约（PRICEUPDATE/SIGNAL/ORDERPARTIALLYFILLED/ORDERCANCELACK）
+  - PortfolioT1Backtest：继承 Base 4 个 + 自己加 4 个
+    （on_order_filled/on_position_update/on_capital_update/on_portfolio_update）
+  - PortfolioLive：换映射（PRICEUPDATE→on_price_update，方法名漂移）+
+    一方法多 event（ORDERFILLED+ORDERPARTIALLYFILLED→on_order_partially_filled，取代转发壳）+
+    继承 Base signal/cancel_ack
+
+_subscriptions 是类属性（__init_subclass__ 在类创建期生成），无需实例化 Portfolio，
+import 类即可断言 —— 避开 Portfolio 重型依赖（notification_service/analyzers/context）。
+"""
+
+from ginkgo.enums import EVENT_TYPES
+from ginkgo.trading.bases.portfolio_base import PortfolioBase
+from ginkgo.trading.portfolios.t1backtest import PortfolioT1Backtest
+from ginkgo.trading.portfolios.portfolio_live import PortfolioLive
+
+
+class TestPortfolioBaseSubscriptionContract:
+    """PortfolioBase 直接订阅 3 事件（对照 tce:771-772 + engine_assembly:714 manual register）
+
+    ORDERPARTIALLYFILLED 不在此列：回测路径经 TradeGateway.on_order_partially_filled
+    路由器按 portfolio_id 转发调用 Portfolio.on_order_partially_filled（方法调用，
+    非引擎订阅）。若 Portfolio 直接订阅，引擎触发 + Gateway 路由 = 双重处理。
+    on_order_partially_filled 仍是抽象方法，约束子类实现以供 Gateway 路由调用。
+    """
+
+    def test_base_declares_three_direct_subscriptions(self):
+        s = PortfolioBase._subscriptions
+        assert s[EVENT_TYPES.PRICEUPDATE] == "on_price_received"
+        assert s[EVENT_TYPES.SIGNALGENERATION] == "on_signal"
+        assert s[EVENT_TYPES.ORDERCANCELACK] == "on_order_cancel_ack"
+        # ORDERPARTIALLYFILLED 通过 Gateway 路由，Portfolio 不直接订阅
+        assert EVENT_TYPES.ORDERPARTIALLYFILLED not in s
+
+
+class TestT1BacktestSubscriptionContract:
+    """T1Backtest 继承 Base 3 直接订阅 + 自己加 ORDERFILLED（对照 tce:770-777）"""
+
+    def test_t1_inherits_base_three_direct(self):
+        s = PortfolioT1Backtest._subscriptions
+        assert s[EVENT_TYPES.PRICEUPDATE] == "on_price_received"
+        assert s[EVENT_TYPES.SIGNALGENERATION] == "on_signal"
+        assert s[EVENT_TYPES.ORDERCANCELACK] == "on_order_cancel_ack"
+        assert EVENT_TYPES.ORDERPARTIALLYFILLED not in s  # Gateway 路由
+
+    def test_t1_adds_order_filled_subscription(self):
+        """T1Backtest 只额外加 on_order_filled。
+
+        POSITIONUPDATE/CAPITALUPDATE/PORTFOLIOUPDATE 在旧 tce:798-807 注册表写了，
+        但 T1Backtest 无此方法（hasattr False，死注册），迁移后不应出现幽灵映射。
+        """
+        s = PortfolioT1Backtest._subscriptions
+        assert s[EVENT_TYPES.ORDERFILLED] == "on_order_filled"
+        assert EVENT_TYPES.POSITIONUPDATE not in s
+        assert EVENT_TYPES.CAPITALUPDATE not in s
+        assert EVENT_TYPES.PORTFOLIOUPDATE not in s
+
+
+class TestPortfolioLiveSubscriptionContract:
+    """PortfolioLive：换映射 + 一方法多 event + 继承（取代旧类名注册缺失 + 转发壳）"""
+
+    def test_live_remaps_priceupdate_to_on_price_update(self):
+        """方法名漂移：on_price_update 覆盖父类 on_price_received 映射（B2 换映射免费）"""
+        s = PortfolioLive._subscriptions
+        assert s[EVENT_TYPES.PRICEUPDATE] == "on_price_update"
+
+    def test_live_one_method_many_events_for_order_filled(self):
+        """on_order_partially_filled 同时订阅 PARTIALLY_FILLED + FILLED（取代 :383 转发壳）"""
+        s = PortfolioLive._subscriptions
+        assert s[EVENT_TYPES.ORDERPARTIALLYFILLED] == "on_order_partially_filled"
+        assert s[EVENT_TYPES.ORDERFILLED] == "on_order_partially_filled"
+
+    def test_live_inherits_signal_and_cancel_ack(self):
+        """继承 Base 的 signal/cancel_ack（同名 override，不需重标）"""
+        s = PortfolioLive._subscriptions
+        assert s[EVENT_TYPES.SIGNALGENERATION] == "on_signal"
+        assert s[EVENT_TYPES.ORDERCANCELACK] == "on_order_cancel_ack"

--- a/tests/unit/trading/test_feeder_gateway_subscription_contract.py
+++ b/tests/unit/trading/test_feeder_gateway_subscription_contract.py
@@ -1,0 +1,42 @@
+"""
+BacktestFeeder + TradeGateway 事件订阅契约测试（ADR-017 迁移 #13）
+
+对照 tce:778-785 component_event_mapping：
+  - BacktestFeeder: INTERESTUPDATE→on_interest_update
+  - TradeGateway: PRICEUPDATE→on_price_received、ORDERACK→on_order_ack、
+                  ORDERPARTIALLYFILLED→on_order_partially_filled（路由器，按 portfolio_id 转发）
+
+_subscriptions 是类属性（__init_subclass__ 在类创建期生成），import 类即可断言，
+无需实例化 —— 避开 Broker/Router/数据源重依赖。
+"""
+
+from ginkgo.enums import EVENT_TYPES
+from ginkgo.trading.feeders.backtest_feeder import BacktestFeeder
+from ginkgo.trading.gateway.trade_gateway import TradeGateway
+
+
+class TestBacktestFeederSubscriptionContract:
+    """BacktestFeeder 订阅利息更新（对照 tce:780）"""
+
+    def test_feeder_subscribes_interest_update(self):
+        s = BacktestFeeder._subscriptions
+        assert s[EVENT_TYPES.INTERESTUPDATE] == "on_interest_update"
+
+
+class TestTradeGatewaySubscriptionContract:
+    """TradeGateway 路由器订阅 3 事件（对照 tce:783-785）"""
+
+    def test_gateway_subscribes_price_update(self):
+        """PRICEUPDATE→on_price_received：更新 Broker 市场数据缓存（处理器，非路由）"""
+        assert TradeGateway._subscriptions[EVENT_TYPES.PRICEUPDATE] == "on_price_received"
+
+    def test_gateway_subscribes_order_ack(self):
+        """ORDERACK→on_order_ack：记录订单确认 + 选 Broker 执行（处理器）"""
+        assert TradeGateway._subscriptions[EVENT_TYPES.ORDERACK] == "on_order_ack"
+
+    def test_gateway_subscribes_order_partially_filled(self):
+        """ORDERPARTIALLYFILLED→on_order_partially_filled：按 portfolio_id 路由到 Portfolio"""
+        assert (
+            TradeGateway._subscriptions[EVENT_TYPES.ORDERPARTIALLYFILLED]
+            == "on_order_partially_filled"
+        )


### PR DESCRIPTION
## 背景

README 组件计数多处过时(策略写 15、风控 18 等),且与 CLAUDE.md、实际目录三方口径打架。按源文件实测订正,并厘清三套本不该混的口径。

## 改动

### README.md

按 `src/ginkgo/` 源文件实测订正 18 个数字点:

| 项目 | 原 | 新 | 依据 |
|---|---|---|---|
| 策略(可用) | 15 | **11** | 剔 `simple_test_strategy`(测试桩)+ `moving_loss_limit`(零注册),两者在 src 其余处零引用 |
| 风控 | 18 | 16 | `risk_management/` 文件数 |
| 选择器 | 5 | 4 | `selectors/` 文件数 |
| Feeders | 6 | 7 | 含 OKX 双变体(okx_feeder + okx_data_feeder) |
| Analyzers | 24 | 21 | 剔 `registry.py` |
| Models / CRUD / Services | 51/52/33 | 50/49/31 | 文件数 |
| Features | 17 | 16 | `features/definitions/` |
| API / Web / CLI | 15/19/40 | 16/17/35 | `include_router` 16 处 / 顶层 view 17 / `*_cli.py` 35 命令组 |

**策略双口径(各自真实,不冲突)**:
- Component Inventory + mermaid `STR` 节点 = **可用数 11**(剔桩)
- mermaid `strategies/ (13)` = **目录文件数**(含 2 个零引用文件,描述代码结构)

### CLAUDE.md

策略清单拆分,消除原 14 名混列:
- **内置类 11**:random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor
- **DB 脚本组件 3**:social_signal, game_theory, random_choice(src 无类,DB component 表用户创建的实例)

## 结果

README 可用策略 11 = CLAUDE 内置类 11 ✓ 一致;DB 脚本组件与测试桩各自标注,不再混入策略类数。

## 验证

- 纯文档改动,无代码逻辑变更,不影响构建/测试
- 数字均经 `find`/`grep` 源文件实测,非估算
- `simple_test_strategy`/`moving_loss_limit` 零引用经全仓 grep 确认(仅自身定义文件命中)
