### PR TITLE
fix: crud.info() 顶层暴露 db0 keys，修 dashboard Redis key count 恒 N/A (#4663)

### DIFF
--- a/src/ginkgo/data/crud/redis_crud.py
+++ b/src/ginkgo/data/crud/redis_crud.py
@@ -540,12 +540,15 @@ class RedisCRUD:
                 return {"connected": False, "error": "Connection failed"}
                 
             info_data = self._redis.info()
+            # db0 keyspace 与 version/memory 等同属展示型字段，从 raw_info 提到顶层，
+            # 消费端（dashboard health）无需感知 Redis INFO 的嵌套结构。#4663
             return {
                 "connected": True,
                 "version": info_data.get("redis_version"),
                 "used_memory": info_data.get("used_memory_human"),
                 "connected_clients": info_data.get("connected_clients"),
                 "uptime": info_data.get("uptime_in_seconds"),
+                "db0": info_data.get("db0", {}),
                 "raw_info": info_data
             }
             

--- a/tests/api/test_dashboard_system_sanitization.py
+++ b/tests/api/test_dashboard_system_sanitization.py
@@ -90,3 +90,60 @@ class TestEndpointSanitization:
         error_text = payload.get("data", {}).get("error", "") if isinstance(payload, dict) else ""
         assert "10.0.0.1" not in error_text, f"泄露内部地址: {error_text}"
         assert "Access denied" not in error_text, f"泄露异常细节: {error_text}"
+
+
+class TestRedisHealthKeysDisplay:
+    """#4663: dashboard Redis key count 应显示真实 keys 数而非恒 N/A。
+    契约：crud.info() 在顶层暴露 db0（与其他提炼字段对齐），dashboard 读顶层 db0 即生效。
+    """
+
+    def test_check_health_redis_online_shows_real_key_count(self):
+        """Redis online 且有 keyspace 时 detail 显示真实 keys 数（非 N/A）"""
+        from api.dashboard import _check_health
+
+        mock_container = MagicMock()
+        # MySQL 走通，避免干扰 Redis 断言
+        mysql_result = MagicMock()
+        mysql_result.is_success.return_value = True
+        mysql_result.data = {"count": 5}
+        mock_container.portfolio_service.return_value.count.return_value = mysql_result
+        # Redis online，get_redis_info 返回 crud 修复后的结构（顶层 db0）
+        mock_container.redis_service.return_value.ping.return_value = True
+        mock_container.redis_service.return_value.get_redis_info.return_value = {
+            "connected": True,
+            "version": "7.0.0",
+            "db0": {"keys": 100, "expires": 50},
+            "raw_info": {"db0": {"keys": 100, "expires": 50}},
+        }
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            health = _check_health()
+
+        redis_item = next(h for h in health if h.name == "Redis")
+        assert redis_item.status == "ONLINE"
+        assert "100" in redis_item.detail, f"应显示真实 keys 数: {redis_item.detail}"
+        assert "N/A" not in redis_item.detail, f"不应显示 N/A: {redis_item.detail}"
+
+    def test_check_health_redis_online_empty_db_shows_na(self):
+        """Redis online 但无 keyspace（空库）时 detail 显示 N/A，不崩"""
+        from api.dashboard import _check_health
+
+        mock_container = MagicMock()
+        mysql_result = MagicMock()
+        mysql_result.is_success.return_value = True
+        mysql_result.data = {"count": 5}
+        mock_container.portfolio_service.return_value.count.return_value = mysql_result
+        mock_container.redis_service.return_value.ping.return_value = True
+        # crud 对空库返回 db0={}（详见 test_redis_crud_mock）
+        mock_container.redis_service.return_value.get_redis_info.return_value = {
+            "connected": True,
+            "db0": {},
+            "raw_info": {},
+        }
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            health = _check_health()
+
+        redis_item = next(h for h in health if h.name == "Redis")
+        assert redis_item.status == "ONLINE"
+        assert "N/A" in redis_item.detail

--- a/tests/unit/data/crud/test_redis_crud_mock.py
+++ b/tests/unit/data/crud/test_redis_crud_mock.py
@@ -279,6 +279,33 @@ class TestRedisCRUDSystemInfo:
         assert result["connected_clients"] == 5
 
     @pytest.mark.unit
+    def test_info_exposes_db0_keys_at_top_level(self, redis_crud):
+        """info() 顶层暴露 db0 keys（#4663：dashboard 读顶层 db0，crud 需提炼到位）"""
+        redis_crud.redis.info.return_value = {
+            "redis_version": "7.0.0",
+            "db0": {"keys": 100, "expires": 50, "avg_ttl": 0},
+        }
+
+        result = redis_crud.info()
+
+        # db0 从 raw_info 提到顶层，dashboard 无需深入 raw_info
+        assert result["connected"] is True
+        assert result["db0"] == {"keys": 100, "expires": 50, "avg_ttl": 0}
+        assert result["db0"]["keys"] == 100
+        # raw_info 仍保留完整原始数据（向后兼容）
+        assert result["raw_info"]["db0"]["keys"] == 100
+
+    @pytest.mark.unit
+    def test_info_db0_absent_yields_empty_dict(self, redis_crud):
+        """Redis 无 keyspace 数据时顶层 db0 为空 dict（dashboard 显示 N/A，不崩）"""
+        redis_crud.redis.info.return_value = {"redis_version": "7.0.0"}
+
+        result = redis_crud.info()
+
+        assert result["connected"] is True
+        assert result["db0"] == {}
+
+    @pytest.mark.unit
     def test_ping_success(self, redis_crud):
         """Redis ping 成功返回 True"""
         redis_crud.redis.ping.return_value = True


### PR DESCRIPTION
## Summary

修复 #4663：dashboard Redis key count 始终显示 N/A。

**根因**：`redis_crud.info()` 返回 `{connected, version, used_memory, connected_clients, uptime, raw_info}`，db0 keyspace 只嵌在 `raw_info` 内。dashboard 读顶层 `info["db0"]` 永远落空 → key count 恒显 N/A。

**方案**：crud 层在顶层提炼 `db0`（与 version/memory 等展示字段对齐），符合 `API→Service→CRUD→DB` 分层——消费端无需感知 Redis INFO 的嵌套结构。dashboard 原代码读顶层 db0 的意图本就正确，crud 补齐后即生效。

**向后兼容**：仅新增顶层字段，不改动现有字段。其他消费者（kafka_cli/cache_cli）只读 connected/version/error，不受影响。

## 改动

- `src/ginkgo/data/crud/redis_crud.py`：`info()` 顶层增加 `"db0": info_data.get("db0", {})`
- `api/api/dashboard.py` **未改动**（其原代码 `info.get("db0", {}).get("keys", "N/A")` 即正确，根因在 crud 未提供顶层 db0）

## Test plan

- [x] `tests/unit/data/crud/test_redis_crud_mock.py`：info() 顶层 db0 含 keys；空库 db0={}（23 passed）
- [x] `tests/api/test_dashboard_system_sanitization.py`：Redis online 显示真实 keys 非 N/A；空库显示 N/A 不崩（6 passed）
- [x] `tests/unit/data/services/test_redis_service.py`：service 透传不破坏（20 passed）
- [x] `tests/unit/client/test_kafka_cli.py` + `test_cache_cli.py`：消费者向后兼容（38 passed）
- [x] py_compile 全量（src + api）通过

Closes #4663
