### PR TITLE
refactor: 回测派发契约判别联合化（ADR-018）

### DIFF
--- a/docs/adrs/ADR-018-backtest-assignment-contract.md
+++ b/docs/adrs/ADR-018-backtest-assignment-contract.md
@@ -1,0 +1,103 @@
+# ADR-018: 回测派发契约（判别联合 + DTO 层 wire spec）
+
+**Status:** Accepted
+**Date:** 2026-06-28
+**Related:** ADR-010（Entity/ORM/DTO 三层 + DTO=状态信使）、ADR-017（声明式类型契约 > 字符串分派）、#5646（派发前校验，部分缓解）；细化 ADR-009（不触 Base）；候选源自 `/improve-codebase-architecture` 评审 + `/grill-with-docs` 拷问
+
+## Context
+
+回测任务命令（assignment）跨 Kafka 边界（`BACKTEST_ASSIGNMENTS` topic），契约无 owner，真相散落 5 处，drift 静默发生且无法测。经 grep/Read 核实（搜索须覆盖 `src/`+`api/` 全仓——曾因只搜 `src/` 误判 `stop_task` 为死方法）：
+
+- **生产端 3 处手搓 dict literal**，三命令同 topic、不同 shape：
+  - `start_task`（`backtest_task_service.py:716-722`）：`{task_uuid, portfolio_uuid, name, command:"start", config:{...14 keys}}`
+  - `stop_task`（`:768-771`）/ `cancel_task`（`:821-824`）：`{task_uuid, command}` 仅 2 键
+  - 三处共用 `producer=GinkgoProducer(); .send(); .flush(2.0); .close()` 样板
+- **消费端字符串分派**：`command = assignment.get("command","start")`（`node.py:224`）按字符串 if/elif，无类型守护"stop 不能带 config"。
+- **stop 消费无 handler**（拷问发现）：`stop_task` 经 API `POST /{uuid}/stop`（`api/backtest.py:527`）真在调用、真发 Kafka `{command:"stop"}`，但 `node.py:227-230` 的 if/elif 只有 start/cancel——**stop 消息静默掉 void 后照常提交 offset**。这是活契约（端点+service+Kafka 全通）的消费侧缺口，非死代码。端点 docstring 还区分 stop="停 running 任务"、cancel="取消 created/pending 任务"，设计上是有意两回事，只是 stop 的 worker 动作没实现。
+- **默认值双源**：生产端从 `config_snapshot` 恢复（`:698-703`），消费端全硬编码（`node.py:346-353`：`initial_cash=100000.0`/`commission_rate=0.0003`/`slippage_rate=0.0001`/`benchmark_return=0.0`/`max_position_ratio=0.3`/`stop_loss_ratio=0.05`/`take_profit_ratio=0.15`/`frequency="DAY"`/`analyzers=[]`）。两边对得上纯属巧合，非契约。
+- **死字段**：生产端发 `broker_type/broker_attitude/commission_min`（`:699`），消费端 worker `BacktestConfig`（`models.py:48`）根本不读。
+- **校验重复且错位**：service 层只 `portfolio_uuid or task.portfolio_id` coalesce（`:718`）不显式拒；消费端字面拒 `"portfolio_uuid is required"`（`:310`）、`"Missing dates"`（`:324`）。错误信息跨 Kafka 降级，根因在 service、暴露在 worker（#5646 部分缓解：API 层加 BusinessError 预校验，但重复仍在）。
+- **孤儿 DTO**：`interfaces/dtos/backtest_assignment_dto.py` 定义 `BacktestAssignmentDTO`(dataclass)/`BacktestProgressDTO`，grep 零引用——边界处无人用，是第三份自漂移 shape（带 `priority/timeout` 真消息没有；`to_json()->str` 形态错，producer 收 dict）。且用 dataclass 偏离 DTO 层 pydantic 惯例（10:1）。
+
+判定三条全中（难逆转 / 反直觉 / 真实取舍 A vs B vs C），立本 ADR。
+
+## Decision
+
+把回测派发契约深化为**判别联合（discriminated union）+ DTO 层 wire spec**，单一 owner 藏构造/校验/默认/序列化，两端只绑类型。
+
+### DTO 层（`interfaces/dtos/backtest_assignment_dto.py`，复活孤儿，pydantic BaseModel）
+
+- `BacktestAssignmentConfig`——wire spec，11 字段：
+  - **required**：`start_date:str`、`end_date:str`
+  - **optional**（带默认，唯一默认表）：`initial_cash:float=100000.0`、`commission_rate:float=0.0003`、`slippage_rate:float=0.0001`、`benchmark_return:float=0.0`、`max_position_ratio:float=0.3`、`stop_loss_ratio:float=0.05`、`take_profit_ratio:float=0.15`、`frequency:str="DAY"`、`analyzers:list[dict]=[]`
+  - `analyzers` 透传 `list[dict]`（内部结构是 worker `AnalyzerConfig` 的事，DTO 不解析——ADR-010 信使/主体分离）；dates 为 `str`（worker `BacktestConfig.start_date/end_date` 同型，`to_payload` 无需日期序列化）
+- `StartAssignment | StopAssignment | CancelAssignment`（pydantic BaseModel）：
+  - 共享 `task_uuid:str`（三命令通用 required）
+  - 各持 `command: ClassVar[str]`（`"start"`/`"stop"`/`"cancel"`）——类型标记**非实例字段**，不进 `model_dump()`
+  - Start 独有 required：`portfolio_uuid:str`、`name:str`、`config:BacktestAssignmentConfig`
+- `from_payload(dict) -> Start|Stop|Cancel`：按 `command` 分流返子类；pydantic 构造自动校验 required/类型；畸形（缺 task_uuid、未知 command、start 缺 portfolio_uuid/dates）raise `MalformedAssignmentError(ValueError)`。stop/cancel 的多余字段（如误带的 config）**忽略**——判别联合的守护在返回类型层面（`StopAssignment` 无 `config` 字段，消费端 match 拿到也无法误用），无需 `from_payload` 对 raw 多余字段逐项拒
+- `to_payload() -> dict`：`model_dump()` + 显式注入 `"command": self.command`（对齐今天 wire 结构）；目标 **dict 非 json str**（`producer.send` 收 dict，订正孤儿 `to_json()->str` 双重编码风险）
+
+### 生产端（data/services）
+
+`start_task`/`stop_task`/`cancel_task` 三处手搓 dict literal → `StartAssignment(...).to_payload()` 等 → `producer.send`。死字段 `broker_type/broker_attitude/commission_min` 停发（不进 spec）。
+
+### 消费端（workers）
+
+- `node.py._handle_task_assignment`：`command` 字符串分派 → `cmd = from_payload(raw)` + `match cmd`：
+  - `case StartAssignment():` `_start_task(cmd)`（传 cmd 非裸 dict）
+  - `case StopAssignment():` `GLOG.WARN("stop handler 未实现")` + 不改任务状态 + 提交 offset（**A1**：stop 是活契约但消费侧 handler 缺失，显式记录而非静默掉 void；graceful-stop 单开 issue）
+  - `case CancelAssignment():` `_cancel_task(cmd.task_uuid)`
+- 畸形：`except MalformedAssignmentError as e:` `report_failed_by_uuid(error=str(e))` + `return`（保持今天"标记失败 + 提交 offset"语义，at-least-once）。**窄捕**：只接契约畸形，其他异常（真 bug）照常向上抛触发重投
+- `_start_task` 删字面校验块（`:309-329`）+ 手搓 BacktestConfig（`:343-355`）+ 默认表（`:346-353`），改调 `assignment_to_backtest_config(cmd)`
+
+### 映射层（`workers/backtest_worker/models.py`）
+
+模块级 `assignment_to_backtest_config(cmd:StartAssignment) -> BacktestConfig`，含 analyzers `AnalyzerConfig(**d)` 转换（dict 字段不全 → try/except 转 `MalformedAssignmentError`，与消费端窄捕一致）。**DTO 不 import worker 类型**（信使不知主体，ADR-010）；worker import DTO（消费方向）。映射是第三者胶水，不挂信使也不挂状态主体。
+
+## Considered Options
+
+- **联合形态**：
+  - A 扁平单类（`command:Literal[...]` 运行时字段）：否决——type 不阻 stop+config，config 须额外纪律保 typed 才不退化成裸 dict 套壳（默认漂移原样存活）。
+  - **B 判别联合（本 ADR）**："哪个命令"是类型，构造期强制 stop 不能带 config。
+  - C 信封 port（`BacktestCommand` port + Kafka adapter，藏传输）：否决——3 命令的 seam 嫌过重；今天 Kafka-only，传输不会变，port 是假设性 seam（删掉只回到 B，无增量集中）。
+
+- **stop 处置**：A1 保留三元 + 消费端显式 WARN no-op（本 ADR）/ A2 stop 复用 cancel / C 现在实现 graceful handler。否决 A2（掩盖缺口）、C（新功能不塞 ADR）。
+
+- **死字段**：A 不进 spec + 生产停发（本 ADR）/ B 进 spec 标 deprecated / C 进 spec 不标。否决 B/C（契约=双方真实交互最小集，死字段进 spec 是噪音）。
+
+- **错误传播**：A raise `MalformedAssignmentError`（本 ADR）/ B return Optional / C 错误信封。否决 B（None 丢原因+吞 bug）、C（签名丑）。
+
+- **映射位置**：A worker 侧独立函数 `assignment_to_backtest_config`（本 ADR）/ B DTO 方法 / C BacktestConfig classmethod。否决 B（DTO 反向依赖 worker，违 ADR-010）、C（主体职责膨胀）。
+
+## Rationale
+
+- **类型强制是消除 drift 的真杠杆**：stop+config、缺字段、未知 command 都在**构造期**报错，而非靠人记得同步五处。与 ADR-017 选"声明式类型契约 > 字符串分派"同根。
+- **defaults 归一处**：DTO `BacktestAssignmentConfig` 持唯一默认表 → worker BacktestConfig 默认删除。"双源靠巧合对齐"彻底消失。
+- **serde 目标是 dict 非 json str**：`producer.send(topic, assignment)` 收 dict（`:724`），孤儿 DTO 现行 `to_json()->str` 形态错。订正为 `to_payload()->dict`/`from_payload(dict)`。
+- **DTO ↔ 内部模型映射是 feature 非累赘**：wire 契约与 worker 内部表示解耦，生产端改 wire 字段不影响 worker，反之亦然——ADR-010"DTO 不持不变量、状态主体持"的落点。
+- **不复活孤儿 DTO 的 priority/timeout**：真消息从未带，是历史臆测字段，丢弃。`BacktestProgressDTO` 同样零引用（反向 worker→API 进度链路从未走 DTO），一并删。
+- **不抽共享 config mixin / 不动 Base**：worker BacktestConfig 是内部模型、与 wire spec 角色不同，强行合并牵动 worker 内部（ProgressTracker 耦合）面更大；遵守 ADR-009 不触 Base。
+
+## Consequences
+
+- **删**：生产端 3 dict literal + 样板、消费端 `.get()` 默认表（`node.py:346-353`）、字面校验块（`:309-329` 上移到 DTO 构造期）、孤儿 DTO 旧实现（`BacktestAssignmentDTO` dataclass + `priority/timeout`）、`BacktestProgressDTO`（死代码）、死字段 `broker_type/broker_attitude/commission_min`（生产端停发）。
+- **worker BacktestConfig 默认**：删（DTO 构造期已由唯一默认表填齐 9 字段）。
+- **stop 消费缺口**：A1 显式 WARN no-op 记录；graceful-stop handler 单开 issue（不塞本 ADR）。
+- **#5646 收敛**（迁移门⑤）：API 预校验走 DTO 构造（`StartAssignment(...)`/`from_payload`），`MalformedAssignmentError` 被 service 层 `try/except`（`:731-733`）转 `ServiceResult.error`。#5646 那套手写 BusinessError 字面预校验被 DTO 构造取代，校验更严（缺字段在构造期而非 service 字面 if）。
+- **魔法数标注**：service 哨兵（`:712` `if initial_cash != 100000.0 ...`）与 DTO `initial_cash` 默认共享 `100000.0` 这个数，**改一处须同步**。
+- **测试面（replace 不 layer）**：`tests/unit/interfaces/test_backtest_assignment_dto.py`——round-trip `to_payload(from_payload(d))==d`、9 默认值应用、`from_payload` 拒畸形（缺 task_uuid / 未知 command / stop 带 start-config / 缺 portfolio_uuid·dates）。消费端硬编码默认断言、字面校验断言删除。
+- **迁移顺序**（单分支 `6447-refactor/backtest-assignment-contract`，单 PR 5 commit，TDD 每步先测试）：
+  ① DTO 层 3 类 + config spec + from/to_payload + seam 测试（含本 ADR；不动调用方，纯新增零风险）
+  ② 生产端 3 dict → `Assignment(...).to_payload()`，门：新旧 payload 字节级相等（除死字段）
+  ③ 消费端 `.get()`+默认表 → `from_payload`+match+`assignment_to_backtest_config`，门：同 payload 构出同 BacktestConfig
+  ④ 删死代码 + 验证死字段停发，门：grep 零命中死字段+旧 API
+  ⑤ #5646 API 预校验收敛进 DTO 构造，门：缺字段任务在 service 层即 `ServiceResult.error`，不进 Kafka
+- **风险**：全量测试 OOM（~20GB，见测试原则）——主门用 backtest 派发/消费路径分模块测，全量终验；`BacktestConfig` 映射须逐字段确认语义。
+- **交叉引用**：ADR-010（DTO=状态信使、状态主体分离）、ADR-017（类型契约 > 字符串分派）、ADR-009（不触 Base）、ADR-002（DTO 在边界层，service→CRUD 层化不涉及）。
+
+## 判定标准自检
+
+- ① **难逆转**：契约 shape 承诺跨生产+消费+测试，回退需重散 5 处——满足。
+- ② **反直觉**：未来见 `StartAssignment|StopAssignment|CancelAssignment` 三类 + `from_payload` + Stop 的 WARN no-op 会问"为何不是一个 dict / stop 为何不执行"——满足。
+- ③ **真实权衡**：联合形态 A/B/C + stop 处置 + 死字段 + 错误传播 + 映射位置五轴均有真实备选——满足。

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -29,6 +29,8 @@
 | ADR-014 | [core/database.py 半 gitignore + api 层禁裸 SQL](ADR-014-core-database-gitignored.md) | Accepted | 2026-06-19 |
 | ADR-015 | [web-ui 以 shadcn-vue 为唯一 UI 组件标准栈](ADR-015-webui-shadcn-vue.md) | Accepted | 2026-06-19 |
 | ADR-016 | [回测标识符边界（task_id / engine_id / uuid）](ADR-016-backtest-id-boundary.md) | Accepted | 2026-06-19 |
+| ADR-017 | [事件订阅契约归组件（@subscribes + __init_subclass__）](ADR-017-event-subscription-contract.md) | Accepted | 2026-06-23 |
+| ADR-018 | [回测派发契约（判别联合 + DTO 层 wire spec）](ADR-018-backtest-assignment-contract.md) | Accepted | 2026-06-28 |
 
 ## 如何新增 / 修订
 

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -189,7 +189,12 @@ def run_task(
         initial_cash=config_snapshot.get("initial_cash", 100000),
         commission_rate=config_snapshot.get("commission_rate", 0.0003),
         slippage_rate=config_snapshot.get("slippage_rate", 0.0001),
+        benchmark_return=config_snapshot.get("benchmark_return", 0.0),
+        max_position_ratio=config_snapshot.get("max_position_ratio", 0.3),
+        stop_loss_ratio=config_snapshot.get("stop_loss_ratio", 0.05),
+        take_profit_ratio=config_snapshot.get("take_profit_ratio", 0.15),
         frequency=config_snapshot.get("frequency", "DAY"),
+        analyzers=[],
     )
 
     portfolio_uuid = task.portfolio_id

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -601,6 +601,17 @@ class BacktestTaskService(BaseService):
                     f"Task must be in one of: {', '.join(startable_states)}"
                 )
 
+            # 校验 portfolio 关联：派发前确认 portfolio_uuid 可解析，否则 worker
+            # 消费空值时会报误导性的 'portfolio_uuid is required'（#5646）
+            # 时序不变式：必须在清理块（删 9 表，CH 不可逆）之前——孤儿任务在删数据前即拒，
+            # 否则历史 order/position/signal/analyzer 被永久删除后才在 DTO 处拒绝（#6461 回归）
+            if not (portfolio_uuid or task.portfolio_id):
+                return ServiceResult.error(
+                    f"Backtest task '{task.uuid[:8]}' has no portfolio associated. "
+                    f"Recreate the backtest with a valid --portfolio binding so the "
+                    f"worker receives a non-empty portfolio_uuid."
+                )
+
             # ========== 重新运行：删除旧数据 ==========
             task_id = task.task_id
 

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -601,6 +601,24 @@ class BacktestTaskService(BaseService):
                     f"Task must be in one of: {', '.join(startable_states)}"
                 )
 
+            # 解析派发输入（snapshot_config / dates）：必须在守卫与清理块之前完成，
+            # 下方 portfolio/dates 守卫据此判定有效性——空字段同样要在删数据前即拒。
+            try:
+                snapshot_config = json.loads(task.config_snapshot) if task.config_snapshot else {}
+            except (json.JSONDecodeError, TypeError):
+                snapshot_config = {}
+
+            # 优先级：显式参数 > 数据库列 backtest_start/end_date > config_snapshot > ""
+            if not start_date and task.backtest_start_date:
+                start_date = task.backtest_start_date.strftime("%Y-%m-%d")
+            elif not start_date:
+                start_date = snapshot_config.get("start_date", "")
+
+            if not end_date and task.backtest_end_date:
+                end_date = task.backtest_end_date.strftime("%Y-%m-%d")
+            elif not end_date:
+                end_date = snapshot_config.get("end_date", "")
+
             # 校验 portfolio 关联：派发前确认 portfolio_uuid 可解析，否则 worker
             # 消费空值时会报误导性的 'portfolio_uuid is required'（#5646）
             # 时序不变式：必须在清理块（删 9 表，CH 不可逆）之前——孤儿任务在删数据前即拒，
@@ -610,6 +628,17 @@ class BacktestTaskService(BaseService):
                     f"Backtest task '{task.uuid[:8]}' has no portfolio associated. "
                     f"Recreate the backtest with a valid --portfolio binding so the "
                     f"worker receives a non-empty portfolio_uuid."
+                )
+
+            # 校验日期范围：空 dates 同样需在清理块之前拒——否则重跑先删光 9 表历史
+            # 数据（CH 5 表异步 mutation 不可逆）后才在 DTO 构造期拒绝，数据永久丢失。
+            # （#6461 round-4 finding 的 dates 维度：与 portfolio 守卫同一时序不变式）
+            if not start_date or not end_date:
+                return ServiceResult.error(
+                    f"Backtest task '{task.uuid[:8]}' has no valid date range "
+                    f"(start_date={start_date!r}, end_date={end_date!r}). "
+                    f"Recreate the backtest with valid --start/--end bindings so the "
+                    f"worker receives a non-empty date range."
                 )
 
             # ========== 重新运行：删除旧数据 ==========
@@ -670,22 +699,8 @@ class BacktestTaskService(BaseService):
 
             real_uuid = task.uuid  # 用于更新状态
 
-            # 从 config_snapshot 恢复配置作为基础
-            try:
-                snapshot_config = json.loads(task.config_snapshot) if task.config_snapshot else {}
-            except (json.JSONDecodeError, TypeError):
-                snapshot_config = {}
-
-            # 如果没有提供日期，依次尝试数据库列和 config_snapshot
-            if not start_date and task.backtest_start_date:
-                start_date = task.backtest_start_date.strftime("%Y-%m-%d")
-            elif not start_date:
-                start_date = snapshot_config.get("start_date", "")
-
-            if not end_date and task.backtest_end_date:
-                end_date = task.backtest_end_date.strftime("%Y-%m-%d")
-            elif not end_date:
-                end_date = snapshot_config.get("end_date", "")
+            # snapshot_config / start_date / end_date 已在守卫前解析完成（见上方），
+            # 此处直接用于组装 Kafka config 与状态更新。
 
             # 先更新状态为 pending，确保 Worker 查询时能看到正确的状态
             status_result = self.update_status(real_uuid, status="pending")
@@ -714,8 +729,10 @@ class BacktestTaskService(BaseService):
             if initial_cash != 100000.0 or "initial_cash" not in kafka_config:
                 kafka_config["initial_cash"] = initial_cash
 
-            # ADR-018 第⑤步：DTO 构造期校验（缺 portfolio_uuid/空 dates 等）取代手写预校验，
-            # 缺字段在 service 层即拒，不进 Kafka（#5646 收敛）
+            # DTO 构造期校验作为二次门：缺 portfolio_uuid / 空 dates 等已由上方
+            # 早返回守卫在不可逆清理块之前拦截（时序不变式，#6461 round-4 finding）；
+            # 此处 DTO Field(min_length=1) 再兜底校验 wire spec，构造失败则不派发 Kafka（#5646）。
+            # 两层并存是有意为之：守卫保时序（先于删数据），DTO 保契约（派发本体）。
             from pydantic import ValidationError
             from ginkgo.interfaces.dtos.backtest_assignment_dto import (
                 BacktestAssignmentConfig, StartAssignment,

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -695,8 +695,8 @@ class BacktestTaskService(BaseService):
             # 构建 Kafka config：从 config_snapshot 恢复，显式参数覆盖
             kafka_config = {}
             # 从 snapshot 恢复所有字段作为基础
+            # ADR-018：死字段 broker_type/broker_attitude/commission_min 不进 wire spec（消费端 BacktestConfig 不读）
             for key in ("initial_cash", "commission_rate", "slippage_rate", "frequency",
-                        "broker_type", "broker_attitude", "commission_min",
                         "benchmark_return", "max_position_ratio",
                         "stop_loss_ratio", "take_profit_ratio"):
                 if key in snapshot_config:
@@ -712,14 +712,17 @@ class BacktestTaskService(BaseService):
             if initial_cash != 100000.0 or "initial_cash" not in kafka_config:
                 kafka_config["initial_cash"] = initial_cash
 
+            # ADR-018：手搓 dict literal → 判别联合 DTO（构造期校验 + 唯一默认表 + dict 序列化）
+            from ginkgo.interfaces.dtos.backtest_assignment_dto import (
+                BacktestAssignmentConfig, StartAssignment,
+            )
             producer = GinkgoProducer()
-            assignment = {
-                "task_uuid": task_id,  # task_id 保持不变
-                "portfolio_uuid": portfolio_uuid or task.portfolio_id,
-                "name": name or task.name or f"backtest_{task_id[:8]}",
-                "command": "start",
-                "config": kafka_config,
-            }
+            assignment = StartAssignment(
+                task_uuid=task_id,  # task_id 保持不变
+                portfolio_uuid=portfolio_uuid or task.portfolio_id,
+                name=name or task.name or f"backtest_{task_id[:8]}",
+                config=BacktestAssignmentConfig(**kafka_config),
+            ).to_payload()
 
             producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
             producer.flush(timeout=2.0)
@@ -764,11 +767,10 @@ class BacktestTaskService(BaseService):
 
             real_uuid = task.uuid  # 用于更新状态
             task_id = task.task_id   # 任务标识
+            # ADR-018：StopAssignment.to_payload() —— 判别联合，command 是类型标记非手写字段
+            from ginkgo.interfaces.dtos.backtest_assignment_dto import StopAssignment
             producer = GinkgoProducer()
-            assignment = {
-                "task_uuid": task_id,  # 使用 task_id
-                "command": "stop",
-            }
+            assignment = StopAssignment(task_uuid=task_id).to_payload()  # 使用 task_id
 
             producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
             producer.flush(timeout=2.0)
@@ -817,11 +819,10 @@ class BacktestTaskService(BaseService):
 
             real_uuid = task.uuid  # 用于更新状态
             task_id = task.task_id   # 任务标识
+            # ADR-018：CancelAssignment.to_payload() —— 判别联合
+            from ginkgo.interfaces.dtos.backtest_assignment_dto import CancelAssignment
             producer = GinkgoProducer()
-            assignment = {
-                "task_uuid": task_id,  # 使用 task_id
-                "command": "cancel",
-            }
+            assignment = CancelAssignment(task_uuid=task_id).to_payload()  # 使用 task_id
 
             producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
             producer.flush(timeout=2.0)

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -601,15 +601,6 @@ class BacktestTaskService(BaseService):
                     f"Task must be in one of: {', '.join(startable_states)}"
                 )
 
-            # 校验 portfolio 关联：派发前确认 portfolio_uuid 可解析，否则 worker
-            # 消费空值时会报误导性的 'portfolio_uuid is required'（#5646）
-            if not (portfolio_uuid or task.portfolio_id):
-                return ServiceResult.error(
-                    f"Backtest task '{task.uuid[:8]}' has no portfolio associated. "
-                    f"Recreate the backtest with a valid --portfolio binding so the "
-                    f"worker receives a non-empty portfolio_uuid."
-                )
-
             # ========== 重新运行：删除旧数据 ==========
             task_id = task.task_id
 
@@ -712,17 +703,22 @@ class BacktestTaskService(BaseService):
             if initial_cash != 100000.0 or "initial_cash" not in kafka_config:
                 kafka_config["initial_cash"] = initial_cash
 
-            # ADR-018：手搓 dict literal → 判别联合 DTO（构造期校验 + 唯一默认表 + dict 序列化）
+            # ADR-018 第⑤步：DTO 构造期校验（缺 portfolio_uuid/空 dates 等）取代手写预校验，
+            # 缺字段在 service 层即拒，不进 Kafka（#5646 收敛）
+            from pydantic import ValidationError
             from ginkgo.interfaces.dtos.backtest_assignment_dto import (
                 BacktestAssignmentConfig, StartAssignment,
             )
             producer = GinkgoProducer()
-            assignment = StartAssignment(
-                task_uuid=task_id,  # task_id 保持不变
-                portfolio_uuid=portfolio_uuid or task.portfolio_id,
-                name=name or task.name or f"backtest_{task_id[:8]}",
-                config=BacktestAssignmentConfig(**kafka_config),
-            ).to_payload()
+            try:
+                assignment = StartAssignment(
+                    task_uuid=task_id,  # task_id 保持不变
+                    portfolio_uuid=portfolio_uuid or task.portfolio_id,
+                    name=name or task.name or f"backtest_{task_id[:8]}",
+                    config=BacktestAssignmentConfig(**kafka_config),
+                ).to_payload()
+            except ValidationError as e:
+                return ServiceResult.error(f"Invalid backtest assignment config: {e}")
 
             producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
             producer.flush(timeout=2.0)

--- a/src/ginkgo/interfaces/dtos/backtest_assignment_dto.py
+++ b/src/ginkgo/interfaces/dtos/backtest_assignment_dto.py
@@ -34,9 +34,9 @@ class BacktestAssignmentConfig(BaseModel):
     契约化后此表是唯一源，worker BacktestConfig 默认删除（迁移 ③）。
     """
 
-    # required
-    start_date: str
-    end_date: str
+    # required（min_length=1 拒空串，ADR-018 第⑤步补第③步删 worker 校验后的真空）
+    start_date: str = Field(min_length=1)
+    end_date: str = Field(min_length=1)
 
     # optional（唯一默认表 —— 改任一处须同步 service 哨兵 :712 的 100000.0）
     initial_cash: float = 100000.0

--- a/src/ginkgo/interfaces/dtos/backtest_assignment_dto.py
+++ b/src/ginkgo/interfaces/dtos/backtest_assignment_dto.py
@@ -67,8 +67,9 @@ class StartAssignment(_AssignmentBase):
     """启动回测命令：须带 portfolio + name + config。"""
 
     command: ClassVar[str] = "start"
-    portfolio_uuid: str
-    name: str
+    # required（min_length=1 拒空串，#5646 回归：与 config 字段同守 ADR-018 第⑤步真空）
+    portfolio_uuid: str = Field(min_length=1)
+    name: str = Field(min_length=1)
     config: BacktestAssignmentConfig
 
 

--- a/src/ginkgo/interfaces/dtos/backtest_assignment_dto.py
+++ b/src/ginkgo/interfaces/dtos/backtest_assignment_dto.py
@@ -1,105 +1,122 @@
-# Upstream: API层/Scheduler (构建分配消息)、BacktestWorker (消费进度消息)
-# Downstream: Kafka消息队列 (序列化传输)
-# Role: BacktestAssignmentDTO/BacktestProgressDTO回测任务分配与进度消息数据传输对象
+# Upstream: BacktestTaskService (start_task/stop_task/cancel_task)
+# Downstream: BacktestWorker node.py (_handle_task_assignment)
+# Role: 回测派发契约 wire spec —— 判别联合 + DTO 信使（ADR-018）
 
 """
-Backtest Assignment DTO
+回测派发契约 DTO 层（ADR-018）。
 
-回测任务分配消息（API/Scheduler → BacktestWorker）
+判别联合（discriminated union）：StartAssignment | StopAssignment | CancelAssignment，
+"哪个命令"是类型（ClassVar）非运行时字段，构造期即强制 stop 不能带 config。
+
+唯一 owner 藏构造/校验/默认/序列化：
+- 生产端 StartAssignment(...).to_payload() → producer.send(dict)
+- 消费端 from_payload(raw) → match cmd（type-guard 分派）
+
+详见 docs/adrs/ADR-018-backtest-assignment-contract.md
 """
+from typing import ClassVar, Union
 
-from dataclasses import dataclass
-from typing import Optional, Dict, Any
-from datetime import datetime
+from pydantic import BaseModel, Field, ValidationError
 
 
-@dataclass
-class BacktestAssignmentDTO:
-    """回测任务分配消息"""
+class MalformedAssignmentError(ValueError):
+    """from_payload 解析畸形 wire 载荷时抛出（缺 required / 未知或缺失 command / 类型错）。
 
-    command: str  # "start" or "cancel"
+    继承 ValueError：契约畸形属"输入错误"，消费端窄捕此异常标记任务失败 +
+    提交 offset（at-least-once），不触发重投。
+    """
+
+
+class BacktestAssignmentConfig(BaseModel):
+    """wire spec：start 命令的回测配置（11 字段，唯一默认表）。
+
+    默认值原样来自消费端 node.py:346-353 的硬编码表（双源靠巧合对齐）；
+    契约化后此表是唯一源，worker BacktestConfig 默认删除（迁移 ③）。
+    """
+
+    # required
+    start_date: str
+    end_date: str
+
+    # optional（唯一默认表 —— 改任一处须同步 service 哨兵 :712 的 100000.0）
+    initial_cash: float = 100000.0
+    commission_rate: float = 0.0003
+    slippage_rate: float = 0.0001
+    benchmark_return: float = 0.0
+    max_position_ratio: float = 0.3
+    stop_loss_ratio: float = 0.05
+    take_profit_ratio: float = 0.15
+    frequency: str = "DAY"
+    analyzers: list[dict] = Field(default_factory=list)  # 透传 list[dict]，worker 侧转 AnalyzerConfig（ADR-010 信使/主体分离）
+
+
+class _AssignmentBase(BaseModel):
+    """三命令共享：task_uuid + command 标记 + to_payload 序列化。"""
+
     task_uuid: str
+    command: ClassVar[str]  # 类型标记，非实例字段，不进 model_dump()
+
+    def to_payload(self) -> dict:
+        """model_dump() + 显式注入 command —— 目标 dict 非 json str（producer.send 收 dict）。"""
+        payload = self.model_dump()
+        payload["command"] = self.command
+        return payload
+
+
+class StartAssignment(_AssignmentBase):
+    """启动回测命令：须带 portfolio + name + config。"""
+
+    command: ClassVar[str] = "start"
     portfolio_uuid: str
     name: str
-    config: Dict[str, Any]
-
-    # 可选字段
-    priority: int = 0  # 优先级
-    timeout: Optional[int] = None  # 超时时间（秒）
-
-    def to_json(self) -> str:
-        """转换为JSON"""
-        import json
-        return json.dumps({
-            "command": self.command,
-            "task_uuid": self.task_uuid,
-            "portfolio_uuid": self.portfolio_uuid,
-            "name": self.name,
-            "config": self.config,
-            "priority": self.priority,
-            "timeout": self.timeout,
-        })
-
-    @classmethod
-    def from_json(cls, json_str: str) -> "BacktestAssignmentDTO":
-        """从JSON创建"""
-        import json
-        data = json.loads(json_str)
-        return cls(**data)
+    config: BacktestAssignmentConfig
 
 
-@dataclass
-class BacktestProgressDTO:
-    """回测进度消息（BacktestWorker → API）"""
+class StopAssignment(_AssignmentBase):
+    """停止 running 任务（端点 docstring 有意区别于 cancel 的取消 created/pending）。
 
-    type: str  # "progress", "stage", "completed", "failed", "cancelled"
-    task_uuid: str
-    worker_id: str
+    注：消费侧 graceful-stop handler 未实现（A1），node.py 仅 WARN no-op；
+    误带的 config 等多余字段由 from_payload 的 model_fields 过滤忽略——
+    判别联合的守护在返回类型层面（本类无 config 字段）。
+    """
 
-    # 进度信息
-    progress: Optional[float] = None
-    current_date: Optional[str] = None
-    state: Optional[str] = None
+    command: ClassVar[str] = "stop"
 
-    # 阶段信息
-    stage: Optional[str] = None
-    message: Optional[str] = None
 
-    # 结果/错误
-    result: Optional[Dict[str, Any]] = None
-    error: Optional[str] = None
+class CancelAssignment(_AssignmentBase):
+    """取消 created/pending 任务。"""
 
-    timestamp: Optional[str] = None
+    command: ClassVar[str] = "cancel"
 
-    def to_json(self) -> str:
-        """转换为JSON"""
-        import json
-        data = {
-            "type": self.type,
-            "task_uuid": self.task_uuid,
-            "worker_id": self.worker_id,
-        }
-        if self.progress is not None:
-            data["progress"] = self.progress
-        if self.current_date:
-            data["current_date"] = self.current_date
-        if self.state:
-            data["state"] = self.state
-        if self.stage:
-            data["stage"] = self.stage
-        if self.message:
-            data["message"] = self.message
-        if self.result:
-            data["result"] = self.result
-        if self.error:
-            data["error"] = self.error
-        if self.timestamp:
-            data["timestamp"] = self.timestamp
-        return json.dumps(data)
 
-    @classmethod
-    def from_json(cls, json_str: str) -> "BacktestProgressDTO":
-        """从JSON创建"""
-        import json
-        data = json.loads(json_str)
-        return cls(**data)
+# 判别联合类型别名（from_payload 返回类型 + 消费端 match 主体）
+Assignment = Union[StartAssignment, StopAssignment, CancelAssignment]
+
+
+def from_payload(raw: dict) -> Assignment:
+    """按 command 分流返子类，pydantic 构造期校验 required/类型，畸形 raise MalformedAssignmentError。
+
+    多余字段（如 stop 误带 config）按 model_fields 过滤忽略——守护在返回类型层面。
+    """
+    if not isinstance(raw, dict):
+        raise MalformedAssignmentError(
+            f"assignment payload must be dict, got {type(raw).__name__}"
+        )
+
+    command = raw.get("command")
+    if command == "start":
+        cls = StartAssignment
+    elif command == "stop":
+        cls = StopAssignment
+    elif command == "cancel":
+        cls = CancelAssignment
+    else:
+        # 缺 command 或未知 command 均畸形（今天消费 .get('command','start') 默认 start 的行为收紧）
+        raise MalformedAssignmentError(f"unknown or missing command: {command!r}")
+
+    # 只传子类已声明字段（model_fields 不含 ClassVar），多余键自动剔除
+    fields = {k: v for k, v in raw.items() if k != "command" and k in cls.model_fields}
+    try:
+        return cls(**fields)
+    except ValidationError as e:
+        raise MalformedAssignmentError(str(e)) from e

--- a/src/ginkgo/workers/backtest_worker/models.py
+++ b/src/ginkgo/workers/backtest_worker/models.py
@@ -62,6 +62,37 @@ class BacktestConfig:
     analyzers: list[AnalyzerConfig] = field(default_factory=list)
 
 
+def assignment_to_backtest_config(cmd) -> "BacktestConfig":
+    """ADR-018：StartAssignment（DTO 信使）→ BacktestConfig（worker 状态主体）。
+
+    第三者胶水映射，不挂 DTO 也不挂状态主体（ADR-010 信使/主体分离）。
+    analyzers list[dict] → list[AnalyzerConfig]，字段不全转 MalformedAssignmentError
+    （与消费端窄捕一致）。DTO 唯一默认表已填齐 9 optional，此处逐字段复制。
+    """
+    from ginkgo.interfaces.dtos.backtest_assignment_dto import MalformedAssignmentError
+
+    cfg = cmd.config
+    analyzers = []
+    for d in cfg.analyzers:
+        try:
+            analyzers.append(AnalyzerConfig(**d))
+        except TypeError as e:
+            raise MalformedAssignmentError(f"invalid analyzer config {d!r}: {e}") from e
+    return BacktestConfig(
+        start_date=cfg.start_date,
+        end_date=cfg.end_date,
+        initial_cash=cfg.initial_cash,
+        commission_rate=cfg.commission_rate,
+        slippage_rate=cfg.slippage_rate,
+        benchmark_return=cfg.benchmark_return,
+        max_position_ratio=cfg.max_position_ratio,
+        stop_loss_ratio=cfg.stop_loss_ratio,
+        take_profit_ratio=cfg.take_profit_ratio,
+        frequency=cfg.frequency,
+        analyzers=analyzers,
+    )
+
+
 @dataclass
 class BacktestTask:
     """回测任务"""

--- a/src/ginkgo/workers/backtest_worker/models.py
+++ b/src/ginkgo/workers/backtest_worker/models.py
@@ -70,8 +70,10 @@ def assignment_to_backtest_config(cmd) -> "BacktestConfig":
     """ADR-018：StartAssignment（DTO 信使）→ BacktestConfig（worker 状态主体）。
 
     第三者胶水映射，不挂 DTO 也不挂状态主体（ADR-010 信使/主体分离）。
-    analyzers list[dict] → list[AnalyzerConfig]，字段不全转 MalformedAssignmentError
-    （与消费端窄捕一致）。DTO 唯一默认表已填齐 9 optional，此处逐字段复制。
+    analyzers list[dict] → list[AnalyzerConfig]，字段不全转 MalformedAssignmentError。
+    消费端窄捕在 BacktestWorker._handle_task_assignment 的 match 块：from_payload 与本映射
+    抛错均走 MalformedAssignmentError 窄捕 → report_failed + 提交 offset（不重投，防毒丸死循环）。
+    DTO 唯一默认表已填齐 9 optional，此处逐字段复制。
     """
     from ginkgo.interfaces.dtos.backtest_assignment_dto import MalformedAssignmentError
 

--- a/src/ginkgo/workers/backtest_worker/models.py
+++ b/src/ginkgo/workers/backtest_worker/models.py
@@ -46,20 +46,24 @@ class AnalyzerConfig:
 
 @dataclass
 class BacktestConfig:
-    """回测配置"""
+    """回测配置（状态主体，ADR-018：默认表归 DTO BacktestAssignmentConfig）
+
+    无默认值——所有 11 字段 required。映射函数 assignment_to_backtest_config 显式传全；
+    进程内直接构造（测试/CLI 直跑）也须显式传全，杜绝 BacktestConfig↔DTO 默认 drift。
+    """
 
     start_date: str
     end_date: str
-    initial_cash: float = 100000.0
-    commission_rate: float = 0.0003
-    slippage_rate: float = 0.0001
-    benchmark_return: float = 0.0
-    max_position_ratio: float = 0.3
-    stop_loss_ratio: float = 0.05
-    take_profit_ratio: float = 0.15
-    frequency: str = "DAY"
+    initial_cash: float
+    commission_rate: float
+    slippage_rate: float
+    benchmark_return: float
+    max_position_ratio: float
+    stop_loss_ratio: float
+    take_profit_ratio: float
+    frequency: str
     # 分析器配置（Engine 级别）
-    analyzers: list[AnalyzerConfig] = field(default_factory=list)
+    analyzers: list[AnalyzerConfig]
 
 
 def assignment_to_backtest_config(cmd) -> "BacktestConfig":

--- a/src/ginkgo/workers/backtest_worker/node.py
+++ b/src/ginkgo/workers/backtest_worker/node.py
@@ -24,7 +24,7 @@ from ginkgo.libs import GLOG
 from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
 from ginkgo.workers.backtest_worker.progress_tracker import ProgressTracker
 from ginkgo.workers.backtest_worker.metrics import BacktestMetrics
-from ginkgo.workers.backtest_worker.models import BacktestTask, BacktestTaskState, AnalyzerConfig
+from ginkgo.workers.backtest_worker.models import BacktestTask, BacktestTaskState
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoConsumer, GinkgoProducer
 from ginkgo.data.drivers import create_redis_connection
 from ginkgo.libs import GCONF
@@ -215,24 +215,43 @@ class BacktestWorker:
         self.task_consumer_thread.start()
 
     def _handle_task_assignment(self, assignment: dict):
-        """处理任务分配
+        """处理任务分配（ADR-018：from_payload + match 判别联合）。
 
         #5399②: Kafka offset 在派发决策成功「之后」提交（at-least-once）。
         派发/处理异常时不提交，留给重启后 DB 状态去重 + Kafka 重投。
         """
-        task_uuid = assignment.get("task_uuid")
-        command = assignment.get("command", "start")
+        from ginkgo.interfaces.dtos.backtest_assignment_dto import (
+            from_payload, StartAssignment, StopAssignment, CancelAssignment,
+            MalformedAssignmentError,
+        )
 
+        # 畸形契约：构造期校验失败，标记任务失败 + 提交 offset（不重投，at-least-once）
         try:
-            if command == "start":
-                self._start_task(assignment)
-            elif command == "cancel":
-                self._cancel_task(task_uuid)
+            cmd = from_payload(assignment)
+        except MalformedAssignmentError as e:
+            task_uuid = assignment.get("task_uuid", "")
+            task_short = task_uuid[:8] if task_uuid else "unknown"
+            GLOG.ERROR(f"[{task_short}] Malformed assignment, marking failed: {e}")
+            self.progress_tracker.report_failed_by_uuid(task_uuid=task_uuid, error=str(e))
+            self._commit_assignment_offset(task_uuid)
+            return
+
+        task_uuid = cmd.task_uuid
+        try:
+            match cmd:
+                case StartAssignment():
+                    self._start_task(cmd)
+                case StopAssignment():
+                    # ADR-018 A1：stop 消费侧 handler 未实现，显式 WARN no-op（非静默掉 void）
+                    # graceful-stop handler 单开 issue；不改任务状态，提交 offset（消息已正确消费决策）
+                    GLOG.WARN(f"[{task_uuid[:8]}] stop command received but graceful-stop handler not implemented, no-op")
+                case CancelAssignment():
+                    self._cancel_task(task_uuid)
         except Exception as e:
             GLOG.ERROR(f"Error handling assignment {task_uuid}: {e}")
             raise
 
-        # 派发决策完成（派发/skip/discard 均视为消息已正确消费）后提交 offset
+        # 派发决策完成（派发/skip/no-op 均视为消息已正确消费）后提交 offset
         self._commit_assignment_offset(task_uuid)
 
     def _commit_assignment_offset(self, task_uuid: str):
@@ -245,11 +264,13 @@ class BacktestWorker:
             except Exception as e:
                 GLOG.ERROR(f"[{task_short}] Failed to commit offset after dispatch: {e}")
 
-    def _start_task(self, assignment: dict):
-        """启动新任务（阻塞等待空闲槽位）"""
-        # #5399③: 去重查找用完整 task_uuid（与 self.tasks 存储 key 一致），
-        # 日志显示单独截断，避免 [:8] 截断导致 :238 查找与 :354 存储 key 不匹配
-        task_uuid = assignment.get("task_uuid", "unknown")
+    def _start_task(self, cmd):
+        """启动新任务（阻塞等待空闲槽位）。
+
+        ADR-018：cmd 是 StartAssignment（DTO 构造期已校验 portfolio_uuid/dates/config）。
+        #5399③: 去重用完整 task_uuid（与 self.tasks 存储 key 一致）。
+        """
+        task_uuid = cmd.task_uuid
         task_short = task_uuid[:8] if task_uuid else "unknown"
 
         # 检查任务是否已经在 Worker 中运行
@@ -259,7 +280,7 @@ class BacktestWorker:
                 return
 
         # 检查任务状态
-        existing_status = self.progress_tracker.get_task_status(assignment.get("task_uuid"))
+        existing_status = self.progress_tracker.get_task_status(task_uuid)
         GLOG.DEBUG(f"[{task_short}] Current task status: {existing_status}")
 
         # 如果任务已完成/失败/取消，跳过
@@ -274,7 +295,7 @@ class BacktestWorker:
             try:
                 # 尝试重置状态为 created
                 result = self.progress_tracker.task_service.update_status(
-                    uuid=assignment.get("task_uuid"),
+                    uuid=task_uuid,
                     status="created"
                 )
                 if result.is_success():
@@ -305,66 +326,22 @@ class BacktestWorker:
                 GLOG.INFO(f"[{task_short}] Slot available, proceeding with task")
                 break
 
-        # 验证必要的任务参数
-        portfolio_uuid = assignment.get("portfolio_uuid")
-        if not portfolio_uuid:
-            GLOG.ERROR(f"[{task_short}] ERROR: portfolio_uuid is required but missing, discarding task")
-            # 上报任务失败到数据库
-            self.progress_tracker.report_failed_by_uuid(
-                task_uuid=assignment.get("task_uuid", ""),
-                error="portfolio_uuid is required"
-            )
-            return
-
-        # 验证日期参数
-        config_dict = assignment.get("config", {})
-        start_date = config_dict.get("start_date")
-        end_date = config_dict.get("end_date")
-        if not start_date or not end_date:
-            GLOG.ERROR(f"[{task_short}] ERROR: start_date and end_date are required, discarding task")
-            self.progress_tracker.report_failed_by_uuid(
-                task_uuid=assignment.get("task_uuid", ""),
-                error=f"Missing dates: start_date={start_date}, end_date={end_date}"
-            )
-            return
-
-        # 解析任务配置
-        from ginkgo.workers.backtest_worker.models import BacktestConfig
-
-        config_dict = assignment.get("config", {})
-
-        # 转换 analyzers 配置
-        analyzers = []
-        if "analyzers" in config_dict:
-            for analyzer_dict in config_dict["analyzers"]:
-                analyzers.append(AnalyzerConfig(**analyzer_dict))
-
-        # 创建 BacktestConfig（包含 analyzers）
-        config = BacktestConfig(
-            start_date=config_dict.get("start_date"),
-            end_date=config_dict.get("end_date"),
-            initial_cash=config_dict.get("initial_cash", 100000.0),
-            commission_rate=config_dict.get("commission_rate", 0.0003),
-            slippage_rate=config_dict.get("slippage_rate", 0.0001),
-            benchmark_return=config_dict.get("benchmark_return", 0.0),
-            max_position_ratio=config_dict.get("max_position_ratio", 0.3),
-            stop_loss_ratio=config_dict.get("stop_loss_ratio", 0.05),
-            take_profit_ratio=config_dict.get("take_profit_ratio", 0.15),
-            frequency=config_dict.get("frequency", "DAY"),
-            analyzers=analyzers,  # Engine 级别的分析器
-        )
+        # ADR-018：DTO 构造期已校验 portfolio_uuid/dates，删除字面校验块；
+        # BacktestConfig 由映射函数从 cmd 构造（唯一默认表归 DTO，消费端硬编码默认表删除）
+        from ginkgo.workers.backtest_worker.models import assignment_to_backtest_config
+        config = assignment_to_backtest_config(cmd)
 
         task = BacktestTask(
-            task_uuid=assignment["task_uuid"],
-            portfolio_uuid=assignment["portfolio_uuid"],
-            name=assignment["name"],
+            task_uuid=cmd.task_uuid,
+            portfolio_uuid=cmd.portfolio_uuid,
+            name=cmd.name,
             config=config,
             state=BacktestTaskState.PENDING,
         )
 
         GLOG.INFO(f"Starting task {task.task_uuid[:8]}: {task.name}")
-        if analyzers:
-            GLOG.INFO(f"  with {len(analyzers)} analyzers: {[a.name for a in analyzers]}")
+        if task.config.analyzers:
+            GLOG.INFO(f"  with {len(task.config.analyzers)} analyzers: {[a.name for a in task.config.analyzers]}")
 
         # 创建Processor
         processor = BacktestProcessor(task, self.worker_id, self.progress_tracker)

--- a/src/ginkgo/workers/backtest_worker/node.py
+++ b/src/ginkgo/workers/backtest_worker/node.py
@@ -247,11 +247,18 @@ class BacktestWorker:
                     GLOG.WARN(f"[{task_uuid[:8]}] stop command received but graceful-stop handler not implemented, no-op")
                 case CancelAssignment():
                     self._cancel_task(task_uuid)
+        except MalformedAssignmentError as e:
+            # 畸形 analyzer/config：from_payload 已通过，_start_task 映射期抛错。
+            # 对称窄捕（与上方 from_payload 畸形处理器同方法）——report_failed + 落到下方提交 offset。
+            # 不向上抛：否则 except Exception→raise 跳过 commit，poll 重投同一消息；
+            # 且映射抛错前 task 状态未置 failed，DB 去重兜不住 → Kafka 毒丸永久死循环。
+            GLOG.ERROR(f"[{task_uuid[:8]}] Malformed assignment (analyzer/config mapping), marking failed: {e}")
+            self.progress_tracker.report_failed_by_uuid(task_uuid=task_uuid, error=str(e))
         except Exception as e:
             GLOG.ERROR(f"Error handling assignment {task_uuid}: {e}")
             raise
 
-        # 派发决策完成（派发/skip/no-op 均视为消息已正确消费）后提交 offset
+        # 派发决策完成（派发/skip/no-op/畸形窄捕 均视为消息已正确消费）后提交 offset
         self._commit_assignment_offset(task_uuid)
 
     def _commit_assignment_offset(self, task_uuid: str):

--- a/tests/integration/backtest/test_backtest_orchestrator_smoke.py
+++ b/tests/integration/backtest/test_backtest_orchestrator_smoke.py
@@ -161,7 +161,12 @@ class TestOrchestratorSmoke:
             initial_cash=100000,
             commission_rate=0.0003,
             slippage_rate=0.0001,
+            benchmark_return=0.0,
+            max_position_ratio=0.3,
+            stop_loss_ratio=0.05,
+            take_profit_ratio=0.15,
             frequency="DAY",
+            analyzers=[],
         )
 
         backtest_task_svc = container.backtest_task_service()

--- a/tests/unit/data/services/test_backtest_task_assignment_payload.py
+++ b/tests/unit/data/services/test_backtest_task_assignment_payload.py
@@ -1,0 +1,144 @@
+"""
+ADR-018 第②步：生产端 payload 契约（StartAssignment/StopAssignment/CancelAssignment.to_payload）
+
+门：新旧 payload 字节级相等（除死字段 broker_type/broker_attitude/commission_min 停发）。
+聚焦 payload 结构 + 死字段停发 + 11 字段齐全；config 值恢复细节由
+test_backtest_task_start_config.py 覆盖（此处不重复）。
+
+详见 docs/adrs/ADR-018-backtest-assignment-contract.md
+"""
+import sys
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_task(**overrides):
+    task = MagicMock()
+    task.uuid = "uuid-1234-5678"
+    task.task_id = "task-abc"
+    task.portfolio_id = "portfolio-001"
+    task.name = "test_backtest"
+    task.backtest_start_date = None
+    task.backtest_end_date = None
+    task.status = "completed"
+    task.config_snapshot = json.dumps({
+        "start_date": "2025-06-01",
+        "end_date": "2026-06-01",
+        "initial_cash": 200000.0,
+    })
+    for k, v in overrides.items():
+        setattr(task, k, v)
+    return task
+
+
+@contextmanager
+def _mock_kafka():
+    mock_producer = MagicMock()
+    mock_container = MagicMock()
+    with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer), \
+         patch("ginkgo.data.containers.container", mock_container):
+        yield mock_producer
+
+
+@pytest.fixture
+def service():
+    crud = MagicMock()
+    return BacktestTaskService(crud_repo=crud)
+
+
+def _setup_task(service, task):
+    service._crud_repo.get_by_uuid.return_value = task
+    service._crud_repo.find.return_value = []
+    service.update_status = MagicMock(return_value=ServiceResult.success(task, "ok"))
+
+
+def _sent_payload(mock_producer):
+    """producer.send(topic, payload) 的 payload（第二位置参数）。"""
+    return mock_producer.send.call_args[0][1]
+
+
+# ---------- start payload 契约 ----------
+
+class TestStartPayload:
+    DEAD_FIELDS = ("broker_type", "broker_attitude", "commission_min")
+
+    @pytest.mark.unit
+    def test_start_payload_structure(self, service):
+        """start payload = StartAssignment.to_payload()：5 键 task_uuid/portfolio_uuid/name/command/config。"""
+        task = _make_task()
+        _setup_task(service, task)
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234-5678")
+        assert result.is_success()
+        payload = _sent_payload(mp)
+        assert set(payload.keys()) == {"task_uuid", "portfolio_uuid", "name", "command", "config"}
+        assert payload["command"] == "start"
+        assert payload["task_uuid"] == "task-abc"
+
+    @pytest.mark.unit
+    def test_dead_fields_not_sent(self, service):
+        """ADR-018：死字段 broker_type/broker_attitude/commission_min 生产端停发，不进 wire config。"""
+        snapshot = {
+            "start_date": "2025-06-01", "end_date": "2026-06-01",
+            "broker_type": "mock", "broker_attitude": "real", "commission_min": 5.0,
+        }
+        task = _make_task(config_snapshot=json.dumps(snapshot))
+        _setup_task(service, task)
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234-5678")
+        assert result.is_success()
+        config = _sent_payload(mp)["config"]
+        for dead in self.DEAD_FIELDS:
+            assert dead not in config, f"死字段 {dead} 不应进 wire payload"
+
+    @pytest.mark.unit
+    def test_config_has_eleven_fields(self, service):
+        """config 唯一默认表归 DTO：snapshot 未给的 optional 由 DTO 构造期填默认，11 字段齐全。"""
+        task = _make_task()  # snapshot 只给 start/end/initial_cash
+        _setup_task(service, task)
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234-5678")
+        assert result.is_success()
+        config = _sent_payload(mp)["config"]
+        expected = {"start_date", "end_date", "initial_cash", "commission_rate",
+                    "slippage_rate", "benchmark_return", "max_position_ratio",
+                    "stop_loss_ratio", "take_profit_ratio", "frequency", "analyzers"}
+        assert set(config.keys()) == expected
+
+
+# ---------- stop payload 契约 ----------
+
+class TestStopPayload:
+    @pytest.mark.unit
+    def test_stop_payload_minimal(self, service):
+        """stop payload = StopAssignment.to_payload()：仅 {task_uuid, command}。"""
+        task = _make_task(status="running")
+        _setup_task(service, task)
+        with _mock_kafka() as mp:
+            result = service.stop_task(uuid="uuid-1234-5678")
+        assert result.is_success()
+        assert _sent_payload(mp) == {"task_uuid": "task-abc", "command": "stop"}
+
+
+# ---------- cancel payload 契约 ----------
+
+class TestCancelPayload:
+    @pytest.mark.unit
+    def test_cancel_payload_minimal(self, service):
+        """cancel payload = CancelAssignment.to_payload()：仅 {task_uuid, command}。"""
+        task = _make_task(status="created")
+        _setup_task(service, task)
+        with _mock_kafka() as mp:
+            result = service.cancel_task(uuid="uuid-1234-5678")
+        assert result.is_success()
+        assert _sent_payload(mp) == {"task_uuid": "task-abc", "command": "cancel"}

--- a/tests/unit/data/services/test_backtest_task_start_config.py
+++ b/tests/unit/data/services/test_backtest_task_start_config.py
@@ -134,15 +134,20 @@ class TestStartTaskRestoresConfigFromSnapshot:
 
     @pytest.mark.unit
     def test_fallback_when_config_snapshot_empty(self, service):
-        """config_snapshot 为空时回退到默认值"""
+        """config_snapshot 为空且无 DB dates → ADR-018 第⑤步收敛：缺 dates 在 service 层
+        DTO 构造期即拒（Field min_length=1），不进 Kafka（#5646）。
+
+        旧 #5839 断言「空 snapshot 回退空串仍派发」已与此矛盾——空 dates 派发给 worker 是
+        #5646 要修的 bug（worker 侧字面校验第③步已删，DTO 是唯一关口）。
+        config_snapshot 空时 initial_cash 等可选字段的默认表归 DTO BacktestAssignmentConfig，
+        不再有「空 snapshot 派发空 dates」路径。
+        """
         task = _make_task(config_snapshot="{}", backtest_start_date=None, backtest_end_date=None)
         _setup_task(service, task)
 
         with _mock_kafka_and_container() as mock_producer:
             result = service.start_task(uuid="uuid-1234-5678")
 
-        assert result.is_success()
-        config = _get_kafka_config(mock_producer)
-        assert config["start_date"] == ""
-        assert config["end_date"] == ""
-        assert config["initial_cash"] == 100000.0
+        assert not result.is_success(), \
+            f"空 snapshot 无 dates 应在 service 层被拒（ADR-018⑤），got success"
+        mock_producer.send.assert_not_called()

--- a/tests/unit/data/services/test_backtest_task_start_validation.py
+++ b/tests/unit/data/services/test_backtest_task_start_validation.py
@@ -1,10 +1,12 @@
-"""ADR-018 第⑤步：#5646 预校验收敛进 DTO 构造。
+"""ADR-018：回测派发契约的早返回守卫 + DTO 二次校验（两层并存，职责不同）。
 
-门（L95）：缺字段任务在 service 层即 ServiceResult.error，不进 Kafka。
-- 空 dates → DTO BacktestAssignmentConfig Field(min_length=1) 构造期 ValidationError
-  （补第③步删 worker 字面校验后的真空——空串 dates 现由 DTO 构造期拒）
-- 缺 portfolio_uuid → DTO StartAssignment required str 构造期 ValidationError
-  （删 service :604-611 手写 portfolio_uuid if，DTO 构造期校验取代，校验更严）
+门：缺字段任务在 service 层即 ServiceResult.error，不进 Kafka。
+- 早返回守卫（start_task 状态检查后/清理块前）守「拒绝先于不可逆清理」时序不变式：
+  缺 portfolio_uuid / 空 dates 在删 9 表历史数据（CH 5 表异步 mutation 不可逆 +
+  MySQL 4 表单事务 commit）之前即拒，否则「先删后拒」数据永久丢失（#6461 round-4）。
+  含 test_*_rejects_before_cleanup：断言 9 表清理 CRUD.remove 未被调用（副作用非返回值）。
+- DTO 构造期 Field(min_length=1) 作为二次门守 wire spec 兜底（#5646），与守卫职责
+  不可互替——守卫保时序（先于删数据），DTO 保契约（派发本体）。
 
 详见 docs/adrs/ADR-018-backtest-assignment-contract.md
 """

--- a/tests/unit/data/services/test_backtest_task_start_validation.py
+++ b/tests/unit/data/services/test_backtest_task_start_validation.py
@@ -1,0 +1,84 @@
+"""ADR-018 第⑤步：#5646 预校验收敛进 DTO 构造。
+
+门（L95）：缺字段任务在 service 层即 ServiceResult.error，不进 Kafka。
+- 空 dates → DTO BacktestAssignmentConfig Field(min_length=1) 构造期 ValidationError
+  （补第③步删 worker 字面校验后的真空——空串 dates 现由 DTO 构造期拒）
+- 缺 portfolio_uuid → DTO StartAssignment required str 构造期 ValidationError
+  （删 service :604-611 手写 portfolio_uuid if，DTO 构造期校验取代，校验更严）
+
+详见 docs/adrs/ADR-018-backtest-assignment-contract.md
+"""
+import sys
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_task(**overrides):
+    task = MagicMock()
+    task.uuid = "uuid-1234"
+    task.task_id = "task-abc"
+    task.portfolio_id = "portfolio-001"
+    task.name = "test"
+    task.backtest_start_date = None
+    task.backtest_end_date = None
+    task.status = "created"
+    task.config_snapshot = json.dumps({"start_date": "2025-01-01", "end_date": "2025-12-31"})
+    for k, v in overrides.items():
+        setattr(task, k, v)
+    return task
+
+
+@contextmanager
+def _mock_kafka():
+    mp = MagicMock()
+    with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mp), \
+         patch("ginkgo.data.containers.container", MagicMock()):
+        yield mp
+
+
+@pytest.fixture
+def service():
+    return BacktestTaskService(crud_repo=MagicMock())
+
+
+def _setup(service, task):
+    service._crud_repo.get_by_uuid.return_value = task
+    service._crud_repo.find.return_value = []
+    service.update_status = MagicMock(return_value=ServiceResult.success(task, "ok"))
+
+
+class TestStartTaskValidationInDto:
+    """#5646 预校验收敛：缺字段在 service 层 DTO 构造期即拒，不进 Kafka。"""
+
+    @pytest.mark.unit
+    def test_empty_dates_returns_error_no_kafka(self, service):
+        """空 dates → DTO 构造期 ValidationError → ServiceResult.error，producer.send 不调。"""
+        task = _make_task(config_snapshot=json.dumps({"start_date": "", "end_date": "2025-12-31"}))
+        _setup(service, task)
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234")
+        assert not result.is_success(), f"空 dates 应在 service 层被拒，got success: {result.error}"
+        mp.send.assert_not_called()
+
+    @pytest.mark.unit
+    def test_missing_portfolio_returns_error_no_kafka(self, service):
+        """缺 portfolio_uuid（task.portfolio_id 也无）→ DTO StartAssignment required str → ServiceResult.error，不进 Kafka。"""
+        task = _make_task(
+            portfolio_id=None,
+            config_snapshot=json.dumps({"start_date": "2025-01-01", "end_date": "2025-12-31"}),
+        )
+        _setup(service, task)
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234")  # 不传 portfolio_uuid
+        assert not result.is_success(), f"缺 portfolio_uuid 应在 service 层被拒，got success"
+        mp.send.assert_not_called()

--- a/tests/unit/data/services/test_backtest_task_start_validation.py
+++ b/tests/unit/data/services/test_backtest_task_start_validation.py
@@ -46,6 +46,43 @@ def _mock_kafka():
         yield mp
 
 
+def _inject_cleanup_cruds(service):
+    """注入 9 个 mock 清理 CRUD（CH 5 + MySQL 4），返回 {name: MagicMock}。
+
+    用于断言「先删后拒」副作用：孤儿/空字段重跑时，9 表清理 CRUD.remove
+    不应在拒绝前被调用（不可逆删除历史数据，见 #6461 round-4 finding）。
+    """
+    cleanup = {
+        "signal": MagicMock(), "position_record": MagicMock(),
+        "analyzer_record": MagicMock(), "order_record": MagicMock(),
+        "transfer_record": MagicMock(),            # ClickHouse 5（异步 mutation，不可逆）
+        "order": MagicMock(), "position": MagicMock(),
+        "transfer": MagicMock(), "signal_tracker": MagicMock(),  # MySQL 4（单事务）
+    }
+    service._signal_crud = cleanup["signal"]
+    service._position_record_crud = cleanup["position_record"]
+    service._analyzer_record_crud = cleanup["analyzer_record"]
+    service._order_record_crud = cleanup["order_record"]
+    service._transfer_record_crud = cleanup["transfer_record"]
+    service._order_crud = cleanup["order"]
+    service._position_crud = cleanup["position"]
+    service._transfer_crud = cleanup["transfer"]
+    service._signal_tracker_crud = cleanup["signal_tracker"]
+    return cleanup
+
+
+def _assert_no_cleanup_ran(cleanup, *, dimension):
+    """断言清理块未执行：9 个 CRUD.remove 均未被调用。
+
+    违反「拒绝必须先于不可逆清理」时序不变式时，给出泄漏表名。
+    """
+    leaked = [n for n, c in cleanup.items() if c.remove.called]
+    assert not leaked, (
+        f"{dimension} 守卫缺失：清理块在拒绝前执行，删除了 {leaked}"
+        f"（违反'拒绝先于不可逆清理'时序不变式，见 #6461 round-4 finding）"
+    )
+
+
 @pytest.fixture
 def service():
     return BacktestTaskService(crud_repo=MagicMock())
@@ -98,28 +135,34 @@ class TestStartTaskValidationInDto:
             config_snapshot=json.dumps({"start_date": "2025-01-01", "end_date": "2025-12-31"}),
         )
         _setup(service, task)
-        # 注入 mock 清理 CRUD，验证清理块未执行（否则数据被删）
-        cleanup = {
-            "signal": MagicMock(), "position_record": MagicMock(),
-            "analyzer_record": MagicMock(), "order_record": MagicMock(),
-            "transfer_record": MagicMock(),  # ClickHouse 5
-            "order": MagicMock(), "position": MagicMock(),
-            "transfer": MagicMock(), "signal_tracker": MagicMock(),  # MySQL 4
-        }
-        service._signal_crud = cleanup["signal"]
-        service._position_record_crud = cleanup["position_record"]
-        service._analyzer_record_crud = cleanup["analyzer_record"]
-        service._order_record_crud = cleanup["order_record"]
-        service._transfer_record_crud = cleanup["transfer_record"]
-        service._order_crud = cleanup["order"]
-        service._position_crud = cleanup["position"]
-        service._transfer_crud = cleanup["transfer"]
-        service._signal_tracker_crud = cleanup["signal_tracker"]
+        cleanup = _inject_cleanup_cruds(service)
 
         with _mock_kafka() as mp:
             result = service.start_task(uuid="uuid-1234")  # 不传 portfolio_uuid
 
         assert not result.is_success(), "孤儿任务应在 service 层被拒"
         mp.send.assert_not_called()
-        leaked = [n for n, c in cleanup.items() if c.remove.called]
-        assert not leaked, f"#5646 守卫缺失：清理块在拒绝前执行，删除了 {leaked}"
+        _assert_no_cleanup_ran(cleanup, dimension="portfolio")
+
+    @pytest.mark.unit
+    def test_empty_dates_rejects_before_cleanup(self, service):
+        """dates 守卫扩展：portfolio 有效但 start_date 空时，重跑必须在清理块之前拒——
+        9 表清理 CRUD.remove 不应被调用（同 #5646 时序不变式，dates 维度）。
+
+        复现：原找回的守卫仅覆盖 portfolio，空 dates 仍走「清理→置 pending→DTO 拒」，
+        先删光历史 order/position/signal/transfer/analyzer 数据后才拒绝。
+        """
+        task = _make_task(
+            portfolio_id="portfolio-001",  # 有效 portfolio（绕过 portfolio 守卫）
+            status="completed",            # 重跑场景：任务曾跑过，有历史数据
+            config_snapshot=json.dumps({"start_date": "", "end_date": "2025-12-31"}),
+        )
+        _setup(service, task)
+        cleanup = _inject_cleanup_cruds(service)
+
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234")  # 不传 start/end
+
+        assert not result.is_success(), "空 dates 应在 service 层被拒"
+        mp.send.assert_not_called()
+        _assert_no_cleanup_ran(cleanup, dimension="dates")

--- a/tests/unit/data/services/test_backtest_task_start_validation.py
+++ b/tests/unit/data/services/test_backtest_task_start_validation.py
@@ -72,7 +72,10 @@ class TestStartTaskValidationInDto:
 
     @pytest.mark.unit
     def test_missing_portfolio_returns_error_no_kafka(self, service):
-        """缺 portfolio_uuid（task.portfolio_id 也无）→ DTO StartAssignment required str → ServiceResult.error，不进 Kafka。"""
+        """缺 portfolio_uuid（task.portfolio_id 也无）→ #5646 守卫在清理块之前早返回 ServiceResult.error，不进 Kafka。
+
+        守卫恢复后拒绝发生在守卫（早返回），非 DTO 构造期；二者皆 service 层拒绝，不进 Kafka。
+        """
         task = _make_task(
             portfolio_id=None,
             config_snapshot=json.dumps({"start_date": "2025-01-01", "end_date": "2025-12-31"}),
@@ -82,3 +85,41 @@ class TestStartTaskValidationInDto:
             result = service.start_task(uuid="uuid-1234")  # 不传 portfolio_uuid
         assert not result.is_success(), f"缺 portfolio_uuid 应在 service 层被拒，got success"
         mp.send.assert_not_called()
+
+    @pytest.mark.unit
+    def test_missing_portfolio_rejects_before_cleanup(self, service):
+        """#5646 守卫回归：孤儿任务（无 portfolio）重跑必须在清理块之前拒——
+        9 表清理 CRUD.remove 不应被调用，否则历史数据在拒绝前被不可逆删除。
+        （复现 PR 删守卫引入的回归：清理块在 DTO 拒绝前执行，删光 order/position/signal/analyzer 历史）
+        """
+        task = _make_task(
+            portfolio_id=None,
+            status="completed",  # 重跑场景：任务曾跑过，有历史数据
+            config_snapshot=json.dumps({"start_date": "2025-01-01", "end_date": "2025-12-31"}),
+        )
+        _setup(service, task)
+        # 注入 mock 清理 CRUD，验证清理块未执行（否则数据被删）
+        cleanup = {
+            "signal": MagicMock(), "position_record": MagicMock(),
+            "analyzer_record": MagicMock(), "order_record": MagicMock(),
+            "transfer_record": MagicMock(),  # ClickHouse 5
+            "order": MagicMock(), "position": MagicMock(),
+            "transfer": MagicMock(), "signal_tracker": MagicMock(),  # MySQL 4
+        }
+        service._signal_crud = cleanup["signal"]
+        service._position_record_crud = cleanup["position_record"]
+        service._analyzer_record_crud = cleanup["analyzer_record"]
+        service._order_record_crud = cleanup["order_record"]
+        service._transfer_record_crud = cleanup["transfer_record"]
+        service._order_crud = cleanup["order"]
+        service._position_crud = cleanup["position"]
+        service._transfer_crud = cleanup["transfer"]
+        service._signal_tracker_crud = cleanup["signal_tracker"]
+
+        with _mock_kafka() as mp:
+            result = service.start_task(uuid="uuid-1234")  # 不传 portfolio_uuid
+
+        assert not result.is_success(), "孤儿任务应在 service 层被拒"
+        mp.send.assert_not_called()
+        leaked = [n for n, c in cleanup.items() if c.remove.called]
+        assert not leaked, f"#5646 守卫缺失：清理块在拒绝前执行，删除了 {leaked}"

--- a/tests/unit/interfaces/test_backtest_assignment_dto.py
+++ b/tests/unit/interfaces/test_backtest_assignment_dto.py
@@ -133,6 +133,12 @@ class TestRejectMalformed:
             from_payload({"task_uuid": "t", "portfolio_uuid": "p", "name": "n",
                           "command": "start", "config": {}})
 
+    def test_start_empty_dates_rejected(self):
+        """空串 dates 视同缺失（ADR-018 第⑤步：补第③步删 worker 校验后的真空）。"""
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "portfolio_uuid": "p", "name": "n",
+                          "command": "start", "config": {"start_date": "", "end_date": "2025-01-01"}})
+
 
 # ---------- stop/cancel 多余字段忽略（守护在返回类型层面）----------
 

--- a/tests/unit/interfaces/test_backtest_assignment_dto.py
+++ b/tests/unit/interfaces/test_backtest_assignment_dto.py
@@ -1,0 +1,160 @@
+"""seam 测试：回测派发契约 DTO 层（ADR-018）。
+
+测接口面（replace 不 layer）——不起 Kafka、不调 service，只断言 DTO 层契约：
+- round-trip to_payload/from_payload（start/stop/cancel）
+- 9 默认值应用（唯一默认表归 DTO）
+- from_payload 拒畸形（缺 task_uuid / 未知或缺 command / start 缺 portfolio_uuid·dates）
+- stop/cancel 多余字段忽略（判别联合守护在返回类型层面）
+- 订正孤儿：to_payload 不含 priority/timeout；BacktestProgressDTO 已删
+
+详见 docs/adrs/ADR-018-backtest-assignment-contract.md
+"""
+import pytest
+
+from ginkgo.interfaces.dtos.backtest_assignment_dto import (
+    BacktestAssignmentConfig,
+    StartAssignment,
+    StopAssignment,
+    CancelAssignment,
+    from_payload,
+    MalformedAssignmentError,
+)
+
+
+# ---------- helpers ----------
+
+def _full_config_dict():
+    """完整 config（全 11 字段），用于 round-trip。"""
+    return {
+        "start_date": "2025-01-01",
+        "end_date": "2025-12-31",
+        "initial_cash": 500000.0,
+        "commission_rate": 0.0005,
+        "slippage_rate": 0.0002,
+        "benchmark_return": 0.08,
+        "max_position_ratio": 0.5,
+        "stop_loss_ratio": 0.07,
+        "take_profit_ratio": 0.2,
+        "frequency": "WEEK",
+        "analyzers": [{"name": "win_rate", "type": "analyzer", "config": {"window": 30}}],
+    }
+
+
+def _full_start_raw():
+    return {
+        "task_uuid": "abc123",
+        "portfolio_uuid": "port-1",
+        "name": "test-backtest",
+        "command": "start",
+        "config": _full_config_dict(),
+    }
+
+
+# ---------- round-trip ----------
+
+class TestRoundTrip:
+    def test_start_round_trip_object(self):
+        cmd = from_payload(_full_start_raw())
+        assert isinstance(cmd, StartAssignment)
+        # 对象 round-trip：to_payload → from_payload 回到相等对象
+        assert from_payload(cmd.to_payload()) == cmd
+
+    def test_start_to_payload_structure(self):
+        back = from_payload(_full_start_raw()).to_payload()
+        assert back["command"] == "start"
+        assert back["task_uuid"] == "abc123"
+        assert back["portfolio_uuid"] == "port-1"
+        assert back["name"] == "test-backtest"
+        assert back["config"] == _full_config_dict()  # 含 analyzers 透传
+
+    def test_stop_round_trip(self):
+        cmd = from_payload({"task_uuid": "abc123", "command": "stop"})
+        assert isinstance(cmd, StopAssignment)
+        assert cmd.task_uuid == "abc123"
+        assert cmd.to_payload() == {"task_uuid": "abc123", "command": "stop"}
+
+    def test_cancel_round_trip(self):
+        cmd = from_payload({"task_uuid": "xyz", "command": "cancel"})
+        assert isinstance(cmd, CancelAssignment)
+        assert cmd.to_payload() == {"task_uuid": "xyz", "command": "cancel"}
+
+
+# ---------- 默认值（唯一默认表归 DTO）----------
+
+class TestDefaults:
+    def test_defaults_applied_when_optional_missing(self):
+        """config 只给 required，9 optional 填默认（消除消费端硬编码默认表）。"""
+        raw = {
+            "task_uuid": "t1", "portfolio_uuid": "p1", "name": "n", "command": "start",
+            "config": {"start_date": "2025-01-01", "end_date": "2025-12-31"},
+        }
+        cfg = from_payload(raw).config
+        assert cfg.initial_cash == 100000.0
+        assert cfg.commission_rate == 0.0003
+        assert cfg.slippage_rate == 0.0001
+        assert cfg.benchmark_return == 0.0
+        assert cfg.max_position_ratio == 0.3
+        assert cfg.stop_loss_ratio == 0.05
+        assert cfg.take_profit_ratio == 0.15
+        assert cfg.frequency == "DAY"
+        assert cfg.analyzers == []
+
+    def test_provided_values_override_defaults(self):
+        cfg = from_payload(_full_start_raw()).config
+        assert cfg.initial_cash == 500000.0
+        assert cfg.frequency == "WEEK"
+
+
+# ---------- 拒畸形（构造即校验）----------
+
+class TestRejectMalformed:
+    def test_missing_task_uuid(self):
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"command": "start", "portfolio_uuid": "p", "name": "n",
+                          "config": {"start_date": "s", "end_date": "e"}})
+
+    def test_missing_command_rejected(self):
+        """契约化后缺 command = 畸形（今天消费 .get('command','start') 默认 start 的行为收紧）。"""
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "portfolio_uuid": "p", "name": "n",
+                          "config": {"start_date": "s", "end_date": "e"}})
+
+    def test_unknown_command(self):
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "command": "foo"})
+
+    def test_start_missing_portfolio_uuid(self):
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "command": "start", "name": "n",
+                          "config": {"start_date": "s", "end_date": "e"}})
+
+    def test_start_missing_dates(self):
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "portfolio_uuid": "p", "name": "n",
+                          "command": "start", "config": {}})
+
+
+# ---------- stop/cancel 多余字段忽略（守护在返回类型层面）----------
+
+class TestStopIgnoresExtras:
+    def test_stop_with_extra_config_ignored(self):
+        """stop 误带 config 不 raise，多余字段忽略；StopAssignment 类型本身无 config 字段。"""
+        cmd = from_payload({"task_uuid": "t", "command": "stop", "config": {"start_date": "s"}})
+        assert isinstance(cmd, StopAssignment)
+        assert cmd.task_uuid == "t"
+        assert not hasattr(cmd, "config")
+
+
+# ---------- 订正孤儿 DTO ----------
+
+class TestOrphanCorrection:
+    def test_to_payload_no_priority_timeout(self):
+        payload = from_payload(_full_start_raw()).to_payload()
+        assert "priority" not in payload
+        assert "timeout" not in payload
+
+    def test_backtest_progress_dto_deleted(self):
+        """BacktestProgressDTO（反向链路死代码）已删。"""
+        import ginkgo.interfaces.dtos.backtest_assignment_dto as mod
+        assert not hasattr(mod, "BacktestProgressDTO")
+        assert not hasattr(mod, "BacktestAssignmentDTO")  # 旧 dataclass 实现已替换

--- a/tests/unit/interfaces/test_backtest_assignment_dto.py
+++ b/tests/unit/interfaces/test_backtest_assignment_dto.py
@@ -139,6 +139,18 @@ class TestRejectMalformed:
             from_payload({"task_uuid": "t", "portfolio_uuid": "p", "name": "n",
                           "command": "start", "config": {"start_date": "", "end_date": "2025-01-01"}})
 
+    def test_start_empty_portfolio_uuid_rejected(self):
+        """空串 portfolio_uuid 视同缺失（#5646 回归：start 字段与 config 同守 min_length=1 拒空串）。"""
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "portfolio_uuid": "", "name": "n",
+                          "command": "start", "config": {"start_date": "s", "end_date": "e"}})
+
+    def test_start_empty_name_rejected(self):
+        """空串 name 视同缺失（#5646 回归：start 字段与 config 同守 min_length=1 拒空串）。"""
+        with pytest.raises(MalformedAssignmentError):
+            from_payload({"task_uuid": "t", "portfolio_uuid": "p", "name": "",
+                          "command": "start", "config": {"start_date": "s", "end_date": "e"}})
+
 
 # ---------- stop/cancel 多余字段忽略（守护在返回类型层面）----------
 

--- a/tests/unit/workers/test_backtest_worker_assignment_dispatch.py
+++ b/tests/unit/workers/test_backtest_worker_assignment_dispatch.py
@@ -1,0 +1,119 @@
+"""
+ADR-018 第③步：消费端 from_payload + match 判别联合 + assignment_to_backtest_config 映射
+
+覆盖：
+- 映射函数 StartAssignment→BacktestConfig（11 字段 + analyzers 转换 + 缺字段拒）
+- _handle_task_assignment 分派：start→_start_task / stop→WARN no-op(A1) / cancel→_cancel_task
+- 畸形 payload：report_failed + 提交 offset（at-least-once，不重投）
+
+详见 docs/adrs/ADR-018-backtest-assignment-contract.md
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+import sys
+
+project_root = Path(__file__).parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.interfaces.dtos.backtest_assignment_dto import (
+    from_payload, StartAssignment, MalformedAssignmentError,
+)
+from ginkgo.workers.backtest_worker.models import (
+    BacktestConfig, AnalyzerConfig, assignment_to_backtest_config,
+)
+
+
+def _make_start_cmd(**config_overrides) -> StartAssignment:
+    raw = {
+        "task_uuid": "abcdef1234567890abcdef1234567890",
+        "portfolio_uuid": "portfolio-1",
+        "name": "test",
+        "command": "start",
+        "config": {"start_date": "2025-01-01", "end_date": "2025-06-01", **config_overrides},
+    }
+    return from_payload(raw)
+
+
+# ---------- 映射函数（DTO 信使 → worker 状态主体）----------
+
+class TestAssignmentToBacktestConfig:
+    @pytest.mark.unit
+    def test_maps_eleven_fields(self):
+        cmd = _make_start_cmd(initial_cash=500000.0, frequency="WEEK")
+        cfg = assignment_to_backtest_config(cmd)
+        assert isinstance(cfg, BacktestConfig)
+        assert cfg.start_date == "2025-01-01"
+        assert cfg.end_date == "2025-06-01"
+        assert cfg.initial_cash == 500000.0
+        assert cfg.frequency == "WEEK"
+        assert cfg.commission_rate == 0.0003  # DTO 唯一默认表补齐
+
+    @pytest.mark.unit
+    def test_maps_analyzers(self):
+        cmd = _make_start_cmd(analyzers=[{"name": "wr", "type": "analyzer", "config": {"w": 30}}])
+        cfg = assignment_to_backtest_config(cmd)
+        assert len(cfg.analyzers) == 1
+        assert isinstance(cfg.analyzers[0], AnalyzerConfig)
+        assert cfg.analyzers[0].name == "wr"
+
+    @pytest.mark.unit
+    def test_rejects_malformed_analyzer(self):
+        """analyzer dict 缺字段 → MalformedAssignmentError（与消费端窄捕一致）。"""
+        cmd = _make_start_cmd(analyzers=[{"name": "wr"}])  # 缺 type
+        with pytest.raises(MalformedAssignmentError):
+            assignment_to_backtest_config(cmd)
+
+
+# ---------- 分派 match ----------
+
+class TestHandleAssignmentDispatch:
+    def _worker(self):
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+        worker = BacktestWorker("test-dispatch")
+        worker.task_consumer = MagicMock()
+        worker.progress_tracker = MagicMock()
+        worker.progress_tracker.get_task_status.return_value = None
+        return worker
+
+    @pytest.mark.unit
+    def test_start_dispatches_to_start_task(self):
+        worker = self._worker()
+        with patch("ginkgo.workers.backtest_worker.node.BacktestProcessor"):
+            worker._handle_task_assignment({
+                "task_uuid": "abcdef1234567890abcdef1234567890",
+                "portfolio_uuid": "p", "name": "n", "command": "start",
+                "config": {"start_date": "s", "end_date": "e"},
+            })
+        worker.task_consumer.commit.assert_called_once()
+
+    @pytest.mark.unit
+    def test_stop_no_op_warns(self):
+        """ADR-018 A1：stop 消费侧 handler 未实现，WARN no-op（不调 _start_task/_cancel_task）但仍提交 offset。"""
+        worker = self._worker()
+        worker._start_task = MagicMock()
+        worker._cancel_task = MagicMock()
+        worker._handle_task_assignment({"task_uuid": "abc123", "command": "stop"})
+        worker._start_task.assert_not_called()
+        worker._cancel_task.assert_not_called()
+        worker.task_consumer.commit.assert_called_once()  # no-op 仍提交 offset
+
+    @pytest.mark.unit
+    def test_cancel_dispatches_to_cancel_task(self):
+        worker = self._worker()
+        worker._cancel_task = MagicMock()
+        worker._handle_task_assignment({"task_uuid": "xyz", "command": "cancel"})
+        worker._cancel_task.assert_called_once_with("xyz")
+        worker.task_consumer.commit.assert_called_once()
+
+    @pytest.mark.unit
+    def test_malformed_marks_failed_and_commits(self):
+        """畸形契约：report_failed + 提交 offset（at-least-once，不重投），不进 _start_task。"""
+        worker = self._worker()
+        worker._start_task = MagicMock()
+        worker._handle_task_assignment({"task_uuid": "bad", "command": "unknown"})  # 未知 command
+        worker.progress_tracker.report_failed_by_uuid.assert_called_once()
+        worker._start_task.assert_not_called()
+        worker.task_consumer.commit.assert_called_once()

--- a/tests/unit/workers/test_backtest_worker_assignment_dispatch.py
+++ b/tests/unit/workers/test_backtest_worker_assignment_dispatch.py
@@ -117,3 +117,19 @@ class TestHandleAssignmentDispatch:
         worker.progress_tracker.report_failed_by_uuid.assert_called_once()
         worker._start_task.assert_not_called()
         worker.task_consumer.commit.assert_called_once()
+
+    @pytest.mark.unit
+    def test_malformed_analyzer_marks_failed_and_commits(self):
+        """畸形 analyzer（from_payload 通过、_start_task 映射期抛 MalformedAssignmentError）：
+        对称窄捕——report_failed + 提交 offset，不向上抛。
+        防 Kafka 毒丸死循环：否则 except Exception→raise 跳过 commit，poll 重投同一消息，
+        且映射抛错前 task 状态未置 failed，DB 去重兜不住 → 永久死循环。
+        """
+        worker = self._worker()
+        worker._handle_task_assignment({
+            "task_uuid": "abcdef1234567890abcdef1234567890",
+            "portfolio_uuid": "p", "name": "n", "command": "start",
+            "config": {"start_date": "s", "end_date": "e", "analyzers": [{"name": "wr"}]},  # 缺 type
+        })
+        worker.progress_tracker.report_failed_by_uuid.assert_called_once()
+        worker.task_consumer.commit.assert_called_once()

--- a/tests/unit/workers/test_backtest_worker_node.py
+++ b/tests/unit/workers/test_backtest_worker_node.py
@@ -49,12 +49,14 @@ class TestStartTaskDedupByFullUuid:
         worker.progress_tracker = MagicMock()
         worker.progress_tracker.get_task_status.return_value = None  # DB 无既有记录
 
-        assignment = _make_assignment()
+        # ADR-018：_start_task 接收 StartAssignment（DTO）非裸 dict
+        from ginkgo.interfaces.dtos.backtest_assignment_dto import from_payload
+        cmd = from_payload(_make_assignment())
 
         with patch("ginkgo.workers.backtest_worker.node.BacktestProcessor") as MockProc:
             MockProc.return_value = MagicMock()
-            worker._start_task(assignment)
-            worker._start_task(assignment)  # 重复派发同一任务
+            worker._start_task(cmd)
+            worker._start_task(cmd)  # 重复派发同一任务
 
         # 修复后：第二次被 self.tasks 完整 UUID 检测拦截，processor 只创建一次
         assert MockProc.call_count == 1, (

--- a/tests/unit/workers/test_task_processor_error_logging.py
+++ b/tests/unit/workers/test_task_processor_error_logging.py
@@ -41,13 +41,31 @@ def _make_processor(task) -> BacktestProcessor:
     return proc
 
 
+def _full_backtest_config(start: str = "2025-01-01", end: str = "2025-06-01") -> BacktestConfig:
+    """ADR-018：BacktestConfig 删默认值后，进程内构造须显式传全 11 字段。
+    config 内容对 task_processor 测试无关，集中此 helper 避免每处重复。"""
+    return BacktestConfig(
+        start_date=start,
+        end_date=end,
+        initial_cash=100000.0,
+        commission_rate=0.0003,
+        slippage_rate=0.0001,
+        benchmark_return=0.0,
+        max_position_ratio=0.3,
+        stop_loss_ratio=0.05,
+        take_profit_ratio=0.15,
+        frequency="DAY",
+        analyzers=[],
+    )
+
+
 @pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
 @pytest.mark.tdd
 class TestOnProgressLogsOnStatsFailure:
     """#6031-A: _on_progress 统计获取失败时必须发 WARN，而非静默 pass。"""
 
     def test_warns_when_portfolio_stats_gather_raises(self, monkeypatch):
-        cfg = BacktestConfig(start_date="2025-01-01", end_date="2025-06-01")
+        cfg = _full_backtest_config()
         task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
         proc = _make_processor(task)
 
@@ -83,7 +101,7 @@ class TestAggregateResultsRoutesTracebackToGlog:
     GLOG.ERROR 落库，而非 print_exc() 泄漏到控制台流（后台 worker 不捕获）。"""
 
     def test_traceback_logged_not_printed(self, monkeypatch, capsys):
-        cfg = BacktestConfig(start_date="2025-01-01", end_date="2025-06-01")
+        cfg = _full_backtest_config()
         task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
         task.started_at = datetime(2025, 1, 1)
         task.completed_at = datetime(2025, 1, 2)


### PR DESCRIPTION
## 概述

ADR-018 回测派发契约迁移：手搓 dict literal + worker 字面校验 → **判别联合 DTO + 唯一默认表 + 构造期校验**。

5 步 TDD 提交（每步红→绿，独立可读）：

| 步 | commit | 内容 |
|---|---|---|
| ① | `4b4b97b1` | DTO 层（判别联合 Start/Stop/Cancel + `to_payload`/`from_payload`）+ seam 测试 |
| ② | `ac67bf13` | 生产端 3 处 dict → `Assignment.to_payload()` |
| ③ | `957ad589` | 消费端 `from_payload` + `match` 分派 + DTO→`BacktestConfig` 映射 |
| ④ | `9f661f71` | 删 `BacktestConfig` 9 默认值（唯一默认表归 DTO）+ 验证死字段停发 |
| ⑤ | `d2678744` | 预校验收敛进 DTO 构造（`Field(min_length=1)` + 窄捕 `ValidationError`） |

## 契约要点

- **判别联合（discriminated union）**：命令是 `ClassVar` 类型标记，非运行时字段——构造期即强制 `stop` 不能带 `config`，多余字段按 `model_fields` 自动过滤。
- **唯一默认表**：DTO `BacktestAssignmentConfig` 持有 9 个 optional 默认；worker `BacktestConfig` 全必填（删 9 默认）——消除「双源靠巧合对齐」的 drift。
- **校验关口前移**：缺 dates / portfolio 在 service 层 DTO 构造期即 `ServiceResult.error`，不进 Kafka（worker 侧字面校验已删，DTO 是唯一关口）。

## 测试

- `tests/unit/interfaces/test_backtest_assignment_dto.py` — round-trip + 默认表 + 拒畸形 + 孤儿订正
- `tests/unit/data/services/test_backtest_task_assignment_payload.py` — 生产端 payload 结构 + 死字段停发
- `tests/unit/data/services/test_backtest_task_start_validation.py` — service 层校验收敛（缺 dates/portfolio 即拒）
- `tests/unit/workers/test_backtest_worker_assignment_dispatch.py` — 消费端 `match` 分派 + 畸形标记 failed
- 全链路 38 测试绿；`git stash` 对比确认 `tests/unit/data/services/` 既有 9 失败（portfolio/param/engine fixture）与本 PR 无关

详见 `docs/adrs/ADR-018-backtest-assignment-contract.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
