### PR TITLE
fix(#5429): 回测 Orders 端点支持分页，不再返回全量数据

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -686,20 +686,29 @@ async def get_backtest_signals(
 
 
 @router.get("/{uuid}/orders")
-async def get_backtest_orders(uuid: str):
-    """获取回测订单记录"""
+async def get_backtest_orders(
+    uuid: str,
+    page: int = Query(1, ge=1, description="页码"),
+    page_size: int = Query(50, ge=1, le=500, description="每页数量")
+):
+    """获取回测订单记录
+
+    分页与同模块 /signals 端点对齐: orders 按 order_id 去重(取最新终态)后
+    再分页, total 为去重后订单总数(独立于当前页条数)。默认 page_size=50,
+    上限 le=500 防大回测全量返回致前端 OOM(#5429)。
+    """
     try:
         task_service = get_backtest_task_service()
-        result = task_service.list_orders(uuid)
+        result = task_service.list_orders(uuid, page=page, page_size=page_size)
 
         if not result.is_success():
-            return paginated(items=[], total=0,
+            return paginated(items=[], total=0, page=page, page_size=page_size,
                              message=result.error or "Failed to retrieve orders")
 
         items = result.data
         total = result.metadata.get("total", 0)
         return paginated(items=[o.dict() for o in items], total=total,
-                         page=1, page_size=max(total, 1),
+                         page=page, page_size=page_size,
                          message="Orders retrieved successfully")
 
     except NotFoundError:

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -1098,8 +1098,12 @@ class BacktestTaskService(BaseService):
             GLOG.ERROR(f"list_signals failed: {e}")
             return ServiceResult.error(f"Failed to list signals: {e}")
 
-    def list_orders(self, uuid: str) -> "ServiceResult":
-        """获取回测订单列表，返回 list[BacktestOrderItem]"""
+    def list_orders(self, uuid: str, page: int = 1, page_size: int = 0) -> "ServiceResult":
+        """获取回测订单列表，返回 list[BacktestOrderItem]
+
+        page_size 默认 0=全量(向后兼容 CLI/分析引擎等内部全量调用方);
+        端点层(Query 默认 50)显式传入时分页。
+        """
         from ginkgo.data.services.backtest_task_schemas import BacktestOrderItem
 
         try:
@@ -1109,7 +1113,7 @@ class BacktestTaskService(BaseService):
 
             from ginkgo.data.containers import container
             result_service = container.result_service()
-            result = result_service.get_orders(task_id=task_id)
+            result = result_service.get_orders(task_id=task_id, page=page, page_size=page_size)
             if not result.is_success():
                 return ServiceResult.success(data=[], message=result.error)
 

--- a/src/ginkgo/data/services/result_service.py
+++ b/src/ginkgo/data/services/result_service.py
@@ -425,7 +425,9 @@ class ResultService(BaseService):
     def get_orders(
         self,
         task_id: str,
-        portfolio_id: Optional[str] = None
+        portfolio_id: Optional[str] = None,
+        page: int = 1,
+        page_size: int = 0,
     ) -> ServiceResult:
         """
         获取回测订单（去重后，每个 order_id 取时间最新的最终态）。
@@ -434,12 +436,17 @@ class ResultService(BaseService):
         多条状态流转(NEW→SUBMITTED→FILLED)只保留最终态一条; 失败单
         (CANCELED/REJECTED)也保留其终态。完整状态流水见 get_order_records。
 
+        分页在去重之后做: 不能下推到 crud.find, 否则按流水切片会切断同一 order_id
+        的多条状态记录, 跨页去重丢失订单。total 为去重后唯一订单总数, 独立于当前页。
+
         Args:
             task_id: 运行会话ID
             portfolio_id: 投资组合ID（可选）
+            page: 页码(从 1 起)
+            page_size: 每页数量
 
         Returns:
-            ServiceResult[Dict]: {"data": 去重后订单列表, "total": 唯一订单数}
+            ServiceResult[Dict]: {"data": 当前页订单, "total": 唯一订单总数}
         """
         try:
             if not task_id:
@@ -457,8 +464,16 @@ class ResultService(BaseService):
                 seen.add(oid)
                 unique.append(r)
 
-            GLOG.INFO(f"获取 task_id={task_id} 的订单成功: {len(unique)} 个唯一订单 (流水 {len(records)} 条)")
-            return ServiceResult.success({"data": unique, "total": len(unique)})
+            total = len(unique)
+            # 去重后内存分页(page 从 1 起); page/page_size 非法时回退全量
+            if page >= 1 and page_size >= 1:
+                start = (page - 1) * page_size
+                paged = unique[start:start + page_size]
+            else:
+                paged = unique
+
+            GLOG.INFO(f"获取 task_id={task_id} 的订单成功: {total} 个唯一订单 (流水 {len(records)} 条), 返回第 {page} 页 {len(paged)} 条")
+            return ServiceResult.success({"data": paged, "total": total, "page": page, "page_size": page_size})
 
         except Exception as e:
             GLOG.ERROR(f"获取订单失败: {e}")

--- a/tests/api/test_backtest_orders_endpoint_5429.py
+++ b/tests/api/test_backtest_orders_endpoint_5429.py
@@ -1,0 +1,91 @@
+"""#5429: GET /{uuid}/orders 分页失效——端点忽略 page_size 返回全量。
+
+本测试覆盖 API 路由层: 直调路由函数, mock task_service, 断言 /orders 端点
+接受 page/page_size 并透传给 list_orders, 返回结构含独立 total(去重总数,
+非当前页条数)。行为与同模块 /signals 端点对齐(参考 test_backtest_pagination)。
+"""
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _mock_item(order_id):
+    m = MagicMock()
+    m.dict.return_value = {"order_id": order_id}
+    return m
+
+
+class TestBacktestOrdersPagination:
+    """#5429: /{uuid}/orders 端点分页参数透传与返回结构。"""
+
+    @pytest.mark.unit
+    def test_orders_passes_pagination_to_service(self):
+        """端点应接受 page/page_size 并透传给 task_service.list_orders。"""
+        from api.backtest import get_backtest_orders
+
+        items = [_mock_item("ord-A"), _mock_item("ord-B")]
+        sr = ServiceResult(success=True, data=items)
+        sr.set_metadata("total", 10)
+
+        mock_svc = MagicMock()
+        mock_svc.list_orders.return_value = sr
+
+        with patch("api.backtest.get_backtest_task_service", return_value=mock_svc):
+            resp = asyncio.run(get_backtest_orders("any-uuid", page=1, page_size=2))
+
+        # 透传: page/page_size 必须传给 list_orders
+        mock_svc.list_orders.assert_called_once_with("any-uuid", page=1, page_size=2)
+        # 返回结构: total 独立于当前页条数(2 条 data, total=10)
+        assert len(resp["data"]) == 2
+        assert resp["meta"]["total"] == 10
+        assert resp["meta"]["page"] == 1
+        assert resp["meta"]["page_size"] == 2
+
+    @pytest.mark.unit
+    def test_orders_default_page_size_is_fifty(self):
+        """签名默认 page=1/page_size=50(对齐 agent brief, 非全量 max(total,1))。
+
+        直调端点时 FastAPI Query 默认值不自动解析成 int(见 arch_api_test_
+        query_default_direct_await), 故用 inspect 验证签名契约——签名默认值
+        即 FastAPI 运行时实际下发的值。
+        """
+        import inspect
+        from api.backtest import get_backtest_orders
+
+        sig = inspect.signature(get_backtest_orders)
+        page_default = sig.parameters["page"].default
+        ps_default = sig.parameters["page_size"].default
+
+        # Query 参数对象有 .default 属性; 裸 int 默认值没有, 故用 hasattr 鉴别。
+        # ge/le 约束由 FastAPI 运行时校验, 签名声明见端点源码 Query(50, ge=1, le=500)。
+        assert hasattr(page_default, "default") and page_default.default == 1
+        assert hasattr(ps_default, "default"), "page_size 必须是 Query 参数对象, 非裸 int"
+        assert ps_default.default == 50, "默认 page_size 应为 50, 非 max(total,1) 全量"
+
+    @pytest.mark.unit
+    def test_orders_total_independent_of_page_size(self):
+        """不同 page_size 应返回相同 total(total=DB 去重总数, 非当前页条数)。"""
+        from api.backtest import get_backtest_orders
+
+        def make_sr(n_items, total):
+            sr = ServiceResult(success=True, data=[_mock_item(f"o{i}") for i in range(n_items)])
+            sr.set_metadata("total", total)
+            return sr
+
+        # page_size=2 返回 2 条
+        mock_svc = MagicMock()
+        mock_svc.list_orders.return_value = make_sr(2, 10)
+        with patch("api.backtest.get_backtest_task_service", return_value=mock_svc):
+            resp_small = asyncio.run(get_backtest_orders("any-uuid", page=1, page_size=2))
+        assert len(resp_small["data"]) == 2
+        assert resp_small["meta"]["total"] == 10
+
+        # page_size=50 返回更多条, 但 total 仍应相同
+        mock_svc.list_orders.return_value = make_sr(8, 10)
+        with patch("api.backtest.get_backtest_task_service", return_value=mock_svc):
+            resp_large = asyncio.run(get_backtest_orders("any-uuid", page=1, page_size=50))
+        assert len(resp_large["data"]) == 8
+        assert resp_large["meta"]["total"] == 10, "total 必须与 page_size 无关"

--- a/tests/unit/services/test_result_service_orders_pagination_5429.py
+++ b/tests/unit/services/test_result_service_orders_pagination_5429.py
@@ -1,0 +1,108 @@
+"""#5429: result_service.get_orders 去重后内存分页核心逻辑。
+
+get_orders 不能像 get_signals 那样把分页下推到 crud.find——按 order_id 取最新
+终态的去重必须基于全量流水, 否则按流水切片会切断同一 order_id 的多条状态记录,
+跨页去重丢失订单。本测试在 CRUD 入口(_find_order_records 的 OrderRecordCRUD.find)
+注入流水, 验证"去重 → 再分页"的完整交互(total 独立、切片边界正确)。
+"""
+import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.result_service import ResultService
+
+
+def _rec(order_id: str, status: int, day: int):
+    """构造一条订单流水(timestamp 由 day 决定, 控制去重时的'最新态'顺序)。"""
+    return SimpleNamespace(
+        uuid=f"u-{order_id}-{status}", order_id=order_id,
+        portfolio_id="port-1", engine_id="eng-1", task_id="task-1",
+        code="000001.SZ", direction=1, order_type=1, status=status,
+        volume=100, limit_price=10.0, transaction_price=10.0,
+        transaction_volume=100, fee=5.0,
+        timestamp=datetime.datetime(2025, 6, day, 9, 30),
+    )
+
+
+# 5 条流水, 3 个唯一 order_id(A 各 2 条, B 各 2 条, C 1 条)
+# find 按 timestamp desc 返回; 去重后 unique = [C, B, A]
+FLOW = [
+    _rec("ord-C", 4, 5),   # day5 最新
+    _rec("ord-B", 4, 4),
+    _rec("ord-A", 4, 3),
+    _rec("ord-B", 1, 2),   # B 的旧态, 去重丢弃
+    _rec("ord-A", 2, 1),   # A 的旧态, 去重丢弃
+]
+EXPECTED_UNIQUE_IDS = ["ord-C", "ord-B", "ord-A"]
+
+
+class TestGetOrdersPaginateAfterDedup:
+    """#5429: get_orders 先按 order_id 去重, 再对 unique 列表分页。"""
+
+    @pytest.mark.unit
+    def test_page_one_returns_first_slice_with_full_total(self):
+        svc = ResultService(MagicMock())
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD.find", return_value=FLOW):
+            result = svc.get_orders("task-1", page=1, page_size=2)
+
+        assert result.is_success()
+        data = result.data["data"]
+        total = result.data["total"]
+        # 去重后 3 个 unique; page_size=2 切前 2 条
+        assert total == 3, "total 必须是去重后唯一订单数, 非流水数(5)也非当前页条数(2)"
+        assert len(data) == 2
+        assert [getattr(r, "order_id") for r in data] == ["ord-C", "ord-B"]
+
+    @pytest.mark.unit
+    def test_page_two_returns_remainder_with_same_total(self):
+        """翻页 total 不变(独立于 page), 第 2 页返回剩余 unique。"""
+        svc = ResultService(MagicMock())
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD.find", return_value=FLOW):
+            result = svc.get_orders("task-1", page=2, page_size=2)
+
+        assert result.is_success()
+        data = result.data["data"]
+        assert result.data["total"] == 3, "第 2 页 total 必须仍为 3(去重总数), 非当前页条数"
+        assert len(data) == 1
+        assert getattr(data[0], "order_id") == "ord-A"
+
+    @pytest.mark.unit
+    def test_large_page_size_returns_all_unique(self):
+        """page_size >= unique 数时返回全部 unique(等价旧行为), total 仍独立。"""
+        svc = ResultService(MagicMock())
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD.find", return_value=FLOW):
+            result = svc.get_orders("task-1", page=1, page_size=50)
+
+        data = result.data["data"]
+        assert len(data) == 3
+        assert [getattr(r, "order_id") for r in data] == EXPECTED_UNIQUE_IDS
+        assert result.data["total"] == 3
+
+    @pytest.mark.unit
+    def test_total_independent_of_page_size(self):
+        """不同 page_size 必须返回相同 total(关键分页语义, brief 验收点)。"""
+        svc = ResultService(MagicMock())
+        totals = []
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD.find", return_value=FLOW):
+            for ps in (1, 2, 3, 50):
+                r = svc.get_orders("task-1", page=1, page_size=ps)
+                totals.append(r.data["total"])
+        assert len(set(totals)) == 1 and totals[0] == 3, \
+            f"total 必须与 page_size 无关, 实测: {totals}"
+
+    @pytest.mark.unit
+    def test_default_page_size_returns_all_unique(self):
+        """page_size 默认 0=全量(向后兼容 engine.py 分析引擎/CLI --trades 全量调用)。
+
+        这两处内部调用方不传分页参数, 依赖 get_orders 默认返回全部去重订单。
+        端点层(Query 默认 50)才显式分页。改此默认会破坏分析引擎完整性。
+        """
+        svc = ResultService(MagicMock())
+        with patch("ginkgo.data.crud.order_record_crud.OrderRecordCRUD.find", return_value=FLOW):
+            result = svc.get_orders("task-1")  # 不传 page/page_size
+
+        data = result.data["data"]
+        assert len(data) == 3, "默认(page_size=0)应返回全部 unique, 非 50 切片"
+        assert [getattr(r, "order_id") for r in data] == EXPECTED_UNIQUE_IDS


### PR DESCRIPTION
## Summary

修复 `GET /api/v1/backtests/{uuid}/orders` 端点忽略 `page_size` 返回全量数据的问题。原实现 `page_size=max(total,1)` 等于全量，大回测（数千笔订单）返回 MB 级数据有前端 OOM 风险。

**根因（三层缺失，非单点）**：
1. `get_backtest_orders` 端点签名无 `page`/`page_size` Query 参数
2. `list_orders` service 无分页参数
3. `get_orders` result_service 无分页参数 + 兜底 `max(total,1)`

**关键架构约束——去重后分页**：`get_orders` 不能像 `get_signals` 那样把分页下推到 `crud.find`。它必须先全量拉流水 → 按 `order_id` 内存去重（取最新终态）→ **去重后**才能分页。流水层切片会切断同一 `order_id` 的多条状态记录，跨页去重丢失订单。

**分层默认值设计**：
- 端点层 `Query(50, ge=1, le=500)`——brief 要求的合理默认 + 上限
- service 层 `page_size=0`（全量）——**向后兼容内部全量调用方**：
  - `trading/analysis/engine.py:153` 分析引擎需全量订单构建 DataFrame（默认分页会破坏分析完整性）
  - `client/flat_cli.py:677` CLI `--trades` 显示全部成交（默认分页会导致 `total=624` 但只列 50 条的不一致）

## Test plan

- [x] `tests/api/test_backtest_orders_endpoint_5429.py`（3）：端点透传 page/page_size、默认 50、total 独立于 page_size
- [x] `tests/unit/services/test_result_service_orders_pagination_5429.py`（5）：get_orders 去重后分页切片边界、翻页 total 不变、默认全量（向后兼容）
- [x] 既有回归：`test_backtest_pagination` / `test_backtest_order_records_endpoint` / `test_backtest_task_service_order_records` 全绿
- [x] 冒烟三层：py_compile ✅｜启动路径 smoke（user_crud/containers/user_cli 29 passed）✅

## Acceptance criteria 对齐（agent brief）

- [x] `/backtest/{uuid}/orders?page=1&page_size=50` 返回 ≤50 条 + 独立 `total`
- [x] 同一回测不同 `page_size` 返回相同 `total`
- [x] 行为与同模块 signals 端点一致（参数名、返回结构）
- [x] 大订单量回测不返回全量（受 page_size 约束）

Closes #5429

🤖 Generated with [Claude Code](https://claude.com/claude-code)