### PR TITLE
docs(trading): FixedSelector 空 codes 告警示例改用 key 形式 (#6466)

### DIFF
--- a/src/ginkgo/trading/selectors/fixed_selector.py
+++ b/src/ginkgo/trading/selectors/fixed_selector.py
@@ -31,7 +31,7 @@ class FixedSelector(BaseSelector):
             GLOG.WARNING(
                 f"FixedSelector({name}) codes 为空，pick() 将始终返回空列表，"
                 f"回测会零信号/零交易。请在 portfolio bind-component 时设置 codes "
-                f"(如 --param '0:\"000001.SZ\"')。(#5363)"
+                f"(如 --param 'codes:\"000001.SZ\"')。(#5363)"
             )
 
     def pick(self, time: any = None, *args, **kwargs) -> list[str]:

--- a/tests/unit/trading/selectors/test_fixed_selector.py
+++ b/tests/unit/trading/selectors/test_fixed_selector.py
@@ -46,3 +46,23 @@ class TestFixedSelectorEmptyCodesWarns:
         with patch("ginkgo.trading.selectors.fixed_selector.GLOG"):
             sel = FixedSelector(codes="")
         assert sel.pick() == []
+
+    def test_warning_codes_example_uses_key_form_not_misleading_index(self):
+        """#6466: 空 codes 告警里的绑定示例不得用 index 0。
+
+        portfolio_cli 的 index 语义: index 0 = name, index 1 = codes (见 #5955)。
+        若示例写成 --param '0:"000001.SZ"'，用户照做会把股票代码塞进 name、codes 仍空，
+        正好触发本告警所警告的零信号坑。须改用 key 形式 codes:"..."（最不易歧义）。
+        """
+        with patch("ginkgo.trading.selectors.fixed_selector.GLOG") as mock_glog:
+            FixedSelector(codes="")
+        msg = mock_glog.WARNING.call_args[0][0]
+        # 反向: 不得出现 index 0 绑定 codes 的示例（index 0 是 name）
+        assert "'0:\"" not in msg, (
+            "告警示例不得用 index 0 绑定 codes（index 0=name），"
+            "会误导用户触发零信号坑 #6466"
+        )
+        # 正向: 须用 key 形式 codes:"..."（issue #6466 推荐，避免 index 歧义）
+        assert "codes:\"" in msg, (
+            "告警示例应用 key 形式 codes:\"...\" 绑定 codes，避免 index 歧义 #6466"
+        )


### PR DESCRIPTION
## Summary

修复 #6466：`FixedSelector` 空 codes 告警（#5363）里的 `--param` 绑定示例 index 错误，会误导用户踩"回测零信号"坑。

**问题**：`src/ginkgo/trading/selectors/fixed_selector.py:34` 的 WARNING 注释示例原为 `--param '0:"000001.SZ"'`。但 `bind-component` 的 index 语义是 **index 0 = `name`、index 1 = `codes`**（`portfolio_cli.py` `param_names={0:"name",1:"codes"}` + `parameters[int(key_str)]=value`，见 #5955）。照此示例操作会把股票代码塞进 `name`、`codes` 仍为空 → 正好触发该注释正在警告的零信号坑，注释与自身警告自相矛盾。

**修复**：示例改为 key 形式 `--param 'codes:"000001.SZ"'`（最不易歧义，issue 推荐）。

### AC2 全仓核对（`--param '0:"..."'` 其他出现）

| 位置 | 内容 | 判定 |
|---|---|---|
| `fixed_selector.py:34` | `0:"000001.SZ"`（设 codes） | ❌ 已修 → `codes:"..."` |
| `README.md:259` / `CLAUDE.md:87` | `0:"MyStrategy"`（Strategy 设 name） | ✅ 正确（Strategy 首参即 name） |
| `docs/archive/cli-strategy-iteration-log.md` | `0:"RandomSignalStrategy"`（name） | ✅ 正确（archive 历史记录） |
| `docs/loop-backtest-*.md` / `research-diary.md` | 已用 `1:"..."` | ✅ 正确 |
| `src/ginkgo.egg-info/PKG-INFO` | 构建产物（`.gitignored`） | ⏭️ 下次构建从 README 重生成 |

唯一错误点 = `fixed_selector.py:34`，其余 `0:"..."` 均为 Strategy 类 name 绑定（语义正确），不动。

## Test plan

- [x] 新增文档契约测试 `test_warning_codes_example_uses_key_form_not_misleading_index`：断言空 codes 告警消息**不含** index 0 绑定示例（`'0:"'`）、**须含** key 形式（`codes:"`），守护注释正确性防回归
- [x] `test_fixed_selector.py` 全 5 测试通过（含原 #5363 的 4 个行为测试未受影响）
- [x] Layer 1 py_compile（全 src/api）通过
- [x] Layer 2 启动路径 smoke（user_crud / containers / user_cli，29 passed）通过
- [x] Layer 3 变更相关测试（fixed_selector）通过

Closes #6466
