### PR TITLE
fix(client): 恢复 ginkgo eval 三命令(被 #4652 误屏蔽)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,10 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 2. 对比同模块其他文件的 import 路径，确认是否路径漂移
 3. 批量修复 PR（如"一次修 15 个 bug"）逐条抽检归因，最易凑合出事
 
+**深层诱因（架构陷阱）：**
+- 函数级 import（CLI 为快启把重度 import 延到命令体内）让路径漂移只在命令实跑时暴露——模块 import 不崩，最容易误判"未实现"
+- `return` stub 让失败静默（命令"安静失败"而非"响亮报错"），反而盖住真因，后续无人回头查；宁可原样 `raise` 也别加 stub 兜底
+
 ## Key Commands
 ```bash
 ginkgo version / status                       # 版本/状态

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,12 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 ### 基础组件
 **禁止擅自修改 Base 类**（BaseCRUD、BaseService 等），在具体实现层处理
 
+### 归因纪律（防 #4652 类事故）
+撞 `ImportError` / 命令跑不通，**禁止直接判"未实现"加 `return`+TODO 存根**。#4652 把 `BacktestEvaluator` 的 import 路径漂移（`ginkgo.trading.evaluation` → `ginkgo.trading.analysis.evaluation.backtest_evaluator`）误判为"功能未实现"，加 stub 屏蔽了 `ginkgo eval stability/monitor-create/monitor-live` 三命令，而底层实现完好、且有 3 个调用方在真实运行。判未实现前必做：
+1. `grep` 类名/函数名全仓引用，看有无调用方在使用（有调用方 = 实现必存在）
+2. 对比同模块其他文件的 import 路径，确认是否路径漂移
+3. 批量修复 PR（如"一次修 15 个 bug"）逐条抽检归因，最易凑合出事
+
 ## Key Commands
 ```bash
 ginkgo version / status                       # 版本/状态

--- a/src/ginkgo/client/evaluation_cli.py
+++ b/src/ginkgo/client/evaluation_cli.py
@@ -168,8 +168,8 @@ def evaluate_strategy(
 
 @app.command("stability")
 def evaluate_stability(
-    portfolio: Annotated[str, typer.Option("--portfolio", "-p", help=":briefcase: Portfolio ID")] = None,
-    engine: Annotated[str, typer.Option("--engine", "-e", help=":gear: Engine ID")] = None,
+    portfolio: Annotated[str, typer.Option("--portfolio", "-p", help=":briefcase: Portfolio ID")],
+    engine: Annotated[str, typer.Option("--engine", "-e", help=":gear: Engine ID")],
     start_date: Annotated[Optional[str], typer.Option("--start", help=":calendar: Start date (YYYY-MM-DD)")] = None,
     end_date: Annotated[Optional[str], typer.Option("--end", help=":calendar: End date (YYYY-MM-DD)")] = None,
     export: Annotated[Optional[str], typer.Option("--export", help=":floppy_disk: Export report to file")] = None,
@@ -179,43 +179,10 @@ def evaluate_stability(
     """
     :chart_with_upwards_trend: Evaluate backtest stability using slice analysis.
     """
-    console.print("[yellow]⚠ This command requires BacktestEvaluator (not yet implemented).[/yellow]")
-    console.print("[dim]Track progress: https://github.com/Kaoruha/GinkGO/issues/4639[/dim]")
-    return
-    # TODO(#4639): Implement BacktestEvaluator for stability analysis
+    from ginkgo.trading.analysis.evaluation.backtest_evaluator import BacktestEvaluator
     try:
-        # Step 1: Validate inputs or show available options
-        if portfolio is None:
-            portfolio_ids = get_portfolio_ids_from_analyzer_records()
-            if not portfolio_ids:
-                console.print(":exclamation: [yellow]No portfolios found in analyzer records.[/yellow]")
-                return
-                
-            console.print("Please specify a portfolio ID. Available portfolios:")
-            for pid in portfolio_ids[:10]:  # Show first 10
-                console.print(f"  • {pid}")
-            if len(portfolio_ids) > 10:
-                console.print(f"  ... and {len(portfolio_ids) - 10} more")
-            console.print(f"\n[dim]Use: ginkgo evaluation stability --portfolio <portfolio_id>[/dim]")
-            return
-            
-        if engine is None:
-            engine_ids = get_engine_ids_from_analyzer_records()
-            if not engine_ids:
-                console.print(":exclamation: [yellow]No engines found in analyzer records.[/yellow]")
-                return
-                
-            console.print("Please specify an engine ID. Available engines:")
-            for eid in engine_ids[:10]:  # Show first 10
-                console.print(f"  • {eid}")
-            if len(engine_ids) > 10:
-                console.print(f"  ... and {len(engine_ids) - 10} more")
-            console.print(f"\n[dim]Use: ginkgo evaluation stability --portfolio {portfolio} --engine <engine_id>[/dim]")
-            return
-            
-        # Step 2: Run stability evaluation
         console.print(f":hourglass_flowing_sand: [yellow]Evaluating stability for portfolio {portfolio}, engine {engine}...[/yellow]")
-        
+
         evaluator = BacktestEvaluator(
             min_signals_per_slice=min_signals,
             min_orders_per_slice=min_orders
@@ -259,13 +226,10 @@ def create_monitor(
     """
     :telescope: Create monitoring baseline from backtest data.
     """
-    console.print("[yellow]⚠ This command requires BacktestEvaluator (not yet implemented).[/yellow]")
-    console.print("[dim]Track progress: https://github.com/Kaoruha/GinkGO/issues/4639[/dim]")
-    return
-    # TODO(#4639): Implement BacktestEvaluator for monitor baseline
+    from ginkgo.trading.analysis.evaluation.backtest_evaluator import BacktestEvaluator
     try:
         console.print(f":hourglass_flowing_sand: [yellow]Creating monitoring baseline from portfolio {portfolio}, engine {engine}...[/yellow]")
-        
+
         evaluator = BacktestEvaluator()
         
         # Run evaluation to get baseline
@@ -307,17 +271,15 @@ def monitor_live(
     """
     :eyes: Start live monitoring using baseline (demo mode).
     """
-    console.print("[yellow]⚠ This command requires BacktestEvaluator (not yet implemented).[/yellow]")
-    console.print("[dim]Track progress: https://github.com/Kaoruha/GinkGO/issues/4639[/dim]")
-    return
-    # TODO(#4639): Implement BacktestEvaluator for live monitoring
+    import time
+    from ginkgo.trading.analysis.evaluation.backtest_evaluator import BacktestEvaluator
     try:
         # Load baseline
         with open(baseline, 'r', encoding='utf-8') as f:
             baseline_data = json.load(f)
-            
+
         console.print(f":telescope: [green]Loaded baseline from: {baseline}[/green]")
-        
+
         # Create live monitor
         evaluator = BacktestEvaluator()
         monitor = evaluator.create_live_monitor(baseline_data)
@@ -357,7 +319,7 @@ def _display_stability_results(result: dict):
     # Overview panel
     overview_text = f"""
 [bold]Portfolio:[/bold] {result['portfolio_id']}
-[bold]Engine:[/bold] {result['engine_id']}
+[bold]Engine:[/bold] {result.get('engine_id') or result.get('task_id', 'N/A')}
 [bold]Evaluation Time:[/bold] {result['evaluation_time']}
 [bold]Status:[/bold] :white_check_mark: Success
     """

--- a/tests/unit/client/test_evaluation_cli.py
+++ b/tests/unit/client/test_evaluation_cli.py
@@ -1,0 +1,189 @@
+"""
+TDD for ginkgo eval 三命令(stability/monitor-create/monitor-live)恢复。
+
+背景:#4652 误把 import 路径漂移当"未实现",加 return stub 屏蔽。
+底层 BacktestEvaluator 实现完好,3 调用方在用。本测试守护命令真正调通 evaluator,
+并防回归(输出不得再含 "not yet implemented")。
+"""
+
+import sys
+import json
+import re
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+sys.path.insert(0, _path)
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+from ginkgo.client.evaluation_cli import app  # noqa: E402
+
+# patch 源模块(命令体为函数级 import,每次执行从源模块取属性)
+_EVALUATOR_PATH = "ginkgo.trading.analysis.evaluation.backtest_evaluator.BacktestEvaluator"
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _success_result() -> dict:
+    """匹配 _display_stability_results / _display_baseline_summary 期望的键。"""
+    return {
+        "status": "success",
+        "evaluation_time": "2026-07-01T10:00:00",
+        "portfolio_id": "port-001",
+        # 返回键是 task_id(ADR-016),展示层读 engine_id → 兼容读取
+        "task_id": "task-001",
+        "data_summary": {
+            "analyzer_records": 100,
+            "signal_records": 50,
+            "order_records": 40,
+            "time_span": {"days": 244},
+        },
+        "optimal_slice_config": {
+            "period_days": 30,
+            "stability_score": 0.85,
+            "slice_count": 8,
+        },
+        "stability_analysis": {
+            "cross_metric_comparison": {
+                "ranking": [("sharpe", 0.85), ("max_drawdown", 0.72)],
+            }
+        },
+        "recommendations": ["consider more slices"],
+        "monitoring_baseline": {
+            "slice_period_days": 30,
+            "total_slices": 8,
+            "creation_time": "2026-07-01",
+            "baseline_stats": {
+                "sharpe": {"mean": 1.2, "std_dev": 0.3, "range": 0.9},
+            },
+        },
+    }
+
+
+# ---- stability ----
+
+def test_stability_success():
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate_backtest_stability.return_value = _success_result()
+
+    with patch(_EVALUATOR_PATH, return_value=mock_evaluator):
+        result = runner.invoke(
+            app, ["stability", "--portfolio", "port-001", "--engine", "task-001"]
+        )
+
+    out = _strip_ansi(result.output)
+    assert result.exit_code == 0, result.output
+    assert "not yet implemented" not in out
+    mock_evaluator.evaluate_backtest_stability.assert_called_once_with(
+        portfolio_id="port-001",
+        task_id="task-001",
+        start_date=None,
+        end_date=None,
+    )
+    # 展示层渲染了 result 关键值
+    assert "port-001" in out
+    assert "244" in out  # time span days
+    assert "0.8500" in out  # stability_score :.4f
+
+
+def test_stability_no_stub():
+    """防回归 #4652: 不得再 return stub。"""
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate_backtest_stability.return_value = _success_result()
+
+    with patch(_EVALUATOR_PATH, return_value=mock_evaluator):
+        result = runner.invoke(
+            app, ["stability", "--portfolio", "port-001", "--engine", "task-001"]
+        )
+
+    out = _strip_ansi(result.output)
+    assert "not yet implemented" not in out
+    assert "4639" not in out  # TODO issue 链接也不应在用户输出里
+
+
+def test_stability_failed():
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate_backtest_stability.return_value = {
+        "status": "failed",
+        "reason": "invalid_data",
+    }
+
+    with patch(_EVALUATOR_PATH, return_value=mock_evaluator):
+        result = runner.invoke(
+            app, ["stability", "--portfolio", "port-001", "--engine", "task-001"]
+        )
+
+    out = _strip_ansi(result.output)
+    assert result.exit_code == 0
+    assert "invalid_data" in out
+
+
+def test_stability_portfolio_required():
+    """--portfolio/--engine 必填(删交互式列出后)。"""
+    result = runner.invoke(app, ["stability"])
+    assert result.exit_code != 0  # typer 缺必填参数
+
+
+# ---- monitor-create ----
+
+def test_monitor_create_success(tmp_path):
+    mock_evaluator = MagicMock()
+    mock_evaluator.evaluate_backtest_stability.return_value = _success_result()
+    out_file = tmp_path / "baseline.json"
+
+    with patch(_EVALUATOR_PATH, return_value=mock_evaluator):
+        result = runner.invoke(
+            app,
+            [
+                "monitor-create",
+                "-p", "port-001",
+                "-e", "task-001",
+                "-o", str(out_file),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "not yet implemented" not in _strip_ansi(result.output)
+    assert out_file.exists()
+    saved = json.loads(out_file.read_text(encoding="utf-8"))
+    assert saved["slice_period_days"] == 30
+
+
+# ---- monitor-live ----
+
+def test_monitor_live_no_stub(tmp_path):
+    """monitor-live 去 stub 后真调 create_live_monitor(demo loop 用异常短路)。"""
+    baseline_file = tmp_path / "b.json"
+    baseline_file.write_text(
+        json.dumps(_success_result()["monitoring_baseline"]), encoding="utf-8"
+    )
+
+    mock_evaluator = MagicMock()
+    # 让 demo loop 第一次 sleep 即抛错,被 except Exception 捕获后正常返回
+    with patch(_EVALUATOR_PATH, return_value=mock_evaluator), \
+            patch(
+                "time.sleep",
+                side_effect=RuntimeError("short-circuit demo loop"),
+            ):
+        result = runner.invoke(
+            app,
+            [
+                "monitor-live",
+                "-b", str(baseline_file),
+                "-p", "port-001",
+                "--interval", "1",
+            ],
+        )
+
+    out = _strip_ansi(result.output)
+    assert "not yet implemented" not in out
+    assert mock_evaluator.create_live_monitor.called


### PR DESCRIPTION
## 背景
`ginkgo eval stability/monitor-create/monitor-live` 三命令被 #4652 误屏蔽——把 `BacktestEvaluator` 的 **import 路径漂移**(`ginkgo.trading.evaluation` -> `ginkgo.trading.analysis.evaluation.backtest_evaluator`)误判为"未实现",加 `return` stub。而底层实现完好,3 个调用方在真实运行:`workers/paper_trading_worker.py` / `client/portfolio_cli.py`(deploy 算监控基线) / `deviation_checker.py`。

## 改动
- 修 3 处函数级 import 路径(对齐 `portfolio_cli:941`)
- 删 3 处 `return` stub + 依赖已删 helper 的交互式列出分支(**净删 38 行**)
- `stability` 的 `--portfolio`/`--engine` 改必填(对齐 monitor-create)
- `monitor-live` 补 `import time`(原函数体用 `time.sleep` 但从未 import)
- `_display_stability_results` 的 `engine_id` 兼容读取 `task_id`(ADR-016 返回键)
- CLAUDE.md 加"归因纪律":撞 ImportError 先 grep 调用方+对比路径再判未实现

## 测试
新增 `tests/unit/client/test_evaluation_cli.py` 6 用例全绿。其中 `test_stability_no_stub`(**防回归**,断言输出不含 "not yet implemented")在开发中抓住了"Edit 报 success 但残留 return"的隐蔽 bug。

## 验证
- `ginkgo eval --help` -> 列 stability/monitor-create/monitor-live
- `ginkgo eval stability --help` -> `--portfolio`/`--engine` 标 `[required]`,无 stub

## 不做
- 不改 `backtest_evaluator.py`(实现完好);不接 validation_service 4 法(另一套);`--engine` flag 重命名(ADR-016)作 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)