### PR TITLE
fix(#5973): SharpeRatio 加退化序列守卫，防低换手净值爆量

### DIFF
--- a/src/ginkgo/trading/analysis/analyzers/sharpe_ratio.py
+++ b/src/ginkgo/trading/analysis/analyzers/sharpe_ratio.py
@@ -42,10 +42,22 @@ class SharpeRatio(BaseAnalyzer):
                     mean_excess_return = np.mean(excess_returns)
                     std = np.std(returns_array, ddof=1)
 
-                    if std > 0:
-                        sharpe_ratio = mean_excess_return / std * np.sqrt(252)
-                    else:
+                    # 退化序列守卫 (issue #5973)：
+                    # sharpe = mean_excess / std 的前提是收益序列近似连续分布。
+                    # 低换手策略（长期空仓/单股稀疏交易）下大量交易日收益为 0，
+                    # std 被压到趋零（实测 fe0cef7b：74% 零收益日，std≈1.5e-4），
+                    # 同时 rf_daily(0.03/252≈1.19e-4) 主导 excess return，
+                    # 除法爆量到 ±10 量级（实测 -13.1571）。此时公式前提不成立，
+                    # 返回 0.0 sentinel（与首日/数据不足/std==0 等无效值语义一致）。
+                    #
+                    # 阈值选择：brief 建议 std 绝对阈值，但实测 std≈1.5e-4 仍爆量，
+                    # 纯绝对阈值(<1e-6)卡不住真实退化场景且会误伤低波动正常策略；
+                    # 零收益日占比 > 50% 是低换手的直接代理指标，精准且不误伤。
+                    zero_ratio = float(np.count_nonzero(returns_array == 0.0)) / len(returns_array)
+                    if std < 1e-8 or zero_ratio > 0.5:
                         sharpe_ratio = 0.0
+                    else:
+                        sharpe_ratio = mean_excess_return / std * np.sqrt(252)
                 else:
                     sharpe_ratio = 0.0
             else:

--- a/tests/unit/backtest/analyzers/test_sharpe_ratio.py
+++ b/tests/unit/backtest/analyzers/test_sharpe_ratio.py
@@ -224,5 +224,88 @@ class TestSharpeRatioBoundaryConditions(unittest.TestCase):
         self.assertEqual(len(analyzer._returns), 0)
 
 
+class TestSharpeRatioDegenerateSeries(unittest.TestCase):
+    """退化序列守卫 (issue #5973)。
+
+    低换手策略（长期空仓/单股稀疏交易）下大量交易日收益为 0，
+    std 被压到趋零，同时 rf_daily 主导 excess return，导致
+    (mean_excess / std) * sqrt(252) 爆量到 ±10 量级（实测 -13）。
+    此时 Sharpe 公式前提（近似连续分布的收益）不成立，应返回 0.0 sentinel。
+    """
+
+    def setUp(self):
+        self.test_time = datetime(2024, 1, 1, 9, 30, 0)
+
+    def _make(self, risk_free_rate=0.03):
+        a = SharpeRatio("test_sharpe_degen", risk_free_rate=risk_free_rate)
+        a.set_time_provider(LogicalTimeProvider(initial_time=self.test_time))
+        a.advance_time(self.test_time)
+        a.set_analyzer_id("test_degen_001")
+        a.set_portfolio_id("test_degen_p_001")
+        return a
+
+    def test_low_turnover_majority_zero_days(self):
+        """>70% 交易日零收益（贴近 fe0cef7b 实测）→ 退化，sharpe 应为 0.0。
+
+        复现 owner 坐实场景：542 日，~74% 零收益日，std 被压到 ~1.5e-4，
+        rf_daily(1.19e-4) 主导 excess，未守卫时爆量到 -13.1571。
+        """
+        analyzer = self._make()
+        worth = 100000.0
+        analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": worth})
+        # 541 个交易日：402 个零收益（74.3%），139 个 ±0.05% 微动
+        zero_pattern = [True] * 402 + [False] * 139  # 74.3% 零收益
+        rng = np.random.RandomState(42)
+        for i, is_zero in enumerate(zero_pattern, start=1):
+            if not is_zero:
+                worth *= (1 + rng.normal(0, 0.0005))
+            analyzer.advance_time(self.test_time + timedelta(days=i))
+            analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": worth})
+
+        # 未守卫时此处为 -7 ~ -13 量级；守卫后必须落入 0.0 sentinel
+        self.assertEqual(analyzer.current_sharpe_ratio, 0.0)
+
+    def test_segment_constant_worth(self):
+        """净值分段常数（长期持平偶发跳变）→ 退化，sharpe 应为 0.0。
+
+        贴近"净值分段常数"退化场景：std 趋零且零收益日占比极高。
+        守卫须同时覆盖 std 绝对趋零与高零收益占比两条路径。
+        """
+        analyzer = self._make()
+        worth = 100000.0
+        analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": worth})
+        # 300 个交易日，仅第 100、200 天跳变 ±1%，其余持平
+        for i in range(1, 301):
+            if i == 100:
+                worth *= 1.01
+            elif i == 200:
+                worth *= 0.995
+            analyzer.advance_time(self.test_time + timedelta(days=i))
+            analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": worth})
+
+        self.assertEqual(analyzer.current_sharpe_ratio, 0.0)
+
+    def test_normal_volatility_not_guarded(self):
+        """正常波动序列（日 std~3e-3，零收益日 < 50%）→ 公式照算，sharpe 在 ±3。
+
+        回归守卫：确认守卫不误伤健康序列，sqrt(252) 年化与 rf 转换路径仍生效。
+        对照 owner 数据：标准回测 0d27a3b6 raw sharpe +0.61。
+        """
+        analyzer = self._make()
+        worth = 100000.0
+        analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": worth})
+        rng = np.random.RandomState(7)
+        for i in range(1, 252):
+            # 每日都有波动（零收益日 = 0），std ~ 3e-3 量级
+            worth *= (1 + rng.normal(0, 0.003))
+            analyzer.advance_time(self.test_time + timedelta(days=i))
+            analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": worth})
+
+        sharpe = analyzer.current_sharpe_ratio
+        self.assertNotEqual(sharpe, 0.0, "正常波动序列不应被退化守卫捕获")
+        self.assertGreater(sharpe, -3.0)
+        self.assertLess(sharpe, 3.0)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

修 `SharpeRatio` analyzer 在低换手/低方差净值序列上爆量到 -13~-7（正常 ±3）的系统性错误。

**根因**（owner 在 issue comments 已坐实）：低换手策略（长期空仓/单股稀疏交易）下大量交易日收益为 0，`std` 被压到趋零（实测 fe0cef7b：74% 零收益日，std≈1.5e-4），同时 `rf_daily(0.03/252≈1.19e-4)` 主导 excess return，导致 `(mean_excess/std)×√252` 除法爆量到 -13.1571。原守卫仅 `std > 0`，阈值过松。

**修复**：在 `SharpeRatio._do_activate` 公式路径前加退化序列守卫——零收益日占比 > 50% 或 `std < 1e-8` 时返回 `0.0` sentinel（与首日/数据不足/std==0 等既有无效值语义一致）。

**阈值选择偏离 brief 字面的理由**：brief 建议 `std < 1e-6` 绝对或 `std < |mean|×1e-3` 相对，但两者都卡不住 owner 实测场景（std=1.5e-4 仍爆量），且纯绝对阈值会误伤低波动正常策略（债券类）。零收益日占比是低换手的直接代理指标，精准且不误伤健康序列（owner 标准回测 0d27a3b6 zero_days 28.6% 不触发）。

**公式路径保留**：`√252` 年化、`rf=annual/252`、`excess/std` 全部不动。

## Test plan

新增 `TestSharpeRatioDegenerateSeries` 三个场景测试（`tests/unit/backtest/analyzers/test_sharpe_ratio.py`）：
- ✅ `test_low_turnover_majority_zero_days`：541 日 74% 零收益 → 0.0（复现 fe0cef7b）
- ✅ `test_segment_constant_worth`：净值分段常数 → 0.0
- ✅ `test_normal_volatility_not_guarded`：正常波动（std~3e-3）→ 公式照算、sharpe 在 ±3、非 0（回归守卫）

三层冒烟全过：py_compile ✅ / 启动路径 smoke（user_crud+containers+user_cli）29 passed / 变更相关（analyzer service smoke + sharpe 全测）22 passed。既有 15 个 sharpe 测试无回归。

Closes #5973