### PR TITLE
refactor(#4630): ComponentLoader 提取组件类检测 helper + 合并双映射

### DIFF
--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -17,18 +17,94 @@ from ginkgo.trading.portfolios import PortfolioT1Backtest
 from ginkgo.enums import FILE_TYPES
 
 
-# 源码回退导入映射：动态加载失败时，按组件类型从对应源码包回退导入。
+# 组件类型元数据 —— 单一映射源（#4630: 原 type_map 与 SOURCE_FALLBACK_IMPORT_MAP
+# 双映射各写一份、键集相同却无单一真相源，曾致 #5880 缺陷4a 漂移）。
 # key 必须用 FILE_TYPES 的 .value（int），与传入的 component_type(int) 比较一致。
-# NOTE: ENGINE(=7) 不在此映射 —— engine 是内置回测/实盘引擎，非用户上传 .py 组件，
-# 无需源码回退。原实现 key 7 错指 risk_managements（7=ENGINE 却映射到 risk），
-# 已修正为 key 3（RISKMANAGER）—— 见 #5880 缺陷4a。
-SOURCE_FALLBACK_IMPORT_MAP = {
-    FILE_TYPES.STRATEGY.value: ("ginkgo.trading.strategies", "strategies"),
-    FILE_TYPES.SELECTOR.value: ("ginkgo.trading.selectors", "selectors"),
-    FILE_TYPES.SIZER.value: ("ginkgo.trading.sizers", "sizers"),
-    FILE_TYPES.RISKMANAGER.value: ("ginkgo.trading.risk_managements", "risk_managements"),
-    FILE_TYPES.ANALYZER.value: ("ginkgo.trading.analysis.analyzers", "analyzers"),
+# ENGINE(=7) 不在此映射 —— engine 是内置回测/实盘引擎，非用户上传 .py 组件，无需源码回退。
+COMPONENT_TYPE_INFO: Dict[int, Dict[str, str]] = {
+    FILE_TYPES.STRATEGY.value: {
+        "name": "strategy",
+        "module_path": "ginkgo.trading.strategies",
+        "subpackage": "strategies",
+    },
+    FILE_TYPES.SELECTOR.value: {
+        "name": "selector",
+        "module_path": "ginkgo.trading.selectors",
+        "subpackage": "selectors",
+    },
+    FILE_TYPES.SIZER.value: {
+        "name": "sizer",
+        "module_path": "ginkgo.trading.sizers",
+        "subpackage": "sizers",
+    },
+    FILE_TYPES.RISKMANAGER.value: {
+        "name": "risk_manager",
+        "module_path": "ginkgo.trading.risk_managements",
+        "subpackage": "risk_managements",
+    },
+    FILE_TYPES.ANALYZER.value: {
+        "name": "analyzer",
+        "module_path": "ginkgo.trading.analysis.analyzers",
+        "subpackage": "analyzers",
+    },
 }
+
+# 源码回退导入映射：从单一源派生，保持 (module_path, subpackage) 元组形状不变
+# （test_component_loader_source_fallback.py 锁定了元组值）。
+SOURCE_FALLBACK_IMPORT_MAP = {
+    ftype: (info["module_path"], info["subpackage"]) for ftype, info in COMPONENT_TYPE_INFO.items()
+}
+
+
+# --------------------------------------------------------------------------- #
+# 组件类检测（#4630: 主路径与源码 fallback 路径原各写一份检测循环，收敛为单一 helper）
+# --------------------------------------------------------------------------- #
+
+# method 2 命中的基类名后缀（含 SelectorBase）与精确基类名（Base* 抽象基类）
+_COMPONENT_BASE_SUFFIXES = ("Strategy", "Selector", "SelectorBase", "Sizer", "RiskManagement", "Analyzer")
+_COMPONENT_BASE_EXACT = ("BaseStrategy", "BaseSelector", "BaseSizer", "BaseRiskManagement", "BaseAnalyzer")
+
+# method 3 命中的类名后缀（不含 SelectorBase —— 与主路径原逻辑一致）
+_COMPONENT_NAME_SUFFIXES = ("Strategy", "Selector", "Sizer", "RiskManagement", "Analyzer")
+
+
+def _is_component_class(attr: type, attr_name: str) -> bool:
+    """判定一个类是否为组件类。
+
+    三种检测方法（任一命中即判定为组件类）：
+    1. ``__abstract__`` 属性存在且为 False（非抽象）；
+    2. 任一基类名匹配组件基类后缀（含 SelectorBase）或精确基类名（Base*）；
+    3. 类名本身匹配组件后缀，且不在 Base* 抽象基类排除清单内。
+    """
+    # method 1：__abstract__ 属性
+    if hasattr(attr, "__abstract__") and not getattr(attr, "__abstract__", True):
+        return True
+    # method 2：基类名
+    for base in getattr(attr, "__bases__", ()):
+        base_name = getattr(base, "__name__", "")
+        if any(base_name.endswith(s) for s in _COMPONENT_BASE_SUFFIXES) or base_name in _COMPONENT_BASE_EXACT:
+            return True
+    # method 3：类名本身（排除 Base* 抽象基类）
+    if attr_name not in _COMPONENT_BASE_EXACT and any(attr_name.endswith(s) for s in _COMPONENT_NAME_SUFFIXES):
+        return True
+    return False
+
+
+def _detect_component_class(module, logger=None):
+    """从模块属性中扫描首个组件类，找不到返回 None。
+
+    跳过下划线开头与非 type 属性。主路径与源码 fallback 路径共用此 helper，
+    保证 fallback 获得与主路径相同的检测能力（AC#2）。
+    """
+    for attr_name in dir(module):
+        if attr_name.startswith("_"):
+            continue
+        attr = getattr(module, attr_name)
+        if isinstance(attr, type) and hasattr(attr, "__bases__") and _is_component_class(attr, attr_name):
+            if logger is not None:
+                logger.DEBUG(f"Found component class: {attr.__name__}")
+            return attr
+    return None
 
 
 def resolve_param_kwargs(
@@ -204,8 +280,7 @@ class ComponentLoader:
                             from ginkgo.data.services.component_parameter_extractor import get_component_parameter_names
                             # #6103: 复用已取的 mfile.name，取代 container.cruds.file() 重复查询
                             comp_name = getattr(mfile, "name", None)
-                            type_map = {6: "strategy", 4: "selector", 5: "sizer", 3: "risk_manager", 1: "analyzer"}
-                            file_type_str = type_map.get(component_type)
+                            file_type_str = COMPONENT_TYPE_INFO.get(component_type, {}).get("name")
                             if comp_name and file_type_str:
                                 param_names = get_component_parameter_names(comp_name, code_content, file_type_str, file_id)
                                 component_kwargs = resolve_param_kwargs(
@@ -246,58 +321,9 @@ class ComponentLoader:
                         spec.loader.exec_module(module)
                         self._logger.DEBUG(f"Module imported successfully")
 
-                        # 查找组件类
+                        # 查找组件类（#4630: 提取为 _detect_component_class，与源码 fallback 共用）
                         self._logger.DEBUG("Starting component class detection")
-                        component_class = None
-                        all_classes = []
-                        for attr_name in dir(module):
-                            if attr_name.startswith("_"):
-                                continue
-                            attr = getattr(module, attr_name)
-                            if isinstance(attr, type) and hasattr(attr, "__bases__"):
-                                all_classes.append(attr_name)
-                                is_component = False
-
-                                # 方法1：检查__abstract__属性
-                                if hasattr(attr, "__abstract__") and not getattr(attr, "__abstract__", True):
-                                    is_component = True
-
-                                # 方法2：检查基类名称
-                                for base in attr.__bases__:
-                                    if hasattr(base, "__name__"):
-                                        base_name = base.__name__
-                                        if (
-                                            base_name.endswith("Strategy")
-                                            or base_name.endswith("Selector")
-                                            or base_name.endswith("SelectorBase")
-                                            or base_name.endswith("Sizer")
-                                            or base_name.endswith("RiskManagement")
-                                            or base_name.endswith("Analyzer")
-                                            or base_name == "BaseStrategy"
-                                            or base_name == "BaseSelector"
-                                            or base_name == "BaseSizer"
-                                            or base_name == "BaseRiskManagement"
-                                            or base_name == "BaseAnalyzer"
-                                        ):
-                                            is_component = True
-                                            break
-
-                                # 方法3：检查类名本身
-                                if (
-                                    attr_name.endswith("Strategy")
-                                    or attr_name.endswith("Selector")
-                                    or attr_name.endswith("Sizer")
-                                    or attr_name.endswith("RiskManagement")
-                                    or attr_name.endswith("Analyzer")
-                                ) and attr_name not in ["BaseStrategy", "BaseSelector", "BaseSizer", "BaseRiskManagement", "BaseAnalyzer"]:
-                                    is_component = True
-
-                                if is_component:
-                                    component_class = attr
-                                    self._logger.DEBUG(f"Found component class: {attr.__name__}")
-                                    break
-
-                        self._logger.DEBUG(f"Component detection completed. Found classes: {all_classes}")
+                        component_class = _detect_component_class(module, self._logger)
                         if component_class is None:
                             class_names = [name for name in dir(module) if not name.startswith("_") and isinstance(getattr(module, name), type)]
                             class_details = []
@@ -373,29 +399,9 @@ class ComponentLoader:
                         self._logger.INFO(f"🔧 [SOURCE FALLBACK] Trying to import: {full_module_path}")
                         module = importlib.import_module(full_module_path)
 
-                        component_class = None
-                        for attr_name in dir(module):
-                            if attr_name.startswith("_"):
-                                continue
-                            attr = getattr(module, attr_name)
-                            if isinstance(attr, type) and hasattr(attr, "__bases__"):
-                                is_component = False
-                                if hasattr(attr, "__abstract__") and not getattr(attr, "__abstract__", True):
-                                    is_component = True
-                                else:
-                                    for base in attr.__bases__:
-                                        base_name = base.__name__
-                                        if base_name.endswith("Strategy") or base_name.endswith("Selector") or \
-                                           base_name.endswith("Sizer") or base_name.endswith("RiskManagement") or \
-                                           base_name.endswith("Analyzer") or base_name == "BaseStrategy" or \
-                                           base_name == "BaseSelector" or base_name == "BaseSizer" or \
-                                           base_name == "BaseRiskManagement" or base_name == "BaseAnalyzer":
-                                            is_component = True
-                                            break
-
-                                if is_component:
-                                    component_class = attr
-                                    break
+                        # #4630: 与主路径共用 _detect_component_class。原 fallback 缺 method 3
+                        # （类名后缀检测）、base.__name__ 未防 object 致 AttributeError，现统一修复。
+                        component_class = _detect_component_class(module, self._logger)
 
                         if component_class is None:
                             return None, f"No component class found in source module {full_module_path}"

--- a/tests/unit/trading/services/test_component_loader_detect_class.py
+++ b/tests/unit/trading/services/test_component_loader_detect_class.py
@@ -1,0 +1,203 @@
+# Issue #4630: ComponentLoader 提取组件类检测逻辑消除重复
+# Upstream: ginkgo.trading.services._assembly.component_loader (_detect_component_class,
+#           _is_component_class, COMPONENT_TYPE_INFO, SOURCE_FALLBACK_IMPORT_MAP)
+# Downstream: _instantiate_component_from_file 主路径 + 源码 fallback 路径
+# Role: 钉住提取后的组件类检测行为（三种检测方法 + 排除规则）与单一类型映射源。
+#
+# 这些测试在 helper 提取前为 RED（函数/常量不存在），提取后转 GREEN。
+# 行为源自主路径原检测逻辑（component_loader.py 250-298），属"钉住既有行为"非想象。
+
+import types
+
+import pytest
+
+from ginkgo.trading.services._assembly.component_loader import (
+    COMPONENT_TYPE_INFO,
+    SOURCE_FALLBACK_IMPORT_MAP,
+    _detect_component_class,
+    _is_component_class,
+)
+from ginkgo.enums import FILE_TYPES
+
+
+# --------------------------------------------------------------------------- #
+# 测试用 fake 组件类（真实 type，带 __bases__，非 SimpleNamespace）
+# --------------------------------------------------------------------------- #
+
+class _AbstractThing:
+    """模拟抽象类：__abstract__=True、名无组件后缀，三种方法都不应命中。"""
+    __abstract__ = True
+
+
+class _ConcreteBaseStrategy:
+    """基类名精确等于 BaseStrategy，供 method 2 精确匹配。"""
+    pass
+
+
+# 给 _ConcreteBaseStrategy 一个能命中 method 2 精确匹配的名字
+_ConcreteBaseStrategy.__name__ = "BaseStrategy"
+_ConcreteBaseStrategy.__abstract__ = True  # 抽象基类自身不应被当组件
+
+
+class _InheritedStrategy(_ConcreteBaseStrategy):
+    """子类：继承自名为 BaseStrategy 的基类 → method 2 命中。"""
+    pass
+
+
+class _LonelyStrategy:
+    """类名以 Strategy 结尾、无识别基类、无 __abstract__ → method 3 命中。
+
+    这是源码 fallback 路径原本缺失的检测能力（AC#2 要求收敛到主路径）。
+    """
+    pass
+
+
+class _AbstractFlagged:
+    """__abstract__=False、无识别基类/名 → 仅靠 method 1 命中。"""
+    __abstract__ = False
+
+
+class _PlainFoo:
+    """无关类，三种方法都不应命中。"""
+    pass
+
+
+class _UnderscoreStrategy:
+    """下划线开头，_detect_component_class 应跳过。"""
+    pass
+
+
+# --------------------------------------------------------------------------- #
+# _is_component_class：单一类的判定（三种方法 + 排除）
+# --------------------------------------------------------------------------- #
+
+class TestIsComponentClass:
+    """三种检测方法（任一命中即为组件类）+ 排除规则。"""
+
+    def test_method1_abstract_flagged_is_component(self):
+        """method 1：__abstract__ 属性为 False → 组件类"""
+        assert _is_component_class(_AbstractFlagged, "_AbstractFlagged") is True
+
+    def test_method1_abstract_true_not_component(self):
+        """method 1：__abstract__=True 且名无后缀 → 三种方法都不命中"""
+        assert _is_component_class(_AbstractThing, "_AbstractThing") is False
+
+    def test_method2_base_exact_match(self):
+        """method 2：基类名精确等于 BaseStrategy → 组件类"""
+        assert _is_component_class(_InheritedStrategy, "_InheritedStrategy") is True
+
+    def test_method2_selector_base_suffix(self):
+        """method 2：基类名以 SelectorBase 结尾 → 组件类（fallback 原缺）"""
+        # 构造一个直接继承名以 SelectorBase 结尾的基类
+        BaseSelectorBase = type("BaseSelectorBase", (), {})
+        Derived = type("Derived", (BaseSelectorBase,), {})
+        assert _is_component_class(Derived, "Derived") is True
+
+    def test_method3_class_name_suffix(self):
+        """method 3：类名以 Strategy 结尾、无识别基类 → 组件类（fallback 原缺）"""
+        assert _is_component_class(_LonelyStrategy, "_LonelyStrategy") is True
+
+    def test_base_strategy_itself_excluded(self):
+        """名为 BaseStrategy 的抽象基类自身不应被当组件（method 3 排除 Base*）"""
+        # _ConcreteBaseStrategy 名为 BaseStrategy 且 __abstract__=True
+        assert _is_component_class(_ConcreteBaseStrategy, "BaseStrategy") is False
+
+    def test_plain_foo_not_component(self):
+        """无关类 Foo 三种方法都不命中"""
+        assert _is_component_class(_PlainFoo, "_PlainFoo") is False
+
+
+# --------------------------------------------------------------------------- #
+# _detect_component_class：模块级扫描
+# --------------------------------------------------------------------------- #
+
+def _make_module(**attrs) -> types.ModuleType:
+    """构造一个临时模块，挂载给定属性。"""
+    mod = types.ModuleType("fake_dynamic_component")
+    for name, val in attrs.items():
+        setattr(mod, name, val)
+    return mod
+
+
+class TestDetectComponentClass:
+    """从模块属性中扫描首个组件类。"""
+
+    def test_returns_first_matching_component(self):
+        """模块含一个组件类 → 返回该类"""
+        mod = _make_module(MyStrategy=_LonelyStrategy)
+        result = _detect_component_class(mod)
+        assert result is _LonelyStrategy
+
+    def test_skips_underscore_attrs(self):
+        """下划线开头的属性被跳过"""
+        mod = _make_module(_Hidden=_LonelyStrategy, Visible=_PlainFoo)
+        # _Hidden 被跳过，Visible 是 Foo 不命中 → None
+        assert _detect_component_class(mod) is None
+
+    def test_returns_none_when_no_component(self):
+        """模块无组件类 → None"""
+        mod = _make_module(Foo=_PlainFoo, Bar=_PlainFoo)
+        assert _detect_component_class(mod) is None
+
+    def test_skips_non_type_attrs(self):
+        """非 type 属性（函数/常量）被跳过，组件类按其模块属性名被识别"""
+        mod = _make_module(
+            some_func=lambda: None,
+            COUNT=42,
+            RealStrategy=_LonelyStrategy,
+        )
+        assert _detect_component_class(mod) is _LonelyStrategy
+
+    def test_picks_component_over_noise(self):
+        """混杂属性中精确选出组件类"""
+        mod = _make_module(
+            Helper=_PlainFoo,
+            DataValue=42,
+            TheStrategy=_LonelyStrategy,
+        )
+        assert _detect_component_class(mod) is _LonelyStrategy
+
+
+# --------------------------------------------------------------------------- #
+# COMPONENT_TYPE_INFO 单一映射源（AC#3）
+# --------------------------------------------------------------------------- #
+
+class TestComponentTypeInfo:
+    """type_map 与 SOURCE_FALLBACK_IMPORT_MAP 统一为单一映射源。"""
+
+    @pytest.mark.parametrize("ftype,name", [
+        (FILE_TYPES.STRATEGY.value, "strategy"),
+        (FILE_TYPES.SELECTOR.value, "selector"),
+        (FILE_TYPES.SIZER.value, "sizer"),
+        (FILE_TYPES.RISKMANAGER.value, "risk_manager"),
+        (FILE_TYPES.ANALYZER.value, "analyzer"),
+    ])
+    def test_each_type_has_name(self, ftype, name):
+        """5 种组件类型在单一源中均有 name 字段"""
+        assert COMPONENT_TYPE_INFO[ftype]["name"] == name
+
+    @pytest.mark.parametrize("ftype", [
+        FILE_TYPES.STRATEGY.value,
+        FILE_TYPES.SELECTOR.value,
+        FILE_TYPES.SIZER.value,
+        FILE_TYPES.RISKMANAGER.value,
+        FILE_TYPES.ANALYZER.value,
+    ])
+    def test_each_type_has_module_path_and_subpackage(self, ftype):
+        """每条记录含 module_path / subpackage（供 fallback 派生）"""
+        info = COMPONENT_TYPE_INFO[ftype]
+        assert "module_path" in info and isinstance(info["module_path"], str)
+        assert "subpackage" in info and isinstance(info["subpackage"], str)
+
+    def test_source_fallback_map_derived_from_single_source(self):
+        """SOURCE_FALLBACK_IMPORT_MAP 必须与单一源完全一致（防双映射漂移）"""
+        for ftype, info in COMPONENT_TYPE_INFO.items():
+            assert SOURCE_FALLBACK_IMPORT_MAP[ftype] == (
+                info["module_path"],
+                info["subpackage"],
+            )
+
+    def test_no_engine_in_mappings(self):
+        """ENGINE(=7) 非用户上传组件，不进映射（回归保护，#5880 缺陷4a）"""
+        assert FILE_TYPES.ENGINE.value not in COMPONENT_TYPE_INFO
+        assert FILE_TYPES.ENGINE.value not in SOURCE_FALLBACK_IMPORT_MAP


### PR DESCRIPTION
## Summary

#4630 重构：`ComponentLoader` 组件类检测逻辑去重 + 双类型映射收敛为单一源。

**背景**：`_instantiate_component_from_file` 中组件类检测逻辑出现两份（主路径 + 源码 fallback 路径），且 fallback 路径能力弱于主路径；`type_map`（内联裸 int 字面量）与 `SOURCE_FALLBACK_IMPORT_MAP`（模块级 FILE_TYPES）双映射键集相同却各写一份，无单一真相源（曾致 #5880 缺陷4a 漂移）。

**改动**（单文件 `component_loader.py` + 新测试）：

1. **提取 `_detect_component_class(module, logger)` + `_is_component_class(attr, name)`**（AC#1）：两处各 ~50 行的检测循环收敛为单点调用，三种检测方法（`__abstract__` / 基类名后缀+精确 / 类名后缀）封装为纯函数。

2. **fallback 路径获得主路径同等检测能力**（AC#2）：
   - 补齐 fallback 原缺的 method 3（类名后缀检测）；
   - 顺手修复 fallback `base.__name__` 未防 `object`（无 `__name__`）致 `AttributeError` 的隐性崩溃——原被外层 `except Exception` 吞成 "Source fallback failed"，统一 helper 改用 `getattr(base, "__name__", "")`。
   - 严格超集改进：原 fallback 能检测的组件仍能检测，且能检测更多。

3. **双映射统一为单一源**（AC#3）：引入模块级 `COMPONENT_TYPE_INFO`（`FILE_TYPES → {name, module_path, subpackage}`），`SOURCE_FALLBACK_IMPORT_MAP` 改为从其派生（`(module_path, subpackage)` 元组值不变，`test_component_loader_source_fallback.py` 锁定通过），内联 `type_map` 改查 `COMPONENT_TYPE_INFO.get(component_type, {}).get("name")`。

4. **现有组件加载行为不变**（AC#4）。

## Test plan

- [x] 新增 `tests/unit/trading/services/test_component_loader_detect_class.py`（24 用例）：钉住 `_is_component_class` 三方法 + 排除规则、`_detect_component_class` 模块扫描（跳下划线/非 type、首个匹配、无匹配 None）、`COMPONENT_TYPE_INFO` 单一源完整性 + 与 `SOURCE_FALLBACK_IMPORT_MAP` 派生一致性。
- [x] 既有 `test_component_loader_source_fallback.py` / `_param_compat.py` / `_param_resolution.py` / smoke 全绿（44 用例）——回归保护。
- [x] assembly 调用方测试全绿（`test_assemble_live_portfolio` / `test_engine_assembly_*`，90 passed）。
- [x] 三层 smoke：py_compile（src+api）✅ ｜ CI 启动路径点名（user_crud/containers/user_cli 29 passed）✅ ｜ 变更相关测试 ✅。

Closes #4630
