### PR TITLE
fix(#6483): 回测超时改报 incomplete/FAILED，不再静默标 completed

### DIFF
--- a/src/ginkgo/trading/services/backtest_orchestrator.py
+++ b/src/ginkgo/trading/services/backtest_orchestrator.py
@@ -3,6 +3,7 @@
 # Role: 回测编排器，统一回测执行链路：加载→装配→运行→收集结果
 
 
+import os
 from datetime import datetime
 from typing import Any, Dict, Optional
 
@@ -41,7 +42,8 @@ class BacktestOrchestrator:
         self._result_aggregator = result_aggregator
 
     def run(self, task_id: str, config, portfolio_id: str,
-            timeout: float = 3600.0, progress_callback=None) -> OrchestratorResult:
+            timeout: Optional[float] = None,
+            progress_callback=None) -> OrchestratorResult:
         """
         执行完整回测链路。
 
@@ -49,12 +51,26 @@ class BacktestOrchestrator:
             task_id: 回测任务 ID
             config: BacktestConfig 或等价配置对象
             portfolio_id: Portfolio UUID
-            timeout: 等待引擎完成的最大秒数
+            timeout: 等待引擎完成的最大秒数。None 时依次取环境变量
+                GINKGO_BACKTEST_TIMEOUT、默认 3600s（#6483：使超时可配置）。
 
         Returns:
             OrchestratorResult
         """
         try:
+            # #6483: timeout 可配置——None 时读 GINKGO_BACKTEST_TIMEOUT，再 fallback 3600
+            if timeout is None:
+                env_val = os.environ.get("GINKGO_BACKTEST_TIMEOUT")
+                if env_val:
+                    try:
+                        timeout = float(env_val)
+                    except ValueError:
+                        GLOG.WARN(
+                            f"invalid GINKGO_BACKTEST_TIMEOUT={env_val!r}, using 3600"
+                        )
+                        timeout = 3600.0
+                else:
+                    timeout = 3600.0
             # 1. 加载 portfolio 元数据（轻量，不绑定组件）
             portfolio_data = self._load_portfolio_metadata(portfolio_id)
 
@@ -68,8 +84,8 @@ class BacktestOrchestrator:
             # 4. 运行引擎
             engine.start()
 
-            # 5. 等待完成
-            self._wait_for_engine(engine, timeout)
+            # 5. 等待完成（#6483: 返回是否超时，供聚合层如实报告状态）
+            timed_out = self._wait_for_engine(engine, timeout)
 
             # 6. 通知分析器
             if hasattr(engine, 'notify_analyzers_backtest_end'):
@@ -77,8 +93,21 @@ class BacktestOrchestrator:
 
             # 7. 收集结果
             agg_result = self._aggregate_results(
-                task_id, portfolio_id, config,
+                task_id, portfolio_id, config, timed_out=timed_out,
+                engine=engine,
             )
+
+            # #6483: 超时返回 success=False，task_processor.run L107
+            # `if not result.is_success(): raise` 据此自动标 FAILED，主流程零改动。
+            if timed_out:
+                return OrchestratorResult(
+                    success=False,
+                    error=(
+                        "Backtest timed out: engine did not finish within the "
+                        "wall-clock limit (data may be truncated)"
+                    ),
+                    data=agg_result.data if agg_result.is_success() else {},
+                )
 
             return OrchestratorResult(
                 success=True,
@@ -133,21 +162,34 @@ class BacktestOrchestrator:
 
         return result.data
 
-    def _wait_for_engine(self, engine, timeout: float):
-        """等待引擎主线程完成。"""
+    def _wait_for_engine(self, engine, timeout: float) -> bool:
+        """等待引擎主线程完成。
+
+        Returns:
+            True 表示引擎超时未完成（已被强制 stop）；False 表示正常结束。
+            #6483: 调用方据此决定回测报 incomplete 还是 completed，避免超时被吞。
+        """
         main_thread = getattr(engine, '_main_thread', None)
         if main_thread is None:
-            return
+            return False
         if not main_thread.is_alive():
-            return
+            return False
         main_thread.join(timeout=timeout)
         if main_thread.is_alive():
             GLOG.WARN(f"Engine did not complete within {timeout}s")
             engine.stop()
             main_thread.join(timeout=10.0)
+            return True
+        return False
 
-    def _aggregate_results(self, task_id, portfolio_id, config):
-        """汇总分析器结果。"""
+    def _aggregate_results(self, task_id, portfolio_id, config,
+                           timed_out: bool = False, engine=None):
+        """汇总分析器结果。
+
+        #6483: 超时不再静默标 completed——如实写 incomplete 并附 error_message，
+        避免被墙钟超时截断的回测显示"已完成"。超时时 backtest_end_date 取
+        引擎实际跑到的时间（engine.now），而非配置的谎言值。
+        """
         backtest_start = None
         backtest_end = None
         if hasattr(config, 'start_date') and config.start_date:
@@ -163,11 +205,32 @@ class BacktestOrchestrator:
                 GLOG.DEBUG(f"handled error")
                 pass
 
+        if timed_out:
+            status = "incomplete"
+            error_message = (
+                "Backtest timed out: engine did not finish within the "
+                "wall-clock limit (data may be truncated)"
+            )
+            # #6483: end_date 取引擎实际跑到的时间，而非配置的 end_date（后者会让
+            # 用户误以为跑满整个区间）。engine.now 是 @property（见
+            # arch_engine_now_property_exists），防御性读取防异常引擎。
+            if engine is not None and hasattr(engine, 'now'):
+                try:
+                    engine_now = engine.now
+                    if isinstance(engine_now, datetime):
+                        backtest_end = engine_now
+                except Exception:
+                    GLOG.DEBUG("handled error reading engine.now on timeout")
+        else:
+            status = "completed"
+            error_message = ""
+
         return self._result_aggregator.aggregate_and_save(
             task_id=task_id,
             portfolio_id=portfolio_id,
             engine_id=task_id,
-            status="completed",
+            status=status,
+            error_message=error_message,
             backtest_start_date=backtest_start,
             backtest_end_date=backtest_end,
         )

--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -130,8 +130,11 @@ class BacktestProcessor(Thread):
             GLOG.clear_context()
 
     def _wait_for_engine_completion(self, timeout: float = 3600.0):
-        """
-        等待引擎主线程完成
+        """⚠️ 死代码（#6483）：无调用点。
+
+        回测等待已统一由 BacktestOrchestrator._wait_for_engine 处理（返回 timed_out
+        供聚合层报告 incomplete）。勿复活此方法——它只 force-stop 不报告状态，
+        会重新引入"超时静默标 completed"的 #6483 bug。
 
         Args:
             timeout: 最大等待时间（秒），默认1小时
@@ -350,7 +353,12 @@ class BacktestProcessor(Thread):
             }
 
     def _aggregate_and_save_results(self):
-        """汇总分析器结果并保存到数据库"""
+        """⚠️ 死代码（#6483）：无调用点。
+
+        结果聚合已统一由 BacktestOrchestrator._aggregate_results 处理（超时写
+        status=incomplete + backtest_end_date=engine.now）。勿复活此方法——其
+        L391 status="completed" 硬编码会重新引入 #6483 bug。
+        """
         try:
             # 从 data_container 获取服务（不直接使用 CRUD）
             from ginkgo.data.containers import container as data_container

--- a/tests/unit/trading/services/test_backtest_orchestrator.py
+++ b/tests/unit/trading/services/test_backtest_orchestrator.py
@@ -279,3 +279,155 @@ class TestOrchestratorErrorHandling:
                                    timeout=0.01)
         # Should have called stop on timeout
         engine.stop.assert_called()
+
+
+class TestOrchestratorTimeoutReporting:
+    """#6483: 引擎超时不应静默标 completed，应如实报告为 incomplete。
+
+    背景：3600s 挂钟超时被 _aggregate_results 硬编码 status="completed" 吞掉，
+    导致 ~600 行截断的回测显示"已完成"。验收：超时分支写非 completed 状态、
+    附 error_message、backtest_end_date 取引擎实际跑到的时间（非配置 end_date）。
+    """
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_timeout_marks_status_incomplete_not_completed(
+        self, mock_load_components, orchestrator,
+        mock_portfolio_service, mock_assembly_service, mock_aggregator):
+        """超时分支调 aggregator 时 status 必须不是 'completed'。"""
+        import datetime as _dt
+        config = _make_config()
+        engine = _make_engine_mock()
+        # join 超时（仍 alive），engine.stop() 后再 join 死亡
+        main_thread = MagicMock()
+        main_thread.is_alive.side_effect = [True, True, False]
+        engine._main_thread = main_thread
+        # 引擎实际跑到的时间点（远早于 config.end_date 2025-12-31）
+        engine.now = _dt.datetime(2023, 10, 5)
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=engine,
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        orchestrator.run(task_id="t", config=config, portfolio_id="p", timeout=0.01)
+
+        agg_kwargs = mock_aggregator.aggregate_and_save.call_args.kwargs
+        assert agg_kwargs["status"] != "completed", (
+            "超时不应静默标 completed（#6483）：实际 status="
+            f"{agg_kwargs.get('status')!r}"
+        )
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_timeout_end_date_uses_engine_now_not_config(
+        self, mock_load_components, orchestrator,
+        mock_portfolio_service, mock_assembly_service, mock_aggregator):
+        """超时时 backtest_end_date 应取引擎实际跑到的时间，而非配置 end_date。
+
+        #6483 诊断价值：让用户看到"跑到 2023-10"而非谎报配置的 2025-12-31。
+        """
+        import datetime as _dt
+        config = _make_config()  # end_date = "2025-12-31"
+        engine = _make_engine_mock()
+        main_thread = MagicMock()
+        main_thread.is_alive.side_effect = [True, True, False]
+        engine._main_thread = main_thread
+        engine_now = _dt.datetime(2023, 10, 5)
+        engine.now = engine_now  # 引擎实际只跑到 2023-10
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=engine,
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        orchestrator.run(task_id="t", config=config, portfolio_id="p", timeout=0.01)
+
+        agg_kwargs = mock_aggregator.aggregate_and_save.call_args.kwargs
+        assert agg_kwargs["backtest_end_date"] == engine_now, (
+            "超时 end_date 应反映引擎实际跑到的时间（#6483 诊断价值）："
+            f"期望 {engine_now}，实际 {agg_kwargs.get('backtest_end_date')}"
+        )
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_timeout_run_returns_failure_so_processor_can_raise(
+        self, mock_load_components, orchestrator,
+        mock_portfolio_service, mock_assembly_service, mock_aggregator):
+        """超时时 run() 应返回 success=False + timeout error。
+
+        #6483: task_processor.run L107 `if not result.is_success(): raise` 据此自动
+        标 FAILED，task_processor 主流程零改动。
+        """
+        config = _make_config()
+        engine = _make_engine_mock()
+        main_thread = MagicMock()
+        main_thread.is_alive.side_effect = [True, True, False]
+        engine._main_thread = main_thread
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=engine,
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        result = orchestrator.run(task_id="t", config=config, portfolio_id="p", timeout=0.01)
+
+        assert not result.is_success(), (
+            "超时应返回 success=False（#6483），让 task_processor L107 自动 raise"
+        )
+        assert result.error and "timed out" in result.error.lower(), (
+            f"error 应含 'timed out' 描述，实际: {result.error!r}"
+        )
+
+
+class TestOrchestratorTimeoutConfig:
+    """#6483: 超时阈值应可通过 GINKGO_BACKTEST_TIMEOUT 环境变量配置（覆盖默认 3600s）。"""
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_env_var_overrides_default_timeout(
+        self, mock_load_components, orchestrator,
+        mock_portfolio_service, mock_assembly_service,
+        mock_aggregator, monkeypatch):
+        """不显式传 timeout 时，GINKGO_BACKTEST_TIMEOUT 环境变量生效。"""
+        monkeypatch.setenv("GINKGO_BACKTEST_TIMEOUT", "42")
+        config = _make_config()
+        engine = _make_engine_mock()
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=engine,
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        # spy _wait_for_engine 捕获实际传入的 timeout
+        captured = {}
+        original_wait = orchestrator._wait_for_engine
+
+        def spy_wait(engine_arg, t):
+            captured["timeout"] = t
+            return original_wait(engine_arg, t)
+
+        orchestrator._wait_for_engine = spy_wait
+
+        orchestrator.run(task_id="t", config=config, portfolio_id="p")  # 不传 timeout
+
+        assert captured.get("timeout") == 42.0, (
+            "GINKGO_BACKTEST_TIMEOUT 应覆盖默认 timeout："
+            f"实际 _wait_for_engine 收到 {captured.get('timeout')}"
+        )

--- a/tests/unit/workers/test_task_processor_timeout.py
+++ b/tests/unit/workers/test_task_processor_timeout.py
@@ -1,0 +1,108 @@
+"""#6483: 回测超时时 task_processor 应将任务标 FAILED（而非静默 COMPLETED）。
+
+契约链：orchestrator 超时返回 success=False → task_processor.run L107
+``if not result.is_success(): raise`` → except 分支 state=FAILED + report_failed。
+
+修复前 orchestrator 超时仍返回 success=True，task_processor 据此标 COMPLETED，
+配合 _aggregate_results 硬编码 status="completed" 双重吞掉超时，~600 行截断的
+回测显示"已完成"。本测试锁定修复后的端到端契约，防回归。
+"""
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
+    from ginkgo.workers.backtest_worker.models import (
+        BacktestTask,
+        BacktestConfig,
+        BacktestTaskState,
+    )
+    from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+def _full_backtest_config() -> BacktestConfig:
+    """ADR-018：BacktestConfig 删默认值后须显式传全 11 字段。"""
+    return BacktestConfig(
+        start_date="2025-01-01",
+        end_date="2025-12-31",
+        initial_cash=100000.0,
+        commission_rate=0.0003,
+        slippage_rate=0.0001,
+        benchmark_return=0.0,
+        max_position_ratio=0.3,
+        stop_loss_ratio=0.05,
+        take_profit_ratio=0.15,
+        frequency="DAY",
+        analyzers=[],
+    )
+
+
+def _make_processor(task: BacktestTask) -> BacktestProcessor:
+    """构造最小可测处理器：跳过 __init__ 的 service 容器装配。"""
+    proc = BacktestProcessor.__new__(BacktestProcessor)
+    proc.task = task
+    proc.worker_id = "w-test"
+    proc.progress_tracker = MagicMock()
+    proc._stop_event = Event()
+    proc._engine = None
+    proc._exception = None
+    proc._result = {}
+    proc._assembly_service = MagicMock()
+    proc._portfolio_service = MagicMock()
+    return proc
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+class TestProcessorMarksTimeoutAsFailed:
+    """#6483: orchestrator 返回超时失败时，task 必须转 FAILED。"""
+
+    def test_orchestrator_timeout_failure_marks_task_failed(self, monkeypatch):
+        cfg = _full_backtest_config()
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+
+        # 跳过 run() 开头的 sleep，加速测试
+        monkeypatch.setattr(
+            "ginkgo.workers.backtest_worker.task_processor.time.sleep",
+            lambda *_: None,
+        )
+
+        # mock data_container（run() 内函数级 import）
+        mock_container = MagicMock()
+        mock_container.analyzer_service.return_value = MagicMock()
+        mock_container.backtest_task_service.return_value = MagicMock()
+        monkeypatch.setattr("ginkgo.data.containers.container", mock_container)
+
+        # mock BacktestOrchestrator：run() 返回超时失败（#6483 修复后行为）
+        timeout_result = OrchestratorResult(
+            success=False,
+            error=(
+                "Backtest timed out: engine did not finish within the "
+                "wall-clock limit (data may be truncated)"
+            ),
+        )
+        mock_orch_instance = MagicMock()
+        mock_orch_instance.run.return_value = timeout_result
+        mock_orch_class = MagicMock(return_value=mock_orch_instance)
+        monkeypatch.setattr(
+            "ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator",
+            mock_orch_class,
+        )
+
+        proc.run()  # 同步执行 Thread.run
+
+        assert proc.task.state == BacktestTaskState.FAILED, (
+            "#6483: 超时应标 FAILED，非静默 COMPLETED"
+        )
+        assert proc.task.error and "timed out" in proc.task.error.lower(), (
+            f"task.error 应含 'timed out'，实际: {proc.task.error!r}"
+        )
+        proc.progress_tracker.report_failed.assert_called_once()
+        # 绝不能标完成
+        proc.progress_tracker.report_completed.assert_not_called()


### PR DESCRIPTION
## Summary

#6483: 回测在 ~600 行 net_value 处被 3600s 墙钟超时静默截断，但仍标 `completed`，误导用户以为跑满整个区间。

### 根因
`BacktestOrchestrator._wait_for_engine` 超时只 WARN+stop+正常返回；`_aggregate_results` 硬编码 `status="completed"`。双重静默吞掉超时。

### 修复
1. `_wait_for_engine` 返回 `timed_out: bool`
2. `_aggregate_results` 超时分支写 `status="incomplete"` + `error_message`，`backtest_end_date` 取 `engine.now`（引擎实际跑到的时间）而非配置谎言值
3. `run()` 超时返回 `OrchestratorResult(success=False)`，复用 `task_processor.run` L107 既有契约 `if not result.is_success(): raise` 自动标 FAILED——主流程零改动，无需新增 `timed_out` 字段（YAGNI）
4. 超时阈值可通过 `GINKGO_BACKTEST_TIMEOUT` 环境变量配置（默认 3600s）
5. task_processor 两段死代码（`_wait_for_engine_completion` / `_aggregate_and_save_results`，无调用点）加 #6483 锚点 docstring，防复活重新引入 bug

## Test plan
- [x] `test_timeout_marks_status_incomplete_not_completed`
- [x] `test_timeout_end_date_uses_engine_now_not_config`
- [x] `test_timeout_run_returns_failure_so_processor_can_raise`
- [x] `test_orchestrator_timeout_failure_marks_task_failed`（task→FAILED 端到端契约）
- [x] `test_env_var_overrides_default_timeout`（GINKGO_BACKTEST_TIMEOUT 生效）
- [x] 三层冒烟：py_compile / 启动路径 smoke (29 passed) / 变更相关 (11 passed)

Closes #6483