### PR TITLE
fix(#6495): 对齐 task_processor 测试 WARN 断言 + list_paper_accounts 补 HTTPException 透传

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -231,6 +231,8 @@ async def list_paper_accounts():
 
     except BusinessError:
         raise
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error listing paper accounts: {str(e)}")
         raise BusinessError(f"Error listing paper accounts: {str(e)}")

--- a/tests/api/test_trading_helpers.py
+++ b/tests/api/test_trading_helpers.py
@@ -121,3 +121,31 @@ def test_get_paper_account_endpoint_propagates_http_500(api_modules):
         with pytest.raises(HTTPException) as exc:
             asyncio.run(trading_mod.get_paper_account("acct-1"))
     assert exc.value.status_code == 500
+
+
+# #6495: #6380 给 get_paper_account/get_paper_positions/get_paper_orders 三端点加了
+# except HTTPException: raise，但 list_paper_accounts（循环内调 _query_positions）漏改，
+# DB 故障被 except Exception 吞成 BusinessError(400) 非 AC1 的 500。
+# 修法：异常链补 except HTTPException: raise，与三 sibling 对齐。
+def test_list_paper_accounts_endpoint_propagates_http_500(api_modules):
+    """AC1: list_paper_accounts 端点同型透传 HTTPException(500)（循环内 _query_positions raise）。"""
+    import asyncio
+    import api.trading as trading_mod
+    from ginkgo.data.services.base_service import ServiceResult
+
+    # list_paper_accounts 经 portfolio_service.get(mode=PAPER) 拿账户列表，循环内调 _query_positions
+    mock_p = MagicMock()
+    mock_p.uuid = "p1"
+    mock_p.initial_capital = 100000
+    mock_p.cash = 100000
+    mock_p.name = "paper-1"
+
+    svc = MagicMock()
+    svc.get.return_value = ServiceResult.success([mock_p])
+
+    with patch.object(trading_mod, "_get_portfolio_service", return_value=svc), \
+         patch.object(trading_mod, "_query_positions",
+                      side_effect=HTTPException(status_code=500, detail="DB down")):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(trading_mod.list_paper_accounts())
+    assert exc.value.status_code == 500

--- a/tests/unit/workers/test_task_processor_on_progress.py
+++ b/tests/unit/workers/test_task_processor_on_progress.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 
 def test_on_progress_logs_on_stats_failure():
-    """统计聚合异常 → GLOG.ERROR 被调用（非静默 pass），主流程仍上报进度。"""
+    """统计聚合异常 → GLOG.WARN 被调用（非静默 pass），主流程仍上报进度。"""
     from ginkgo.workers.backtest_worker import task_processor as tp_mod
     from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
 
@@ -30,5 +30,5 @@ def test_on_progress_logs_on_stats_failure():
     with patch.object(tp_mod, "GLOG") as m_glog:
         proc._on_progress(0.5, "2026-01-01")  # 不应抛（主流程继续）
 
-    assert m_glog.ERROR.called, "统计失败应记 GLOG.ERROR 而非静默 pass"
+    assert m_glog.WARN.called, "统计失败应记 GLOG.WARN 而非静默 pass"
     assert progress_tracker.report_progress.called, "主流程上报不应中断"


### PR DESCRIPTION
## Summary

修 #6380（#5479）合并后两处遗留问题。

### 问题1（P1）：test_on_progress_logs_on_stats_failure 断言级别错
- 测试断言 `GLOG.ERROR.called`，但 `BacktestProcessor._on_progress` 统计失败分支用 `GLOG.WARN`（#6031 约定：统计聚合失败非致命用 WARN，**实现正确**）。
- **修法**：测试断言改 `WARN.called`，docstring 同步；实现不动。

### 问题2（P2）：list_paper_accounts 漏 HTTPException 透传
- #6380 给 `get_paper_account`/`get_paper_positions`/`get_paper_orders` 三端点加了 `except HTTPException: raise`，但 `list_paper_accounts`（循环内调 `_query_positions`）漏改。
- DB 故障时 `_query_positions` raise HTTPException(500) 落入 `except Exception` 被改写成 BusinessError(400)——HTTPException 继承 Exception，被先于框架处理器捕获。
- **修法**：异常链补 `except HTTPException: raise`，与三 sibling 对齐，500 原样透传。

## Test plan

- [x] `pytest tests/unit/workers/test_task_processor_on_progress.py -o addopts=""` — 1 passed（断言对齐 WARN）
- [x] `pytest tests/api/test_trading_helpers.py -o addopts=""` — 7 passed（含新增 `test_list_paper_accounts_endpoint_propagates_http_500`）
- [x] py_compile（src+api 全量）通过
- [x] 启动路径 smoke（test_user_crud_mock + test_containers + test_user_cli）— 29 passed
- 注：unit 与 api 不可混跑（core.logging 命名空间歧义，非 bug），分两次 pytest

Closes #6495
