### PR TITLE
fix(#5689): bars API total 取 DB count 而非当前页条数

### DIFF
--- a/api/api/data.py
+++ b/api/api/data.py
@@ -374,6 +374,19 @@ async def get_bars(
         # asc → 升序（最旧在前）；desc / None / 无效值 → 降序（最新在前，符合验收默认）。
         desc_order = (order or "").lower() != "asc"
 
+        # #5689: total 来自独立 DB count 查询，与分页 page_size 解耦。
+        # 旧实现 total=len(bar_summaries)=当前页条数，随 page_size 变化（5 vs 100），
+        # 调用方无法据此判断数据总量或总页数。count 与 get 共用同一 where 条件
+        # （code/frequency/timestamp 范围），仿 stocks 端点（见本文件 stockinfo 分支）。
+        # count 失败时降级为 len(items)（旧行为），不抛 500。
+        count_result = bar_service.count(
+            code=code,
+            frequency=FREQUENCY_TYPES.DAY,
+            start_date=start_dt,
+            end_date=end_dt,
+        )
+        db_total = count_result.data if count_result.is_success() else None
+
         # 使用BarService.get方法，支持分页
         result = bar_service.get(
             code=code,
@@ -388,7 +401,11 @@ async def get_bars(
         )
 
         if not result.is_success() or not result.data:
-            return paginated(items=[], total=0, page=page, page_size=page_size)
+            # items 空仍返回真实 DB total，前端可据此判断其他页有数据（#5689）
+            return paginated(
+                items=[], total=db_total if db_total is not None else 0,
+                page=page, page_size=page_size,
+            )
 
         # 处理返回的数据
         # bar_service.get() 返回裸 list[MBar]（无 to_entities）；
@@ -413,9 +430,8 @@ async def get_bars(
 
         return paginated(
             items=bar_summaries,
-            # 裸 list 的 .count() 需要参数（#5599/#5610 500 根因）；
-            # 直接用 len(bar_summaries)，total 与返回 items 数一致
-            total=len(bar_summaries),
+            # #5689: total=DB count（与 page_size 解耦）；count 失败降级为当前页条数
+            total=db_total if db_total is not None else len(bar_summaries),
             page=page,
             page_size=page_size
         )

--- a/tests/api/test_data_bars_500_fix.py
+++ b/tests/api/test_data_bars_500_fix.py
@@ -58,12 +58,15 @@ class TestGetBarsBareListFix:
         mock_service = MagicMock()
         # 真实环境 bar_service.get().data 是裸 list（非空，无 to_entities）
         mock_service.get.return_value = make_mock_result(data=[make_bar()])
+        # #5689: 端点现额外调 bar_service.count()；mock 出整数避免 MagicMock 穿透
+        mock_service.count.return_value = make_mock_result(data=1)
 
         from api.data import get_bars
 
         with patch("api.data.get_bar_service", return_value=mock_service):
+            # 显式传 page/page_size：直接调端点时 Query(ge=1,le=500) 默认是对象非 int
             # 修复前：line 339 bars_list=[] → line 358 [bar].count() TypeError → 500
-            result = run_async(get_bars(code="000001.SZ"))
+            result = run_async(get_bars(code="000001.SZ", page=1, page_size=100))
 
         assert result.get("code") == 0
 
@@ -73,11 +76,12 @@ class TestGetBarsBareListFix:
         mock_service.get.return_value = make_mock_result(
             data=[make_bar("b1", "000001.SZ"), make_bar("b2", "000002.SZ")]
         )
+        mock_service.count.return_value = make_mock_result(data=2)
 
         from api.data import get_bars
 
         with patch("api.data.get_bar_service", return_value=mock_service):
-            result = run_async(get_bars(code="000001.SZ"))
+            result = run_async(get_bars(code="000001.SZ", page=1, page_size=100))
 
         # 修复前：line 339 bars_list=[] → items=[]（数据丢失）
         assert result.get("code") == 0
@@ -85,16 +89,22 @@ class TestGetBarsBareListFix:
         assert result["data"][0]["code"] == "000001.SZ"
 
     def test_total_matches_items_for_bare_list(self):
-        """TDD Red: total 应等于 len(bar_summaries)，不调用 list.count()"""
+        """裸 list 场景 total 来自 count()，本例 count==items 数（2）
+
+        #5599/#5610 原 intent：total 不调 list.count()（会抛 TypeError）。
+        #5689 后：total 来自独立 bar_service.count() 查询。本例 DB 总数恰好等于
+        当前页 items 数（2），故 total==2 仍成立，且验证裸 list 端到端不崩。
+        """
         mock_service = MagicMock()
         mock_service.get.return_value = make_mock_result(
             data=[make_bar("b1"), make_bar("b2")]
         )
+        mock_service.count.return_value = make_mock_result(data=2)
 
         from api.data import get_bars
 
         with patch("api.data.get_bar_service", return_value=mock_service):
-            result = run_async(get_bars(code="000001.SZ"))
+            result = run_async(get_bars(code="000001.SZ", page=1, page_size=100))
 
         assert result.get("code") == 0
         assert result["meta"]["total"] == 2

--- a/tests/api/test_data_bars_total.py
+++ b/tests/api/test_data_bars_total.py
@@ -1,0 +1,139 @@
+# Issue: #5689 — GET /api/v1/data/bars 的 meta.total 返回当前页条数而非 DB 总记录数
+# Upstream: api.api.data.get_bars
+# Downstream: BarService.get() (分页 items) + BarService.count() (DB 总数)
+# Role: 验证 total 来自独立 count 查询，与 page_size 解耦
+
+"""
+data/bars total 字段修复测试（#5689）
+
+根因：get_bars 端点 total=len(bar_summaries)，bar_summaries 是已分页结果，
+len() 随 page_size 变化，非 DB 总记录数。
+
+修复：仿 stocks 端点（data.py:271）单独调 bar_service.count()，
+total 来自 count 结果，与分页 items 数解耦。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(data=None, success=True):
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.data = data
+    return result
+
+
+def make_bar(uuid="b1", code="000001.SZ"):
+    """模拟 MBar（有 uuid/code/timestamp/OHLCV，无 to_entities）"""
+    bar = MagicMock()
+    bar.uuid = uuid
+    bar.code = code
+    bar.timestamp = datetime(2025, 1, 1)
+    bar.open = 1.0
+    bar.high = 2.0
+    bar.low = 0.5
+    bar.close = 1.5
+    bar.volume = 100.0
+    bar.amount = 200.0
+    del bar.to_entities
+    return bar
+
+
+class TestGetBarsTotalFromDB:
+    """#5689: meta.total 来自 DB count，不随 page_size 变化"""
+
+    def test_total_from_db_count_not_items_count(self):
+        """TDD Red: total 应来自 bar_service.count()，而非 len(items)
+
+        场景：当前页返回 2 条，但 DB 共 50 条匹配。
+        修复前：total=len(bar_summaries)=2（错）
+        修复后：total=bar_service.count()=50（对）
+        """
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(
+            data=[make_bar("b1"), make_bar("b2")]
+        )
+        # DB 总数 50，远大于当前页 2 条
+        mock_service.count.return_value = make_mock_result(data=50)
+
+        from api.data import get_bars
+
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            # 显式传 page/page_size：直接调端点时 Query(default=100,ge=1,le=500)
+            # 默认是 Query 对象非 int（#5689 测试约束，对齐 arch_api_test_query_default_direct_await）
+            result = run_async(get_bars(code="000001.SZ", page=1, page_size=100))
+
+        assert result["meta"]["total"] == 50, (
+            f"total 应=DB count(50)，非 len(items)(2)，实际 {result['meta']['total']}")
+
+    def test_total_invariant_across_page_sizes(self):
+        """验收1: 同 code+日期范围，不同 page_size 返回相同 total
+
+        这是 #5689 的核心验收标准。修复前 page_size=5→total=5，
+        page_size=100→total=100（随页大小变化）。修复后两者都=DB 总数。
+        """
+        def _run(page_size):
+            mock_service = MagicMock()
+            mock_service.get.return_value = make_mock_result(data=[make_bar("b1")])
+            mock_service.count.return_value = make_mock_result(data=50)
+
+            from api.data import get_bars
+            with patch("api.data.get_bar_service", return_value=mock_service):
+                return run_async(get_bars(code="000001.SZ", page=1, page_size=page_size))
+
+        total_small = _run(page_size=10)["meta"]["total"]
+        total_large = _run(page_size=100)["meta"]["total"]
+
+        assert total_small == total_large == 50, (
+            f"不同 page_size total 应相同(=DB 50)，实际 ps=10→{total_small}, ps=100→{total_large}")
+
+    def test_count_uses_same_filters_as_get(self):
+        """验收2: count 查询与列表查询共用同一 where 条件
+
+        count 须收到与 get 相同的 code/frequency/start_date/end_date，
+        否则 total 与 items 条件不匹配（如按 code 过滤的 total 包含其他 code）。
+        """
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(data=[make_bar("b1")])
+        mock_service.count.return_value = make_mock_result(data=50)
+
+        from api.data import get_bars
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            run_async(get_bars(
+                code="000001.SZ", page=1, page_size=100,
+                start_date="2025-01-01", end_date="2025-12-31",
+            ))
+
+        count_kwargs = mock_service.count.call_args.kwargs
+        assert count_kwargs.get("code") == "000001.SZ", (
+            f"count 须收 code 过滤，实际 {count_kwargs.get('code')}")
+        assert count_kwargs.get("start_date") is not None, "count 须收 start_date 过滤"
+        assert count_kwargs.get("end_date") is not None, "count 须收 end_date 过滤"
+
+    def test_count_failure_falls_back_to_items_len(self):
+        """降级: count 查询失败时 total 回退为 len(items)（旧行为），不抛 500
+
+        设计意图：count 是独立 DB 查询，可能因连接/超时失败。
+        失败时降级而非 500，保证列表仍可用（total 暂时不准但数据不丢）。
+        """
+        mock_service = MagicMock()
+        mock_service.get.return_value = make_mock_result(
+            data=[make_bar("b1"), make_bar("b2")]
+        )
+        # count 失败
+        mock_service.count.return_value = make_mock_result(success=False, data=None)
+
+        from api.data import get_bars
+        with patch("api.data.get_bar_service", return_value=mock_service):
+            result = run_async(get_bars(code="000001.SZ", page=1, page_size=100))
+
+        assert result.get("code") == 0, "count 失败不应致 500，列表仍可返回"
+        assert result["meta"]["total"] == 2, (
+            f"count 失败应降级为 len(items)=2，实际 {result['meta']['total']}")


### PR DESCRIPTION
## Summary

`GET /api/v1/data/bars` 的 `meta.total` 返回当前页条数（`len(bar_summaries)`）而非 DB 总记录数，随 `page_size` 变化：同一查询 `page_size=5→total=5`、`page_size=100→total=100`，调用方无法判断数据总量或总页数。

**根因**：`bar_summaries` 来自已分页的 `ModelList`，`len()` 是当前页条数。

**修复**：仿 stocks 端点（data.py:271）独立调 `bar_service.count()`，count 与 get 共用同一 where 条件（code / frequency / timestamp 范围），`total` 与 `page_size` 解耦。count 失败降级为 `len(items)`（旧行为）不抛 500。

```
GET /bars?code=000001.SZ&page_size=5   → meta.total = 50 (DB 总数)
GET /bars?code=000001.SZ&page_size=100 → meta.total = 50 (相同)
```

### 文件变更
- `api/api/data.py`: `get_bars` 加 `bar_service.count()`，empty 与 items 两分支 `total` 均取 `db_total`（count 失败降级 `len(items)`）
- `tests/api/test_data_bars_total.py`: 新增 4 项验收测试
- `tests/api/test_data_bars_500_fix.py`: 补 `count` mock + 显式 `page_size`（total 语义变更）

### 设计决策
- **不改 `bar_service.get()` 返回契约**：该方法有 7 个调用方（backtest_feeder / component_loader / strategy_data_mixin / validation_cli 等，含回测热路径），改返回 `(items, total)` 会全部破坏。改为端点层单独调 `count()`，零侵入。
- **count 已存在**：`BarService.count()`（bar_service.py:1100）走 `_crud_repo.count(filters)`，filters 与 `get()` 的 `_build_bar_filters` 一致，无需新建。

## Test plan

- [x] `tests/api/test_data_bars_total.py` 4 项全绿：
  - total 来自 DB count 非 len(items)
  - 不同 page_size（10/100）返回相同 total
  - count 收到与 get 相同的 code/start_date/end_date filters
  - count 失败降级为 len(items)，不 500
- [x] `tests/api/test_data_bars_500_fix.py` 3 项全绿（裸 list 路径回归）
- [x] py_compile src+api 全通过
- [x] 启动路径 smoke（user_crud_mock + containers + user_cli）29 passed

## 附带发现（pre-existing，非本 PR 回归）

`tests/api/test_data_bars_order.py`（3）与 `tests/api/test_data_bars_code_normalize.py`（6）在 master 上既有 9 个失败（直接调用端点踩 FastAPI 签名错配：`Query(ge=,le=)` 默认是对象 + `code: str` 必填位置参数直调报 TypeError 非 422）。已用 `git stash` 对照实证：本 PR 改动零新增回归。`tests/api/` 不在 CI（只跑 Smoke+py_compile）致长期潜伏，宜另开 issue 处理。

Closes #5689

🤖 Generated with [Claude Code](https://claude.com/claude-code)