### PR TITLE
feat(#5694): engines 列表端点支持分页 + 僵尸清理验证

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -328,16 +328,20 @@ async def list_backtests(
 
 @router.get("/engines")
 async def list_backtest_engines(
-    is_live: bool = Query(False, description="过滤是否实盘引擎")
+    is_live: bool = Query(False, description="过滤是否实盘引擎"),
+    page: int = Query(1, ge=1, description="页码(1-based)"),
+    page_size: int = Query(20, ge=1, le=100, description="每页数量"),
 ):
-    """获取可用的回测引擎列表"""
+    """获取可用的回测引擎列表（分页，#5694）"""
     try:
         engine_service = get_engine_service()
-        # is_live=0 表示回测引擎
-        result = engine_service.get(is_live=0 if not is_live else 1)
+        # is_live=0 表示回测引擎；page 1-based → service 0-based
+        result = engine_service.get(
+            is_live=0 if not is_live else 1, page=page - 1, page_size=page_size
+        )
 
         if not result.is_success():
-            return ok(data=[], message="Engines retrieved successfully")
+            return paginated(items=[], total=0, page=page, page_size=page_size)
 
         engines = []
         for engine in (result.data or []):
@@ -354,7 +358,8 @@ async def list_backtest_engines(
                 "end_date": engine_dict.get("backtest_end_date"),
             })
 
-        return ok(data=engines, message="Engines retrieved successfully")
+        total = result.metadata.get("total", 0)
+        return paginated(items=engines, total=total, page=page, page_size=page_size)
 
     except Exception as e:
         logger.error(f"Error listing engines: {str(e)}")

--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -47,7 +47,8 @@ class EngineService(BaseService):
 
     # Standard interface methods
     def get(self, engine_id: str = None, name: str = None, is_live: bool = None,
-            status: ENGINESTATUS_TYPES = None) -> ServiceResult:
+            status: ENGINESTATUS_TYPES = None,
+            page: Optional[int] = None, page_size: Optional[int] = None) -> ServiceResult:
         """
         Get engine data
 
@@ -56,9 +57,13 @@ class EngineService(BaseService):
             name: Engine name
             is_live: Whether live trading
             status: Engine status
+            page: 0-based page number; None=不分行全量返回（默认，向后兼容）
+            page_size: 每页数量；仅当 page 非 None 时生效
 
         Returns:
-            ServiceResult: Query result with ModelList data
+            ServiceResult: Query result with ModelList data。
+            分页模式（page 非 None）额外设 metadata.total = 总匹配数，
+            供 API 层 paginated 响应消费；全量模式不设 total。
         """
         try:
             # Build filter conditions
@@ -76,9 +81,13 @@ class EngineService(BaseService):
             filters['is_del'] = False
 
             # #3955 Execute query - always return ModelList
-            result = self._crud_repo.find(filters=filters)
-
-            return ServiceResult.success(result, f"Successfully retrieved engine data")
+            # #5694: page/page_size 透传 CRUD；None=全量（向后兼容调用方）
+            result = self._crud_repo.find(filters=filters, page=page, page_size=page_size)
+            sr = ServiceResult.success(result, f"Successfully retrieved engine data")
+            # 分页模式补 total 供 paginated 响应；全量模式不设（避免误导）
+            if page is not None:
+                sr.set_metadata("total", self._crud_repo.count(filters=filters))
+            return sr
 
         except Exception as e:
             return ServiceResult.error(f"Failed to get engine data: {str(e)}")

--- a/tests/api/test_backtest_engine_list_pagination.py
+++ b/tests/api/test_backtest_engine_list_pagination.py
@@ -1,0 +1,81 @@
+"""
+#5694: GET /engines 列表分页端点测试。
+
+直调端点函数（避开 app 启动 / root main.py 遮蔽），
+patch get_engine_service 注入 mock。
+"""
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _engine(uuid, name="engine", start=None, end=None):
+    """构造引擎 mock（属性式，匹配端点 getattr 取值路径）。"""
+    e = MagicMock()
+    e.uuid = uuid
+    e.name = name
+    e.backtest_start_date = start
+    e.backtest_end_date = end
+    return e
+
+
+class TestListBacktestEnginesPagination:
+    """GET /engines 分页契约（#5694）。"""
+
+    def test_pagination_passes_page_and_returns_paginated(self):
+        """传 page/page_size → service.get 传 0-based page，返回 paginated(items, total)。"""
+        from api.backtest import list_backtest_engines
+
+        mock_service = MagicMock()
+        sr = ServiceResult.success(data=[_engine("e1"), _engine("e2")])
+        sr.set_metadata("total", 15)
+        mock_service.get.return_value = sr
+
+        with patch("api.backtest.get_engine_service", return_value=mock_service):
+            result = asyncio.run(list_backtest_engines(is_live=False, page=2, page_size=10))
+
+        # page=2(1-based) → service 传 page=1(0-based)
+        mock_service.get.assert_called_once_with(is_live=0, page=1, page_size=10)
+        assert result["code"] == 0
+        assert result["meta"]["total"] == 15
+        assert result["meta"]["page"] == 2
+        assert result["meta"]["page_size"] == 10
+        assert len(result["data"]) == 2
+        assert result["data"][0]["uuid"] == "e1"
+
+    def test_page_one_maps_to_zero_based(self):
+        """page=1(首页, 1-based) → service 传 page=0(0-based) 转换正确。
+
+        注：Query 默认值由 FastAPI 框架保证（HTTP 请求路径），直调端点
+        无法触发默认值注入（arch_api_test_query_default_direct_await），
+        故此处显式传 page=1 验证 1-based→0-based 转换逻辑。
+        """
+        from api.backtest import list_backtest_engines
+
+        mock_service = MagicMock()
+        sr = ServiceResult.success(data=[])
+        sr.set_metadata("total", 0)
+        mock_service.get.return_value = sr
+
+        with patch("api.backtest.get_engine_service", return_value=mock_service):
+            result = asyncio.run(list_backtest_engines(is_live=False, page=1, page_size=20))
+
+        # page=1(1-based) → service page=0(0-based)
+        mock_service.get.assert_called_once_with(is_live=0, page=0, page_size=20)
+        assert result["meta"]["page"] == 1
+        assert result["meta"]["total"] == 0
+
+    def test_service_missing_total_defaults_to_zero(self):
+        """service 未设 total（异常分支）→ paginated total 兜底 0 不崩。"""
+        from api.backtest import list_backtest_engines
+
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.success(data=[])  # 无 metadata
+
+        with patch("api.backtest.get_engine_service", return_value=mock_service):
+            result = asyncio.run(list_backtest_engines(is_live=False, page=1, page_size=5))
+
+        assert result["code"] == 0
+        assert result["meta"]["total"] == 0

--- a/tests/unit/data/services/test_engine_service_mock.py
+++ b/tests/unit/data/services/test_engine_service_mock.py
@@ -228,6 +228,35 @@ class TestGet:
         assert result.success is False
         assert "query failed" in result.error
 
+    @pytest.mark.unit
+    def test_get_with_pagination_passes_page_and_sets_total(self, service, mock_deps):
+        """分页查询：传 page/page_size → find 带分页参数 + metadata.total = count(#5694)"""
+        mock_deps["crud_repo"].find.return_value = [_make_engine("e1"), _make_engine("e2")]
+        mock_deps["crud_repo"].count.return_value = 15
+
+        result = service.get(is_live=False, page=1, page_size=2)
+
+        assert result.success is True
+        call_kwargs = mock_deps["crud_repo"].find.call_args
+        assert call_kwargs[1]["page"] == 1
+        assert call_kwargs[1]["page_size"] == 2
+        assert result.metadata.get("total") == 15
+
+    @pytest.mark.unit
+    def test_get_without_pagination_backward_compatible(self, service, mock_deps):
+        """向后兼容：不传 page → find 不带分页 + 不设 metadata.total(#5694)"""
+        mock_deps["crud_repo"].find.return_value = [_make_engine("e1"), _make_engine("e2")]
+
+        result = service.get(is_live=False)
+
+        assert result.success is True
+        call_kwargs = mock_deps["crud_repo"].find.call_args
+        # 不分页时 page/page_size 应为 None（CRUD 全量）
+        assert call_kwargs[1].get("page") is None
+        assert call_kwargs[1].get("page_size") is None
+        # 不分页不设 total（避免误导调用方）
+        assert "total" not in result.metadata
+
 
 # ============================================================
 # count 测试


### PR DESCRIPTION
## Summary

解决 #5694 原始验收的两项：

### 1. engines 列表支持分页（代码变更）
`list_backtest_engines` 端点原先无分页参数全量返回（复核 comment 两次点名）。本 PR 加 DB 层分页：
- `EngineService.get` 加可选 `page`/`page_size` 参数（默认 None=全量，**向后兼容全部 11 个调用方**）；分页模式补 `metadata.total`
- `list_backtest_engines` 端点加 `page`(1-based)/`page_size` Query 参数，返回 `paginated(items, total)`
- `data` 字段仍是 items 列表，前端取 `.data` 向后兼容（仅多了 `meta`）

### 2. 僵尸清理端点验证（零代码，已在 issue comment 报告）
清理端点 `DELETE /engines/stale` (#5779/#6406) 验证有效：
| 步骤 | 结果 |
|---|---|
| 代码层 5 测 | 全绿（僵尸判据/dry_run 安全/不误删正常引擎/透传契约） |
| dry_run 预览 | stale_count=34（准确，与 SQL `is_del=0 AND 双空` 一致） |
| 实清 | Test DB 34 条僵尸软删除成功 |
| 实清后归零 | 未删僵尸=0，二次 dry_run=0 ✅ |

**203 vs 34 澄清**：SQL 直查 203 含 169 已软删(is_del=1)历史残留 + 34 未删。service 正确加 `is_del=False` 过滤，非截断 bug。

## Test plan
- `pytest tests/unit/data/services/test_engine_service_mock.py tests/unit/data/services/test_engine_service_cleanup.py` → 45 passed
- `pytest tests/api/test_backtest_engine_list_pagination.py tests/api/test_backtest_engine_cleanup.py` → 5 passed
- 真实 DB 端到端：分页 page0/page1 size10 两页 0 重叠，total 恒定（27）；dry_run/实清归零

## 变更文件
- `src/ginkgo/data/services/engine_service.py` — get() 加分页参数
- `api/api/backtest.py` — list_backtest_engines 加分页
- `tests/unit/data/services/test_engine_service_mock.py` — +2 测（分页/向后兼容）
- `tests/api/test_backtest_engine_list_pagination.py` — 新文件 +3 测

Closes #5694