### PR TITLE
docs: README/CLAUDE 组件清单口径订正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ ginkgo backtest cat <backtest_id>
 
 > **实际命名**：DB 组件名多为 `<name>_<type>` 格式（如 `fixed_selector`/`atr_sizer`/`fixed_sizer`），部分带描述前缀（如 `qr_momentum_selector`/`sharpe_ratio`）。`bind-component` 前用 `ginkgo component list` 查实际 `file_id` 与名称；下表为短名速查。
 
-- **Strategy**: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor, social_signal, game_theory, random_choice
+- **Strategy**（内置类 11）: random_signal, moving_average_crossover, mean_reversion, momentum, trend_follow, trend_reverse, dual_thrust, scalping, price_action, volume_activate, ml_predictor；另有 DB 脚本组件（src 无类，DB component 表实例）: social_signal, game_theory, random_choice
 - **Selector**: fixed, cn_all, momentum, popularity, multi_params
 - **Sizer**: fixed, atr, ratio
-- **Risk**: no_risk, position_ratio, loss_limit, profit_target, max_drawdown, volatility, concentration, capital, liquidity, margin, market_cap, sector_rotation, correlation, currency, suspension, trading_time
+- **Risk**: no_risk, position_ratio, loss_limit, profit_target, max_drawdown, volatility, concentration, capital, liquidity, margin, market_cap, sector_rotation, correlation, currency, suspension, trading_time, time_based

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Ginkgo is a quantitative trading framework featuring event-driven backtesting, m
 ```mermaid
 graph TB
     subgraph "🖥️ Application Layer"
-        CLI["<b>CLI</b><br/>Typer + Rich<br/><i>40 commands</i>"]
-        API["<b>REST API</b><br/>FastAPI<br/><i>15 routers</i>"]
-        WEB["<b>Web UI</b><br/>Vue 3 + shadcn-vue<br/><i>19 views</i>"]
+        CLI["<b>CLI</b><br/>Typer + Rich<br/><i>35 command groups</i>"]
+        API["<b>REST API</b><br/>FastAPI<br/><i>16 routers</i>"]
+        WEB["<b>Web UI</b><br/>Vue 3 + shadcn-vue<br/><i>17 views</i>"]
     end
 
     subgraph "⚙️ Worker Layer"
@@ -41,12 +41,12 @@ graph TB
 
     subgraph "📊 Trading Engine"
         EE["EventEngine<br/><i>事件队列 + 线程分发</i>"] --> TCE["TimeControlledEngine<br/><i>回测/实盘统一</i>"]
-        EE --> FDR["Data Feeders (6)"]
+        EE --> FDR["Data Feeders (7)"]
         EE --> PTF["Portfolio<br/><i>中央编排器</i>"]
-        PTF --> STR["Strategy (15)"]
-        PTF --> RSK["Risk (18)"]
+        PTF --> STR["Strategy (11)"]
+        PTF --> RSK["Risk (17)"]
         PTF --> SIZ["Sizer (3)"]
-        PTF --> SEL2["Selector (5)"]
+        PTF --> SEL2["Selector (4)"]
     end
 
     subgraph "🔀 Gateway & Brokers"
@@ -124,22 +124,22 @@ graph LR
             engines["engines/<br/>BaseEngine → EventEngine → TimeControlled"]
             events["events/<br/>PriceUpdate · Signal · Order<br/>TimeAdvance · Portfolio"]
             bases["bases/<br/>Portfolio · Position · Order<br/>Strategy · Selector · Sizer · Risk"]
-            strat["strategies/ (15)"]
-            risk["risk_management/ (18)"]
-            sel["selectors/ (5)"]
+            strat["strategies/ (13)"]
+            risk["risk_management/ (17)"]
+            sel["selectors/ (4)"]
             sizer["sizers/ (3)"]
             brk["brokers/ (8)"]
-            fdr["feeders/ (6)"]
-            analysis["analysis/<br/>analyzers (24) · reports · plots"]
+            fdr["feeders/ (7)"]
+            analysis["analysis/<br/>analyzers (21) · reports · plots"]
             evl["evaluation/<br/>pipeline · rules · visualization"]
         end
 
         subgraph "data/"
             direction TB
             drv["drivers/<br/>ClickHouse · MySQL<br/>MongoDB · Redis · Kafka"]
-            mdl["models/ (51)"]
-            crud["crud/ (52)"]
-            svc["services/ (33)"]
+            mdl["models/ (50)"]
+            crud["crud/ (49)"]
+            svc["services/ (31)"]
             src["sources/ (5)"]
             stm["streaming/<br/>cache · checkpoint · recovery"]
         end
@@ -152,7 +152,7 @@ graph LR
         end
 
         subgraph "Supporting"
-            feat["features/<br/>definitions (17) · expression engine"]
+            feat["features/<br/>definitions (16) · expression engine"]
             ml["quant_ml/<br/>models · features · strategies"]
             res["research/<br/>IC · factor · orthogonal · decay"]
             val["validation/<br/>MonteCarlo · WalkForward · Sensitivity"]
@@ -179,13 +179,13 @@ graph LR
 
 | Category | Count | Examples |
 |----------|-------|---------|
-| **Strategies** | 15 | MA Crossover, Momentum, Mean Reversion, Dual Thrust, Scalping, ML Predictor |
-| **Risk Managers** | 18 | Position Ratio, Loss Limit, Profit Target, Max Drawdown, Volatility, Concentration |
-| **Selectors** | 5 | Fixed, CN All, Momentum, Popularity |
+| **Strategies** | 11 | MA Crossover, Momentum, Mean Reversion, Dual Thrust, Scalping, ML Predictor |
+| **Risk Managers** | 17 | Position Ratio, Loss Limit, Profit Target, Max Drawdown, Volatility, Concentration, Time Based |
+| **Selectors** | 4 | Fixed, CN All, Momentum, Popularity |
 | **Sizers** | 3 | Fixed, ATR, Ratio |
 | **Brokers** | 8 | Sim, AShare, HK Stock, US Stock, Futures, OKX, Manual, Auto |
-| **Feeders** | 6 | Backtest, Live, OKX, Alpaca, EastMoney, Fushu |
-| **Analyzers** | 24 | Net Value, Max Drawdown, Sharpe, Calmar, Profit Factor, Annualized Returns |
+| **Feeders** | 7 | Backtest, Live, OKX, OKX Data, Alpaca, EastMoney, Fushu |
+| **Analyzers** | 21 | Net Value, Max Drawdown, Sharpe, Calmar, Profit Factor, Annualized Returns |
 | **Data Sources** | 5 | Tushare, AKShare, Yahoo, BaoStock, TDX |
 | **DB Drivers** | 5 | ClickHouse, MySQL, MongoDB, Redis, Kafka |
 | **Factors** | 158+ | Alpha158, Barra, Fama-French, WorldQuant Alpha101 |


### PR DESCRIPTION
## 背景

替代 #6457（该 PR 原 stack 在 #6441 之上，squash 会夹带 ADR-017 核心交易路径重构；现 #6441 已于 2026-06-28 02:57:58Z 合入 master，stack 根因消除）。本 PR rebase 为基于最新 master 的纯 docs 分支，并按上一轮 review 第 2 项订正风控口径。

README 组件计数多处过时（策略 15、风控 18 等），且与 CLAUDE.md、实际目录三方口径打架。按 `src/ginkgo/` 源文件实测订正。

## 改动

### README.md

按源文件实测订正计数点（节选）：

| 项目 | 原 | 新 | 依据 |
|---|---|---|---|
| 策略(可用) | 15 | 11 | 剔 simple_test_strategy(测试桩) + moving_loss_limit(零注册)，两零引用文件 |
| 风控 | 18 | 17 | `risk_management/` 文件数，纳入 time_based_risk |
| 选择器 | 5 | 4 | `selectors/` 文件数 |
| Feeders | 6 | 7 | 含 OKX 双变体 |
| Analyzers | 24 | 21 | 剔 registry.py |
| Models/CRUD/Services | 51/52/33 | 50/49/31 | 文件数 |
| API/Web/CLI | 15/19/40 | 16/17/35 | include_router/顶层view/命令组 |

策略双口径（各自真实，不冲突）：可用数 11（剔桩）= CLAUDE 内置类 11；mermaid 目录文件数 13 描述代码结构。

### CLAUDE.md

- 策略清单拆分：内置类 11 + DB 脚本组件 3（social_signal/game_theory/random_choice，src 无类）
- 风控清单补 time_based 成 17 项，与 README 文件数口径一致（原 16 项漏 time_based_risk）

## 验证

- 纯文档改动，无代码逻辑变更，不影响构建/测试
- 数字均经 find/grep 源文件实测
- diff 仅 README + CLAUDE 两文件（23+/23-），基于最新 master（含 #6441）

## 与 #6457 的差异

本 PR = #6457 docs 内容 + 风控口径订正（16→17，纳入 time_based），且 base 为含 #6441 的最新 master，无 stack。
