### PR TITLE
refactor(#6498): Sizer lot_size 参数化（复用 LotAlignableMixin）

### DIFF
--- a/src/ginkgo/trading/sizers/atr_sizer.py
+++ b/src/ginkgo/trading/sizers/atr_sizer.py
@@ -12,6 +12,7 @@ from ginkgo.trading.bases.sizer_base import SizerBase as BaseSizer
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.entities import Order
 from ginkgo.entities import Signal
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.libs import GLOG
 from ginkgo.trading.computation.technical.average_true_range import AverageTrueRange as ATR  # #3958 restored import
 from ginkgo.data.containers import container
@@ -20,7 +21,7 @@ import datetime
 import pandas as pd
 
 
-class ATRSizer(BaseSizer):
+class ATRSizer(LotAlignableMixin, BaseSizer):
     # The class with this __abstract__  will rebuild the class from bytes.
     # If not run time function will pass the class.
     __abstract__ = False
@@ -32,6 +33,7 @@ class ATRSizer(BaseSizer):
         risk: float = 0.01,
         risk_ratio: float = 2,
         min_atr_percent: float = 0.005,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -43,6 +45,9 @@ class ATRSizer(BaseSizer):
         # zero (halt / limit board / stale quotes) the raw max_money/atr would
         # produce oversized positions; floor ATR before sizing.
         self.min_atr_percent = min_atr_percent
+        # #6498: 最小交易单位（手），A 股默认 100；参数化以支持美股(1)/港股。
+        # 仅作用于开仓(LONG)路径的 lot 对齐；平仓(SHORT)路径全量下单不受影响。
+        self._lot_size = lot_size
 
     def set_risk(self, risk: float):
         self.risk = risk
@@ -106,7 +111,7 @@ class ATRSizer(BaseSizer):
                 )
                 atr = min_atr
             max_money = portfolio_info["cash"] * self.risk
-            max_shares = int((max_money / atr) / 100) * 100
+            max_shares = self.align_to_lot(int(max_money / atr))  # 向下对齐到 lot_size 整数倍（#6498，原硬编码 100）
             price = close * 1.1
             o = self.create_order(
                 code=signal.code,

--- a/src/ginkgo/trading/sizers/fixed_sizer.py
+++ b/src/ginkgo/trading/sizers/fixed_sizer.py
@@ -14,11 +14,12 @@ from typing import Tuple, Optional
 
 from ginkgo.trading.bases.sizer_base import SizerBase as BaseSizer
 from ginkgo.entities import Order, Signal
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.libs import to_decimal, GLOG
 
 
-class FixedSizer(BaseSizer):
+class FixedSizer(LotAlignableMixin, BaseSizer):
     # The class with this __abstract__  will rebuild the class from bytes.
     # If not run time function will pass the class.
     """
@@ -33,6 +34,7 @@ class FixedSizer(BaseSizer):
         commission_rate: float = 0.0003,
         commission_min: float = 5,
         stamp_tax: float = 0.001,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -42,12 +44,16 @@ class FixedSizer(BaseSizer):
             commission_rate(float): 手续费率，默认对齐 SimBroker (0.0003)。
             commission_min(float): 最小手续费（元），默认对齐 SimBroker (5)。
             stamp_tax(float): 印花税率（仅卖出收取），默认 0.001；买入估算不计。
+            lot_size(int): 最小交易单位（手），A 股默认 100；参数化以支持
+                美股(1)/港股等不同最小交易单位（#6498）。仅作用于开仓(LONG)
+                路径的递减步长；平仓(SHORT)路径全量下单不受影响。
         """
         super().__init__(name, *args, **kwargs)
         self._volume = self._convert_to_int(volume, 150)
         self._commission_rate = Decimal(str(commission_rate))
         self._commission_min = Decimal(str(commission_min))
         self._stamp_tax = Decimal(str(stamp_tax))
+        self._lot_size = lot_size
 
     @property
     def volume(self) -> float:
@@ -78,7 +84,7 @@ class FixedSizer(BaseSizer):
             planned_cost = self._estimate_cost(last_price, size)
             if cash >= planned_cost:
                 return (size, planned_cost)
-            size -= 100
+            size -= self._lot_size
         return (0, 0)
 
     def cal(self, portfolio_info, signal: Signal, *args, **kwargs) -> Optional[Order]:

--- a/src/ginkgo/trading/sizers/ratio_sizer.py
+++ b/src/ginkgo/trading/sizers/ratio_sizer.py
@@ -11,11 +11,12 @@ from typing import Tuple, Optional
 
 from ginkgo.trading.bases.sizer_base import SizerBase as BaseSizer
 from ginkgo.entities import Order, Signal
+from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.libs import to_decimal, GLOG
 
 
-class RatioSizer(BaseSizer):
+class RatioSizer(LotAlignableMixin, BaseSizer):
     # The class with this __abstract__  will rebuild the class from bytes.
     # If not run time function will pass the class.
     """
@@ -30,6 +31,7 @@ class RatioSizer(BaseSizer):
         commission_rate: float = 0.0003,
         commission_min: float = 5,
         stamp_tax: float = 0.001,
+        lot_size: int = 100,
         *args,
         **kwargs,
     ):
@@ -39,12 +41,16 @@ class RatioSizer(BaseSizer):
             commission_rate(float): 手续费率，默认对齐 SimBroker (0.0003)。
             commission_min(float): 最小手续费（元），默认对齐 SimBroker (5)。
             stamp_tax(float): 印花税率（仅卖出收取），默认 0.001；买入估算不计。
+            lot_size(int): 最小交易单位（手），A 股默认 100；参数化以支持
+                美股(1)/港股等不同最小交易单位（#6498）。仅作用于开仓(LONG)
+                路径的 lot 对齐/递减步长；平仓(SHORT)路径全量下单不受影响。
         """
         super().__init__(name, *args, **kwargs)
         self._ratio = float(ratio)
         self._commission_rate = Decimal(str(commission_rate))
         self._commission_min = Decimal(str(commission_min))
         self._stamp_tax = Decimal(str(stamp_tax))
+        self._lot_size = lot_size
 
     @property
     def ratio(self) -> float:
@@ -73,12 +79,12 @@ class RatioSizer(BaseSizer):
         budget = to_decimal(cash) * Decimal(str(ratio))
         # 粗估可买股数上限（忽略手续费，偏大），后续循环按真实成本递减校正
         size = int(budget / to_decimal(last_price))
-        size = (size // 100) * 100  # round down to nearest 100 (A-share lot size)
+        size = self.align_to_lot(size)  # 向下对齐到 lot_size 整数倍（#6498，原硬编码 100）
         while size > 0:
             planned_cost = self._estimate_cost(last_price, size)
             if budget >= planned_cost:
                 return (size, planned_cost)
-            size -= 100
+            size -= self._lot_size
         return (0, 0)
 
     def cal(self, portfolio_info, signal: Signal, *args, **kwargs) -> Optional[Order]:

--- a/tests/unit/trading/sizers/test_sizer_lot_size.py
+++ b/tests/unit/trading/sizers/test_sizer_lot_size.py
@@ -1,0 +1,228 @@
+"""
+Unit tests for Sizer lot_size 参数化（#6498）。
+
+三个 Sizer（FixedSizer / RatioSizer / ATRSizer）原将 A 股 100 股/手硬编码在
+开仓（LONG）路径。本组测试验证 lot_size 已参数化（复用 LotAlignableMixin，
+默认 100 保持 A 股向后兼容），并锁定 lot_size=50 / lot_size=1（美股）行为。
+
+SHORT/平仓路径本就全量下单（volume=pos.volume），不受 lot 对齐约束——
+agent brief 已剔除 Claim #3，此处加守护测试防回归。
+"""
+import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.entities import Signal
+from ginkgo.trading.sizers.fixed_sizer import FixedSizer
+from ginkgo.trading.sizers.ratio_sizer import RatioSizer
+from ginkgo.trading.sizers.atr_sizer import ATRSizer
+
+
+# --------------------------------------------------------------------------- #
+# 共用 fixture / helper
+# --------------------------------------------------------------------------- #
+def _time_provider():
+    tp = MagicMock()
+    tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+    return tp
+
+
+def _make_signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG):
+    s = Signal(code=code, direction=direction)
+    s._portfolio_id = "test-portfolio"
+    s._engine_id = "test-engine"
+    return s
+
+
+def _portfolio_info(cash=Decimal("500000"), positions=None):
+    return {"cash": cash, "positions": positions or {}}
+
+
+@pytest.mark.parametrize(
+    "cls,kwargs",
+    [
+        (FixedSizer, {"volume": "100"}),
+        (RatioSizer, {"ratio": "0.1"}),
+        (ATRSizer, {"period": 14, "risk": 0.01, "risk_ratio": 2}),
+    ],
+)
+class TestSizerLotSizeParam:
+    """lot_size 构造器参数：默认 100（A 股向后兼容），可配。"""
+
+    def test_default_lot_size_is_100(self, cls, kwargs):
+        """未传 lot_size 时默认 100，保持 A 股现状。"""
+        sizer = cls(name="T", **kwargs)
+        assert sizer.lot_size == 100
+
+    def test_lot_size_configurable(self, cls, kwargs):
+        """lot_size 可通过构造器配置（复用 LotAlignableMixin.lot_size 属性）。"""
+        sizer = cls(name="T", lot_size=50, **kwargs)
+        assert sizer.lot_size == 50
+
+
+class TestFixedSizerLotSize:
+    """FixedSizer 开仓路径递减步长由 lot_size 决定（原硬编码 100）。"""
+
+    def test_lot_size_1_us_stock_not_zeroed(self):
+        """lot_size=1（美股 1 股/手）：资金紧张时步长 1 精确找到可买量，不被 100 步长跨过拒单。
+
+        volume=100、price=$100、cash=$6000：100 股需 $10005 > $6000。
+        默认 lot_size=100：100-=100 → 0，while size>0 结束 → (0,0) 拒单
+            （即便 ~59 股实际买得起，100 步长直接跨过）；
+        lot_size=1：100→99→...→59（$5905 ≤ $6000）→ 成交 59 股。
+        """
+        # 默认 lot_size=100：100 步长跨过可买区间 → 拒单
+        sizer_default = FixedSizer(name="T", volume="100")
+        size_default, _ = sizer_default.calculate_order_size(
+            initial_size=100, last_price=Decimal("100"), cash=Decimal("6000")
+        )
+        assert size_default == 0  # A 股：资金不足 1 手 → 拒单
+
+        # lot_size=1（美股）：步长 1 精确定位可买量
+        sizer_us = FixedSizer(name="T", volume="100", lot_size=1)
+        size_us, _ = sizer_us.calculate_order_size(
+            initial_size=100, last_price=Decimal("100"), cash=Decimal("6000")
+        )
+        assert size_us == 59  # 美股：不被 100 步长跨过
+
+    def test_lot_size_50_decrement_step(self):
+        """lot_size=50：递减步长为 50，资金不足时按 50 股递减试探。
+
+        volume=200、price=$100、cash 仅够 150 股（$15000+手续费）：
+        默认 lot_size=100：200→100（步长 100），100 股资金够 → 返回 100；
+        lot_size=50：200→150（步长 50），150 股资金够 → 返回 150。
+        """
+        sizer_default = FixedSizer(name="T", volume="200")
+        size_default, _ = sizer_default.calculate_order_size(
+            initial_size=200, last_price=Decimal("100"), cash=Decimal("15500")
+        )
+        assert size_default == 100  # 200 不够 → 减 100 → 100 够
+
+        sizer_50 = FixedSizer(name="T", volume="200", lot_size=50)
+        size_50, _ = sizer_50.calculate_order_size(
+            initial_size=200, last_price=Decimal("100"), cash=Decimal("15500")
+        )
+        assert size_50 == 150  # 200 不够 → 减 50 → 150 够
+
+
+class TestRatioSizerLotSize:
+    """RatioSizer 开仓路径 lot 对齐由 lot_size 决定（原硬编码 100）。"""
+
+    def test_lot_size_50_aligns_via_cal(self):
+        """lot_size=50 经 cal() 端到端：开仓量对齐 50 而非 100。
+
+        ratio=0.1、cash=550000 → budget=55000；price=40 → raw=int(55000/40)=1375。
+        默认 lot_size=100：(1375//100)*100=1300，资金够 → 成交 1300；
+        lot_size=50：align_to_lot(1375)=1350，资金够 → 成交 1350。
+        """
+        df = pd.DataFrame({"close": [40.0, 40.0, 40.0]})
+
+        # 默认 lot_size=100
+        sizer_default = RatioSizer(name="T", ratio="0.1")
+        sizer_default._time_provider = _time_provider()
+        feeder_default = MagicMock()
+        feeder_default.get_historical_data.return_value = df
+        sizer_default._data_feeder = feeder_default
+        order_default = sizer_default.cal(
+            _portfolio_info(cash=Decimal("550000")), _make_signal()
+        )
+        assert order_default.volume == 1300
+
+        # lot_size=50
+        sizer_50 = RatioSizer(name="T", ratio="0.1", lot_size=50)
+        sizer_50._time_provider = _time_provider()
+        feeder_50 = MagicMock()
+        feeder_50.get_historical_data.return_value = df
+        sizer_50._data_feeder = feeder_50
+        order_50 = sizer_50.cal(
+            _portfolio_info(cash=Decimal("550000")), _make_signal()
+        )
+        assert order_50.volume == 1350
+
+
+class TestATRSizerLotSize:
+    """ATRSizer 开仓路径 lot 对齐由 lot_size 决定（原硬编码 100 内联）。
+
+    ATRSizer 仍用 container.bar_service 取价（未迁 _data_feeder），故 patch
+    ginkgo.trading.sizers.atr_sizer.container（同 test_atr_sizer.py 范式）。
+    """
+
+    @staticmethod
+    def _bar_df(n, high, low, close):
+        return pd.DataFrame({"high": [high] * n, "low": [low] * n, "close": [close] * n})
+
+    def test_lot_size_50_aligns_via_cal(self):
+        """lot_size=50 经 cal() 端到端：开仓量对齐 50 而非 100。
+
+        TR=1.5（high=11.5/low=10/close=10）、period=14、risk_ratio=2 → atr=3；
+        cash=500000 * risk=0.01 → max_money=5000；raw=int(5000/3)=1666。
+        默认 lot_size=100：int(1666/100)*100=1600；
+        lot_size=50：align_to_lot(1666)=1650。
+        """
+        df = self._bar_df(15, high=11.5, low=10.0, close=10.0)
+        signal = _make_signal()
+        info = {"cash": 500000.0, "positions": {}}  # float：atr_sizer 不做 Decimal 强转
+
+        # 默认 lot_size=100
+        sizer_default = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2)
+        sizer_default.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+            order_default = sizer_default.cal(info, signal)
+        assert order_default.volume == 1600
+
+        # lot_size=50
+        sizer_50 = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2, lot_size=50)
+        sizer_50.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
+            service = MagicMock()
+            result = MagicMock()
+            result.success = True
+            result.data.to_dataframe.return_value = df
+            service.get.return_value = result
+            cm.bar_service.return_value = service
+            order_50 = sizer_50.cal(info, signal)
+        assert order_50.volume == 1650
+
+
+class TestShortCloseFullVolume:
+    """平仓(SHORT)路径全量下单守护（agent brief 已剔除 Claim #3）。
+
+    三个 Sizer 的 SHORT 分支均直接 volume=pos.volume 全量下单，不受 lot 对齐
+    约束——零股持仓（送股/拆股/历史遗留）平仓不受影响。加守护防回归。
+    """
+
+    @staticmethod
+    def _position(volume):
+        pos = MagicMock()
+        pos.volume = volume
+        return pos
+
+    def test_fixed_sizer_short_uses_full_odd_lot_volume(self):
+        """FixedSizer SHORT：含零股(17 股)持仓全量平仓，不被 lot 对齐截断。"""
+        sizer = FixedSizer(name="T", volume="100", lot_size=100)
+        sizer._time_provider = _time_provider()
+        signal = _make_signal(direction=DIRECTION_TYPES.SHORT)
+        info = _portfolio_info(positions={"000001.SZ": self._position(17)})
+        order = sizer.cal(info, signal)
+        assert order is not None
+        assert order.volume == 17  # 零股全量平仓
+
+    def test_ratio_sizer_short_uses_full_odd_lot_volume(self):
+        """RatioSizer SHORT：含零股(17 股)持仓全量平仓。"""
+        sizer = RatioSizer(name="T", ratio="0.1", lot_size=100)
+        sizer._time_provider = _time_provider()
+        signal = _make_signal(direction=DIRECTION_TYPES.SHORT)
+        info = _portfolio_info(positions={"000001.SZ": self._position(17)})
+        order = sizer.cal(info, signal)
+        assert order is not None
+        assert order.volume == 17


### PR DESCRIPTION
## Summary

三个 Sizer（`FixedSizer` / `RatioSizer` / `ATRSizer`）开仓(LONG)路径原将 A 股 100 股/手硬编码，未与 Risk 层 `LotAlignableMixin`（lot_size 可配，#6038/#6443 已落地）对齐。非 A 股市场（美股 lot_size=1）开仓量计算会被 lot 对齐抹零拒单。

本 PR 仿 Risk 层模式，让三个 Sizer 复用 `LotAlignableMixin`，新增 `lot_size` 构造器参数（默认 100，A 股向后兼容），将开仓路径三处硬编码 `100` 改为 `self.align_to_lot()` / `self._lot_size`：

| Sizer | 原硬编码 | 改后 |
|---|---|---|
| FixedSizer | `size -= 100`（递减步长） | `size -= self._lot_size` |
| RatioSizer | `(size//100)*100` + `size -= 100` | `self.align_to_lot(size)` + `size -= self._lot_size` |
| ATRSizer | `int((max_money/atr)/100)*100` | `self.align_to_lot(int(max_money/atr))` |

**向后兼容**：默认 `lot_size=100` 数学等价（`int(x/100)*100 ≡ int(x)//100*100`，x≥0），现有 sizer 测试全部不变通过。

**Claim #3（开仓/平仓零股语义）按 agent brief 剔除**：三个 Sizer 的 SHORT/平仓路径本就 `volume=pos.volume` 全量下单，不受 lot 对齐约束，零股持仓可全量平仓。新增守护测试锁此行为。

## Test plan

新增 `tests/unit/trading/sizers/test_sizer_lot_size.py`（TDD 红→绿）：
- `TestSizerLotSizeParam`：三 Sizer `lot_size` 默认 100 + 可配（证 mixin 接入）
- `TestFixedSizerLotSize`：`lot_size=1` 美股资金紧张时不被 100 步长跨过拒单（返回 59 而非 0）；`lot_size=50` 递减步长为 50
- `TestRatioSizerLotSize`：`lot_size=50` 经 `cal()` 端到端开仓量对齐 50（raw 1375 → 1350 vs 默认 1300）
- `TestATRSizerLotSize`：`lot_size=50` 经 `cal()` 端到端（raw 1666 → 1650 vs 默认 1600）
- `TestShortCloseFullVolume`：SHORT 平仓零股(17 股)持仓全量下单守护

本地三层冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1 py_compile（src+api 全通过）
- ✅ Layer 2 启动路径 smoke（test_user_crud_mock / test_containers / test_user_cli，29 passed）
- ✅ Layer 3 变更相关：`tests/unit/trading/sizers/`（33 passed）+ strategy/lab/backtest sizer 测试（54 passed），含既有测试不变全绿

Closes #6498

🤖 Generated with [Claude Code](https://claude.com/claude-code)