### PR TITLE
fix(#6465): 诊断日志分流到 stderr，保留 stdout 给 CLI 业务输出

### DIFF
--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -8,6 +8,7 @@
 
 
 import os
+import sys
 import yaml
 import shutil
 import base64
@@ -83,7 +84,7 @@ class GinkgoConfig(object):
                     os.environ.setdefault("GINKGO_FROM_ADDRESS", from_addr)
                 os.environ.setdefault("GINKGO_FROM_NAME", from_name)
             except Exception as e:
-                print(f"[GCONF] Error loading config to env: {e}")
+                print(f"[GCONF] Error loading config to env: {e}", file=sys.stderr)
 
         if self._has_local_secure:
             try:
@@ -155,7 +156,7 @@ class GinkgoConfig(object):
                     if fushu.get("api_key"):
                         os.environ.setdefault("GINKGO_FUSHU_API_KEY", fushu["api_key"])
             except Exception as e:
-                print(f"[GCONF] Error loading secure config to env: {e}")
+                print(f"[GCONF] Error loading secure config to env: {e}", file=sys.stderr)
 
         self._env_vars_initialized = True
 
@@ -237,10 +238,10 @@ class GinkgoConfig(object):
             if os.path.exists(origin_path):
                 os.makedirs(path, exist_ok=True)
                 shutil.copy(origin_path, config_path)
-                print(f"[GCONF] Copy config.yml from {origin_path} to {config_path}")
+                print(f"[GCONF] Copy config.yml from {origin_path} to {config_path}", file=sys.stderr)
                 self._has_local_config = True  # ✅ 更新缓存
             else:
-                print(f"[GCONF] Source config not found, will use environment variables")
+                print(f"[GCONF] Source config not found, will use environment variables", file=sys.stderr)
                 self._has_local_config = False  # ✅ 更新缓存
         else:
             self._has_local_config = True  # ✅ 文件已存在
@@ -252,10 +253,10 @@ class GinkgoConfig(object):
             if os.path.exists(origin_path):
                 os.makedirs(path, exist_ok=True)
                 shutil.copy(origin_path, secure_path)
-                print(f"[GCONF] Copy secure.yml from {origin_path} to {secure_path}")
+                print(f"[GCONF] Copy secure.yml from {origin_path} to {secure_path}", file=sys.stderr)
                 self._has_local_secure = True  # ✅ 更新缓存
             else:
-                print(f"[GCONF] Source secure config not found, will use environment variables")
+                print(f"[GCONF] Source secure config not found, will use environment variables", file=sys.stderr)
                 self._has_local_secure = False  # ✅ 更新缓存
         else:
             self._has_local_secure = True  # ✅ 文件已存在
@@ -275,11 +276,11 @@ class GinkgoConfig(object):
                     config_data = yaml.safe_load(file)
                 self._config_cache = config_data
                 self._config_mtime = current_mtime
-                print(f"[GCONF] Config cache updated (mtime: {current_mtime})")
+                print(f"[GCONF] Config cache updated (mtime: {current_mtime})", file=sys.stderr)
 
             return self._config_cache
         except Exception as e:
-            print(f"[GCONF] Error reading config: {e}")
+            print(f"[GCONF] Error reading config: {e}", file=sys.stderr)
             return {}
 
     def _read_secure(self) -> dict:
@@ -297,11 +298,11 @@ class GinkgoConfig(object):
                     secure_data = yaml.safe_load(file)
                 self._secure_cache = secure_data
                 self._secure_mtime = current_mtime
-                print(f"[GCONF] Secure cache updated (mtime: {current_mtime})")
+                print(f"[GCONF] Secure cache updated (mtime: {current_mtime})", file=sys.stderr)
 
             return self._secure_cache
         except Exception as e:
-            print(f"[GCONF] Error reading secure config: {e}")
+            print(f"[GCONF] Error reading secure config: {e}", file=sys.stderr)
             return {}
 
     def _get_config(self, key: str, default: any = None, section: str = None) -> any:
@@ -346,7 +347,7 @@ class GinkgoConfig(object):
                 if key in config and config[key] is not None:
                     return config[key]
             except Exception as e:
-                print(f"[GCONF] Error reading config file: {e}")
+                print(f"[GCONF] Error reading config file: {e}", file=sys.stderr)
 
         # 优先级3: 返回默认值
         return default
@@ -359,7 +360,7 @@ class GinkgoConfig(object):
             with open(self.setting_path, "w") as file:
                 yaml.safe_dump(data, file)
         except Exception as e:
-            print(e)
+            print(e, file=sys.stderr)
             return {}
 
     @property
@@ -1155,7 +1156,7 @@ class GinkgoConfig(object):
                 logging_config = config.get("logging", {})
                 return logging_config.get("mask_fields", [])
             except Exception as e:
-                print(f"[GCONF] Error reading logging.mask_fields: {e}")
+                print(f"[GCONF] Error reading logging.mask_fields: {e}", file=sys.stderr)
                 return []
         # 尝试环境变量
         env_value = os.environ.get("GINKGO_LOGGING_MASK_FIELDS")

--- a/src/ginkgo/libs/core/logger.py
+++ b/src/ginkgo/libs/core/logger.py
@@ -55,6 +55,7 @@ import re
 _caller_local = threading.local()
 from logging.handlers import RotatingFileHandler
 from rich.logging import RichHandler
+from rich.console import Console
 from pathlib import Path
 from ginkgo.libs.core.config import GCONF
 
@@ -624,6 +625,9 @@ class GinkgoLogger:
             omit_repeated_times=False,
             rich_tracebacks=True,
             log_time_format="[%X]",
+            # #6465: 诊断日志走 stderr，保留 stdout 给 CLI 业务输出（如 -r 纯 JSON）。
+            # 本 rich 版本裸 RichHandler 默认写 stdout，会污染机器可读输出。
+            console=Console(stderr=True),
         )
         self.console_handler.set_name(self._console_handler_name)
         self.console_handler.setLevel(self.get_log_level(LOGGING_LEVEL_CONSOLE))

--- a/src/ginkgo/libs/utils/common.py
+++ b/src/ginkgo/libs/utils/common.py
@@ -15,6 +15,10 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeEl
 from ginkgo.libs.core.config import GinkgoConfig
 
 console = Console()
+# #6465: 诊断专用 console，走 stderr。模块级共享 `console` 默认写 stdout，被
+# data_cli 的 `-r` 纯 JSON 业务输出复用；time_logger/retry 的 FUNCTION 等诊断
+# 若也走它，会污染机器可读输出。诊断一律切到 stderr，stdout 只留业务结果。
+console_err = Console(stderr=True)
 _gconf = GinkgoConfig()
 
 
@@ -125,8 +129,8 @@ def time_logger(func=None, *, enabled=None, threshold=None, profile_mode=None):
                 # 异常情况下总是记录性能数据
                 duration = time.time() - start_time
                 if show_log or duration > actual_threshold:
-                    console.print(f":warning: FUNCTION [red]{f.__name__}[/] failed after {format_time_seconds(duration)}")
-                console.print_exception()
+                    console_err.print(f":warning: FUNCTION [red]{f.__name__}[/] failed after {format_time_seconds(duration)}")
+                console_err.print_exception()
                 raise
             finally:
                 if should_monitor or actual_profile_mode:
@@ -145,7 +149,7 @@ def time_logger(func=None, *, enabled=None, threshold=None, profile_mode=None):
                         else:  # 正常
                             icon, color = ":zap:", "green"
                             
-                        console.print(f"{icon} FUNCTION [{color}]{f.__name__}[/] executed in {format_time_seconds(duration)}")
+                        console_err.print(f"{icon} FUNCTION [{color}]{f.__name__}[/] executed in {format_time_seconds(duration)}")
 
         return wrapper
     
@@ -223,7 +227,7 @@ def skip_if_ran(func=None, *, cache_provider=None):
                     _cache[cache_key] = "Yeah"
                 return result
             except Exception as e:
-                console.print_exception()
+                console_err.print_exception()
 
         return wrapper
 
@@ -264,19 +268,19 @@ def retry(func=None, *, max_try: int = None, backoff_factor: float = None):
                     return f(*args, **kwargs)
                 except Exception as e:
                     last_exception = e
-                    console.print(f"[red]Retry FUNCTION [yellow]{f.__name__}[/] {i+1}/{actual_max_try}[/red]")
+                    console_err.print(f"[red]Retry FUNCTION [yellow]{f.__name__}[/] {i+1}/{actual_max_try}[/red]")
                     if i >= actual_max_try - 1:
-                        console.print_exception()
+                        console_err.print_exception()
                         raise e
                     else:
                         if GCONF.DEBUGMODE:
                             # Debug模式：跳过等待，立即重试
-                            console.print(f"[yellow]Debug mode: Skipping wait, immediate retry {i+2}/{actual_max_try}[/]")
+                            console_err.print(f"[yellow]Debug mode: Skipping wait, immediate retry {i+2}/{actual_max_try}[/]")
                         else:
                             # 使用配置的退避因子计算等待时间
                             base_sleep = 30  # 基础等待时间30秒
                             sleep_time = int(base_sleep * (actual_backoff_factor ** i))
-                            console.print(
+                            console_err.print(
                                 f"[yellow]Starting wait: {sleep_time} seconds before retry {i+2}/{actual_max_try}[/]"
                             )
 

--- a/tests/unit/libs/test_log_stream_separation_6465.py
+++ b/tests/unit/libs/test_log_stream_separation_6465.py
@@ -1,0 +1,169 @@
+"""
+TDD tests for #6465: 诊断日志与 CLI 业务输出分流。
+
+Unix 约定：诊断信息走 stderr，命令业务结果（如 `-r` 的纯 JSON）走 stdout。
+历史问题：`[GCONF]` 裸 print、GLOG 的 RichHandler、`time_logger` 的 `⚡ FUNCTION`
+都默认写 stdout，污染 `ginkgo ... -r` 的机器可读输出，导致 jq/json.tool 解析失败。
+
+每条用例对应一处根因，通过公共接口验证「诊断在 stderr、stdout 干净」的行为契约。
+"""
+
+import os
+import re
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_singleton():
+    """每个用例给 GinkgoConfig 单例一个干净起点。"""
+    from ginkgo.libs.core.config import GinkgoConfig
+
+    if hasattr(GinkgoConfig, "_instance"):
+        del GinkgoConfig._instance
+    yield
+    if hasattr(GinkgoConfig, "_instance"):
+        del GinkgoConfig._instance
+
+
+# ---------------------------------------------------------------------------
+# 根因 A: config.py 的 [GCONF] 诊断 print 默认写 stdout
+# ---------------------------------------------------------------------------
+
+
+class TestGconfLogsToStderr:
+    """`[GCONF]` 配置缓存/复制诊断必须写 stderr，不得污染 stdout。"""
+
+    def test_config_cache_update_goes_to_stderr(self, tmp_path, monkeypatch, capsys):
+        """
+        配置缓存刷新时打印的 `[GCONF] Config cache updated` 必须落在 stderr。
+        复现 #6465：此前裸 print() 写 stdout，污染 `data get -r`。
+        """
+        import yaml
+
+        from ginkgo.libs.core.config import GinkgoConfig
+
+        # 指向一个真实存在的临时 config.yml，使 setting_path 可读
+        conf_dir = tmp_path / "ginkgo"
+        conf_dir.mkdir()
+        (conf_dir / "config.yml").write_text(
+            yaml.safe_dump({"logging": {"level": "info"}}), encoding="utf-8"
+        )
+        monkeypatch.setenv("GINKGO_DIR", str(conf_dir))
+
+        cfg = GinkgoConfig()
+        # 强制缓存失效 → 触发重读 + print
+        cfg._has_local_config = True
+        cfg._config_cache = {}
+        cfg._config_mtime = 0
+
+        cfg._read_config()
+
+        captured = capsys.readouterr()
+        # 诊断不得污染 stdout
+        assert "[GCONF]" not in captured.out
+        # 诊断应可见于 stderr
+        assert "[GCONF] Config cache updated" in captured.err
+
+    def test_secure_cache_update_goes_to_stderr(self, tmp_path, monkeypatch, capsys):
+        """secure 缓存刷新诊断同样必须落在 stderr。"""
+        import yaml
+
+        from ginkgo.libs.core.config import GinkgoConfig
+
+        conf_dir = tmp_path / "ginkgo"
+        conf_dir.mkdir()
+        (conf_dir / "secure.yml").write_text(
+            yaml.safe_dump({"key": "val"}), encoding="utf-8"
+        )
+        monkeypatch.setenv("GINKGO_DIR", str(conf_dir))
+
+        cfg = GinkgoConfig()
+        cfg._has_local_secure = True
+        cfg._secure_cache = {}
+        cfg._secure_mtime = 0
+
+        cfg._read_secure()
+
+        captured = capsys.readouterr()
+        assert "[GCONF]" not in captured.out
+        assert "[GCONF] Secure cache updated" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# 根因 B: logger.py 的 RichHandler 默认写 stdout（本 rich 版本实测）
+# ---------------------------------------------------------------------------
+
+
+class TestGlogConsoleToStderr:
+    """GLOG 控制台 RichHandler 必须写 stderr，INFO/WARN/ERROR 不得污染 stdout。
+
+    用 capfd（fd 级捕获）而非 capsys：Rich Console 在构造时缓存 sys.stderr
+    引用，fd 级捕获才能可靠抓到 RichHandler 输出。
+    """
+
+    def test_info_console_goes_to_stderr(self, capfd):
+        """GLOG.INFO 经 RichHandler 应落在 stderr。"""
+        from ginkgo.libs.core.logger import GinkgoLogger
+
+        logger = GinkgoLogger("test_stderr_info_6465", console_log=True)
+        # 短 marker：Rich RichHandler 会把"marker + 调用方源码定位"按 80 列折行并把
+        # 路径塞回 marker 中间，长 marker 必被切碎。短 marker 单行可整段渲染。
+        marker = "M6465I"
+        logger.INFO(marker)
+
+        captured = capfd.readouterr()
+        # Rich RichHandler 会把长日志行（marker + 源码定位）按捕获终端 80 列折行，
+        # 把 marker 从中间断开。行为契约是「marker 到达 stderr、stdout 干净」，
+        # 故剥离空白后再判成员关系，不受 Rich 折行影响。
+        out_norm = re.sub(r"\s+", "", captured.out)
+        err_norm = re.sub(r"\s+", "", captured.err)
+        assert marker not in out_norm
+        assert marker in err_norm
+
+    def test_warn_console_goes_to_stderr(self, capfd):
+        """GLOG.WARN 经 RichHandler 应落在 stderr。"""
+        from ginkgo.libs.core.logger import GinkgoLogger
+
+        logger = GinkgoLogger("test_stderr_warn_6465", console_log=True)
+        marker = "M6465W"
+        logger.WARN(marker)
+
+        captured = capfd.readouterr()
+        # Rich RichHandler 会把长日志行（marker + 源码定位）按捕获终端 80 列折行，
+        # 把 marker 从中间断开。行为契约是「marker 到达 stderr、stdout 干净」，
+        # 故剥离空白后再判成员关系，不受 Rich 折行影响。
+        out_norm = re.sub(r"\s+", "", captured.out)
+        err_norm = re.sub(r"\s+", "", captured.err)
+        assert marker not in out_norm
+        assert marker in err_norm
+
+
+# ---------------------------------------------------------------------------
+# 根因 C: common.py 的 time_logger/retry 用模块级共享 console（默认 stdout）
+# 打印 ⚡ FUNCTION / Retry FUNCTION 性能诊断，污染 -r 纯 JSON
+# ---------------------------------------------------------------------------
+
+
+class TestTimeLoggerDiagnosticToStderr:
+    """time_logger 的 `⚡ FUNCTION ... executed in` 诊断必须走 stderr。
+
+    复现 #6465：模块级共享 `console = Console()` 默认写 stdout，time_logger
+    在慢函数上打印的 `⚡ FUNCTION` 落到 stdout，污染 `data get -r` 的纯 JSON。
+    """
+
+    def test_function_executed_goes_to_stderr(self, capfd):
+        """被装饰慢函数的 FUNCTION 执行耗时诊断应落在 stderr。"""
+        from ginkgo.libs.utils.common import time_logger
+
+        # enabled=True 强制监控、threshold=-1 保证任意耗时都越过阈值触发打印
+        @time_logger(enabled=True, threshold=-1)
+        def slow_op():
+            return 42
+
+        slow_op()
+
+        captured = capfd.readouterr()
+        assert "FUNCTION" not in captured.out
+        assert "FUNCTION" in captured.err
+


### PR DESCRIPTION
## Summary

修复 #6465：CLI 诊断日志（`[GCONF]`、`⚡ FUNCTION`、`INFO`）默认写 **stdout**，污染 `ginkgo data get ... -r` 的机器可读输出，导致 `jq` / `python -m json.tool` 管道解析必然失败，阻碍研究员脚本化探活/抽数。

本 PR 把所有诊断分流到 **stderr**，stdout 仅保留命令业务结果。

### 三处根因与修复

| 根因 | 位置 | 修复 |
|---|---|---|
| A. `[GCONF]` 裸 print | `libs/core/config.py` | 13 处 `print()` → `print(file=sys.stderr)`。**保持 cycle-safe**：不改成 `GLOG.INFO`（会重新引入 `config.py ↔ ginkgo.libs` 循环导入，见 commit `193731de`），沿用裸 `print` 仅切流。 |
| B. RichHandler 默认写 stdout | `libs/core/logger.py` | `RichHandler` 显式 `console=Console(stderr=True)`；裸 RichHandler 在本 rich 版本实测默认写 stdout。 |
| C. `⚡ FUNCTION` / Retry / 异常 | `libs/utils/common.py` | 新增 `console_err = Console(stderr=True)`，`time_logger`/`retry`/`skip_if_ran` 的 FUNCTION 与异常诊断切到 `console_err`。模块级共享 `console`（stdout）**不动**——`data_cli.py` 的 `-r` JSON 业务输出复用它。 |

### 范围说明（重要）

本 issue 与 **#5024**（`-r` 标志不生效、仍输出表格）是**不同层面**：
- #6465（本 PR）：日志**输出流**污染 → 已修复，stdout 不再有 `[GCONF]`/`⚡`/`INFO` 行。
- #5024（独立 open）：`-r` 输出**格式**错误（Rich 表格而非 JSON）→ 不在本 PR 范围。

AC#2（`json.load` 成功）需 #5024 合并后才能完整通过；本 PR 确保：即便 #5024 修好 JSON 输出，#6465 的 stdout 污染也不再破坏管道。

## Test plan

### 单元测试（TDD，覆盖三处根因）
```bash
/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/libs/test_log_stream_separation_6465.py -q -o "addopts="
# 5 passed
```
- `TestGconfLogsToStderr` ×2：config 缓存/secure 缓存刷新诊断 → stderr（capsys + GINKGO_DIR monkeypatch）
- `TestGlogConsoleToStderr` ×2：GLOG.INFO/WARN 经 RichHandler → stderr（capfd）
- `TestTimeLoggerDiagnosticToStderr` ×1：`@time_logger` 的 FUNCTION 执行耗时诊断 → stderr（capfd）

### 三层冒烟（推送门禁）
- Layer 1 `py_compile`：config/logger/common/test 全过
- Layer 2 启动路径：`test_user_crud_mock` + `test_containers` + `test_user_cli` → 29 passed
- Layer 3 回归：`test_ginkgo_config` / `test_core_logger_existing` / `test_log_utils_existing` / `test_config_setters` / `test_cache_with_expiration` + 新测试 → 69 passed, 3 skipped

### 端到端 AC（worktree 代码，PYTHONPATH=src）
```bash
# 诊断全在 stderr，stdout 干净
ginkgo data get day -c 600000.SH -s 20250101 -e 20260105 -r 2>/dev/null \
  | grep -cE "\[GCONF\]|⚡ FUNCTION|INFO "
```
- **修复前（installed binary）：5**（stdout 含 `[GCONF]`×2 / `INFO`×1 / `⚡ FUNCTION`×2）
- **修复后（本 PR）：0** ✅ AC#1 PASS

stderr 侧确认三类诊断可见（`[GCONF] Config cache updated` / `[..] INFO 缓存结果` / `⚡ FUNCTION create_click_connection executed in ...`），`2>&1` 合并时照常显示。

Closes #6465
