### PR TITLE
perf(#4650): MomentumSelector 改批量查询消除 N+1 (O(N)→O(1)/pick)

### DIFF
--- a/src/ginkgo/trading/selectors/momentum_selector.py
+++ b/src/ginkgo/trading/selectors/momentum_selector.py
@@ -5,7 +5,6 @@
 from ginkgo.trading.bases.selector_base import SelectorBase as BaseSelector
 from ginkgo.data.containers import container
 from ginkgo.libs import datetime_normalize, GLOG
-import pandas as pd
 import datetime
 
 
@@ -63,32 +62,36 @@ class MomentumSelector(BaseSelector):
 
         GLOG.INFO(f"MomentumSelector: scanning {len(codes)} stocks, window={self._window}d, top={self._rank}")
 
-        results = []
+        # 批量查询：一次取全市场窗口内全部 bar，内存 groupby 算动量。
+        # 将 DB 查询次数从 O(universe) 降到 O(1)，避免逐股 round-trip。
         bar_crud = container.cruds.bar()
-        for code in codes:
-            try:
-                bars = bar_crud.find(
-                    filters={"code": code, "timestamp__gte": start_date, "timestamp__lte": end_date},
-                    page_size=self._window + 5,
-                )
-                if not bars or len(bars) < 2:
-                    continue
-                df = bars.to_dataframe()
-                if df.empty or len(df) < 2:
-                    continue
-                first_close = float(df["close"].iloc[0])
-                last_close = float(df["close"].iloc[-1])
-                if first_close <= 0:
-                    continue
-                momentum = last_close / first_close - 1
-                results.append({"code": code, "momentum": momentum})
-            except Exception:
-                continue
-
-        if not results:
+        bars = bar_crud.find(
+            filters={"timestamp__gte": start_date, "timestamp__lte": end_date},
+            order_by="timestamp",
+        )
+        # 空结果短路：ModelList 实现 __bool__/__len__，空时不调 to_dataframe。
+        if not bars:
+            return self._interested
+        df = bars.to_dataframe()
+        if df is None or df.empty:
             return self._interested
 
-        res = pd.DataFrame(results).sort_values(by="momentum", ascending=False).head(self._rank)
-        self._interested = res["code"].tolist()
+        # 按 (code, timestamp) 排序，确保每组 first/last 为窗口内最早/最新收盘价，
+        # 不依赖 DB 隐式排序（原逐股版未指定 order_by，属脆弱行为，此处一并修正）。
+        valid_codes = set(codes)
+        df = df.sort_values(["code", "timestamp"])
+        grouped = (
+            df[df["code"].isin(valid_codes)]
+            .groupby("code")["close"]
+            .agg(["first", "last", "count"])
+        )
+        # 过滤无效股票：窗口内不足两条 bar，或首条收盘价非正（动量无意义/除零）。
+        grouped = grouped[(grouped["count"] >= 2) & (grouped["first"] > 0)]
+        if grouped.empty:
+            return self._interested
+
+        grouped["momentum"] = grouped["last"] / grouped["first"] - 1
+        top = grouped.sort_values("momentum", ascending=False).head(self._rank)
+        self._interested = top.index.tolist()
         GLOG.INFO(f"MomentumSelector: picked {len(self._interested)} stocks: {self._interested[:5]}")
         return self._interested

--- a/src/ginkgo/trading/selectors/momentum_selector.py
+++ b/src/ginkgo/trading/selectors/momentum_selector.py
@@ -7,6 +7,10 @@ from ginkgo.data.containers import container
 from ginkgo.libs import datetime_normalize, GLOG
 import datetime
 
+# 动量回看窗口上限（日历日）。业务上动量语义 ≤1 年；技术上防止批量 bar 查询
+# 一次取全表（master 库 5423 code × 35 年 ≈ 1568 万行）导致 OOM/卡死。
+MAX_WINDOW = 365
+
 
 class MomentumSelector(BaseSelector):
     __abstract__ = False
@@ -21,6 +25,12 @@ class MomentumSelector(BaseSelector):
         **kwargs,
     ) -> None:
         super().__init__(name, *args, **kwargs)
+        # 源头校验：window 必须为 [1, MAX_WINDOW] 内 int，避免 timedelta(days=) 语义错
+        # 或批量查询取全表 OOM。bool 是 int 子类，一并拒绝。
+        if isinstance(window, bool) or not isinstance(window, int) or not (1 <= window <= MAX_WINDOW):
+            raise ValueError(
+                f"window must be int in [1, {MAX_WINDOW}], got {window!r}"
+            )
         self._interested = []
         self._interval = interval
         self._rank = rank

--- a/src/ginkgo/trading/selectors/popularity_selector.py
+++ b/src/ginkgo/trading/selectors/popularity_selector.py
@@ -9,6 +9,11 @@ from ginkgo.trading.bases.selector_base import SelectorBase as BaseSelector
 from ginkgo.data.containers import container
 from ginkgo.libs import GLOG
 
+# 热度统计窗口上限（日历日）。与 MomentumSelector.MAX_WINDOW 对齐：业务 ≤1 年，
+# 技术上防止未来改批量查询后一次取全表 OOM（当前逐股路径有 page_size=span+10 兜底，
+# 但参数校验是更上游、更稳的防御）。
+MAX_SPAN = 365
+
 
 class PopularitySelector(BaseSelector):
     __abstract__ = False
@@ -22,6 +27,11 @@ class PopularitySelector(BaseSelector):
         **kwargs,
     ) -> None:
         super().__init__(name, *args, **kwargs)
+        # 源头校验：span 必须为 [1, MAX_SPAN] 内 int。与 MomentumSelector 同款防御。
+        if isinstance(span, bool) or not isinstance(span, int) or not (1 <= span <= MAX_SPAN):
+            raise ValueError(
+                f"span must be int in [1, {MAX_SPAN}], got {span!r}"
+            )
         self.rank = rank
         self.span = span
         self._interested = []

--- a/tests/unit/lab/test_momentum_selector.py
+++ b/tests/unit/lab/test_momentum_selector.py
@@ -40,5 +40,99 @@ class MomentumSelectorTest(unittest.TestCase):
         res = s.pick(time="2020-01-01")
         self.assertEqual(len(res), 0)
 
+    @patch("ginkgo.trading.selectors.momentum_selector.container")
+    def test_pick_batch_selects_top_n_by_momentum(self, mock_container):
+        """批量查询路径：按窗口内首末收盘价正确计算动量并选出 top-N。
+
+        数据按 timestamp 排序（模拟真实 order_by='timestamp' 查询返回）：
+            A: 10→20→30  momentum = 30/10-1 = 2.0
+            B: 5→50→100 momentum = 100/5-1  = 19.0  ← 最高
+            C: 100→50→10 momentum = 10/100-1 = -0.9
+        rank=2 期望 [B, A]。
+        逐股 buggy 实现会对每个 code 用整 df 的 iloc[0]/iloc[-1]（均为 10）算出
+        相同动量 0，稳定排序后得 [A, B]，与本断言不符，确保 RED 可区分。
+        """
+        df = pd.DataFrame(
+            [
+                {"code": "A", "close": 10.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "B", "close": 5.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "C", "close": 100.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "A", "close": 20.0, "timestamp": pd.Timestamp("2019-12-20")},
+                {"code": "B", "close": 50.0, "timestamp": pd.Timestamp("2019-12-20")},
+                {"code": "C", "close": 50.0, "timestamp": pd.Timestamp("2019-12-20")},
+                {"code": "A", "close": 30.0, "timestamp": pd.Timestamp("2019-12-30")},
+                {"code": "B", "close": 100.0, "timestamp": pd.Timestamp("2019-12-30")},
+                {"code": "C", "close": 10.0, "timestamp": pd.Timestamp("2019-12-30")},
+            ]
+        )
+        mock_si = MagicMock()
+        mock_si.get_all_codes.return_value = ["A", "B", "C"]
+        mock_bar = MagicMock()
+        mock_bar.find.return_value.to_dataframe.return_value = df
+        mock_container.cruds.stock_info.return_value = mock_si
+        mock_container.cruds.bar.return_value = mock_bar
+
+        s = MomentumSelector(name="test_selector", window=30, rank=2)
+        res = s.pick(time="2020-01-01")
+        self.assertEqual(res, ["B", "A"])
+
+    @patch("ginkgo.trading.selectors.momentum_selector.container")
+    def test_pick_uses_single_batch_query(self, mock_container):
+        """验收：pick 只发起一次 bar 批量查询（O(1)），不再逐股 round-trip。
+
+        旧逐股实现对 N 支股票调用 find() N 次；批量实现应只调用 1 次。
+        """
+        df = pd.DataFrame(
+            [
+                {"code": "A", "close": 10.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "B", "close": 5.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "A", "close": 20.0, "timestamp": pd.Timestamp("2019-12-30")},
+                {"code": "B", "close": 100.0, "timestamp": pd.Timestamp("2019-12-30")},
+            ]
+        )
+        mock_si = MagicMock()
+        mock_si.get_all_codes.return_value = ["A", "B"]
+        mock_bar = MagicMock()
+        mock_bar.find.return_value.to_dataframe.return_value = df
+        mock_container.cruds.stock_info.return_value = mock_si
+        mock_container.cruds.bar.return_value = mock_bar
+
+        s = MomentumSelector(name="test_selector", window=30, rank=2)
+        s.pick(time="2020-01-01")
+        self.assertEqual(
+            mock_bar.find.call_count,
+            1,
+            "pick() 应只发起一次批量 bar 查询，而非逐股查询",
+        )
+
+    @patch("ginkgo.trading.selectors.momentum_selector.container")
+    def test_pick_filters_invalid_stocks(self, mock_container):
+        """过滤无效股票：窗口内不足两条 bar 或首条收盘价非正的股票不参与排名。
+
+            Z: 10→20      count=2, first=10  → 有效，momentum=1.0
+            X: 15         count=1           → 不足两条，剔除
+            Y: 0→10       count=2, first=0  → 首条非正，剔除
+        rank=2 但仅 Z 有效 → 期望 ['Z']。
+        """
+        df = pd.DataFrame(
+            [
+                {"code": "Z", "close": 10.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "X", "close": 15.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "Y", "close": 0.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "Z", "close": 20.0, "timestamp": pd.Timestamp("2019-12-30")},
+                {"code": "Y", "close": 10.0, "timestamp": pd.Timestamp("2019-12-30")},
+            ]
+        )
+        mock_si = MagicMock()
+        mock_si.get_all_codes.return_value = ["Z", "X", "Y"]
+        mock_bar = MagicMock()
+        mock_bar.find.return_value.to_dataframe.return_value = df
+        mock_container.cruds.stock_info.return_value = mock_si
+        mock_container.cruds.bar.return_value = mock_bar
+
+        s = MomentumSelector(name="test_selector", window=30, rank=2)
+        res = s.pick(time="2020-01-01")
+        self.assertEqual(res, ["Z"])
+
     def test_date_scene(self):
         pass

--- a/tests/unit/trading/selectors/test_momentum_popularity_hasattr.py
+++ b/tests/unit/trading/selectors/test_momentum_popularity_hasattr.py
@@ -29,13 +29,22 @@ def _make_bars(df: pd.DataFrame):
 class MomentumSelectorHasattrRemovalTest(unittest.TestCase):
     @patch("ginkgo.trading.selectors.momentum_selector.container")
     def test_non_empty_bars_uses_to_dataframe(self, mock_container):
-        """非空 bars：直接调 to_dataframe，按 momentum 排序产出 code。"""
+        """非空 bars：直接调 to_dataframe，按 momentum 排序产出 code。
+
+        批量实现（#4650）按 code 列 groupby，故 df 需含真实 bar 的 code/timestamp 列
+        （旧逐股实现 code 来自循环变量，fixture 曾省略 code 列）。
+        """
         mock_stockinfo = MagicMock()
         mock_stockinfo.get_all_codes.return_value = ["000001"]
         mock_container.cruds.stock_info.return_value = mock_stockinfo
 
         df = pd.DataFrame(
-            {"close": [10.0, 12.0], "volume": [100, 200]},
+            {
+                "code": ["000001", "000001"],
+                "close": [10.0, 12.0],
+                "volume": [100, 200],
+                "timestamp": [pd.Timestamp("2020-05-01"), pd.Timestamp("2020-05-31")],
+            }
         )
         mock_bar = MagicMock()
         mock_bar.find.return_value = _make_bars(df)

--- a/tests/unit/trading/selectors/test_selector_param_validation.py
+++ b/tests/unit/trading/selectors/test_selector_param_validation.py
@@ -1,0 +1,73 @@
+"""
+Selector 时间窗口参数校验：momentum.window / popularity.span 必须为 [1, 365] 内 int。
+
+防御：过大的窗口会让 bar 批量查询一次取全表（master 库 5423 code × 35 年 ≈ 1568 万行）
+导致 OOM/卡死。源头 __init__ 拒绝非法值，fail-fast 早于回测运行期崩溃。
+"""
+
+import unittest
+
+from ginkgo.trading.selectors.momentum_selector import MomentumSelector
+from ginkgo.trading.selectors.popularity_selector import PopularitySelector
+
+
+class MomentumSelectorWindowValidationTest(unittest.TestCase):
+    def test_accepts_default_and_boundary_values(self):
+        """window ∈ {1, 20(默认), 365(上限)} 均应正常实例化并落属性。"""
+        for w in (1, 20, 365):
+            with self.subTest(window=w):
+                s = MomentumSelector(name="t", window=w)
+                self.assertEqual(s.window, w)
+
+    def test_rejects_zero(self):
+        """window=0 → 窗口为空，无意义，拒。"""
+        with self.assertRaises(ValueError):
+            MomentumSelector(name="t", window=0)
+
+    def test_rejects_negative(self):
+        """负 window → start>end 空集，静默失败，拒。"""
+        with self.assertRaises(ValueError):
+            MomentumSelector(name="t", window=-5)
+
+    def test_rejects_above_max(self):
+        """window>365 → 批量取数 OOM 风险，拒。"""
+        with self.assertRaises(ValueError):
+            MomentumSelector(name="t", window=366)
+
+    def test_rejects_non_int(self):
+        """str/float/None → timedelta(days=) 语义错误，拒。bool 亦拒（是 int 子类）。"""
+        for bad in ("20", 20.0, None, True):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    MomentumSelector(name="t", window=bad)
+
+
+class PopularitySelectorSpanValidationTest(unittest.TestCase):
+    def test_accepts_default_and_boundary_values(self):
+        """span ∈ {1, 30(默认), 365(上限)} 均应正常实例化并落属性。"""
+        for sp in (1, 30, 365):
+            with self.subTest(span=sp):
+                s = PopularitySelector(name="t", span=sp)
+                self.assertEqual(s.span, sp)
+
+    def test_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            PopularitySelector(name="t", span=0)
+
+    def test_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            PopularitySelector(name="t", span=-5)
+
+    def test_rejects_above_max(self):
+        with self.assertRaises(ValueError):
+            PopularitySelector(name="t", span=366)
+
+    def test_rejects_non_int(self):
+        for bad in ("30", 30.0, None, True):
+            with self.subTest(bad=bad):
+                with self.assertRaises(ValueError):
+                    PopularitySelector(name="t", span=bad)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

修复 #4650：`MomentumSelector.pick()` 全市场逐股 `bar_crud.find()` 导致回测极慢（12 个月 ~24 万次 DB round-trip，预估 3 小时+）。

改为**一次范围查询 + pandas 内存聚合**，DB 查询次数从 `O(universe)` 降到 `O(1)` 每次 pick（24 万 → ~48 次）。

顺带给两个 selector 的时间窗口参数加 `[1, 365]` 上限校验，防止过大的窗口让批量查询一次取全表 OOM。

### 改动

**性能优化（核心）**
- `src/ginkgo/trading/selectors/momentum_selector.py`：移除逐股循环，改为
  `bar_crud.find(filters={timestamp__gte, timestamp__lte}, order_by="timestamp")`
  一次取全市场窗口数据，`groupby("code")` 计算动量。
- 顺带修正原逐股版未指定 `order_by` 的隐式排序脆弱性：现按 `(code, timestamp)`
  排序，first/last 严格为窗口内最早/最新收盘价。
- 过滤无效股票（窗口内 <2 条 bar 或首条收盘价 ≤0，避免除零）。
- 删除 ADR-010 `hasattr(bars, "to_dataframe")` 死分支，空 `ModelList` 用 `__bool__` 短路。

**参数校验防御（d41c915e）**
- `MomentumSelector.window` / `PopularitySelector.span` 在 `__init__` 校验为 `[1, 365]` 内 int（拒 bool/str/float/None/越界），违例 `raise ValueError`。
- 动机：批量查询路径下 `page_size` 不再兜底（旧逐股 `page_size=window+5` 天然封顶 ~25 行/股），过大的 window 会让一次查询取全表——实测 master 库 5423 code × 35 年 ≈ 1568 万行 → OOM/卡死。源头 `__init__` fail-fast 早于回测运行期崩溃。
- PopularitySelector 当前仍是逐股（有 page_size 兜底），但参数校验作为更上游、面向未来改批量的统一防御一并加上。

### 测试
- `tests/unit/lab/test_momentum_selector.py` 新增 3 用例（批量路径）：
  - 批量路径按动量正确选出 top-N（构造 3 股数据，验证 buggy 逐股实现会误判）
  - `bar_crud.find` 仅调用 1 次（O(1) 验收）
  - 无效股票（<2 bar / first_close≤0）被过滤
- `tests/unit/trading/selectors/test_momentum_popularity_hasattr.py`：非空 fixture
  补 `code`/`timestamp` 列（批量路径按 code groupby；旧逐股靠循环变量带 code，
  故 fixture 曾省略，现补为真实 bar 结构）。
- `tests/unit/trading/selectors/test_selector_param_validation.py`（新）：两个 selector 各 5 用例，
  覆盖 accept 边界（1 / 默认 / 365）与 reject（0 / 负 / 366 / 非int / bool）。

## Test plan

- [x] `pytest tests/unit/lab/test_momentum_selector.py` — 6 passed
- [x] `pytest tests/unit/trading/selectors/test_momentum_popularity_hasattr.py` — 4 passed
- [x] `pytest tests/unit/trading/selectors/test_selector_param_validation.py` — 10 passed
- [x] Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）— 29 passed
- [x] `py_compile` 全 src+api — 通过
- [ ] 回归：宽 universe 回测耗时从小时级降到分钟级（需真实数据，留人工验收）

Closes #4650
