### PR TITLE
fix(#4621): result list --page 短选项 -p→-P 消除冲突

### DIFF
--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -614,7 +614,7 @@ def priority(
 def list(
     backtest_id: Optional[str] = typer.Option(None, "--backtest", "-b", help="Filter by backtest ID"),
     portfolio: Optional[str] = typer.Option(None, "--portfolio", "-p", help="Filter by portfolio ID"),
-    page: int = typer.Option(20, "--page", "-p", help="Page size"),
+    page: int = typer.Option(20, "--page", "-P", help="Page size"),
 ):
     """
     :clipboard: List all backtest results.

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -83,6 +83,46 @@ class TestHelp:
 
 
 # ============================================================================
+# 1b. result list -p short-option conflict (#4621)
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestResultListParamConflict:
+    """#4621: --portfolio and --page both declared -p, triggering a Typer
+    'parameter -p is used more than once' warning at command-build time.
+    --portfolio keeps -p (consistent with `result show`, `record`); --page
+    must use a distinct short option.
+    """
+
+    @staticmethod
+    def _duplicate_warnings(records):
+        return [str(w.message) for w in records if "used more than once" in str(w.message)]
+
+    def test_result_list_help_no_duplicate_p_warning(self, cli_runner):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = cli_runner.invoke(flat_cli.result_app, ["list", "--help"])
+        assert result.exit_code == 0
+        assert self._duplicate_warnings(caught) == []
+
+    def test_result_list_portfolio_and_page_are_distinct_options(self, cli_runner):
+        """--portfolio and --page must each parse independently without the
+        duplicate-short-option warning, regardless of order."""
+        import warnings
+
+        for argv in (["list", "--portfolio", "abc123"], ["list", "--page", "2"]):
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = cli_runner.invoke(flat_cli.result_app, argv)
+            assert result.exit_code == 0, f"failed for {argv}: {result.output}"
+            assert self._duplicate_warnings(caught) == [], f"dup -p warning for {argv}"
+
+
+# ============================================================================
 # 2. Component list command
 # ============================================================================
 


### PR DESCRIPTION
## Summary

修复 `ginkgo result list` 命令的 `-p` 短选项冲突。

`result list`（`src/ginkgo/client/flat_cli.py`）的 `--portfolio` 与 `--page` 同时声明了 `-p` 短选项，Typer/Click 在命令注册期报：

```
UserWarning: The parameter -p is used more than once. Remove its duplicate as parameters should be unique.
```

连 `ginkgo result list --help` 都会喷该警告（注册期错误，非运行期）。

**修复**：`--page` 的短选项由 `-p` 改为 `-P`。`-p` 保留给 `--portfolio`，与 `result show`（`-p`=portfolio）、`record` 等全 CLI 一致。Click 短选项大小写敏感，`-P` 与 `-p` 互不冲突。

> 说明：issue brief 锚点 `backtest_result_cli.py` 已漂移——该文件已并入 `flat_cli.py`，实际 bug 位于 `flat_cli.py:617`。issue 原述 record 命令 `data.operations` import 部分早已修复，仅剩此 `-p` 冲突。

## Test plan

新增 `tests/unit/client/test_flat_cli.py::TestResultListParamConflict`（2 用例）：
- `test_result_list_help_no_duplicate_p_warning`：invoke `result list --help`，`warnings.catch_warnings` 捕获并断言无 "used more than once" 警告。
- `test_result_list_portfolio_and_page_are_distinct_options`：`--portfolio <uuid>` 与 `--page <n>` 各自独立调用，exit 0 且无冲突警告。

验收（实跑，PYTHONPATH 锁定 worktree）：
- `result list --help` → exit 0，0 条 `-p` 冲突警告（修前 4 条）
- `result list --page 1` / `--portfolio abc` / `-P 2` / `-p pf` → 各自 exit 0，独立解析

冒烟三层（推送前，对齐 ci.yml #6015）：
- Layer 1 py_compile（src+api）✅
- Layer 2 启动路径点名（user_crud_mock / containers / user_cli）29 passed ✅
- Layer 3 变更相关（TestResultListParamConflict + TestHelp）5 passed ✅
- `TestComponentCreate` 2 失败为 master 既有（exit 2），与本次改动无关，已核对。

Closes #4621
