### PR TITLE
fix: Dual Thrust 历史窗口改用交易日倍数防零信号 (#4658)

### DIFF
--- a/src/ginkgo/trading/strategies/dual_thrust.py
+++ b/src/ginkgo/trading/strategies/dual_thrust.py
@@ -61,7 +61,11 @@ class StrategyDualThrust(BaseStrategy):
         now = portfolio_info.get("now")
         if now is None:
             return []
-        date_start = now - datetime.timedelta(days=(self._spans + 1))
+        # #4658: 按交易日倍数预留日历日窗口。A 股每周 2/7 非交易 + 法定节假日，
+        # spans+1 日历日仅约 (spans+1)*5/7 交易日 < spans+1，触发下方 df.shape[0]
+        # 守卫恒真 → 策略 100% 零信号。spans*2+5 覆盖周末与节假日 buffer，
+        # 多取的历史行被 _calculate_range 的 rolling(window=spans).iloc[-1] 自然忽略。
+        date_start = now - datetime.timedelta(days=(self._spans * 2 + 5))
         df = self.data_feeder.get_historical_data(
             symbols=[event.code], start_time=date_start,
             end_time=now, data_type="bar"

--- a/tests/unit/trading/strategies/test_dual_thrust.py
+++ b/tests/unit/trading/strategies/test_dual_thrust.py
@@ -131,3 +131,32 @@ class TestDualThrustTypeConsistency:
         info = _make_portfolio_info(positions={})
         # 不抛 TypeError 即通过
         s.cal(info, _make_price_event("000001.SZ"))
+
+
+class TestDualThrustHistoryWindow:
+    """#4658: 历史数据窗口须按交易日倍数预留，避免日历日不足致恒零信号"""
+
+    def test_history_window_covers_trading_days(self):
+        """#4658: spans=7 时窗口不可仅 spans+1=8 日历日
+
+        A 股 8 日历日 ≈ 5-6 交易日 < spans+1=8，触发
+        `df.shape[0] < spans+1` 守卫恒真 → 策略 100% 零信号。
+        修复后窗口日历日数须达 spans*2 级别，覆盖周末（每周 2/7 非交易日）
+        与法定节假日 buffer。此断言锁定“按交易日倍数预留”的语义，
+        不耦合具体公式（spans*2+5 / BDay 等任何 >= spans*2 的修复均通过）。
+        """
+        spans = 7
+        s = _make_strategy(LONG_BREAKOUT_DF, spans=spans)
+        info = _make_portfolio_info(now=datetime(2024, 1, 22))  # 周一
+        s.cal(info, _make_price_event("000001.SZ"))
+
+        call = s.data_feeder.get_historical_data.call_args
+        date_start = call.kwargs["start_time"]
+        calendar_days = (info["now"] - date_start).days
+
+        min_required = spans * 2
+        assert calendar_days >= min_required, (
+            f"历史窗口仅 {calendar_days} 日历日 < {min_required}，"
+            f"A 股下交易日数将不足 {spans + 1}，"
+            f"触发 df.shape[0] < spans+1 守卫恒零信号 (#4658)"
+        )


### PR DESCRIPTION
## Summary

修复 #4658：Dual Thrust 策略历史数据窗口用日历日计算，A 股交易日不足导致 100% 零信号零交易。

**根因**：`src/ginkgo/trading/strategies/dual_thrust.py:64` 用 `timedelta(days=spans+1)` 计算窗口起点。spans=7 时取 8 日历日，A 股 8 日历日 ≈ 5-6 交易日 < 8（spans+1），触发 `df.shape[0] < spans+1` 守卫恒真，策略永远 `return []`。

**修复**：改用 `timedelta(days=spans*2+5)`，按交易日倍数预留日历日，覆盖周末（每周 2/7 非交易日）与法定节假日 buffer。多取的历史行被 `_calculate_range` 的 `rolling(window=spans).iloc[-1]` 自然忽略，不影响计算结果。

## Test plan

- [x] 新增 `test_history_window_covers_trading_days`：spans=7 场景断言窗口日历日 >= spans*2=14（RED 修复前 8 失败 → GREEN 修复后 19 通过）
- [x] `tests/unit/trading/strategies/test_dual_thrust.py` 全部 7 测试通过（6 原有 #5496 回归 + 1 新增）
- [x] py_compile 语法检查（src + api）通过
- [x] 启动路径 smoke（user_crud_mock / containers / user_cli）29 测试通过，无回归

Closes #4658
