### PR TITLE
docs(#6480): bind-component 参数索引约定订正为新组合（index0=首业务参数）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,9 @@ ginkgo portfolio get <uuid> --details
 ginkgo component list
 
 # 绑定（参数格式：'index:value'，字符串带引号，数值直接写）
+# 新组合(#5955后)：index0=首个业务参数（name 自动跳过，用构造器默认）；旧组合 index0=name
 ginkgo portfolio bind-component <pid> <file_id> --type strategy \
-  --param '0:"StrategyName"' --param '1:0.3'
+  --param '0:14' --param '1:30'
 
 # 回测
 ginkgo backtest create --portfolio <pid> --start 2025-05-07 --end 2026-05-07 --name "test" --cash 100000


### PR DESCRIPTION
## Summary

#6480 报 `bind-component` 把 `name` 传 `index0`，在新组合被 `resolve_param_kwargs` 错绑给首个业务参数，带类型校验组件实例化崩溃。**核心崩溃已由 #6032 / #6099（`resolve_param_kwargs` 拼接块 `component_loader.py:170-171`）修复**——本 PR 落验收第 4 条：CLAUDE.md 文档同步。

### 验证（master 实测）

`resolve_param_kwargs(['MR_RSI',14,30,70], [0,1,2,3], {0:'rsi_period',1:'oversold',2:'overbought'})` → `{'rsi_period':14,'oversold':30,'overbought':70}` ✅（name `MR_RSI` 被正确跳过，业务参数对齐）

### 文档订正

CLAUDE.md `bind-component` 示例停留在旧组合约定（`index0=name`），与 #5955 后的新组合行为相反：

```diff
 # 绑定（参数格式：'index:value'，字符串带引号，数值直接写）
+# 新组合(#5955后)：index0=首个业务参数（name 自动跳过，用构造器默认）；旧组合 index0=name
 ginkgo portfolio bind-component <pid> <file_id> --type strategy \
-  --param '0:"StrategyName"' --param '1:0.3'
+  --param '0:14' --param '1:30'
```

## Test plan

- [x] 纯 `.md` 改动，py_compile / 启动路径 smoke 不适用
- [x] diff 结构完整（加注释行 + 改示例值，未破坏 markdown 围栏）
- [x] 核心修复在 master 已 live 复现通过（见 #6481 评论「live 复现更新」）

## 关联

#6481 价值大半坍缩进本 issue：37d6b7af 类带参 clone 组合崩溃即 #6480 name 错绑消费端，core 已修。

Closes #6480
