### PR TITLE
fix(#4627): tasktimer 心跳解析支持 ISO 时间戳非 JSON 值降级

### DIFF
--- a/src/ginkgo/client/tasktimer_cli.py
+++ b/src/ginkgo/client/tasktimer_cli.py
@@ -22,9 +22,42 @@ from rich.console import Console
 from ginkgo.libs import GLOG
 from rich.table import Table
 from rich.panel import Panel
+import json
 import signal
 import sys
 import time
+
+
+def parse_heartbeat_value(value):
+    """
+    稳健解析 Redis 心跳值，对非 JSON 值优雅降级（#4627）。
+
+    写入端（heartbeat_manager.py / utils/heartbeat.py）实际写入的是
+    ISO 8601 时间戳字符串，并非 JSON。读侧不应假定 JSON 格式。
+
+    Returns: {timestamp, host, pid, jobs_count}，解析失败时 timestamp 取原值，
+             其余字段为 "N/A"。
+    """
+    try:
+        data = json.loads(value)
+    except (json.JSONDecodeError, TypeError, ValueError):
+        data = None
+
+    if isinstance(data, dict):
+        return {
+            "timestamp": data.get("timestamp", "N/A"),
+            "host": data.get("host", "N/A"),
+            "pid": data.get("pid", "N/A"),
+            "jobs_count": data.get("jobs_count", "N/A"),
+        }
+
+    return {
+        "timestamp": value,
+        "host": "N/A",
+        "pid": "N/A",
+        "jobs_count": "N/A",
+    }
+
 
 app = typer.Typer(help=":alarm_clock: TaskTimer - Scheduled Task Manager", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -183,18 +216,12 @@ def status(
             console.print(f"[green]:white_check_mark: TaskTimer is [bold]ALIVE[/bold][/green]")
             console.print(f"[dim]Heartbeat TTL: {ttl}s[/dim]")
 
-            # Try to parse JSON heartbeat
-            try:
-                import json
-                heartbeat_data = json.loads(heartbeat_value)
-
-                console.print(f"[dim]Host: {heartbeat_data.get('host', 'N/A')}[/dim]")
-                console.print(f"[dim]PID: {heartbeat_data.get('pid', 'N/A')}[/dim]")
-                console.print(f"[dim]Jobs: {heartbeat_data.get('jobs_count', 'N/A')}[/dim]")
-                console.print(f"[dim]Last Heartbeat: {heartbeat_data.get('timestamp', 'N/A')}[/dim]")
-            except Exception as e:
-                GLOG.ERROR(f"Failed to parse heartbeat JSON data: {e}")
-                console.print(f"[dim]Last Heartbeat: {heartbeat_value}[/dim]")
+            # 稳健解析心跳值：写入端写 ISO 时间戳（非 JSON），解析失败时降级展示（#4627）
+            heartbeat_data = parse_heartbeat_value(heartbeat_value)
+            console.print(f"[dim]Host: {heartbeat_data['host']}[/dim]")
+            console.print(f"[dim]PID: {heartbeat_data['pid']}[/dim]")
+            console.print(f"[dim]Jobs: {heartbeat_data['jobs_count']}[/dim]")
+            console.print(f"[dim]Last Heartbeat: {heartbeat_data['timestamp']}[/dim]")
         else:
             console.print(f"[red]:x: TaskTimer is [bold]DEAD[/bold] or not running[/red]")
             console.print(f"[dim]Heartbeat key not found or expired[/dim]")
@@ -291,7 +318,6 @@ def heartbeat(
         from redis import Redis
         from ginkgo.libs import GCONF
         from datetime import datetime
-        import json
 
         redis_client = Redis(
             host=GCONF.REDISHOST,
@@ -329,17 +355,11 @@ def heartbeat(
                         ttl = redis_client.ttl(key)
                         value = redis_client.get(key)
 
-                        # Parse heartbeat data
-                        try:
-                            heartbeat_data = json.loads(value)
-                            last_time = heartbeat_data.get("timestamp", "N/A")
-                            host = heartbeat_data.get("host", "N/A")
-                            pid = heartbeat_data.get("pid", "N/A")
-                        except Exception as e:
-                            GLOG.ERROR(f"Failed to parse heartbeat data for key '{key}': {e}")
-                            last_time = value
-                            host = "N/A"
-                            pid = "N/A"
+                        # 稳健解析心跳值：写入端写 ISO 时间戳（非 JSON），解析失败时降级展示（#4627）
+                        heartbeat_data = parse_heartbeat_value(value)
+                        last_time = heartbeat_data["timestamp"]
+                        host = heartbeat_data["host"]
+                        pid = heartbeat_data["pid"]
 
                         is_alive = ttl > 0 and ttl < 40
 

--- a/tests/unit/client/test_tasktimer_cli.py
+++ b/tests/unit/client/test_tasktimer_cli.py
@@ -1,0 +1,128 @@
+# Upstream: tasktimer_cli(ginkgo tasktimer 命令)
+# Downstream: 无
+# Role: TaskTimer CLI 单元测试，聚焦心跳值解析稳健性（#4627）
+
+"""
+TaskTimer CLI 单元测试
+
+覆盖心跳值解析稳健性（#4627）：
+- parse_heartbeat_value: ISO 时间戳 / JSON dict / 无效值 三路降级
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+
+from unittest.mock import patch, MagicMock
+from typer.testing import CliRunner
+
+from ginkgo.client import tasktimer_cli
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+# ============================================================================
+# parse_heartbeat_value — 心跳值稳健解析
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestParseHeartbeatValue:
+    """parse_heartbeat_value 对各类心跳值优雅降级（#4627）"""
+
+    def test_iso_timestamp_string(self):
+        """ISO 时间戳字符串（写入端实际格式）→ 不崩，timestamp=原值，其余 N/A"""
+        # 写入端 heartbeat_manager.py:194 / utils/heartbeat.py:125 写的就是这种值
+        value = "2026-06-30T16:53:33.123456+00:00"
+        result = tasktimer_cli.parse_heartbeat_value(value)
+        assert result["timestamp"] == value
+        assert result["host"] == "N/A"
+        assert result["pid"] == "N/A"
+        assert result["jobs_count"] == "N/A"
+
+    def test_json_dict(self):
+        """合法 JSON dict（兼容未来/老格式）→ 提取 timestamp/host/pid/jobs_count"""
+        value = '{"timestamp": "2026-06-30T10:00:00Z", "host": "node-1", "pid": 12345, "jobs_count": 7}'
+        result = tasktimer_cli.parse_heartbeat_value(value)
+        assert result["timestamp"] == "2026-06-30T10:00:00Z"
+        assert result["host"] == "node-1"
+        assert result["pid"] == 12345
+        assert result["jobs_count"] == 7
+
+    def test_garbage_value(self):
+        """完全无效的垃圾值 → 不崩，降级 timestamp=原值"""
+        value = "not-a-json-at-all"
+        result = tasktimer_cli.parse_heartbeat_value(value)
+        assert result["timestamp"] == value
+        assert result["host"] == "N/A"
+        assert result["pid"] == "N/A"
+        assert result["jobs_count"] == "N/A"
+
+    def test_json_with_missing_fields(self):
+        """JSON dict 缺字段 → 缺失字段降级为 N/A"""
+        value = '{"timestamp": "2026-06-30T10:00:00Z"}'
+        result = tasktimer_cli.parse_heartbeat_value(value)
+        assert result["timestamp"] == "2026-06-30T10:00:00Z"
+        assert result["host"] == "N/A"
+        assert result["pid"] == "N/A"
+        assert result["jobs_count"] == "N/A"
+
+    def test_none_value(self):
+        """None 值（Redis key 存在但值为空）→ 不崩"""
+        result = tasktimer_cli.parse_heartbeat_value(None)
+        assert result["timestamp"] is None
+        assert result["host"] == "N/A"
+
+
+# ============================================================================
+# heartbeat 命令 — 端到端不崩（#4627 验收）
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestHeartbeatCommand:
+    """heartbeat 命令对非 JSON 心跳值不崩、可读展示（#4627 端到端）"""
+
+    def test_iso_timestamp_value_no_crash(self, cli_runner):
+        """ISO 时间戳心跳值（写入端实际格式）：命令正常退出，展示 ALIVE，无 ERROR 噪声"""
+        fake_redis = MagicMock()
+        fake_redis.keys.return_value = ["heartbeat:node:abc123"]
+        fake_redis.ttl.return_value = 30
+        fake_redis.get.return_value = "2026-06-30T16:53:33.123456+00:00"
+
+        with patch("redis.Redis", return_value=fake_redis):
+            result = cli_runner.invoke(tasktimer_cli.app, ["heartbeat"])
+
+        assert result.exit_code == 0
+        # 节点 id 进入输出（key 解析正常）
+        assert "abc123" in result.output
+        # ALIVE 基于 TTL（30s 存活），不被解析失败污染
+        assert "ALIVE" in result.output
+        # 不再有解析错误噪声
+        assert "Failed to parse" not in result.output
+
+    def test_mixed_json_and_iso_values(self, cli_runner):
+        """混合心跳值（一个 JSON 一个 ISO）：都不崩，各自正确展示"""
+        fake_redis = MagicMock()
+        fake_redis.keys.return_value = ["heartbeat:node:json-node", "heartbeat:node:iso-node"]
+        # ttl/get 按 key 调用顺序返回：第一个 json-node 存活，第二个 iso-node 存活
+        fake_redis.ttl.side_effect = [25, 25]
+        fake_redis.get.side_effect = [
+            '{"timestamp": "2026-06-30T10:00:00Z", "host": "h1", "pid": 111}',
+            "2026-06-30T11:00:00+00:00",  # ISO 时间戳，非 JSON
+        ]
+
+        with patch("redis.Redis", return_value=fake_redis):
+            result = cli_runner.invoke(tasktimer_cli.app, ["heartbeat"])
+
+        assert result.exit_code == 0
+        assert "json-node" in result.output
+        assert "iso-node" in result.output
+        assert "Failed to parse" not in result.output


### PR DESCRIPTION
## Summary

`ginkgo tasktimer heartbeat` / `status` 报 `Extra data: line 1 column 5 (char 4)` 并伴随 ERROR 噪声泛滥，根因是读写两侧序列化契约不一致：

- **写入端**（`heartbeat_manager.py` / `utils/heartbeat.py`）写的是 ISO 8601 时间戳字符串，**并非 JSON**
- **读取端**（`tasktimer_cli.py` 的 status / heartbeat 命令）用 `json.loads` 期望 JSON
- `json.loads("2026-...")` 解析出整数 `2026` 后第 5 字符 `-` 触发 `Extra data` —— 与 issue 报错逐字符合

每次心跳都触发 `GLOG.ERROR` 噪声泛滥；status 的 DEAD 与解析无关（基于 TTL 判定），但噪声掩盖了真实状态。

### 改动
- 提取模块级 `parse_heartbeat_value(value)` 稳健解析 helper：JSON dict / ISO 时间戳 / 垃圾值 / None 四路降级，`timestamp` 取原值、其余字段 `N/A`
- `status` 命令与 `heartbeat` 命令共用 helper，去除 `GLOG.ERROR` 噪声
- `alive` / `dead` 判断仍基于 TTL（`ttl > 0 and ttl < 40`），不被解析失败污染
- 删除冗余的局部 `import json`

### scope
单文件改动（`tasktimer_cli.py`），**不改写入端契约** —— 写入端写 ISO 时间戳是既有设计，贸然改写入端会影响所有读心跳的组件。

## Test plan

- [x] `tests/unit/client/test_tasktimer_cli.py`：7 测试
  - `parse_heartbeat_value` 四路降级（ISO 时间戳 / JSON dict / 垃圾值 / 缺字段 / None）
  - 命令级端到端：mock Redis 返回 ISO 时间戳值，`heartbeat` 命令 exit 0、展示 ALIVE、无 "Failed to parse" 噪声
  - 混合心跳值（JSON + ISO）均不崩
- [x] Layer 1 py_compile 通过
- [x] Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）29 passed
- [x] 三层 smoke 全绿

Closes #4627
