### PR TITLE
fix: 接通 trade_day 日历同步链路修复 paper worker 0 signal (#6488)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -520,7 +520,7 @@ def _is_valid_stock_code(code: str) -> bool:
 
 @app.command()
 def sync(
-    data_type: str = typer.Argument(..., help="Data type to sync (stockinfo/day/tick/adjustfactor)"),
+    data_type: str = typer.Argument(..., help="Data type to sync (stockinfo/day/tick/adjustfactor/trade_day)"),
     code: Optional[str] = typer.Option(None, "--code", "-c", help="Stock code (for day/tick data)"),
     date: Optional[str] = typer.Option(None, "--date", "-d", help="Specific date (YYYYMMDD, for tick data only)"),
     market: Optional[str] = typer.Option(None, "--market", help="Filter by market"),
@@ -576,6 +576,9 @@ def sync(
                 else:
                     # 全代码adjustfactor同步：直接pass参数
                     success = kafka_service.send_adjustfactor_all_signal(full=full, force=force)
+            elif data_type == "trade_day":
+                # 交易日历全量同步（#6488），paper worker 查 is_open 判断开市
+                success = kafka_service.send_trade_day_signal()
 
             if success:
                 console.print(f":white_check_mark: {data_type} sync task successfully queued for background processing")
@@ -831,6 +834,21 @@ def sync(
                 console.print(f":x: Error in adjustfactor sync process: {e}")
                 if not force:
                     raise typer.Exit(1)
+
+        elif data_type == "trade_day":
+            # 交易日历全量同步（#6488）。trade_cal 返回开市/休市标记，
+            # paper worker _run_live_paper_cycle 通过 trade_day_crud 查 is_open 判断开市，
+            # 表空则整轮 skip 致 0 signal。trade_day 无 code 参数，全量同步。
+            from ginkgo.data.containers import container
+            trade_day_service = container.trade_day_service()
+            console.print(":repeat: Syncing trade calendar...")
+            result = trade_day_service.sync()
+            if result and result.is_success():
+                console.print(f":white_check_mark: {result.message}")
+            else:
+                error_msg = result.message if result and hasattr(result, "message") else "unknown error"
+                console.print(f":x: Trade calendar sync failed: {error_msg}")
+                raise typer.Exit(1)
 
         else:
             console.print(f":x: Unknown data type: {data_type}")

--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -57,6 +57,7 @@ from ginkgo.libs import GCONF
 from ginkgo.data.services.adjustfactor_service import AdjustfactorService
 from ginkgo.data.services.backtest_task_service import BacktestTaskService
 from ginkgo.data.services.stockinfo_service import StockinfoService
+from ginkgo.data.services.trade_day_service import TradeDayService
 from ginkgo.data.services.bar_service import BarService
 from ginkgo.data.services.tick_service import TickService
 from ginkgo.data.crud.tick_crud import TickCRUD
@@ -126,6 +127,7 @@ class Container(containers.DeclarativeContainer):
     # Backward compatibility - keep existing explicit providers
     adjustfactor_crud = providers.Singleton(get_crud, "adjustfactor")
     stockinfo_crud = providers.Singleton(get_crud, "stock_info")
+    trade_day_crud = providers.Singleton(get_crud, "trade_day")
     bar_crud = providers.Singleton(get_crud, "bar")
     engine_crud = providers.Singleton(get_crud, "engine")
     file_crud = providers.Singleton(get_crud, "file")
@@ -166,6 +168,11 @@ class Container(containers.DeclarativeContainer):
     # StockinfoService must be defined before AdjustfactorService as it's a dependency
     stockinfo_service = providers.Singleton(
         StockinfoService, crud_repo=stockinfo_crud, data_source=ginkgo_tushare_source
+    )
+
+    # TradeDayService：交易日历同步（#6488），paper worker 查 is_open 判断开市
+    trade_day_service = providers.Singleton(
+        TradeDayService, crud_repo=trade_day_crud, data_source=ginkgo_tushare_source
     )
 
     adjustfactor_service = providers.Singleton(

--- a/src/ginkgo/data/services/kafka_service.py
+++ b/src/ginkgo/data/services/kafka_service.py
@@ -928,6 +928,14 @@ class KafkaService(BaseService):
             "code": ""
         })
 
+    def send_trade_day_signal(self) -> bool:
+        """Send trade calendar update signal (#6488). Worker 消费后调用
+        TradeDayService.sync 落库，供 paper worker 查 is_open 判断开市。"""
+        return self.publish_message(KafkaTopics.DATA_UPDATE, {
+            "type": "trade_day",
+            "code": ""
+        })
+
     def send_adjustfactor_update_signal(self, code: str, full: bool = False, force: bool = False) -> bool:
         """Send adjustment factor update signal"""
         return self.publish_message(KafkaTopics.DATA_UPDATE, {

--- a/src/ginkgo/data/services/trade_day_service.py
+++ b/src/ginkgo/data/services/trade_day_service.py
@@ -148,27 +148,81 @@ class TradeDayService(BaseService):
 
         self._logger.INFO(f"New records: {len(new_items)}, Update records: {len(update_items)}")
 
-        # Step 3: Batch persist（new 直插；update 先 remove 既有日期再 add_batch → 幂等）
+        # Step 3: Batch persist —— 镜像 StockinfoService.sync 分 new/update 两段，
+        # 各有 add_batch → 逐条 add_batch([item]) 容错 fallback（#6488 review 第3轮）。
+        # 关键：update 段 remove 已清旧行后，若 add_batch 失败须逐条回退，
+        # 否则 update_items 旧行已删、新行未写 → 永久丢失 + 静默 success。
         success_count = 0
         with RichProgress() as progress:
-            task = progress.add_task("[green]Syncing Trade Calendar", total=len(valid_items))
-            try:
-                if update_items:
-                    update_dates = [item.timestamp for item in update_items]
+            # 3a: new items 直插（无既有记录，不须 remove）
+            if new_items:
+                task_new = progress.add_task("[green]Adding New Trade Calendar", total=len(new_items))
+                try:
+                    self._crud_repo.add_batch(new_items)
+                    success_count += len(new_items)
+                    self._logger.INFO(
+                        f"Successfully batch inserted {len(new_items)} new trade calendar records"
+                    )
+                    progress.update(task_new, completed=len(new_items))
+                except Exception as e:
+                    self._logger.WARN(f"Batch insert failed, falling back to individual inserts: {e}")
+                    for item in new_items:
+                        try:
+                            self._crud_repo.add_batch([item])
+                            success_count += 1
+                        except Exception as individual_e:
+                            failed_count += 1
+                            self._logger.WARN(
+                                f"Failed to insert trade day {item.timestamp}: {individual_e}"
+                            )
+                        progress.update(task_new, advance=1)
+
+            # 3b: update items 先 remove 既有日期再 add_batch → 幂等；
+            # add 失败逐条回退防数据丢失（已 remove 的 update_items 须能重写）。
+            if update_items:
+                task_update = progress.add_task(
+                    "[blue]Updating Trade Calendar", total=len(update_items)
+                )
+                update_dates = [item.timestamp for item in update_items]
+                try:
                     self._crud_repo.remove(
                         filters={"market": MARKET_TYPES.CHINA, "timestamp__in": update_dates}
                     )
                     self._logger.DEBUG(
                         f"Removed {len(update_dates)} existing trade calendar records for update"
                     )
-                to_add = new_items + update_items
-                self._crud_repo.add_batch(to_add)
-                success_count = len(to_add)
-                self._logger.INFO(f"Successfully batch inserted {len(to_add)} trade calendar records")
-                progress.update(task, completed=len(valid_items))
-            except Exception as e:
-                self._logger.WARN(f"Batch insert failed: {e}")
-                failed_count += len(valid_items)
+                except Exception as e:
+                    self._logger.WARN(
+                        f"Failed to batch remove existing, falling back to individual: {e}"
+                    )
+                    for item in update_items:
+                        try:
+                            self._crud_repo.remove(
+                                filters={"market": MARKET_TYPES.CHINA, "timestamp": item.timestamp}
+                            )
+                        except Exception as remove_e:
+                            self._logger.WARN(f"Failed to remove {item.timestamp}: {remove_e}")
+                try:
+                    self._crud_repo.add_batch(update_items)
+                    success_count += len(update_items)
+                    progress.update(task_update, completed=len(update_items))
+                    self._logger.DEBUG(
+                        f"Successfully updated {len(update_items)} trade calendar records"
+                    )
+                except Exception as e:
+                    self._logger.WARN(
+                        f"Batch update failed, falling back to individual updates: {e}"
+                    )
+                    for item in update_items:
+                        try:
+                            self._crud_repo.add_batch([item])
+                            success_count += 1
+                        except Exception as individual_e:
+                            failed_count += 1
+                            self._logger.WARN(
+                                f"Failed to update trade day {item.timestamp}: {individual_e}"
+                            )
+                        progress.update(task_update, advance=1)
 
         # Update sync result statistics
         duration = time.time() - start_time

--- a/src/ginkgo/data/services/trade_day_service.py
+++ b/src/ginkgo/data/services/trade_day_service.py
@@ -1,0 +1,161 @@
+# Upstream: DataWorker/CLI (调用 sync 同步交易日历)、PaperTradingWorker (查询 is_open 判断开市 #6488)
+# Downstream: BaseService (继承提供标准服务能力)、TradeDayCRUD (MySQL trade_day 持久化)、GinkgoTushare (trade_cal 数据源)
+# Role: TradeDayService 交易日历业务服务镜像 StockinfoService.sync 提供 calendar 同步
+
+
+
+
+"""
+TradeDay Data Service (Class-based)
+
+This service handles the business logic for synchronizing the trading calendar.
+Mirrors StockinfoService.sync —— 「加一种 data_type」对称扩展（#6488）。
+
+paper worker _run_live_paper_cycle 通过 trade_day_crud.find(...).is_open 判断是否开市，
+表空则整轮 skip 致 0 signal（#6488）。本服务接通 sync 链路：data_source → TradeDay → DB。
+"""
+
+import time
+
+from ginkgo.libs import RichProgress, retry
+from ginkgo.libs.data.results import DataSyncResult
+from ginkgo.data.services.base_service import BaseService, ServiceResult
+from ginkgo.entities import TradeDay
+from ginkgo.enums import MARKET_TYPES, SOURCE_TYPES
+
+
+class TradeDayService(BaseService):
+    def __init__(self, crud_repo, data_source, **additional_deps):
+        """
+        Initialize trade calendar service following StockinfoService pattern.
+
+        Args:
+            crud_repo: Database CRUD operation repository
+            data_source: Trade calendar data source (GinkgoTushare)
+            **additional_deps: Additional dependencies
+        """
+        super().__init__(crud_repo=crud_repo, data_source=data_source, **additional_deps)
+
+    @retry(max_try=3)
+    def sync(self) -> ServiceResult:
+        """
+        Sync trading calendar from data source to database.
+
+        Mirrors StockinfoService.sync. trade_cal 返回全量日历（含开市/休市），
+        is_open 为 int 0/1，须 bool(int(...)) 双层转换以满足 TradeDay entity 的
+        严格 isinstance(is_open, bool) 校验（numpy int64 直接 bool() 不可靠）。
+        日历是权威全量覆盖，直接 add_batch，无需 new/update 分离。
+
+        Returns:
+            ServiceResult: Sync result with processing statistics
+        """
+        start_time = time.time()
+        self._log_operation_start("sync")
+
+        try:
+            raw_data = self._data_source.fetch_cn_stock_trade_day()
+            if raw_data is None or raw_data.empty:
+                sync_result = DataSyncResult.create_for_entity(
+                    entity_type="trade_day",
+                    entity_identifier="all",
+                    sync_strategy="full_sync",
+                )
+                sync_result.add_warning("No trade calendar data returned from source")
+                self._logger.WARN("No trade calendar data returned from source.")
+                return ServiceResult.failure(
+                    data=sync_result,
+                    message="No trade calendar data available from source - sync task failed",
+                )
+        except Exception as e:
+            sync_result = DataSyncResult.create_for_entity(
+                entity_type="trade_day",
+                entity_identifier="all",
+                sync_strategy="full_sync",
+            )
+            sync_result.add_error(0, f"Failed to fetch trade calendar from source: {str(e)}")
+            duration = time.time() - start_time
+            self._log_operation_end("sync", False, duration)
+            return ServiceResult.failure(
+                message=f"Failed to fetch trade calendar from source: {str(e)}",
+                data=sync_result,
+            )
+
+        # Initialize sync result
+        sync_result = DataSyncResult.create_for_entity(
+            entity_type="trade_day",
+            entity_identifier="all",
+            sync_strategy="full_sync",
+        )
+        sync_result.set_metadata("initial_records", len(raw_data))
+
+        valid_items = []
+        failed_count = 0
+
+        self._logger.INFO(f"Processing {len(raw_data)} trade calendar records for sync...")
+
+        # Step 1: Convert all rows to TradeDay business objects with error tolerance
+        for _, row in raw_data.iterrows():
+            try:
+                td = TradeDay(
+                    market=MARKET_TYPES.CHINA,
+                    is_open=bool(int(row["is_open"])),
+                    timestamp=row["cal_date"],
+                )
+                # Store source information as attribute for CRUD layer
+                td._source = SOURCE_TYPES.TUSHARE
+                valid_items.append(td)
+            except Exception as e:
+                failed_count += 1
+                cal_date = row.get("cal_date", "Unknown")
+                self._logger.ERROR(f"Failed to create TradeDay for {cal_date}: {e}")
+
+        if not valid_items:
+            sync_result.records_processed = len(raw_data)
+            sync_result.records_added = 0
+            sync_result.records_failed = failed_count
+            sync_result.sync_duration = time.time() - start_time
+            return ServiceResult.failure(
+                message="No valid trade calendar records to process",
+                data=sync_result,
+            )
+
+        self._logger.INFO(f"Successfully parsed {len(valid_items)} records, {failed_count} failed mapping")
+
+        # Step 2: Batch persist all trade calendar records
+        success_count = 0
+        with RichProgress() as progress:
+            task = progress.add_task("[green]Syncing Trade Calendar", total=len(valid_items))
+            try:
+                self._crud_repo.add_batch(valid_items)
+                success_count = len(valid_items)
+                self._logger.INFO(f"Successfully batch inserted {len(valid_items)} trade calendar records")
+                progress.update(task, completed=len(valid_items))
+            except Exception as e:
+                self._logger.WARN(f"Batch insert failed: {e}")
+                failed_count += len(valid_items)
+
+        # Update sync result statistics
+        duration = time.time() - start_time
+        sync_result.records_processed = len(raw_data)
+        sync_result.records_added = success_count
+        sync_result.records_failed = failed_count
+        sync_result.sync_duration = duration
+        sync_result.is_idempotent = True
+
+        self._logger.INFO(
+            f"Trade calendar sync completed: {success_count}/{len(raw_data)} successful, "
+            f"{failed_count} failed"
+        )
+
+        self._log_operation_end("sync", True, duration)
+
+        if failed_count == 0:
+            return ServiceResult.success(
+                data=sync_result,
+                message=f"Trade calendar sync completed successfully: {success_count} records processed",
+            )
+        else:
+            return ServiceResult.success(
+                data=sync_result,
+                message=f"Trade calendar sync completed with {failed_count} failures: {success_count} successful",
+            )

--- a/src/ginkgo/data/services/trade_day_service.py
+++ b/src/ginkgo/data/services/trade_day_service.py
@@ -121,14 +121,50 @@ class TradeDayService(BaseService):
 
         self._logger.INFO(f"Successfully parsed {len(valid_items)} records, {failed_count} failed mapping")
 
-        # Step 2: Batch persist all trade calendar records
+        # Step 2: 幂等去重——镜像 StockinfoService.sync（find existing → 分 new/update → remove-then-add）
+        # 自然键 (market, timestamp)：日历每 (市场,日期) 一行，重复 sync 须先清既有再写，
+        # 否则行数翻倍，与末尾 is_idempotent=True 声明矛盾（#6488 review）。
+        # 按 .date() 比较避免 tz/微秒漂移——语义单位是「日历日」。
+        all_dates = [item.timestamp for item in valid_items]
+        try:
+            existing_records = self._crud_repo.find(
+                filters={"market": MARKET_TYPES.CHINA, "timestamp__in": all_dates},
+                page_size=max(len(all_dates) * 2, 1000),
+            )
+            existing_dates = {r.timestamp.date() for r in existing_records}
+            self._logger.INFO(
+                f"Found {len(existing_dates)} existing records out of {len(all_dates)} trade calendar dates"
+            )
+        except Exception as e:
+            self._logger.WARN(f"Failed to check existing trade calendar, treating all as new: {e}")
+            existing_dates = set()
+
+        new_items, update_items = [], []
+        for item in valid_items:
+            if item.timestamp.date() in existing_dates:
+                update_items.append(item)
+            else:
+                new_items.append(item)
+
+        self._logger.INFO(f"New records: {len(new_items)}, Update records: {len(update_items)}")
+
+        # Step 3: Batch persist（new 直插；update 先 remove 既有日期再 add_batch → 幂等）
         success_count = 0
         with RichProgress() as progress:
             task = progress.add_task("[green]Syncing Trade Calendar", total=len(valid_items))
             try:
-                self._crud_repo.add_batch(valid_items)
-                success_count = len(valid_items)
-                self._logger.INFO(f"Successfully batch inserted {len(valid_items)} trade calendar records")
+                if update_items:
+                    update_dates = [item.timestamp for item in update_items]
+                    self._crud_repo.remove(
+                        filters={"market": MARKET_TYPES.CHINA, "timestamp__in": update_dates}
+                    )
+                    self._logger.DEBUG(
+                        f"Removed {len(update_dates)} existing trade calendar records for update"
+                    )
+                to_add = new_items + update_items
+                self._crud_repo.add_batch(to_add)
+                success_count = len(to_add)
+                self._logger.INFO(f"Successfully batch inserted {len(to_add)} trade calendar records")
                 progress.update(task, completed=len(valid_items))
             except Exception as e:
                 self._logger.WARN(f"Batch insert failed: {e}")

--- a/src/ginkgo/data/worker/worker.py
+++ b/src/ginkgo/data/worker/worker.py
@@ -648,11 +648,12 @@ class DataWorker(threading.Thread):
         处理数据采集命令
 
         DataWorker 订阅 ginkgo.data.commands topic，
-        只会收到 4 个核心数据采集命令：
+        只会收到 5 个核心数据采集命令：
         - bar_snapshot: K线数据采集
         - stockinfo: 股票基础信息同步
         - adjustfactor: 复权因子同步
         - tick: Tick数据采集
+        - trade_day: 交易日历同步
 
         Args:
             command: 命令类型

--- a/src/ginkgo/data/worker/worker.py
+++ b/src/ginkgo/data/worker/worker.py
@@ -676,8 +676,10 @@ class DataWorker(threading.Thread):
                 return self._handle_adjustfactor(payload)
             elif command == "tick":
                 return self._handle_tick(payload)
+            elif command == "trade_day":
+                return self._handle_trade_day(payload)
             else:
-                # 理论上不会到达这里（topic 只有这 4 个命令）
+                # 理论上不会到达这里（topic 只有这 5 个命令）
                 GLOG.WARN(f"[DataWorker:{self._node_id}] Unknown command: {command}")
                 return False
 
@@ -766,6 +768,35 @@ class DataWorker(threading.Thread):
 
         except Exception as e:
             GLOG.ERROR(f"[DataWorker:{self._node_id}] Error handling stockinfo: {e}")
+            import traceback
+            GLOG.ERROR(f"[DataWorker:{self._node_id}] Traceback: {traceback.format_exc()}")
+            return False
+
+    def _handle_trade_day(self, payload: Dict[str, Any]) -> bool:
+        """
+        处理 trade_day 命令 - 交易日历更新（#6488）
+
+        TradeDayService.sync() 同步全量交易日历（开市/休市标记），不支持单日同步。
+        paper worker 通过 trade_day_crud 查 is_open 判断是否开市，表空则整轮 skip 致 0 signal。
+        """
+        try:
+            code = payload.get("code")  # 参数会被忽略，sync() 总是同步全量日历
+            GLOG.INFO(f"[DataWorker:{self._node_id}] Handling trade_day: code={code} (will sync all)")
+
+            from ginkgo.data.containers import container
+            trade_day_service = container.trade_day_service()
+
+            result = trade_day_service.sync()
+
+            if result.success:
+                GLOG.INFO(f"[DataWorker:{self._node_id}] Trade calendar sync completed")
+            else:
+                GLOG.ERROR(f"[DataWorker:{self._node_id}] Trade calendar sync failed: {result.error}")
+
+            return result.success
+
+        except Exception as e:
+            GLOG.ERROR(f"[DataWorker:{self._node_id}] Error handling trade_day: {e}")
             import traceback
             GLOG.ERROR(f"[DataWorker:{self._node_id}] Traceback: {traceback.format_exc()}")
             return False

--- a/tests/unit/client/test_data_cli_sync_trade_day.py
+++ b/tests/unit/client/test_data_cli_sync_trade_day.py
@@ -1,0 +1,59 @@
+"""#6488: data sync trade_day CLI 路由测试。
+
+验证 CLI 入口正确路由 trade_day：daemon 模式发 kafka 信号，同步模式调
+trade_day_service.sync()。镜像 stockinfo 分支（全量同步，无 code 参数）。
+"""
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client.data_cli import app
+
+runner = CliRunner()
+
+
+def _ok_result():
+    r = MagicMock()
+    r.is_success.return_value = True
+    r.message = "Trade calendar sync completed"
+    return r
+
+
+class TestSyncTradeDay:
+    """#6488: data sync trade_day 双模式路由"""
+
+    @pytest.mark.unit
+    def test_daemon_mode_sends_kafka_signal(self):
+        """sync trade_day --daemon → kafka_service.send_trade_day_signal()"""
+        mock_kafka = MagicMock()
+        mock_kafka.send_trade_day_signal.return_value = True
+
+        with patch("ginkgo.data.containers.container.kafka_service", return_value=mock_kafka):
+            result = runner.invoke(app, ["sync", "trade_day", "--daemon"])
+
+        assert result.exit_code == 0, f"stdout: {result.stdout}"
+        mock_kafka.send_trade_day_signal.assert_called_once()
+
+    @pytest.mark.unit
+    def test_sync_mode_calls_service_sync(self):
+        """sync trade_day（同步模式）→ trade_day_service.sync()"""
+        mock_svc = MagicMock()
+        mock_svc.sync.return_value = _ok_result()
+
+        with patch("ginkgo.data.containers.container.trade_day_service", return_value=mock_svc):
+            result = runner.invoke(app, ["sync", "trade_day"])
+
+        assert result.exit_code == 0, f"stdout: {result.stdout}"
+        mock_svc.sync.assert_called_once()

--- a/tests/unit/data/services/test_kafka_trade_day_signal.py
+++ b/tests/unit/data/services/test_kafka_trade_day_signal.py
@@ -1,0 +1,38 @@
+"""
+send_trade_day_signal 单元测试（#6488 kafka wiring）
+
+镜像 send_stockinfo_update_signal 的契约：发 DATA_UPDATE topic + 标识 payload。
+mock publish_message 隔离真 kafka，只验证信号契约（topic + payload 结构）。
+"""
+
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+# 添加项目路径
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.kafka_service import KafkaService
+from ginkgo.interfaces.kafka_topics import KafkaTopics
+
+
+class TestSendTradeDaySignal:
+    """send_trade_day_signal 信号契约测试"""
+
+    @pytest.mark.unit
+    def test_send_trade_day_signal_publishes_correct_payload(self):
+        """send_trade_day_signal 发 DATA_UPDATE topic + trade_day payload"""
+        # __new__ 跳过 __init__，避免 producer 连真 kafka（CI 无 kafka 友好）
+        # 信号方法契约只依赖 self.publish_message，不依赖 producer 实例状态
+        svc = KafkaService.__new__(KafkaService)
+        with patch.object(svc, "publish_message", return_value=True) as mock_pub:
+            result = svc.send_trade_day_signal()
+
+        assert result is True
+        mock_pub.assert_called_once_with(
+            KafkaTopics.DATA_UPDATE, {"type": "trade_day", "code": ""}
+        )

--- a/tests/unit/data/services/test_trade_day_service_mock.py
+++ b/tests/unit/data/services/test_trade_day_service_mock.py
@@ -148,6 +148,90 @@ class TestSync:
             added.extend(call[0][0])
         assert len(added) == 2
 
+    @pytest.mark.unit
+    def test_sync_update_add_batch_failure_falls_back_per_item(self, service, mock_deps, raw_trade_df):
+        """update 分支 add_batch 失败 → 逐条 add_batch([item]) 回退，已 remove 的 update_items 不丢失（#6488 review 第3轮 blocking）
+
+        场景：DB 已含本次源日期（第二次 sync，触发 update 路径）。remove 成功清掉
+        旧行后，add_batch(update_items) 抛异常。若无逐条 fallback，update_items
+        旧行已删、新行未写 → 永久丢失且静默 success。镜像 stockinfo sync update
+        段逐条 add_batch([item]) 容错。
+        """
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = raw_trade_df
+        mock_deps["crud_repo"].find = MagicMock(return_value=[
+            TradeDay(market=MARKET_TYPES.CHINA, is_open=False, timestamp="20240102"),
+            TradeDay(market=MARKET_TYPES.CHINA, is_open=True, timestamp="20240103"),
+        ])
+        mock_deps["crud_repo"].remove = MagicMock()
+        # 批量 add 第1次抛异常（模拟 MySQL batch 死锁），后续逐条调用成功
+        mock_deps["crud_repo"].add_batch = MagicMock(
+            side_effect=[Exception("batch deadlock"), None, None]
+        )
+
+        with patch("ginkgo.data.services.trade_day_service.RichProgress"):
+            result = service.sync()
+
+        # 逐条回退：2 条 update 各经 add_batch([item]) 单条写入 → 数据不丢
+        per_item_calls = [
+            c for c in mock_deps["crud_repo"].add_batch.call_args_list
+            if len(c[0][0]) == 1
+        ]
+        assert len(per_item_calls) == 2, (
+            "add_batch 失败后须逐条回退，2 条 update 各一次单条调用；"
+            f"实际单条调用 {len(per_item_calls)} 次"
+        )
+        # 逐条成功 → success_count 完整，数据未丢
+        assert result.success is True
+        assert result.data.records_added == 2
+        assert result.data.records_failed == 0
+
+    @pytest.mark.unit
+    def test_sync_new_add_batch_failure_falls_back_per_item(self, service, mock_deps, raw_trade_df):
+        """new 分支 add_batch 失败 → 逐条 add_batch([item]) 回退（对称镜像 stockinfo，#6488 review 第3轮）
+
+        场景：find 返回空（首次 sync，全 new）。new_items 批量 add 抛异常，
+        须逐条回退写入，否则全量数据丢失。
+        """
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = raw_trade_df
+        mock_deps["crud_repo"].find = MagicMock(return_value=[])
+        mock_deps["crud_repo"].add_batch = MagicMock(
+            side_effect=[Exception("batch deadlock"), None, None]
+        )
+
+        with patch("ginkgo.data.services.trade_day_service.RichProgress"):
+            result = service.sync()
+
+        per_item_calls = [
+            c for c in mock_deps["crud_repo"].add_batch.call_args_list
+            if len(c[0][0]) == 1
+        ]
+        assert len(per_item_calls) == 2
+        assert result.success is True
+        assert result.data.records_added == 2
+
+    @pytest.mark.unit
+    def test_sync_update_batch_and_per_item_both_fail_records_failure(self, service, mock_deps, raw_trade_df):
+        """update 批量+逐条均失败 → failed_count 计入，不静默 success 掩盖丢失（#6488 review 第3轮）
+
+        场景：add_batch 持续抛异常（批量 + 逐条全失败）。须如实计入 records_failed，
+        不能假装全成功。镜像 stockinfo 逐条失败 failed_count += 1 语义。
+        """
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = raw_trade_df
+        mock_deps["crud_repo"].find = MagicMock(return_value=[
+            TradeDay(market=MARKET_TYPES.CHINA, is_open=False, timestamp="20240102"),
+            TradeDay(market=MARKET_TYPES.CHINA, is_open=True, timestamp="20240103"),
+        ])
+        mock_deps["crud_repo"].remove = MagicMock()
+        # 所有 add_batch 调用（批量 + 逐条）全失败
+        mock_deps["crud_repo"].add_batch = MagicMock(side_effect=Exception("DB down"))
+
+        with patch("ginkgo.data.services.trade_day_service.RichProgress"):
+            result = service.sync()
+
+        # 不静默：2 条 update 全失败计入 records_failed
+        assert result.data.records_failed == 2
+        assert result.data.records_added == 0
+
 
 # ============================================================
 # container 装配测试（DI wiring）

--- a/tests/unit/data/services/test_trade_day_service_mock.py
+++ b/tests/unit/data/services/test_trade_day_service_mock.py
@@ -1,0 +1,133 @@
+"""
+TradeDayService 单元测试（Mock 依赖）
+
+通过 MagicMock 注入所有依赖，隔离测试业务逻辑。
+镜像 test_stockinfo_service_mock.py 的 TestSync 结构——「加一种 data_type」
+的对称扩展，trade_day 日历同步链路（#6488）。
+"""
+
+import sys
+import os
+import pytest
+import pandas as pd
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+# 将项目根目录加入路径
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.trade_day_service import TradeDayService
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.entities import TradeDay
+from ginkgo.enums import MARKET_TYPES
+
+
+# ============================================================
+# 辅助函数：创建带 mock 依赖的 service 实例
+# ============================================================
+
+
+@pytest.fixture
+def mock_deps():
+    """创建 mock 依赖"""
+    return {
+        "crud_repo": MagicMock(),
+        "data_source": MagicMock(),
+    }
+
+
+@pytest.fixture
+def service(mock_deps):
+    """创建 TradeDayService 实例（GLOG 已 mock）"""
+    with patch("ginkgo.libs.GLOG"):
+        svc = TradeDayService(
+            crud_repo=mock_deps["crud_repo"],
+            data_source=mock_deps["data_source"],
+        )
+        return svc
+
+
+# ============================================================
+# sync 测试
+# ============================================================
+
+
+class TestSync:
+    """sync 交易日历同步测试"""
+
+    @pytest.fixture
+    def raw_trade_df(self):
+        """模拟 tushare pro.trade_cal() 返回（原样透传，字段 cal_date/is_open 为 int 0/1）"""
+        return pd.DataFrame({
+            "exchange": ["SSE", "SSE"],
+            "cal_date": ["20240102", "20240103"],
+            "is_open": [0, 1],
+            "pretrade_date": ["20231229", "20240102"],
+        })
+
+    @pytest.mark.unit
+    def test_sync_persists_trade_days(self, service, mock_deps, raw_trade_df):
+        """sync 从数据源拉取日历 → 转 TradeDay → 批量落库（tracer bullet）"""
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = raw_trade_df
+        mock_deps["crud_repo"].add_batch = MagicMock()
+
+        with patch("ginkgo.data.services.trade_day_service.RichProgress"):
+            result = service.sync()
+
+        assert result.success is True
+        mock_deps["data_source"].fetch_cn_stock_trade_day.assert_called_once()
+        # 批量落库被调用，传入的是 TradeDay 列表
+        mock_deps["crud_repo"].add_batch.assert_called_once()
+        persisted = mock_deps["crud_repo"].add_batch.call_args[0][0]
+        assert len(persisted) == 2
+        assert all(isinstance(td, TradeDay) for td in persisted)
+        # is_open int 0/1 正确转 bool（TradeDay entity 严格要求 bool）
+        assert persisted[0].is_open is False
+        assert persisted[1].is_open is True
+        # market 归一为 CHINA
+        assert all(td.market == MARKET_TYPES.CHINA for td in persisted)
+
+    @pytest.mark.unit
+    def test_sync_empty_source(self, service, mock_deps):
+        """数据源返回空 DataFrame 时同步失败"""
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = pd.DataFrame()
+
+        result = service.sync()
+        assert result.success is False
+        assert "No trade calendar data available" in result.message
+
+    @pytest.mark.unit
+    def test_sync_none_source(self, service, mock_deps):
+        """数据源返回 None 时同步失败"""
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = None
+
+        result = service.sync()
+        assert result.success is False
+
+    @pytest.mark.unit
+    def test_sync_source_exception(self, service, mock_deps):
+        """数据源抛异常时同步失败（不向上传播）"""
+        mock_deps["data_source"].fetch_cn_stock_trade_day.side_effect = Exception("API 超时")
+
+        result = service.sync()
+        assert result.success is False
+        assert "API 超时" in result.message
+
+
+# ============================================================
+# container 装配测试（DI wiring）
+# ============================================================
+
+
+class TestContainerWiring:
+    """验证 data container 正确注册 trade_day_service provider（#6488 wiring）"""
+
+    @pytest.mark.unit
+    def test_container_resolves_trade_day_service(self):
+        """container.trade_day_service() 可解析为 TradeDayService 实例"""
+        from ginkgo.data.containers import container
+
+        svc = container.trade_day_service()
+        assert isinstance(svc, TradeDayService)

--- a/tests/unit/data/services/test_trade_day_service_mock.py
+++ b/tests/unit/data/services/test_trade_day_service_mock.py
@@ -115,6 +115,39 @@ class TestSync:
         assert result.success is False
         assert "API 超时" in result.message
 
+    @pytest.mark.unit
+    def test_sync_idempotent_removes_existing_before_add(self, service, mock_deps, raw_trade_df):
+        """重复 sync 幂等：已存在的 (market,timestamp) 先 remove 再 add，不累积重复行（镜像 stockinfo，#6488 review）
+
+        场景：DB 已含本次源返回的两个日期（第二次 sync）。sync 必须 find 出既有、
+        remove 清掉它们、再 add_batch 全量——否则每次 sync 行数翻倍，
+        与声明的 is_idempotent=True 自相矛盾。
+        """
+        mock_deps["data_source"].fetch_cn_stock_trade_day.return_value = raw_trade_df
+        # 模拟 DB 已存在这两个日期（第二次 sync 场景）
+        mock_deps["crud_repo"].find = MagicMock(return_value=[
+            TradeDay(market=MARKET_TYPES.CHINA, is_open=False, timestamp="20240102"),
+            TradeDay(market=MARKET_TYPES.CHINA, is_open=True, timestamp="20240103"),
+        ])
+        mock_deps["crud_repo"].remove = MagicMock()
+        mock_deps["crud_repo"].add_batch = MagicMock()
+
+        with patch("ginkgo.data.services.trade_day_service.RichProgress"):
+            result = service.sync()
+
+        assert result.success is True
+        # 幂等核心 1：先 find 既有记录
+        mock_deps["crud_repo"].find.assert_called_once()
+        find_filters = mock_deps["crud_repo"].find.call_args.kwargs.get("filters", {})
+        assert find_filters.get("market") == MARKET_TYPES.CHINA
+        # 幂等核心 2：既有日期被 remove 清理（防重复累积）
+        mock_deps["crud_repo"].remove.assert_called_once()
+        # 落库总条数 == 源条数（new + update 都经 add_batch，但不翻倍）
+        added = []
+        for call in mock_deps["crud_repo"].add_batch.call_args_list:
+            added.extend(call[0][0])
+        assert len(added) == 2
+
 
 # ============================================================
 # container 装配测试（DI wiring）

--- a/tests/unit/data/worker/test_worker_handle_trade_day.py
+++ b/tests/unit/data/worker/test_worker_handle_trade_day.py
@@ -1,0 +1,63 @@
+"""
+DataWorker _handle_trade_day wiring 测试（#6488）
+
+验证 worker 消费 trade_day 命令 → 调 container.trade_day_service().sync()。
+这是 #6488 的"信号有消费者"闭环——发出去的 kafka 信号必须有 worker handler 消费，
+否则是死信号（arch_paper_trading_control_commands_no_consumer 教训）。
+镜像 _handle_stockinfo 测试结构。__new__ 跳过 DataWorker.__init__（避免连 kafka/mysql）。
+"""
+
+import sys
+import threading
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.worker.worker import DataWorker
+
+
+class TestHandleTradeDay:
+    """_handle_trade_day wiring 测试"""
+
+    @pytest.mark.unit
+    def test_handle_trade_day_invokes_service_sync(self):
+        """_handle_trade_day 调 trade_day_service().sync() 并返回 success（tracer bullet）"""
+        worker = DataWorker.__new__(DataWorker)
+        worker._node_id = "test-node"
+        worker._lock = threading.Lock()
+        worker._stats = {"errors": 0}
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.error = None
+        mock_service = MagicMock()
+        mock_service.sync.return_value = mock_result
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.trade_day_service.return_value = mock_service
+            ok = worker._handle_trade_day({"code": ""})
+
+        assert ok is True
+        mock_service.sync.assert_called_once()
+
+    @pytest.mark.unit
+    def test_dispatch_routes_trade_day_to_handler(self):
+        """_process_command 路由 trade_day 命令到 _handle_trade_day"""
+        worker = DataWorker.__new__(DataWorker)
+        worker._node_id = "test-node"
+        worker._lock = threading.Lock()
+        worker._stats = {"errors": 0}
+
+        with patch.object(worker, "_notify_task_start"), \
+             patch.object(worker, "_handle_trade_day", return_value=True) as mock_h, \
+             patch("ginkgo.data.containers.container"):
+            ok = worker._process_command("trade_day", {"code": ""})
+
+        assert ok is True
+        mock_h.assert_called_once_with({"code": ""})


### PR DESCRIPTION
## Summary

修复 #6488：paper worker `_run_live_paper_cycle` 因 `trade_day` 表空，`trade_day_crud.find(today, CHINA)` 返回空 → 整轮 `skipped=True` → **0 signal**。

**根因**：trade_day 此前完全无 sync 入口——`data_cli sync` 无 trade_day 路由、DataWorker 无 handler、无 TradeDayService、无 kafka 信号。日历表从未被填充，paper worker 查询永远落空。

**修复**：接通完整 sync 链路，镜像 stockinfo 对称扩展第 5 种 data_type：

| 层 | 文件 | 改动 |
|---|---|---|
| Service | `trade_day_service.py`（新）| `TradeDayService.sync`: tushare `trade_cal` → `TradeDay`（`bool(int(is_open))` 双层转换满足 entity 严格 bool）→ `add_batch` 全量落库 |
| DI | `containers.py` | `trade_day_service` provider（crud_repo + ginkgo_tushare_source）|
| Kafka | `kafka_service.py` | `send_trade_day_signal`: 发 `DATA_UPDATE {type:trade_day}` |
| Worker | `worker.py` | `_handle_trade_day` + dispatch elif: 消费信号调 sync（4→5 命令）|
| CLI | `data_cli.py` | `sync trade_day`: daemon 发信号 / 同步直调 sync 双模式 |

## Test plan

- [x] **单元测试**（TDD RED→GREEN，5 wiring 点全覆盖）：
  - `test_trade_day_service_mock.py` — sync 业务逻辑（空源/异常/is_open 转换）+ container wiring
  - `test_kafka_trade_day_signal.py` — 信号契约（DATA_UPDATE + trade_day payload）
  - `test_worker_handle_trade_day.py` — handler 调 sync + dispatch 路由
  - `test_data_cli_sync_trade_day.py` — daemon 发信号 + 同步调 sync 双模式
- [x] **冒烟三层**：py_compile + 启动路径崩溃链（user_crud/containers/user_cli 29 passed）+ 变更相关（10 passed）
- [x] **契约对齐验证**（不依赖 tushare/MySQL，纯实体层）：`TradeDay(timestamp 00:00:00 / market CHINA / is_open bool)` 与 paper worker `find(today, CHINA)` 完全匹配，**same-day match=True**——sync 写入当天记录会被 find 命中，`is_open` 不再空，整轮不再 skip
- [ ] **真实 sync**：需配置 tushare token 后 `ginkgo data sync trade_day`，查 trade_day 表 COUNT > 0（agent 侧 token 未配，属部署配置项非代码缺陷）

## Notes

- `bool(int(row["is_open"]))` 双层转换：tushare 返回 numpy.int64，`TradeDay` entity 严格要求 `isinstance(is_open, bool)`，numpy.bool_ 边界不可靠，`int()` 先归一 Python int 再 bool 才稳
- trade_day 全量同步（日历是权威覆盖），无 new/update 分割，直接 `add_batch`
- tushare token 未配是部署配置问题，配置后链路即通；代码侧已证链路组装正确 + 契约对齐

Closes #6488
