### PR TITLE
fix(#6484): get_total_adjustment 补 query 消除 NameError

### DIFF
--- a/src/ginkgo/data/crud/capital_adjustment_crud.py
+++ b/src/ginkgo/data/crud/capital_adjustment_crud.py
@@ -174,7 +174,11 @@ class CapitalAdjustmentCRUD(BaseCRUD[MCapitalAdjustment]):
     ) -> float:
         """
         Business helper: Get total capital adjustment amount for a portfolio.
+
+        Filters by business_timestamp (业务生效时间) via find_by_business_time,
+        not record timestamp — total aligns with business intent.
         """
+        adjustments = self.find_by_business_time(portfolio_id, start_date, end_date)
         return sum(float(adj.amount) for adj in adjustments if adj.amount)
 
     def find_by_reason(self, reason: str) -> List[MCapitalAdjustment]:

--- a/tests/unit/data/crud/test_capital_adjustment_crud_mock.py
+++ b/tests/unit/data/crud/test_capital_adjustment_crud_mock.py
@@ -189,6 +189,23 @@ class TestCapitalAdjustmentCRUDBusinessHelpers:
 
         assert result == 150000.0
 
+    @pytest.mark.unit
+    def test_get_total_adjustment_filters_by_business_timestamp(self, capital_adjustment_crud):
+        """get_total_adjustment 传 start/end 时按 business_timestamp 过滤（非 record timestamp）"""
+        capital_adjustment_crud.find = MagicMock(return_value=[])
+
+        start = datetime(2025, 1, 1)
+        end = datetime(2025, 12, 31)
+        capital_adjustment_crud.get_total_adjustment("portfolio-001", start, end)
+
+        assert capital_adjustment_crud.find.called
+        call_kwargs = capital_adjustment_crud.find.call_args.kwargs
+        filters = call_kwargs["filters"]
+        assert filters["portfolio_id"] == "portfolio-001"
+        assert "business_timestamp__gte" in filters, "必须按业务时间过滤而非 record timestamp"
+        assert "business_timestamp__lte" in filters
+        assert "timestamp__gte" not in filters, "不应混用 record timestamp 口径"
+
 
 # ============================================================
 # 构造与类型检查测试


### PR DESCRIPTION
## Summary

`CapitalAdjustmentCRUD.get_total_adjustment` 方法体引用未定义变量 `adjustments`，调用必崩 `NameError`（重构漏迁 query，master 既有 bug）。

按 triage brief 业务口径修复：
- 走 `find_by_business_time(portfolio_id, start_date, end_date)` 按 **business_timestamp（业务生效时间）** 过滤
- 非 issue body 建议的 `find_by_portfolio`（timestamp 口径）——总额统计对齐业务口径
- 保留 `if adj.amount` 守卫（防 `float(None)` 崩溃）

## Test plan

- [x] `test_get_total_adjustment` 转 GREEN（原 NameError）
- [x] 新增 `test_get_total_adjustment_filters_by_business_timestamp`：断言 `find` 的 filters 含 `business_timestamp__gte/__lte`，且不含 `timestamp__gte`（堵口径回归缺口）
- [x] Layer 1 py_compile（src+api 全量）通过
- [x] Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）29 passed
- [x] Layer 3 变更相关全文件 12 passed

Closes #6484

🤖 Generated with [Claude Code](https://claude.com/claude-code)