### PR TITLE
fix(#6489): 订正 paper worker LIVE 服务访问路径致部署 0 signal

### DIFF
--- a/src/ginkgo/__init__.py
+++ b/src/ginkgo/__init__.py
@@ -18,9 +18,9 @@ Usage:
 
     # Data services - 完善的数据访问层
     bar_crud = service_hub.data.cruds.bar()
-    bar_service = service_hub.data.services.bar_service()
-    stockinfo_service = service_hub.data.services.stockinfo_service()
-    tick_service = service_hub.data.services.tick_service()
+    bar_service = service_hub.data.bar_service()
+    stockinfo_service = service_hub.data.stockinfo_service()
+    tick_service = service_hub.data.tick_service()
 
     # Trading services - 交易引擎和组件
     engine = service_hub.trading.engines.time_controlled()

--- a/src/ginkgo/trading/services/_assembly/task_engine_builder.py
+++ b/src/ginkgo/trading/services/_assembly/task_engine_builder.py
@@ -118,7 +118,7 @@ class TaskEngineBuilder:
         last_error = None
         for attempt in range(max_retries):
             try:
-                portfolio_service = services.data.services.portfolio_service()
+                portfolio_service = services.data.portfolio_service()
 
                 # #3866: 通过 trading 层装配，data 层提供 writer 基础设施
                 from ginkgo.trading.services.engine_assembly_service import EngineAssemblyService

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -441,7 +441,7 @@ class PaperTradingWorker:
         records = {"analyzers": [], "signals": [], "orders": []}
 
         try:
-            analyzer_service = services.data.services.analyzer_service()
+            analyzer_service = services.data.analyzer_service()
             result = analyzer_service.get_by_task_id(
                 task_id=self._engine.task_id if self._engine else "paper",
                 portfolio_id=portfolio_id,
@@ -459,7 +459,7 @@ class PaperTradingWorker:
 
         # 补充 signal 记录（走 Service 层 + 日期下推查询层，#6030）
         try:
-            sig_service = services.data.services.signal_service()
+            sig_service = services.data.signal_service()
             sig_result = sig_service.get_signals_by_portfolio(
                 portfolio_id=portfolio_id,
                 start_date=day_start,
@@ -477,7 +477,7 @@ class PaperTradingWorker:
 
         # 补充 order 记录（走 Service 层 + 日期下推查询层，#6030）
         try:
-            order_service = services.data.services.order_service()
+            order_service = services.data.order_service()
             order_result = order_service.get_orders_by_portfolio(
                 portfolio_id=portfolio_id,
                 start_date=day_start,
@@ -788,7 +788,7 @@ class PaperTradingWorker:
 
         # 4. 同步拉取当日数据
         try:
-            bar_service = services.data.services.bar_service()
+            bar_service = services.data.bar_service()
             sync_result = bar_service.sync_range_batch(
                 codes=codes,
                 start_date=today,

--- a/tests/unit/test_service_container_paths.py
+++ b/tests/unit/test_service_container_paths.py
@@ -1,0 +1,43 @@
+"""#6489: services 容器 provider 解析路径回归守护。
+
+DynamicContainer 没有 .services 中间层聚合 provider。service provider（bar/signal/
+order/analyzer/portfolio 等）直接注册在 services.data 顶层，必须用 services.data.<svc>()
+直调。本测试锁定正确路径，防止再回退到 services.data.services.<svc>()（抛 AttributeError）。
+"""
+import pytest
+
+
+class TestServiceContainerDirectPath:
+    """services.data.<svc> 直调路径回归。"""
+
+    @pytest.mark.parametrize("svc_name", [
+        "bar_service",
+        "signal_service",
+        "order_service",
+        "analyzer_service",
+        "portfolio_service",
+    ])
+    def test_data_service_provider_resolves_directly(self, svc_name):
+        """五个核心 service provider 必须通过 services.data.<svc> 直调解析（无 AttributeError）。
+
+        这是 #6489 的根因守护：DynamicContainer 上访问 .services 中间层会抛
+        AttributeError，被 worker 的 except 吞成 'Data sync error' → 部署 0 signal。
+        """
+        from ginkgo import services
+
+        # 访问 provider（不调用，仅断言可解析）。直调返回 Singleton/Callable provider。
+        provider = getattr(services.data, svc_name)
+        assert provider is not None, f"services.data.{svc_name} 未解析"
+
+    def test_data_has_no_services_aggregate(self):
+        """services.data 不应有 .services 中间层聚合 provider。
+
+        DynamicContainer 的 __getattr__ 对未注册名返回占位对象，再取属性必抛
+        AttributeError。.services 不是注册名，访问其下的 _service 必抛错。
+        断言 buggy 路径确实不可用，固化"直调是唯一正确路径"这一契约。
+        """
+        from ginkgo import services
+
+        with pytest.raises(AttributeError):
+            # noqa: 故意访问错误路径，证明它确实抛错
+            _ = services.data.services.bar_service  # type: ignore[attr-defined]

--- a/tests/unit/trading/test_task_engine_builder_service_path.py
+++ b/tests/unit/trading/test_task_engine_builder_service_path.py
@@ -1,0 +1,52 @@
+"""#6489: TaskEngineBuilder._load_portfolio_from_task 必须用直调路径获取 portfolio_service。
+
+DynamicContainer 没有 .services 中间层，services.data.services.portfolio_service() 会抛
+AttributeError 被 retry 循环吞掉，导致回测/模拟盘引擎装配静默失败。正确路径是
+services.data.portfolio_service()（service provider 直接注册在容器顶层）。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def builder():
+    from ginkgo.trading.services._assembly.task_engine_builder import TaskEngineBuilder
+    with patch("ginkgo.trading.services._assembly.task_engine_builder.GLOG"):
+        return TaskEngineBuilder()
+
+
+class TestLoadPortfolioServicePath:
+    """#6489: service 获取路径回归。"""
+
+    def test_uses_direct_service_path(self, builder):
+        """_load_portfolio_from_task 必须走 services.data.portfolio_service() 直调。
+
+        buggy 写法 services.data.services.portfolio_service() 在真实 DynamicContainer
+        上抛 AttributeError；本测试只配置直调路径的 mock，断言直调被命中。
+        """
+        mock_portfolio_service = MagicMock()
+        mock_portfolio_service.build_position_writer.return_value = MagicMock()
+        mock_portfolio_service.build_redis_writer.return_value = MagicMock()
+
+        mock_assembly = MagicMock()
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        # 非 PortfolioLive 实例 → 走 `return result.data` 分支，避开 _convert 路径
+        mock_result.data = "loaded_portfolio"
+        mock_assembly.assemble_live_portfolio.return_value = mock_result
+
+        mock_task = MagicMock()
+        mock_task.portfolio_uuid = "12345678-aaaa-bbbb-cccc-dddddddddddd"
+
+        with patch("ginkgo.services") as mock_services, \
+             patch("ginkgo.trading.services.engine_assembly_service.EngineAssemblyService") as mock_asm_cls:
+            # 只配置直调路径
+            mock_services.data.portfolio_service.return_value = mock_portfolio_service
+            mock_asm_cls.return_value = mock_assembly
+
+            result = builder._load_portfolio_from_task(mock_task)
+
+        # 直调路径必须被命中（buggy code 走 .data.services.portfolio_service 不命中此处）
+        mock_services.data.portfolio_service.assert_called_once()
+        assert result == "loaded_portfolio"

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -367,7 +367,7 @@ class TestDailyCycle:
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.cruds.trade_day.return_value = mock_trade_day_crud
-            mock_services.data.services.bar_service.return_value = mock_bar_service
+            mock_services.data.bar_service.return_value = mock_bar_service
             result = worker.run_daily_cycle()
 
         assert result.skipped is False
@@ -399,7 +399,7 @@ class TestDailyCycle:
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.cruds.trade_day.return_value = mock_trade_day_crud
-            mock_services.data.services.bar_service.return_value = mock_bar_service
+            mock_services.data.bar_service.return_value = mock_bar_service
             worker.run_daily_cycle()
 
         # 验证 sync_range_batch 被调用，且 codes 包含两个股票
@@ -455,7 +455,7 @@ class TestDailyCycle:
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.cruds.trade_day.return_value = mock_trade_day_crud
-            mock_services.data.services.bar_service.return_value = mock_bar_service
+            mock_services.data.bar_service.return_value = mock_bar_service
             result = worker.run_daily_cycle()
 
         assert result.advanced is True
@@ -996,7 +996,7 @@ class TestLoadTodayRecords:
         mock_analyzer_svc.get_by_task_id.return_value = mock_result
 
         with patch("ginkgo.services", create=True) as mock_services:
-            mock_services.data.services.analyzer_service.return_value = mock_analyzer_svc
+            mock_services.data.analyzer_service.return_value = mock_analyzer_svc
             records = worker._load_today_records("p-001")
 
         assert len(records["analyzers"]) == 1
@@ -1016,7 +1016,7 @@ class TestLoadTodayRecords:
         )
 
         with patch("ginkgo.services", create=True) as mock_services:
-            mock_services.data.services.analyzer_service.return_value = mock_analyzer_svc
+            mock_services.data.analyzer_service.return_value = mock_analyzer_svc
             records = worker._load_today_records("p-001")
 
         assert records["analyzers"] == []
@@ -1143,17 +1143,17 @@ class TestLoadTodayRecordsServiceLayer:
         mock_sig.get_signals_by_portfolio.return_value = ServiceResult.success(
             data=signals if signals is not None else []
         )
-        mock_services.data.services.signal_service.return_value = mock_sig
+        mock_services.data.signal_service.return_value = mock_sig
 
         mock_order = MagicMock()
         mock_order.get_orders_by_portfolio.return_value = ServiceResult.success(
             data=orders if orders is not None else []
         )
-        mock_services.data.services.order_service.return_value = mock_order
+        mock_services.data.order_service.return_value = mock_order
 
         mock_analy = MagicMock()
         mock_analy.get_by_task_id.return_value = ServiceResult.success(data=[])
-        mock_services.data.services.analyzer_service.return_value = mock_analy
+        mock_services.data.analyzer_service.return_value = mock_analy
 
         return mock_sig, mock_order
 


### PR DESCRIPTION
## Summary

订正 paper worker LIVE 分支及引擎装配路径中错误的 `services.data.services.<svc>()` 调用（多了不存在的 `.services` 中间层），改为既定主流的直调 `services.data.<svc>()`。

**根因**：`services.data` 是 dependency-injector 的 `DynamicContainer`，service provider 直接注册在容器顶层，**从无 `.services` 子聚合 provider**。访问 `services.data.services.<svc>()` 会先取到占位对象再取属性 → `AttributeError: 'DynamicContainer' object has no attribute 'services'`，被 worker 外层 `except` 吞成 `Data sync error`，导致 LIVE daily_cycle 当日 bar 从未喂入 → 部署组合 **0 signal 却显示 RUNNING**。bug 被 #6488 trade_day 闸门长期掩盖（daily_cycle 在 L766 提前 skip，执行流到不了 L791）。

**错误文档是误抄源头**：`src/ginkgo/__init__.py` 的 module docstring `Usage:` 示例把 `service_hub.data.services.bar_service()` 标为"正确用法"，worker 作者据此误抄。

### 变更

5 处运行期调用点改为直调（`grep -rnE "(services|service_hub)\.data\.services\." src` 现 0 命中）：
- `src/ginkgo/workers/paper_trading_worker.py`：`analyzer_service` / `signal_service` / `order_service` / `bar_service`（4 处，LIVE daily_cycle + 报表记录加载）
- `src/ginkgo/trading/services/_assembly/task_engine_builder.py`：`portfolio_service`（1 处，**原 issue 漏报**，在引擎装配 retry 循环内，会一并阻塞回测与模拟盘装配）

docstring 订正：
- `src/ginkgo/__init__.py`：`Usage:` 示例 3 行由 `service_hub.data.services.*` 改直调形式（`service_hub.data.cruds.bar()` 已验证正确，保留）

### 不重构 Container

不为兼容旧写法而向 `Container` 新增 `services` 聚合 provider。直调 `services.data.<svc>()` 是既定主流（全仓 25 处直调 vs 5 处错误中间层），应让 call site 对齐容器而非反之。

### Out of scope

- **端到端"部署组合产出 signal（signal 表 count > 0）"**：依赖 #6488（trade_day 日历同步，仍 open）+ 完整实盘栈，不可在本 PR 复现验证。留作 #6488 合并后的 follow-up。
- #6473（运行时 deploy 漏 pick 种子）是独立 issue，不在此处理。

## Test plan

- [x] `grep -rnE "(services|service_hub)\.data\.services\." src` 返回 0 命中（退出契约）
- [x] Layer 1 py_compile（src + api）全通过
- [x] Layer 2 启动路径 smoke：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29 passed）
- [x] Layer 3 变更相关测试：
  - `test_paper_trading_worker.py`（deselect 已知 replay hang）：4 处 service-path 测试对齐正确路径后通过；2 处 Redis 失败为既有预存（与本 PR 无关）
  - 新增 `test_service_container_paths.py`：5-provider 直调解析 + buggy 路径抛 AttributeError 契约守护（6 passed）
  - 新增 `test_task_engine_builder_service_path.py`：`_load_portfolio_from_task` 直调路径回归（1 passed）
  - `test_task_engine_builder_smoke.py`：实例化冒烟通过
- [ ] #6488 合并后 follow-up：部署组合触发 daily_cycle，signal 表 count > 0（端到端，留 follow-up）

Closes #6489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
