### PR TITLE
fix(#6486): 修守门扫描器缺陷 + 16 处 except-pass 补 logging 留痕

### DIFF
--- a/src/ginkgo/config/package.py
+++ b/src/ginkgo/config/package.py
@@ -8,6 +8,7 @@
 
 
 import os
+import logging
 
 PACKAGENAME = "ginkgo"
 
@@ -27,7 +28,7 @@ def _resolve_version() -> str:
         import importlib.metadata
         return importlib.metadata.version(PACKAGENAME)
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("importlib.metadata version lookup failed", exc_info=True)
     # 2. 解析 pyproject.toml：开发环境 / 构建中（向上逐层查找至 repo root）
     try:
         import tomllib
@@ -45,7 +46,7 @@ def _resolve_version() -> str:
                 break
             parent = nxt
     except Exception:
-        pass
+        logging.getLogger(__name__).debug("pyproject.toml version lookup failed", exc_info=True)
     # 3. 兜底常量（极端情况，永不抛异常）
     return "0.0.0+unknown"
 

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -973,8 +973,8 @@ class BacktestTaskService(BaseService):
             if portfolio_ids and self._portfolio_service:
                 try:
                     portfolio_names = self._portfolio_service.get_names_by_ids(list(portfolio_ids))
-                except Exception:
-                    GLOG.WARN("failed to fetch portfolio names for task list summary", exc_info=True)
+                except Exception as e:
+                    GLOG.WARN(f"failed to fetch portfolio names for task list summary: {e}")
 
             summaries: list[BacktestTaskSummary] = []
             for t in tasks:

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -974,7 +974,7 @@ class BacktestTaskService(BaseService):
                 try:
                     portfolio_names = self._portfolio_service.get_names_by_ids(list(portfolio_ids))
                 except Exception:
-                    pass
+                    GLOG.WARN("failed to fetch portfolio names for task list summary", exc_info=True)
 
             summaries: list[BacktestTaskSummary] = []
             for t in tasks:

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -9,6 +9,7 @@
 
 import os
 import sys
+import logging
 import yaml
 import shutil
 import base64
@@ -194,7 +195,7 @@ class GinkgoConfig(object):
             if not decoded_str.startswith("gAAAAA"):
                 return decoded_str.replace("\n", "")
         except Exception:
-            pass
+            logging.getLogger(__name__).debug("decode base64 password failed, using plaintext fallback", exc_info=True)
 
         # 优先级 3: 明文密码
         return pwd
@@ -1038,7 +1039,7 @@ class GinkgoConfig(object):
                 logging_config = config.get("logging", {})
                 return logging_config.get("mode", "auto")
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.mode failed, using fallback", exc_info=True)
         # 尝试环境变量
         return os.environ.get("GINKGO_LOGGING_MODE", "auto")
 
@@ -1059,7 +1060,7 @@ class GinkgoConfig(object):
                 logging_config = config.get("logging", {})
                 return logging_config.get("format", "json")
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.format failed, using fallback", exc_info=True)
         # 尝试环境变量
         return os.environ.get("GINKGO_LOGGING_FORMAT", "json")
 
@@ -1078,7 +1079,7 @@ class GinkgoConfig(object):
                 value = container_config.get("enabled", True)
                 return str(value).upper() == "TRUE"
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.container.enabled failed, using fallback", exc_info=True)
         # 尝试环境变量
         env_value = os.environ.get("GINKGO_LOGGING_CONTAINER_ENABLED", "true")
         return env_value.upper() == "TRUE"
@@ -1098,7 +1099,7 @@ class GinkgoConfig(object):
                 value = container_config.get("json_output", True)
                 return str(value).upper() == "TRUE"
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.container.json_output failed, using fallback", exc_info=True)
         # 尝试环境变量
         env_value = os.environ.get("GINKGO_LOGGING_CONTAINER_JSON_OUTPUT", "true")
         return env_value.upper() == "TRUE"
@@ -1118,7 +1119,7 @@ class GinkgoConfig(object):
                 value = local_config.get("file_enabled", True)
                 return str(value).upper() == "TRUE"
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.local.file_enabled failed, using fallback", exc_info=True)
         # 尝试环境变量
         env_value = os.environ.get("GINKGO_LOGGING_LOCAL_FILE_ENABLED", "true")
         return env_value.upper() == "TRUE"
@@ -1137,7 +1138,7 @@ class GinkgoConfig(object):
                 local_config = config.get("logging", {}).get("local", {})
                 return local_config.get("file_path", "ginkgo.log")
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.local.file_path failed, using fallback", exc_info=True)
         # 尝试环境变量
         return os.environ.get("GINKGO_LOGGING_LOCAL_FILE_PATH", "ginkgo.log")
 
@@ -1179,7 +1180,7 @@ class GinkgoConfig(object):
                 ttl_config = config.get("logging", {}).get("ttl", {})
                 return int(ttl_config.get("backtest", 180))
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.ttl.backtest failed, using fallback", exc_info=True)
         # #5507: os.environ.get returns str; wrap with int() for type safety
         return int(os.environ.get("GINKGO_LOGGING_TTL_BACKTEST", 180))
 
@@ -1198,7 +1199,7 @@ class GinkgoConfig(object):
                 ttl_config = config.get("logging", {}).get("ttl", {})
                 return int(ttl_config.get("component", 90))
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.ttl.component failed, using fallback", exc_info=True)
         return int(os.environ.get("GINKGO_LOGGING_TTL_COMPONENT", 90))
 
     @property
@@ -1216,7 +1217,7 @@ class GinkgoConfig(object):
                 ttl_config = config.get("logging", {}).get("ttl", {})
                 return int(ttl_config.get("performance", 30))
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.ttl.performance failed, using fallback", exc_info=True)
         return int(os.environ.get("GINKGO_LOGGING_TTL_PERFORMANCE", 30))
 
     @property
@@ -1234,7 +1235,7 @@ class GinkgoConfig(object):
                 logging_config = config.get("logging", {})
                 return float(logging_config.get("sampling_rate", 0.1))
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.sampling_rate failed, using fallback", exc_info=True)
         return float(os.environ.get("GINKGO_LOGGING_SAMPLING_RATE", 0.1))
 
     @property
@@ -1255,7 +1256,7 @@ class GinkgoConfig(object):
                     return whitelist
                 return []
             except Exception:
-                pass
+                logging.getLogger(__name__).debug("read logging.level_whitelist failed, using fallback", exc_info=True)
         # 尝试环境变量（逗号分隔）
         env_value = os.environ.get("GINKGO_LOGGING_LEVEL_WHITELIST")
         if env_value:

--- a/src/ginkgo/workers/backtest_worker/task_helpers.py
+++ b/src/ginkgo/workers/backtest_worker/task_helpers.py
@@ -180,8 +180,8 @@ def _extract_codes_from_value(value: Any) -> List[str]:
             decoded = _json.loads(stripped)
             if decoded:
                 return _extract_codes_from_value(decoded)
-        except Exception:
-            GLOG.DEBUG("json parse failed, regex fallback", exc_info=True)
+        except Exception as e:
+            GLOG.DEBUG(f"json parse failed, regex fallback: {e}")
     return _CODE_TOKEN_RE.findall(value)
 
 

--- a/src/ginkgo/workers/backtest_worker/task_helpers.py
+++ b/src/ginkgo/workers/backtest_worker/task_helpers.py
@@ -181,7 +181,7 @@ def _extract_codes_from_value(value: Any) -> List[str]:
             if decoded:
                 return _extract_codes_from_value(decoded)
         except Exception:
-            pass
+            GLOG.DEBUG("json parse failed, regex fallback", exc_info=True)
     return _CODE_TOKEN_RE.findall(value)
 
 

--- a/tests/unit/core/test_except_pass_logging.py
+++ b/tests/unit/core/test_except_pass_logging.py
@@ -2,6 +2,7 @@
 # Issue #3868 - silent exception swallowing
 import os
 import re
+import textwrap
 import pytest
 
 
@@ -26,20 +27,74 @@ def _find_except_pass_locations(src_dir="src/ginkgo"):
     return locations
 
 
-def _has_logging_before_pass(filepath, pass_line):
-    """Check if there's a GLOG/logging call between except and pass."""
+def _has_logging_before_pass(filepath, except_line):
+    """Check if there's a GLOG/logging call in the except block.
+
+    ``except_line`` is the 1-based line number of the ``except`` statement
+    (as produced by ``_find_except_pass_locations``). Scan downward through the
+    block body; return True if a logging call appears before ``pass`` or the
+    end of the block, False otherwise. Avoids the dead-code trap of checking
+    only a single line (which lands on ``pass`` itself for the common
+    except-immediately-followed-by-pass shape).
+    """
     with open(filepath) as f:
         lines = f.readlines()
-    for i in range(pass_line, pass_line + 1):
-        if i < len(lines):
-            line_content = lines[i]
-            if "GLOG." in line_content or "logging.getLogger" in line_content:
-                return True
+    idx = except_line - 1  # 0-based index of the except line
+    if idx < 0 or idx >= len(lines):
+        return False
+    except_indent = len(lines[idx]) - len(lines[idx].lstrip())
+    for i in range(idx + 1, len(lines)):
+        line_content = lines[i]
+        if not line_content.strip():
+            continue  # blank line
+        cur_indent = len(line_content) - len(line_content.lstrip())
+        if cur_indent <= except_indent:
+            return False  # dedented out of the except block
+        body = line_content.strip()
+        if body.startswith("#"):
+            continue
+        if body == "pass":
+            return False
+        if "GLOG." in line_content or "logging.getLogger" in line_content or re.search(r"\blogging\.", line_content):
+            return True
     return False
 
 
 class TestExceptPassHasLogging:
     """Every except...pass should have at least a GLOG call for observability."""
+
+    def test_has_logging_before_pass_detects_logging_in_block(self, tmp_path):
+        """防御：helper 应识别 except 块内已有 logging 的样本（非死代码）。
+
+        样本里 except 后跟一行业务降级语句、再跟 logging、最后 pass。
+        helper 接收 except 行号（1-based），应向下扫描整个块，命中 logging → True。
+        防止扫描器退化成"只看 except 下一行"的死代码（locator 传 except 行号时，
+        lines[except_1based] 恰为 pass 行 → 永远 False）。
+        """
+        sample = textwrap.dedent("""\
+            try:
+                x()
+            except Exception:
+                fallback = None
+                logging.getLogger(__name__).warning("fail", exc_info=True)
+                pass
+            """)
+        f = tmp_path / "has_log.py"
+        f.write_text(sample)
+        # except 在第 3 行（1-based）；logging 在第 5 行
+        assert _has_logging_before_pass(str(f), 3) is True
+
+    def test_has_logging_before_pass_returns_false_when_no_logging(self, tmp_path):
+        """防御：except 紧接 pass（块内无 logging）仍返回 False。"""
+        sample = textwrap.dedent("""\
+            try:
+                x()
+            except Exception:
+                pass
+            """)
+        f = tmp_path / "no_log.py"
+        f.write_text(sample)
+        assert _has_logging_before_pass(str(f), 3) is False
 
     def test_all_except_pass_have_logging(self):
         locations = _find_except_pass_locations()

--- a/tests/unit/core/test_print_to_glog.py
+++ b/tests/unit/core/test_print_to_glog.py
@@ -27,6 +27,10 @@ _ALLOWED_PRINT_FILES = {
     "notifier/channels/console_channel.py",
     # Logging infrastructure - can't use GLOG
     "libs/core/logger.py",
+    # GCONF startup-phase diagnostics: print(..., file=sys.stderr) runs before
+    # GLOG is initialized (config load / ImportError fallback). Same spirit as
+    # logger.py / core_containers.py above.
+    "libs/core/config.py",
     # GLOG fallback - print() used when GLOG is unavailable (ImportError branch)
     "core/core_containers.py",  # MockLoggerService in except ImportError
     "trading/strategies/random_signal_strategy.py",  # log_error() ImportError fallback
@@ -52,6 +56,10 @@ def _find_bare_prints(src_dir="src/ginkgo"):
                 stripped = line.strip()
                 if stripped.startswith("#") or stripped.startswith("..."):
                     continue
+                # Doctest/docstring examples (>>> prefix) are documentation,
+                # not executable code — AST does not treat them as Call.
+                if stripped.startswith(">>>"):
+                    continue
                 if re.search(r"(?<!\.)print\(", stripped) and "console.print" not in stripped:
                     results.append((rel, i + 1, stripped))
     return results
@@ -59,6 +67,26 @@ def _find_bare_prints(src_dir="src/ginkgo"):
 
 class TestBarePrintReplaced:
     """Bare print() should be replaced with GLOG except in allowed files."""
+
+    def test_find_bare_prints_skips_doctest_examples(self, tmp_path):
+        """防御：扫描器应跳过 >>> docstring/doctest 示例内的 print。
+
+        doctest 示例（>>> 开头）是文档非代码，AST 不视为 Call。扫描器若把
+        >>> print(...) 当真违规会逼作者删文档示例。已跳过 ... 续行，须同样跳 >>>。
+        """
+        (tmp_path / "doctest_mod.py").write_text('>>> print("doctest example")\n')
+        results = _find_bare_prints(str(tmp_path))
+        assert results == [], f"doctest 示例不应被报为违规: {results}"
+
+    def test_find_bare_prints_catches_real_bare_print(self, tmp_path):
+        """防御：扫描器仍能抓真违规（无 file=、无 >>> 的 stdout print）。
+
+        防止跳过逻辑过宽把真违规也漏掉（掏空测试）。
+        """
+        (tmp_path / "real_mod.py").write_text('print("real violation")\n')
+        results = _find_bare_prints(str(tmp_path))
+        assert len(results) == 1, f"应抓到 1 处真违规: {results}"
+        assert "real violation" in results[0][2]
 
     def test_bare_print_replaced_with_glog(self):
         prints = _find_bare_prints()

--- a/tests/unit/workers/test_task_helpers.py
+++ b/tests/unit/workers/test_task_helpers.py
@@ -69,3 +69,21 @@ class TestLoadPortfolioComponentsAssemblyLog:
         log_msg = str(assembly_call)
         assert "selectors=" in log_msg, f"Assembly log should contain selectors=, got: {log_msg}"
         assert "fixed_selector" in log_msg, f"Assembly log should contain selector name, got: {log_msg}"
+
+
+class TestExtractCodesFromValueBadJsonFallback:
+    """#6486 review: _extract_codes_from_value 在 json 解析失败时应走 regex
+    fallback,不应抛 TypeError 把容错降级变崩溃。"""
+
+    def test_bad_json_falls_back_to_regex_without_crash(self):
+        """GLOG.DEBUG 签名 ``(msg: str)`` 不接受 ``exc_info`` 关键字参数;
+        except 块内若误用 ``exc_info=True`` 会在调用签名绑定阶段抛 TypeError,
+        使原本的静默降级(regex fallback)变成异常崩溃。此处刻意不 mock GLOG,
+        以真实调用暴露该签名误用。"""
+        from ginkgo.workers.backtest_worker.task_helpers import _extract_codes_from_value
+
+        # 以 [ 开头触发 json.loads 分支;内容畸形致解析失败 → 走 except → regex fallback
+        result = _extract_codes_from_value("[invalid json 000001.SZ")
+
+        assert isinstance(result, list)
+        assert "000001.SZ" in result


### PR DESCRIPTION
## Summary

修两组结构性守门测试（`test_print_to_glog` / `test_except_pass_logging`）失败。根因是**测试扫描器自身缺陷**（误报 + 死代码）+ **16 处源码合理降级缺可观测 logging**。

### 测试侧（扫描器缺陷）

- **`test_print_to_glog`**：
  - `_ALLOWED_PRINT_FILES` 加 `libs/core/config.py` —— GCONF 启动期 `print(file=sys.stderr)`，GLOG 尚未就绪（同 `logger.py` / `core_containers.py` 性质）
  - `_find_bare_prints` 跳过 `>>>` docstring/doctest 示例行（文档非代码，AST 不视为 Call）—— 解决 `notification_worker.py:712` 误报
  - 补两条防御断言：扫描器仍能抓真 stdout print（`print("x")` 无 file= 无 >>>）/ doctest 示例不被误报
- **`test_except_pass_logging`**：
  - 修 `_has_logging_before_pass` 死代码：原查 `lines[pass_line]`，但 locator 传入的是 except 行号（1-based），`lines[except_1based]`（0-based）恰命中 pass 行本身 → 永远 False。改为**向下扫描整个 except 块体**（含缩进/dedent/pass/logging 判定）
  - 补两条防御断言：识别块内含 logging 的样本（防扫描器退化）/ 无 logging 仍返 False

### 源码侧（16 处降级补 logging，不改降级行为）

| 文件 | 处数 | 改动 |
|---|---|---|
| `libs/core/config.py` | 12 | `except-pass` → `logging.getLogger(__name__).debug(..., exc_info=True)`（GCONF 加载期禁 import ginkgo，用标准库 logging；DEBUG 不刷屏） |
| `config/package.py` | 2 | importlib.metadata / pyproject.toml 版本解析失败 → debug logging（打包元数据层禁 import ginkgo） |
| `data/services/backtest_task_service.py` | 1 | portfolio_names 查询失败 → `GLOG.WARN`（业务异常静默，列表摘要照常出应留痕） |
| `workers/backtest_worker/task_helpers.py` | 1 | JSON 解析失败 → `GLOG.DEBUG`（正则兜底降级） |

**不改**：降级链逻辑、`notification_worker.py` docstring 示例、config.py 的 stderr print 本身（仅加白名单）。

## Test plan

- [x] `pytest tests/unit/core/test_print_to_glog.py -v` —— 3 passed（含 2 防御断言）
- [x] `pytest tests/unit/core/test_except_pass_logging.py -v` —— 3 passed（含 2 防御断言）
- [x] `PYTHONPATH=src python -c "from ginkgo.libs.core.config import GinkgoConfig"` —— import 不崩
- [x] `PYTHONPATH=src python -c "from ginkgo.config.package import VERSION"` —— 返回 0.8.2
- [x] 变更源文件行为测试：`test_backtest_task_service_*` / `test_task_helpers` / `test_backtest_preflight` —— 29 passed
- [x] 启动路径 smoke：`test_user_crud_mock` / `test_containers` / `test_user_cli` —— 29 passed
- [x] py_compile src+api —— 全通过

## 设计说明

- **分层处理两类 print**：config.py 是"白名单"（启动期 stderr 合理），notification_worker 是"扫描精度"（docstring 应被排除）—— 非一刀切白名单。
- **helper 修复是防御性**：修源删 pass 后 16 处不再被 locator 扫到，`_has_logging_before_pass` 修复保证未来 `except: logging; pass` 模式能被正确识别（逻辑正确，不只迁就当前数据）。
- **DEBUG 级 + exc_info=True**：config/package 用 DEBUG 不刷屏；service 用 WARN（业务异常需可见）；worker 用 DEBUG（解析降级可观测即可）。

Closes #6486

🤖 Generated with [Claude Code](https://claude.com/claude-code)