### PR TITLE
fix(#6478): MPortfolio.update 修正 updated_at→update_at 拼写致列不刷新

### DIFF
--- a/src/ginkgo/data/models/model_portfolio.py
+++ b/src/ginkgo/data/models/model_portfolio.py
@@ -139,7 +139,7 @@ class MPortfolio(MMysqlBase):
         if winning_trades is not None:
             self.winning_trades = winning_trades
 
-        self.updated_at = datetime.datetime.now()
+        self.update_at = datetime.datetime.now()
 
     @update.register(pd.Series)
     def _(self, df: pd.DataFrame, *args, **kwargs) -> None:
@@ -151,7 +151,7 @@ class MPortfolio(MMysqlBase):
             self.state = PORTFOLIO_RUNSTATE_TYPES.validate_input(df["state"]) or PORTFOLIO_RUNSTATE_TYPES.INITIALIZED.value
         if "source" in df.keys():
             self.source = df["source"]
-        self.updated_at = datetime.datetime.now()
+        self.update_at = datetime.datetime.now()
 
     def __repr__(self) -> str:
         return base_repr(self, "DB" + self.__tablename__.capitalize(), 12, 46)

--- a/tests/unit/data/models/test_portfolio_model.py
+++ b/tests/unit/data/models/test_portfolio_model.py
@@ -1,0 +1,53 @@
+"""
+MPortfolio model 测试
+
+回归 #6478: MPortfolio.update() 必须刷新映射列 update_at（无 d），
+而非误写为未映射的实例属性 updated_at（带 d），导致 SQLAlchemy flush 忽略、
+update_at 列永不刷新。
+"""
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import datetime
+
+import pandas as pd
+import pytest
+
+from ginkgo.data.models.model_portfolio import MPortfolio
+
+
+@pytest.mark.unit
+class TestMPortfolioUpdateRefreshesTimestamp:
+    """update() 的每个 singledispatch 分支都必须刷新 mapped 列 update_at。"""
+
+    def test_update_via_str_refreshes_update_at(self):
+        """update(name=...) 后 update_at 必须推进（回归 #6478 str 分支）。"""
+        p = MPortfolio(name="old", initial_capital=100000)
+        # 锚定一个明显旧的时间，模拟 insert 时刻的 update_at
+        old = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        p.update_at = old
+
+        p.update("newname")
+
+        assert p.update_at > old, (
+            f"update_at 未被 update(str) 刷新（仍为 {p.update_at}）；"
+            "疑似误写 self.updated_at（带 d）→ mapped 列 update_at 永不更新 #6478"
+        )
+
+    def test_update_via_series_refreshes_update_at(self):
+        """update(pd.Series) 后 update_at 必须推进（回归 #6478 Series 分支）。"""
+        p = MPortfolio(name="old", initial_capital=100000)
+        old = datetime.datetime(2000, 1, 1, 0, 0, 0)
+        p.update_at = old
+
+        p.update(pd.Series({"name": "newname", "source": 0}))
+
+        assert p.update_at > old, (
+            f"update_at 未被 update(Series) 刷新（仍为 {p.update_at}）；"
+            "疑似误写 self.updated_at（带 d）→ mapped 列 update_at 永不更新 #6478"
+        )


### PR DESCRIPTION
## Summary

`MPortfolio.update()` 的两个 `singledispatchmethod` 分支（`str` / `pd.Series`）末尾误写为 `self.updated_at = datetime.datetime.now()`（带 `d`）。基类 `MMysqlBase` 声明的映射列是 `update_at`（无 `d`），因此 `updated_at` 只是一个**未映射的实例属性**——SQLAlchemy flush 时被忽略，`update_at` 列在 portfolio 每次更新后**永不刷新**。

任何依赖 `update_at` 排序/增量读取 portfolio 变更的下游（审计、同步、worker 增量拉取）都会拿到陈旧时间戳，误判"未变更"。

**根因**：属性名拼写与 `mapped_column` 声明不一致。

**修复**：两处 `self.updated_at` → `self.update_at`（model_portfolio.py:142、:154）。

```diff
-        self.updated_at = datetime.datetime.now()
+        self.update_at = datetime.datetime.now()
```

## Test plan

- 新增回归测试 `tests/unit/data/models/test_portfolio_model.py`：锚定旧时间 `update_at`，分别经 `update(str)` 与 `update(pd.Series)` 两个分支后断言 `update_at` 被推进。
- 冒烟三层门禁（对齐 `.github/workflows/ci.yml`）：
  - Layer 1 py_compile（src+api 全量）✅
  - Layer 2 启动路径点名 smoke（`test_user_crud_mock` / `test_containers` / `test_user_cli`）✅ 29 passed
  - Layer 3 变更相关（`test_portfolio_model` + `test_portfolio_crud_mock`）✅ 12 passed，2 个新回归测试全绿
- 备注：合跑中 `test_update_mode_raises_deprecation` 失败为**预存问题**（`PortfolioCRUD.update_mode` 方法在 `origin/master` 同样不存在，已被重命名为 `update_state`），与本 PR 改动无关，不在此处处理。

Closes #6478
