### PR TITLE
fix(#6139): test_on_order_partially_filled 补 mock 让 analyzer hook 触发可见

### DIFF
--- a/tests/unit/trading/portfolios/test_t1backtest.py
+++ b/tests/unit/trading/portfolios/test_t1backtest.py
@@ -560,9 +560,17 @@ class TestOrderLifecycleEvents:
             fill_price=Decimal("10.0"), portfolio_id="pid",
             engine_id="eid", task_id="rid",
         )
+        # partial_fill 真实链路会触发 deduct_from_frozen（无冻结资金）+ Position 构造校验
+        # （portfolio.engine_id/task_id 未设）。本测试聚焦 analyzer activate hook 是否触发，
+        # 故 mock 掉资金扣除与持仓读取（走 deal 分支），与相邻
+        # test_terminal_partial_fill_releases_remaining_frozen_funds 同一mock 套路。
+        existing_pos = Mock()
+        existing_pos.uuid = "posuuid0"  # GLOG f-string 切片 [:8] 需真实 str
         with patch('ginkgo.trading.portfolios.t1backtest.GLOG'), \
              patch('ginkgo.trading.portfolios.t1backtest.container'), \
              patch.object(p, 'is_event_from_future', return_value=False), \
+             patch.object(p, 'deduct_from_frozen'), \
+             patch.object(p, 'get_position', return_value=existing_pos), \
              patch.object(p, 'update_worth'), \
              patch.object(p, 'update_profit'):
             p.on_order_partially_filled(event)


### PR DESCRIPTION
## Summary

修复 `test_on_order_partially_filled_new_implementation` 在 master 即 FAIL 的预存 bug。

**根因**：`PortfolioT1Backtest.on_order_partially_filled` 的 LONG 分支会真实调用：
1. `deduct_from_frozen(cost=1000)` —— 测试 setup 未冻结资金（`frozen=$0`）→ raise `Insufficient frozen funds: have $0, need $1000.0`
2. `Position(engine_id=self.engine_id)` —— portfolio 未设 `engine_id/task_id` → raise `engine_id cannot be empty`（Position 构造校验）

两个 raise 都被方法末尾的宽 `except Exception: log_engine_error_event(...)` 静默吞掉，导致 `ORDERPARTIALLYFILLED` analyzer activate hook 永远走不到，断言 `activate in hook_called` 失败。

**修复**：补两个 mock 屏蔽资金扣除与持仓读取的副作用，聚焦被测行为（hook 触发），与相邻 `test_terminal_partial_fill_releases_remaining_frozen_funds`（#5492/#6109）同一 mock 套路：
- `patch.object(p, "deduct_from_frozen")` —— 跳过资金扣除
- `patch.object(p, "get_position", return_value=Mock())` —— 走 deal 分支，跳过 Position 构造（Mock 设 `uuid` 为真实 str 以满足 GLOG f-string 的 `[:8]` 切片）

> 选 mock 而非 issue 建议的"补 freeze 资金"：测试意图是验证 analyzer hook 触发（公共行为），资金流有专门的相邻测试覆盖；freeze 会激活 LONG 分支全链副作用（add_fee / Position 创建 / container 持久化），让 hook 测试退化为脆弱的 mini 集成测试。详见相邻已修测试的同一 mock 模式。

## Test plan

- [x] 目标测试由 FAIL → PASS：`pytest tests/unit/trading/portfolios/test_t1backtest.py::TestOrderLifecycleEvents::test_on_order_partially_filled_new_implementation`
- [x] 同测试类无回归（7 passed）
- [x] 整文件无回归（46 passed）
- [x] Layer 1 py_compile 通过
- [x] Layer 2 启动路径 smoke 通过（user_crud_mock / containers / user_cli，29 passed）

Closes #6139