### PR TITLE
docs: 订正 CLI 全链路可用性口径 + 入库 e2e 审计报告 (#6459)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,10 +64,12 @@ ginkgo serve worker-backtest --id test2       # 回测 Worker
 - **架构决策记录 (ADR)** → `docs/adrs/README.md`（难逆转/反直觉/真实权衡的决策，触碰架构前先读）
 - **CLI 回测全链路操作指南** → 见下方
 
-## CLI 回测全链路
+## CLI 全链路（构建→回测→模拟盘→实盘）
+
+> **可用性（2026-06-28 实测，详见 [e2e 审计](docs/e2e-cli-flow-audit.md)）**：构建 ✅ ｜ 回测 ⚠️（无数据预检、0 交易定位难）｜ 模拟盘 ⚠️（核心修复 #6164 已落地，端到端待复测）｜ 实盘 ⚠️（`account`/`deploy` 命令就绪，端到端待验证）。文档口径以审计报告为权威，勿超前于代码实际能力。
 
 ### 流程
-创建 Portfolio → 复用/创建 Component → 绑定组件(含参数) → 创建回测 → 运行
+创建 Portfolio → 复用/创建 Component → 绑定组件(含参数) → 创建回测 → 运行 → [deploy 模拟/实盘]
 
 **Python 环境**：`/home/kaoru/.ginkgo/.venv/bin/python`
 
@@ -88,6 +90,13 @@ ginkgo portfolio bind-component <pid> <file_id> --type strategy \
 ginkgo backtest create --portfolio <pid> --start 2025-05-07 --end 2026-05-07 --name "test" --cash 100000
 ginkgo backtest run <backtest_id>
 ginkgo backtest cat <backtest_id>
+
+# 部署（模拟盘/实盘）⚠️ 端到端待复测，见 docs/e2e-cli-flow-audit.md
+ginkgo deploy deploy <pid> --mode paper                          # 模拟盘
+ginkgo deploy deploy <pid> --mode live --account <account_uuid>  # 实盘（需先建账户）
+ginkgo deploy info <deployment_id>                               # 部署详情
+ginkgo account create <user_id> --exchange okx --name "..." --api-key ... --api-secret ...
+ginkgo account list <user_id>
 ```
 
 ### 可用组件

--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ Ginkgo is a quantitative trading framework featuring event-driven backtesting, m
 - **Multiple Data Sources**: Tushare, Yahoo Finance, AKShare, BaoStock, TDX
 - **Complete Risk Control**: Position management, stop-loss/profit, real-time monitoring
 - **Web UI**: Vue 3 + shadcn-vue + Tailwind CSS dashboard for backtest/portfolio/component management
-- **Live Trading**: OKX broker integration with heartbeat monitoring and crash recovery
+- **Live Trading**: OKX broker integration with heartbeat monitoring and crash recovery (⚠️ CLI end-to-end status — see [e2e audit](docs/e2e-cli-flow-audit.md))
 - **CLI Interface**: Typer-based CLI with Rich formatting
+
+> **CLI pipeline status (2026-06-28 verified)**: Build ✅ · Backtest ⚠️ (data traps, no pre-check) · Paper trading ⚠️ (core fix #6164 landed, end-to-end pending re-test) · Live ⚠️ (integration ready, end-to-end pending). Details: [docs/e2e-cli-flow-audit.md](docs/e2e-cli-flow-audit.md).
 
 ## Architecture
 
@@ -266,6 +268,28 @@ ginkgo backtest cat <backtest_id>
 ginkgo backtest list
 ```
 
+### Deployment (Paper / Live)
+
+> ⚠️ End-to-end status: see [e2e audit](docs/e2e-cli-flow-audit.md). Paper-trading core fix landed (#6164 deploy-clone completeness); full paper/live pipeline pending end-to-end re-test.
+
+```bash
+ginkgo deploy deploy <portfolio_id> --mode paper                # Paper trading deployment
+ginkgo deploy deploy <portfolio_id> --mode live --account <id>  # Live deployment (needs a live account)
+ginkgo deploy info <deployment_id>                              # Deployment details
+ginkgo deploy list                                              # List deployments
+```
+
+### Live Account Management
+
+> Added in #6284. Create an account first, then use its UUID with `deploy --mode live --account <id>`.
+
+```bash
+ginkgo account create <user_id> --exchange okx --name "my_okx" \
+  --api-key <key> --api-secret <secret> [--passphrase <pp>] [--environment testnet]
+ginkgo account list <user_id>
+ginkgo account get <account_uuid>
+```
+
 ### Worker Management
 
 ```bash
@@ -320,6 +344,8 @@ Features: portfolio management, backtest creation/monitoring, component editor (
 
 ## Live Trading
 
+> ⚠️ **Status**: OKX integration code is in place (classes below) and the CLI is wired (`ginkgo account` + `ginkgo deploy --mode live`, landed in #6284), but the end-to-end path (real account → order routing → fill) has not been re-verified since the 2026-06-22 audit. See [e2e audit](docs/e2e-cli-flow-audit.md).
+
 OKX exchange integration with:
 
 - **LiveEngine**: Unified lifecycle management
@@ -328,8 +354,13 @@ OKX exchange integration with:
 - **HeartbeatMonitor**: Timeout detection and recovery
 
 ```bash
+# Low-level engine lifecycle
 python -m ginkgo.livecore.main live-start   # Start live engine
 python -m ginkgo.livecore.main live-status  # Check status
+
+# High-level CLI pipeline: create account → deploy live
+ginkgo account create <user_id> --exchange okx --name "my_okx" --api-key <key> --api-secret <secret>
+ginkgo deploy deploy <portfolio_id> --mode live --account <account_uuid>
 ```
 
 ## System Requirements

--- a/docs/e2e-cli-flow-audit.md
+++ b/docs/e2e-cli-flow-audit.md
@@ -1,0 +1,94 @@
+# Ginkgo CLI 全链路审计报告
+
+> 日期：2026-06-22 ｜ ginkgo 0.8.1 ｜ Debug ON
+> 流程：策略构建 → 回测验证 → 模拟盘 → 实盘
+> 方法：CLI 实跑 + 源码核对 + DB 直查
+
+## 结论速览
+
+| 阶段 | 可用性 | 关键问题 |
+|---|---|---|
+| 策略构建 | ✅ 可用 | — |
+| 回测验证 | ⚠️ 可用但有数据陷阱 | 无数据预检，0交易定位难 |
+| 模拟盘 | ❌ 不可用 | deploy 克隆丢组件绑定 |
+| 实盘 | ❌ 不可用 | 无 CLI 建账户，链路断 |
+
+---
+
+## Phase 1 策略构建 ✅
+
+`portfolio create` / `component list` / `portfolio bind-component --type --param 'index:value'` 全部工作。
+
+- 组件源码可见（`component show`），参数索引可查
+- FixedSelector 源码已明确标注"后视偏差，仅回测用"——但 CLI 层无此提示
+
+## Phase 2 回测验证 ⚠️
+
+实测：MA(5,20) on 600000.SH，2025-01~2026-01，**13 信号 → 11 订单**，事件链 `Selector→Strategy→Sizer→Risk→Order→Fill` 完整。
+
+### 缺失 [高] 回测前无数据可用性预检
+- 000001.SZ 在 Test 库仅 **3 天数据**（2023-12-01/04/05），回测返回 `Final Value=100000` + 模糊警告 "selector may have returned empty symbols"
+- 用户需跑完整个回测（~分钟级）才知道 0 交易，且警告归因不准（暗示 selector，实为数据）
+- **建议**：`backtest create/run` 前按 selector codes + 日期窗口预查 bar 数据量，不足时前置报错
+
+### 缺失 [中] 数据覆盖严重不均
+| 股票 | 2025 日线条数 |
+|---|---|
+| 000001.SZ | 3（仅 2023-12） |
+| 000002.SZ | 1 |
+| 600036.SH | 244 |
+| 600000.SH | 244 |
+| 600519.SH | 3880 |
+
+主流股票大面积数据空洞，回测选股需先手动 `data get day` 探活。
+
+### 缺失 [低] 回测无进度反馈
+本地同步执行 ~4 分钟（244 天），无进度条/日志流。
+
+## Phase 3 模拟盘 ❌
+
+`deploy deploy <pid> --mode paper` 返回"部署成功"+建记录+发 Kafka，但 **worker 实际装配失败**。
+
+### BUG [严重] deploy 克隆未完整复制组件绑定
+- 部署日志只显示复制 2/4 映射（risk + selector），strategy + sizer 丢失
+- PaperTradingWorker 装配时 `Strategies: 0` → `CRITICAL No strategy found` → `Component binding failed, skipping`
+- 同一组合回测 13 信号成功，部署后却 0 策略——**回测 OK ≠ 部署 OK**
+- 定位：`deployment_service.py` 的 `_copy_graph` / 文件映射复制逻辑漏抄部分绑定
+
+### BUG [高] deploy 输出 Portfolio ID 截断
+- `deploy deploy` 输出 `f918a74bc99249f5af0ac74a45b8f6e`（**31 位，丢字符**）
+- 库内真实 UUID `f918a74bc99249f5af0ac74a454b8f6e`（32 位）
+- 用户复制输出 ID 查 `deploy info` 必返回"未找到部署记录"
+- 用真实 32 位 ID 查询正常 → 确为输出展示 bug
+
+### 缺失 [中] deploy info 输出问题
+- `状态: 1`（原始 int，非"已部署"）
+- `源回测任务` 字段空（未关联 source backtest task）
+
+### 缺失 [中] 装配失败静默
+PaperTradingWorker 对失败组合仅 `skipping`，deploy 端无回环感知，用户以为部署成功。
+
+## Phase 4 实盘 ❌
+
+### 缺失 [严重] 无 CLI 创建实盘账户
+- 顶层无 `account` 命令（`ginkgo --help | grep -c account` = 0）
+- `MLiveAccount` 表 0 条记录
+- `deploy --mode live --account <id>` 必填 account_id，但无 CLI 产生该 ID
+- 实盘链路从账户管理第一公里即断
+
+### BUG [高] 假 account_id 触发裸 SQL 错误
+`deploy --mode live --account <假id>` → 裸 `pymysql.err.OperationalError (1054, Unknown column 'portfolio.live_account_id AS portfolio_live_account_id')`，非优雅"账户不存在"。
+- 定位：`broker_instance_crud.get_broker_by_live_account` 的 ORM/列映射问题
+
+## 跨阶段问题
+
+- **[高]** 回测与部署无一致性校验：组件绑定可在 deploy 克隆中静默丢失
+- **[中]** Worker 参数风格不统一：`worker-backtest -id`（单横线，CLAUDE.md 记载）vs `worker-paper --id`（双横线）；`-id` 在 typer 下解析为 `-i -d` 报 "No such option: -i"
+- **[中]** `ginkgo` 是 bash 包装脚本（`/home/kaoru/.local/bin/ginkgo`），对 `serve nohup` 特殊处理，增加调试复杂度
+
+## 建议优先级
+1. 修 deploy 克隆丢组件绑定（Phase3 严重 bug）——模拟盘才能走通
+2. 修 deploy 输出 UUID 截断 + deploy info 状态枚举
+3. 加回测前数据预检（改善最常见"0交易"体验）
+4. 补 CLI 实盘账户管理 + deploy live 错误兜底
+5. 统一 worker 参数风格


### PR DESCRIPTION
## Summary

订正 `README.md` 与 `CLAUDE.md` 的 CLI 全链路可用性口径，使其与 `docs/e2e-cli-flow-audit.md`（2026-06-22 实测）及当前代码实际状态一致；并将此前为工作区未追踪文件的审计报告入库作为权威依据。

**核心纪律**：以审计为**线索**，逐条核对当前文档实测，**不机械套用审计**（审计后部分点已修正），亦**不超前宣称可用**。

## 逐条核对记录（当前文档实测 vs 审计/代码实际）

| 审计结论 | 核对结果 | 文档口径 |
|---|---|---|
| Phase4「无 CLI 建账户」(#6284) | #6289 merged（6-23）；`ginkgo account create/list/get` **实测可用且顶层已注册** → 审计此条**已过时** | 实盘：命令就绪 |
| Phase3「deploy 克隆丢绑定」(#6202/#6164) | #6164 merged（6-20）；`_deploy_core` 遍历全部 4 类映射、无类型过滤（#6287 验证不复现）→ 核心**已修** | 模拟盘：核心已修待复测 |
| 跨阶段「worker -id 单横线」 | CLAUDE.md 当前已是 `--id`（双横线）→ 审计此条**已过时**（issue body 已明示） | 无需改 |
| Phase4「裸 SQL」/ Phase3「UUID 截断」 | 当前代码层（broker_instance_crud 走 ORM filter / deploy_cli 直接 print uuid）已无直接复现证据 | 不超前宣称，标待端到端复测 |

端到端（真实账户 → 下单）未经权威复测（#6287 测试 PR 未 merged），故模拟盘/实盘均标 ⚠️ 待验证，不标 ✅。

## 变更

- **README.md**：Features Live Trading 加 ⚠️ + 链审计；新增 CLI pipeline status 横幅；CLI Reference 补 `Deployment` / `Live Account` 小节（实测命令签名）；Live Trading 节加 status 与 CLI 路径。
- **CLAUDE.md**：「CLI 回测全链路」→「CLI 全链路」，加可用性速览、流程延伸 deploy、补 deploy/account 命令块。
- **docs/e2e-cli-flow-audit.md**：入库（此前为工作区未追踪文件），作为口径订正权威依据。

**口径一致**：README 与 CLAUDE.md 均用 ✅/⚠️，模拟盘均提 #6164 核心修复 + 待复测，实盘均提待验证，均链审计报告。

## Test plan

- [x] markdown 代码块配对（README 36 / CLAUDE.md 4 fences 均偶数）
- [x] 审计报告链接目标存在（`docs/e2e-cli-flow-audit.md` 入库）
- [x] `ginkgo account --help` / `ginkgo deploy --help` 实测可用（顶层已注册）
- [x] 命令签名与 `account_cli.py` / `deploy_cli.py` 源码一致
- [x] py_compile deploy_cli.py / account_cli.py 基线通过
- [ ] 文档审阅：口径不超前于代码、不滞后于审计

纯 docs，不触碰代码。

Closes #6459
