### PR TITLE
fix: VolatilityRisk 预警分支缩放因子方向修正（减仓而非放大）(#6497)

### DIFF
--- a/src/ginkgo/trading/risk_management/volatility_risk.py
+++ b/src/ginkgo/trading/risk_management/volatility_risk.py
@@ -123,7 +123,10 @@ class VolatilityRisk(LotAlignableMixin, BaseRiskManagement):
 
         elif current_volatility > self._warning_volatility:
             # 波动率预警，适度减少订单规模
-            reduction_factor = (self._max_volatility / current_volatility) ** 1.5
+            # 分子用 warning_volatility（非 max）：预警区间 warning < cur ≤ max，
+            # warning/cur < 1 使因子 < 1 且随 cur 升高递减（#6497）。
+            # 旧式 (max/cur) 在此区间 ≥ 1 会放大仓位，违反风控单调性。
+            reduction_factor = (self._warning_volatility / current_volatility) ** 1.5
             scaled = int(order.volume * reduction_factor)
             # 最小交易单位 lot_size 对齐(LotAlignableMixin,A 股默认 100 股/手)(#6038)
             aligned = self.align_to_lot(scaled)

--- a/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
+++ b/tests/unit/trading/strategy/risk_managements/test_volatility_risk.py
@@ -141,6 +141,50 @@ class TestVolatilityRiskOrderProcessing:
         # Source adjusts volume based on volatility ratio
         assert order.volume > 0
 
+    def test_warning_branch_reduces_not_amplifies(self):
+        """预警分支(warning < cur ≤ max)必须减仓而非放大仓位。
+
+        Regression guard for #6497：预警分支原照搬高波动分支的
+        (max_volatility/cur)^1.5，但预警区间 cur ≤ max 使 max/cur ≥ 1，
+        因子 ≥ 1 → 放大仓位，违反风控单调性。修法：分子改用
+        warning_volatility，使预警区间因子 < 1 且随 cur 升高递减。
+
+        默认 warning=20/max=25，cur=22 落在预警区间：
+          buggy (25/22)^1.5 ≈ 1.21 → 1211（放大，应失败）
+          fixed (20/22)^1.5 ≈ 0.87 → 866（减仓）
+        """
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0)
+        r._volatility_cache["000001.SZ"] = 22.0  # warning(20) < 22 ≤ max(25)
+        order = _make_order(volume=1000)
+        result = r.cal({}, order)
+        assert result is order
+        # 核心断言：预警触发后仓位必须减少，绝不能放大
+        assert order.volume < 1000, (
+            f"预警分支应减仓，实际 volume={order.volume}（原 1000）；"
+            "若 > 1000 说明因子方向仍错误（#6497 回归）"
+        )
+
+    def test_warning_branch_monotonic_decreasing(self):
+        """预警区间内 cur 越接近 max，减仓越多（因子随 cur 升高单调递减）。
+
+        #6497 影响：旧实现不仅放大仓位，且随 cur 升高放大更多（非单调）。
+        修复后预警分支应在区间内单调递减，到 max 处衔接高波动分支。"""
+        r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0)
+        # cur=21（刚踩预警）应比 cur=24（接近 max）减得更少，但两者都 < 原量
+        r._volatility_cache["000001.SZ"] = 21.0
+        order_low = _make_order(volume=1000)
+        r.cal({}, order_low)
+
+        r._volatility_cache["000001.SZ"] = 24.0
+        order_high = _make_order(volume=1000)
+        r.cal({}, order_high)
+
+        assert order_low.volume < 1000 and order_high.volume < 1000
+        assert order_high.volume < order_low.volume, (
+            f"预警区间应单调递减：cur=24 volume={order_high.volume} 应 < "
+            f"cur=21 volume={order_low.volume}"
+        )
+
     def test_high_volatility_order_reduction(self):
         r = VolatilityRisk(max_volatility=25.0, warning_volatility=20.0)
         r._volatility_cache["000001.SZ"] = 50.0


### PR DESCRIPTION
## Summary

修复 VolatilityRisk 预警分支缩放因子方向错误（#6497）：触发波动率预警时**放大仓位**而非减仓。

### 根因

`VolatilityRisk.cal()` 预警分支（`warning < current_volatility ≤ max`）照搬了高波动分支的 `reduction_factor = (max_volatility / current_volatility) ** 1.5`，但两个分支的 `current_volatility` 区间相反：

| 分支 | 区间 | max/cur | 因子 | 语义 |
|---|---|---|---|---|
| 高波动 (`cur > max`) | cur > max | < 1 | < 1 | ✅ 减仓 |
| 预警 (`warning < cur ≤ max`) | cur ≤ max | **≥ 1** | **≥ 1** | ❌ 放大/持平 |

预警区间 `cur ≤ max` 使 `max/cur ≥ 1`，与"适度减少订单规模"的注释及风控语义完全相反。

### 修法

预警分支分子从 `_max_volatility` 改为 `_warning_volatility`：

```python
reduction_factor = (self._warning_volatility / current_volatility) ** 1.5
```

边界语义：`cur=warning → 1.0`（边界不减），`cur→max → (warning/max)^1.5`（适度减，默认 warn=20/max=25 ≈ 0.72），因子 < 1 且随 cur 升高单调递减。

默认 `warn=20/max=25`，`cur=22` 复现：
- buggy `(25/22)^1.5 ≈ 1.21` → 1211（放大 +21%）
- fixed `(20/22)^1.5 ≈ 0.87` → 866（减仓 -13%）

### 范围说明

- 本 PR 基于 master，独立于 lot 对齐 PR #6443（该 PR 显式声明此项 phased 范围外）。
- 仅触及预警分支因子方向；高波动分支（`cur > max`）公式正确，不受影响。
- 高波动分支在 `max` 边界处因子 ≈1.0 与预警分支 ~0.72 的衔接连续性属另一独立议题，不在本 issue 范围。

## Test plan

TDD（红→绿，2 个守护测试）：

- [x] `test_warning_branch_reduces_not_amplifies` —— AC：`warning < cur < max` 时 `result.volume < original_volume`（RED: 1211 > 1000；GREEN: 866 < 1000）
- [x] `test_warning_branch_monotonic_decreasing` —— 预警区间内 cur 升高减仓递增（cur=21→929, cur=24→760）

本地三层冒烟全绿（对齐 `.github/workflows/ci.yml` #6015）：

- [x] Layer 1: `py_compile` 全量扫 src+api ✅
- [x] Layer 2: 启动路径 smoke（user_crud / containers / user_cli）29 passed ✅
- [x] Layer 3: `test_volatility_risk.py` 全文件 29 passed ✅（无回归，含既有 warning/high 分支测试）

```bash
/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/trading/strategy/risk_managements/test_volatility_risk.py -q -o addopts=
```

Closes #6497
