### PR TITLE
fix(#5423): data/stats total_ticks 取跨分表聚合而非硬编码 0

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -165,10 +165,15 @@ async def get_data_stats():
         # Tick数据概况：抽样统计前10只股票（减少抽样数量以提高性能）
         tick_data_summary = await get_tick_data_summary(stockinfo_service, tick_service, sample_size=10)
 
+        # #5423: tick 按股票代码分表存储（{code}_Tick），count_all 跨分表聚合 system.tables
+        # 元数据的 total_rows（MergeTree 精确计数），与同步历史口径一致；失败降级为 0。
+        tick_count_result = tick_service.count_all()
+        total_ticks = tick_count_result.data if tick_count_result.is_success() else 0
+
         return ok(data={
             "total_stocks": total_stocks,
             "total_bars": total_bars,
-            "total_ticks": 0,  # Tick数据分表存储，无法直接统计总量
+            "total_ticks": total_ticks,
             "total_adjust_factors": total_adjust_factors,
             "tick_data_summary": tick_data_summary,
             "data_sources": ["Tushare", "Yahoo", "BaoStock", "TDX"],

--- a/src/ginkgo/data/crud/tick_crud.py
+++ b/src/ginkgo/data/crud/tick_crud.py
@@ -20,7 +20,7 @@ from ginkgo.data.models import MTick
 from ginkgo.entities import Tick
 from ginkgo.enums import TICKDIRECTION_TYPES, SOURCE_TYPES
 from ginkgo.libs import datetime_normalize, GLOG, Number, to_decimal
-from ginkgo.data.drivers import drop_table
+from ginkgo.data.drivers import drop_table, get_db_connection
 
 # Global registry for dynamically created tick models
 tick_model_registry = {}
@@ -269,6 +269,48 @@ class TickCRUD:
 
         # 统计记录
         return temp_crud.count(filters)
+
+    def count_all(self) -> int:
+        """
+        跨所有动态 _Tick 分表聚合行数（#5423）。
+
+        Tick 数据按股票代码动态分表（表名 ``{code}_Tick``，ClickHouse MergeTree），
+        无法用单次 ``count()`` 统计全量（``count`` 强制要求 code 过滤）。本方法
+        通过 ClickHouse ``system.tables`` 元数据表一次查询聚合所有 ``_Tick`` 后缀
+        分表的 ``total_rows``，返回跨所有股票的 tick 总行数。
+
+        MergeTree 引擎的 ``total_rows`` 为精确值（非 InnoDB 式估算），结果与
+        实际数据量一致。
+
+        Returns:
+            int: 所有 ``_Tick`` 分表行数之和；无分表或查询失败时返回 0
+                 （失败仅记日志，不抛异常——stats 端点不应因统计失败而 500）。
+        """
+        from sqlalchemy import text
+
+        try:
+            conn = get_db_connection(MTick)
+            if conn is None:
+                GLOG.ERROR("Failed to get ClickHouse connection for count_all")
+                return 0
+            with conn.get_session() as session:
+                # match(name, '_Tick$') 锚定命名约定（get_tick_model 生成 {code}_Tick）
+                # database=currentDatabase() 限定当前库，避免跨库同名干扰
+                result = session.execute(
+                    text(
+                        "SELECT sum(total_rows) AS total "
+                        "FROM system.tables "
+                        "WHERE database = currentDatabase() "
+                        "AND match(name, '_Tick$')"
+                    )
+                )
+                row = result.fetchone()
+                if row is None or row[0] is None:
+                    return 0
+                return int(row[0])
+        except Exception as e:
+            GLOG.ERROR(f"Failed to count all tick records across sharded tables: {e}")
+            return 0
 
     def exists(self, filters):
         """

--- a/src/ginkgo/data/services/tick_service.py
+++ b/src/ginkgo/data/services/tick_service.py
@@ -555,6 +555,44 @@ class TickService(BaseService):
                 error=f"Database query failed: {str(e)}"
             )
 
+    def count_all(self) -> ServiceResult:
+        """
+        跨所有股票代码统计 tick 总行数（#5423）。
+
+        Tick 数据按股票代码动态分表，``count(code=...)`` 仅能统计单只股票。
+        本方法委托 ``TickCRUD.count_all()`` 通过 ClickHouse ``system.tables``
+        元数据一次聚合所有 ``_Tick`` 分表的 ``total_rows``，返回全量 tick 数。
+
+        用于 ``GET /api/v1/data/stats`` 的 ``total_ticks`` 字段，使其反映
+        实际数据量而非硬编码 0，与同步历史数据数量级一致。
+
+        Returns:
+            ServiceResult: ``data`` 为跨所有 ``_Tick`` 分表的行数之和（int）；
+            CRUD 层保证不抛异常（失败返回 0）。
+        """
+        start_time = time.time()
+        self._log_operation_start("count_all")
+
+        try:
+            if not self._crud_repo:
+                return ServiceResult.error("CRUD repository not available")
+
+            total = self._crud_repo.count_all()
+            duration = time.time() - start_time
+            self._log_operation_end("count_all", True, duration)
+
+            return ServiceResult.success(
+                data=total,
+                message=f"Total {total} tick records across all sharded tables",
+            )
+        except Exception as e:
+            duration = time.time() - start_time
+            self._log_operation_end("count_all", False, duration)
+            GLOG.ERROR(f"Failed to count all tick records: {e}")
+            return ServiceResult.error(
+                error=f"Database query failed: {str(e)}"
+            )
+
     def validate(self, tick_data: Union[List[Any], pd.DataFrame, ModelList]) -> ServiceResult:
         """
         Validate tick data integrity and quality.

--- a/tests/api/test_data_stats_total_ticks_5423.py
+++ b/tests/api/test_data_stats_total_ticks_5423.py
@@ -1,0 +1,102 @@
+"""#5423: GET /api/v1/data/stats 的 total_ticks 必须反映实际数据量。
+
+原实现第 171 行硬编码 `"total_ticks": 0`（注释：Tick数据分表存储，无法直接统计总量），
+导致同步历史显示 543452 条但 stats 端点恒报 0。本测试锁定：
+  total_ticks 取自 tick_service.count_all()（跨分表聚合），而非硬编码 0。
+
+Upstream: api.data.get_data_stats
+Downstream: TickService.count_all（#5423 新增，跨 _Tick 分表 system.tables 聚合）
+"""
+import asyncio
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_service_getters(total_ticks: int):
+    """构造 4 个 service getter mock，tick_service.count_all 返回 total_ticks。
+
+    其余 count/get 给空数据，避免抽样循环 (get_tick_data_summary) 干扰断言焦点。
+    """
+    from unittest.mock import MagicMock
+
+    mock_stock = MagicMock()
+    mock_stock.count.return_value = ServiceResult.success(data=2)
+    mock_stock.get.return_value = ServiceResult.success(data=[])  # 空样本 → 抽样循环零迭代
+
+    mock_bar = MagicMock()
+    mock_bar.count.return_value = ServiceResult.success(data=100)
+
+    mock_adj = MagicMock()
+    mock_adj.count.return_value = ServiceResult.success(data=5)
+
+    mock_tick = MagicMock()
+    mock_tick.count_all.return_value = ServiceResult.success(data=total_ticks)
+
+    return {
+        "get_stockinfo_service": lambda: mock_stock,
+        "get_bar_service": lambda: mock_bar,
+        "get_adjustfactor_service": lambda: mock_adj,
+        "get_tick_service": lambda: mock_tick,
+    }, mock_tick
+
+
+@pytest.mark.unit
+def test_total_ticks_reflects_count_all_not_hardcoded_zero(api_modules, monkeypatch):
+    """#5423: total_ticks 必须取自 tick_service.count_all()，不能恒为 0。
+
+    RED：当前 data.py:171 硬编码 `"total_ticks": 0`，count_all 返回 543452 但端点报 0。
+    GREEN 后 total_ticks == 543452。
+    """
+    from api.data import get_data_stats
+
+    getters, mock_tick = _make_service_getters(total_ticks=543452)
+    for name, fn in getters.items():
+        monkeypatch.setattr(f"api.data.{name}", fn)
+
+    result = asyncio.run(get_data_stats())
+
+    assert result["data"]["total_ticks"] == 543452, (
+        "total_ticks 应取自 tick_service.count_all()，而非硬编码 0"
+    )
+    mock_tick.count_all.assert_called_once()
+
+
+@pytest.mark.unit
+def test_total_ticks_zero_when_no_tick_data(api_modules, monkeypatch):
+    """无 tick 数据时 count_all 返回 0，total_ticks 也为 0（量级真实，非误导）。
+
+    锁定降级语义：与同步历史一致——若确无数据，0 是真值而非占位。
+    """
+    from api.data import get_data_stats
+
+    getters, mock_tick = _make_service_getters(total_ticks=0)
+    for name, fn in getters.items():
+        monkeypatch.setattr(f"api.data.{name}", fn)
+
+    result = asyncio.run(get_data_stats())
+
+    assert result["data"]["total_ticks"] == 0
+    mock_tick.count_all.assert_called_once()
+
+
+@pytest.mark.unit
+def test_total_ticks_degrades_to_zero_on_count_all_failure(api_modules, monkeypatch):
+    """count_all 失败（service 层返回 error）时 total_ticks 降级为 0，端点不 500。
+
+    CRUD 层已对 DB 异常降级返回 0（见 test_tick_crud_mock），service 层包装错误为
+    ServiceResult.error。端点对 is_success() 失败的 count_all 应取 0，保持与
+    stockinfo/bar/adjustfactor 一致的容错语义。
+    """
+    from api.data import get_data_stats
+
+    getters, mock_tick = _make_service_getters(total_ticks=0)
+    # 覆盖为 error，模拟 service 层异常
+    mock_tick.count_all.return_value = ServiceResult.error(error="db unreachable")
+    for name, fn in getters.items():
+        monkeypatch.setattr(f"api.data.{name}", fn)
+
+    result = asyncio.run(get_data_stats())
+
+    assert result["data"]["total_ticks"] == 0

--- a/tests/unit/data/crud/test_tick_crud_mock.py
+++ b/tests/unit/data/crud/test_tick_crud_mock.py
@@ -213,3 +213,58 @@ class TestTickCRUDConstruction:
         from ginkgo.data.crud.base_crud import BaseCRUD
 
         assert not isinstance(tick_crud, BaseCRUD)
+
+
+# ============================================================
+# count_all 测试 — #5423 跨分表全量统计
+# Tick 数据按股票代码动态分表（{code}_Tick，ClickHouse MergeTree），
+# count_all 通过 system.tables 元数据一次聚合所有分表的 total_rows。
+# ============================================================
+
+
+class TestTickCRUDCountAll:
+    """count_all: 跨所有 _Tick 分表聚合行数（#5423）"""
+
+    @pytest.mark.unit
+    def test_count_all_sums_total_rows_via_system_tables(self, tick_crud):
+        """count_all 应查 system.tables 聚合所有 _Tick 分表的 total_rows 并返回 int"""
+        with patch("ginkgo.data.crud.tick_crud.get_db_connection") as mock_conn_fn:
+            mock_session = MagicMock()
+            mock_result = MagicMock()
+            mock_result.fetchone.return_value = (543452,)
+            mock_session.execute.return_value = mock_result
+            mock_conn = MagicMock()
+            mock_conn.get_session.return_value.__enter__.return_value = mock_session
+            mock_conn_fn.return_value = mock_conn
+
+            total = tick_crud.count_all()
+
+            assert total == 543452
+            # 核心契约：必须查 system.tables 元数据表（跨分表聚合的入口）
+            sql_text = str(mock_session.execute.call_args[0][0])
+            assert "system.tables" in sql_text
+
+    @pytest.mark.unit
+    def test_count_all_returns_zero_when_no_tick_tables(self, tick_crud):
+        """无 _Tick 分表时（sum 为 NULL），应规整为 0 而非 None"""
+        with patch("ginkgo.data.crud.tick_crud.get_db_connection") as mock_conn_fn:
+            mock_session = MagicMock()
+            mock_result = MagicMock()
+            # ClickHouse sum() over empty set 返回 NULL/None
+            mock_result.fetchone.return_value = (None,)
+            mock_session.execute.return_value = mock_result
+            mock_conn = MagicMock()
+            mock_conn.get_session.return_value.__enter__.return_value = mock_session
+            mock_conn_fn.return_value = mock_conn
+
+            assert tick_crud.count_all() == 0
+
+    @pytest.mark.unit
+    def test_count_all_degrades_to_zero_on_db_error(self, tick_crud):
+        """DB 异常时不应抛出，应降级返回 0（stats 端点不能因统计失败而 500）"""
+        with patch("ginkgo.data.crud.tick_crud.get_db_connection") as mock_conn_fn:
+            mock_conn = MagicMock()
+            mock_conn.get_session.side_effect = RuntimeError("clickhouse unreachable")
+            mock_conn_fn.return_value = mock_conn
+
+            assert tick_crud.count_all() == 0

--- a/tests/unit/data/services/test_tick_service.py
+++ b/tests/unit/data/services/test_tick_service.py
@@ -375,6 +375,53 @@ class TestTickServiceCount:
 
 
 # ============================================================================
+# 测试类 - TickService.count_all 跨分表全量统计（#5423）
+# 不依赖真实 DB：构造带 mock crud_repo 的 TickService
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestTickServiceCountAll:
+    """count_all: 包装 CRUD 跨分表统计，返回 ServiceResult（#5423）"""
+
+    def _make_service_with_mock_crud(self, crud_count_all_return):
+        """构造带 mock crud_repo 的 TickService（不触达真实 DB/Redis）"""
+        from unittest.mock import MagicMock
+        from ginkgo.data.services.tick_service import TickService
+
+        mock_crud = MagicMock()
+        mock_crud.count_all.return_value = crud_count_all_return
+        return TickService(
+            data_source=MagicMock(),
+            stockinfo_service=MagicMock(),
+            crud_repo=mock_crud,
+            redis_service=MagicMock(),
+            adjustfactor_service=MagicMock(),
+        )
+
+    @pytest.mark.unit
+    def test_count_all_wraps_crud_and_returns_success(self):
+        """count_all 包装 crud.count_all，返回 ServiceResult.success(data=int)"""
+        service = self._make_service_with_mock_crud(543452)
+
+        result = service.count_all()
+
+        assert result.is_success()
+        assert result.data == 543452
+        service._crud_repo.count_all.assert_called_once()
+
+    @pytest.mark.unit
+    def test_count_all_propagates_zero_when_no_tick_data(self):
+        """crud 返回 0（无分表）时 service 也返回 0，保持数量级真实"""
+        service = self._make_service_with_mock_crud(0)
+
+        result = service.count_all()
+
+        assert result.is_success()
+        assert result.data == 0
+
+
+# ============================================================================
 # 测试类 - Tick数据验证
 # ============================================================================
 


### PR DESCRIPTION
## Summary

`GET /api/v1/data/stats` 的 `total_ticks` 原硬编码 `0`（注释 *"Tick数据分表存储，无法直接统计总量"*），与同步历史显示 543452 条已同步记录矛盾——数据面板恒报 0 误导用户以为 tick 数据为空。

### 根因
Tick 数据按股票代码动态分表（`{code}_Tick`，ClickHouse MergeTree），既有 `TickCRUD.count()` 要求传 `code`（单表计数），端点层无法一次拿到全量，遂用 `0` 占位。

### 修复（三层垂直切片 TDD）
| 层 | 方法 | 职责 |
|---|---|---|
| CRUD | `TickCRUD.count_all()` | 查 `system.tables` 聚合所有 `_Tick` 分表的 `total_rows`（MergeTree 精确计数，单次元查询）；DB 异常降级返回 `0` |
| Service | `TickService.count_all()` | `ServiceResult` 包装 + 计时日志，与既有 `count()` 同款容错 |
| API | `get_data_stats` | `total_ticks = count_all().data if is_success() else 0`，与 `stockinfo/bar/adjustfactor` 三个 count 同款容错 |

口径与同步历史一致（同一批 `_Tick` 分表）；任一层失败降级为 `0`，端点不 500。

## Test plan

三层冒烟全绿（对齐 `.github/workflows/ci.yml` #6015）：
- **Layer 1 py_compile**：`src api` 全量语法 ✅
- **Layer 2 启动路径**：`test_user_crud_mock` / `test_containers` / `test_user_cli` 29 passed ✅
- **Layer 3 变更相关**：
  - `test_tick_crud_mock.py::TestTickCRUDCountAll` 3 passed（system.tables 聚合 / NULL 规整为 0 / DB 异常降级）
  - `test_tick_service.py::TestTickServiceCountAll` 2 passed（包装 CRUD 返回 success / 0 透传）
  - `test_data_stats_total_ticks_5423.py` 3 passed（取 count_all 而非硬编码 / 无数据为 0 / 失败降级为 0 不 500）

变更覆盖率：3 个生产文件均有专属测试。

## 范围外（留作后续）
测试 stderr 暴露 `get_tick_data_summary` 一处既有潜伏 bug：股票列表为空时 `check_limit` 未绑定（`UnboundLocalError`），被 try/except 兜住降级为零值 fallback、无功能影响。非本 issue 范围，未改。

Closes #5423

🤖 Generated with [Claude Code](https://claude.com/claude-code)