### PR TITLE
fix(#6473): 运行时 deploy 路径补 selector.pick() 种子化（消除 INIT/DEPLOY 装配不对称）

### DIFF
--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -178,23 +178,9 @@ class PaperTradingWorker:
         # 6. 绑定 Gateway + Broker
         engine.bind_router(gateway)
 
-        # 7. 初始化 selector interested codes
+        # 7. 初始化 selector interested codes（INIT 与 _handle_deploy 共用 _seed_selectors）
         for portfolio in engine.portfolios:
-            try:
-                if hasattr(portfolio, "_selectors") and portfolio._selectors:
-                    for selector in portfolio._selectors:
-                        if hasattr(selector, "pick"):
-                            # #6159 bug#6: 必须传非 None time。MomentumSelector.pick(time=None)
-                            # → datetime_normalize(None)=None → None-timedelta 崩溃 → selector
-                            # 选股失败 → _interested_codes 空 → feeder WARN "No interested symbols"
-                            # → PRICEUPDATE=0 → signal=0。传 now() 作种子；后续 portfolio.advance_time
-                            # 会用 time provider 的逻辑时间重新 pick 覆盖。CNAllSelector 不用 time 不受影响。
-                            selector.pick(datetime.now())
-            except Exception as e:
-                GLOG.WARN(
-                    f"[PAPER-WORKER] selector.pick() failed for "
-                    f"{portfolio.name}: {e}"
-                )
+            self._seed_selectors(portfolio)
 
         # 8. 恢复状态 / 首次初始化（在设置 task_id 和 time provider 之前，需要读取持久化时间）
         portfolio_service = container.portfolio_service()
@@ -839,6 +825,31 @@ class PaperTradingWorker:
             GLOG.ERROR(f"[PAPER-WORKER] Engine advance error: {e}")
             return DailyCycleResult(skipped=False, advanced=False)
 
+    def _seed_selectors(self, portfolio) -> None:
+        """种子化 portfolio 各 selector 的 _interested，发布首轮 EventInterestUpdate。
+
+        INIT 启动路径（assemble_engine 第 7 步）与运行时部署路径（_handle_deploy）
+        共用此 helper，消除装配不对称：
+        - 不调 → selector._interested 空 → 不发 EventInterestUpdate → BacktestFeeder
+          _interested_codes 永不更新 → advance_time 喂 0 bar → _run_live_paper_cycle
+          skip → 0 signal/order（状态却 RUNNING，仅 worker 重启愈合）。#6473
+        - #6159 bug#6: pick(time=None) → datetime_normalize(None)=None → None-timedelta
+          崩溃（MomentumSelector）。故传 datetime.now() 作种子；后续 portfolio.advance_time
+          会用 time provider 的逻辑时间重新 pick 覆盖。CNAllSelector 不用 time 不受影响。
+        """
+        try:
+            if not (hasattr(portfolio, "_selectors") and portfolio._selectors):
+                return
+            for selector in portfolio._selectors:
+                if hasattr(selector, "pick"):
+                    selector.pick(datetime.now())
+        except Exception as e:
+            name = getattr(portfolio, "name", "?")
+            GLOG.WARN(
+                f"[PAPER-WORKER] selector.pick() failed for "
+                f"{name}: {e}"
+            )
+
     def _handle_deploy(self, params: Dict) -> bool:
         """
         处理 deploy 命令：动态加载新 Portfolio 到引擎
@@ -917,6 +928,10 @@ class PaperTradingWorker:
             # 添加到引擎
             with self._lock:
                 self._engine.add_portfolio(portfolio)
+
+            # #6473: 种子化 selector _interested（与 INIT 启动路径 assemble_engine 第 7 步对称）。
+            # 不调 → feeder 收不到 EventInterestUpdate → 0 行情 → 0 signal（状态却 RUNNING）。
+            self._seed_selectors(portfolio)
 
             GLOG.INFO(
                 f"[PAPER-WORKER] Deployed portfolio {db_portfolio.name} "

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -551,6 +551,59 @@ class TestDeploy:
         assert result is True
         mock_engine.add_portfolio.assert_called_once_with(mock_portfolio_instance)
 
+    @patch("ginkgo.trading.services._assembly.component_loader.ComponentLoader")
+    @patch("ginkgo.trading.portfolios.t1backtest.PortfolioT1Backtest")
+    def test_deploy_seeds_selector_pick_after_add_portfolio(self, mock_portfolio_cls, mock_loader):
+        """#6473: _handle_deploy 应在 add_portfolio 后种子化 selector._interested。
+
+        运行时 deploy 路径漏调 selector.pick()（worker 启动 INIT 路径 L182-192 调了，
+        带 #6159 注释）→ selector._interested 空 → 不发 EventInterestUpdate →
+        BacktestFeeder _interested_codes 永不更新 → advance_time 喂 0 bar →
+        _run_live_paper_cycle skip → 0 signal/order（状态却 RUNNING）。仅 worker
+        重启愈合。验收：deploy 后无需重启即产信号。
+        """
+        from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+
+        worker = PaperTradingWorker(worker_id="test-1")
+        mock_engine = MagicMock()
+        mock_engine.portfolios = []
+        worker._engine = mock_engine
+
+        mock_selector = MagicMock()
+        mock_portfolio_instance = MagicMock()
+        mock_portfolio_instance.uuid = "p-new-001"
+        # 装配后 portfolio 持有 selector 列表（与 INIT 测试 L113 同款 mock）
+        mock_portfolio_instance._selectors = [mock_selector]
+        mock_portfolio_cls.return_value = mock_portfolio_instance
+
+        mock_components = {
+            "strategies": [], "risk_managers": [],
+            "analyzers": [], "selectors": [], "sizers": [],
+        }
+        mock_container = MagicMock()
+        mock_crud = MagicMock()
+        mock_db_portfolio = MagicMock()
+        mock_db_portfolio.uuid = "p-new-001"
+        mock_db_portfolio.code = "test-portfolio"
+        mock_crud.find.return_value = [mock_db_portfolio]
+        mock_container.cruds.portfolio.return_value = mock_crud
+
+        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
+                   return_value=mock_components):
+            with patch("ginkgo.services", create=True) as mock_services:
+                mock_services.data.container = mock_container
+                result = worker._handle_deploy({"portfolio_id": "p-new-001"})
+
+        assert result is True
+        mock_engine.add_portfolio.assert_called_once_with(mock_portfolio_instance)
+        # #6473: deploy 后必须种子化 selector._interested（否则 feeder 0 行情 → 0 signal）
+        mock_selector.pick.assert_called_once()
+        # #6159: pick 必须传非 None time（MomentumSelector.pick(time=None) 崩溃）
+        pick_args = mock_selector.pick.call_args.args
+        pick_kwargs = mock_selector.pick.call_args.kwargs
+        time_arg = pick_args[0] if pick_args else pick_kwargs.get("time")
+        assert time_arg is not None, "selector.pick 必须传非 None time（#6159 bug#6）"
+
     def test_deploy_without_engine_returns_false(self):
         """引擎未初始化时 deploy 应返回 False"""
         from ginkgo.workers.paper_trading_worker import PaperTradingWorker


### PR DESCRIPTION
## Summary

`PaperTradingWorker._handle_deploy()` 在把新 Portfolio 装配进引擎（`engine.add_portfolio`）后、置 RUNNING 前，**漏调 `selector.pick()` 种子首轮选股**——而 worker 启动的 INIT 路径明确调了（带 #6159 注释）。装配不对称致：

- selector `_interested` 空 → 不发 `EventInterestUpdate`
- BacktestFeeder `_interested_codes` 永不更新 → `advance_time` 喂 0 bar
- `_run_live_paper_cycle` 读空 → return skipped
- → 0 signal/order，但组合状态停在 **RUNNING**（状态机绿、数据链路红的静默失败，仅 worker 重启愈合）

### 修复

抽 `_seed_selectors(portfolio)` helper（封装遍历 `_selectors` → `pick(datetime.now())` → try/except WARN），**INIT 启动路径与运行时部署路径共用**，消除装配不对称：

- INIT（`assemble_engine` 第 7 步）：17 行内联 → 3 行调 helper
- `_handle_deploy`：`add_portfolio` 后、置 RUNNING 前新增 `self._seed_selectors(portfolio)`

`#6159` 不回归：pick 仍传非 None `datetime.now()`（MomentumSelector `pick(time=None)` 会崩），后续 `portfolio.advance_time` 用 time provider 逻辑时间重新 pick 覆盖；CNAllSelector 不用 time 不受影响。

## Test plan

- [x] 新增 `test_deploy_seeds_selector_pick_after_add_portfolio`：断言 deploy 后 `selector.pick` 被调且传非 None time（对齐 INIT 路径 #6159 守护断言）
- [x] `TestDeploy` + `TestAssembleEngine` 共 8 passed（含 INIT 路径 `test_assemble_engine_passes_time_to_selector_pick`，重构后 helper 等价）
- [x] 三层冒烟：py_compile 全绿 / 启动路径 smoke 29 passed / worker 测试文件 50 passed（3 个已知失败：2 Redis + 1 hang，与本次变更无关）

Closes #6473
