### PR TITLE
fix(#5424): 回测 running 时 start_time 数据层兜底补全

### DIFF
--- a/src/ginkgo/data/crud/backtest_task_crud.py
+++ b/src/ginkgo/data/crud/backtest_task_crud.py
@@ -297,6 +297,11 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
         updates = {"status": status, "error_message": error_message}
         updates.update(result_fields)
 
+        # #5424: running 时补 start_time，与 end_time 对称。调用方（如 progress_tracker）
+        # 显式传入时尊重其值；CLI 同步路径漏传时由数据层兜底，避免 start_time 恒 NULL。
+        if status == "running" and "start_time" not in updates:
+            updates["start_time"] = datetime.now()
+
         if status in ["completed", "failed", "stopped"]:
             updates["end_time"] = datetime.now()
 

--- a/tests/integration/data/crud/test_backtest_task_crud_integration.py
+++ b/tests/integration/data/crud/test_backtest_task_crud_integration.py
@@ -187,3 +187,40 @@ class TestBacktestTaskCRUDCountAndRemove:
             filters={"engine_id": "TEST_ENGINE_BT_INTEG", "source": SOURCE_TYPES.TEST.value}
         )
         assert cnt_after == 0
+
+
+# ============================================================================
+# 测试类：状态更新与时间戳补全（#5424）
+# ============================================================================
+
+
+@pytest.mark.database
+@pytest.mark.integration
+class TestBacktestTaskCRUDUpdateStatusTimestamps:
+    """update_task_status 时间戳补全（#5424）端到端
+
+    复现路径：CLI run_task 调 update_status(uuid, "running") 不传 start_time，
+    此前 crud running 分支无兜底 → start_time 恒 NULL（实测 82% 缺失）。
+    修复后 running 分支与 end_time 对称自动补 start_time。
+    """
+
+    def test_running_writes_start_time_to_db(self, crud_instance, cleanup, sample_task_params):
+        """#5424 AC: status=running 不传 start_time，DB start_time 非空"""
+        task = crud_instance.create(**sample_task_params)
+        assert task.start_time is None  # 创建时无 start_time
+
+        crud_instance.update_task_status(uuid=task.uuid, status="running")
+
+        refreshed = crud_instance.get_by_uuid(task.uuid)
+        assert refreshed.status == "running"
+        assert refreshed.start_time is not None  # running 后由 crud 兜底落库
+
+    def test_completed_still_writes_end_time(self, crud_instance, cleanup, sample_task_params):
+        """对称回归: completed 分支仍补 end_time（修复不可破坏既有对称）"""
+        task = crud_instance.create(**sample_task_params)
+
+        crud_instance.update_task_status(uuid=task.uuid, status="completed")
+
+        refreshed = crud_instance.get_by_uuid(task.uuid)
+        assert refreshed.status == "completed"
+        assert refreshed.end_time is not None

--- a/tests/unit/data/crud/test_backtest_task_crud_mock.py
+++ b/tests/unit/data/crud/test_backtest_task_crud_mock.py
@@ -160,3 +160,42 @@ class TestBacktestTaskCRUDConstruction:
         assert crud_instance._is_mysql is True
         assert crud_instance._is_clickhouse is False
 
+
+# ============================================================
+# update_task_status 时间戳补全测试（#5424）
+# ============================================================
+
+
+class TestBacktestTaskCRUDUpdateStatusTimestamps:
+    """update_task_status 时间戳自动补全测试
+
+    #5424: 回测 running 时 start_time 应落库。end_time 在 completed/failed/stopped
+    时由 crud 自动补（对称），start_time 此前在 running 分支无对称补全——CLI 同步路径
+    (backtest_cli.run_task) 漏传时 start_time 恒 NULL（实测 82% 记录缺失）。
+    修复：在数据层 running 分支兜底，与 end_time 行为对称。
+    """
+
+    @pytest.mark.unit
+    def test_running_auto_fills_start_time(self, crud_instance):
+        """status=running 不传 start_time 时，crud 自动补 start_time（与 end_time 对称）"""
+        crud_instance.modify = MagicMock(return_value=1)
+
+        crud_instance.update_task_status(uuid="run-001", status="running")
+
+        updates = crud_instance.modify.call_args.kwargs["updates"]
+        assert "start_time" in updates
+        assert updates["start_time"] is not None
+
+    @pytest.mark.unit
+    def test_running_respects_explicit_start_time(self, crud_instance):
+        """status=running 显式传 start_time 时，不覆盖调用方值（progress_tracker 路径）"""
+        from datetime import datetime
+
+        crud_instance.modify = MagicMock(return_value=1)
+        explicit = datetime(2024, 1, 1, 12, 0, 0)
+
+        crud_instance.update_task_status(uuid="run-001", status="running", start_time=explicit)
+
+        updates = crud_instance.modify.call_args.kwargs["updates"]
+        assert updates["start_time"] == explicit
+


### PR DESCRIPTION
## Summary

修复 #5424：回测 `started_at`（对应 DB `backtest_task.start_time` 列）在 status=running 时恒 NULL（owner triage 实测 82% 缺失，918 条 completed 无 start_time）。

### 根因

`backtest_task_crud.update_task_status` 此前仅 `completed/failed/stopped` 分支自动补 `end_time`，**`running` 分支无 `start_time` 对称补全**：

- CLI 同步路径 `backtest_cli.run_task:214` 调 `update_status(uuid, "running")` 漏传 `start_time`
- progress_tracker 写 `start_time` 的路径仅 `BacktestProcessor` 异步线程触发，CLI 同步路径绕过
- 结果：`start_time` 靠调用方显式传，漏传即 NULL；`end_time` 靠 crud 兜底总有值 → 完美解释"end_time 有、start_time 无"

### 修复

在 `update_task_status` 的 running 分支补 `start_time`，与 end_time 对称；调用方显式传时尊重其值（`"start_time" not in updates` 守卫，保护 progress_tracker 路径）。**一处数据层兜底覆盖所有调用路径**（CLI 同步 + worker 异步）。

### AC 对应

- [x] 新建回测 run 后，status 进入 running 时 `start_time` 非空 —— 集成测试 `test_running_writes_start_time_to_db` 端到端验证（create→update(running)→重查 DB）
- [x] `GET /backtest/{uuid}` 返回 `started_at` 非空 —— API 层 `started_at=self._format_dt(getattr(task,"start_time",None))` 读列，列非空则字段非空
- [x] 回测完成后 task 记录 `start_time ≠ NULL` —— 数据层兜底，所有调用路径覆盖

## Test plan

- [x] Layer 1 py_compile（src+api 全量）✅
- [x] Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli，29 passed）✅
- [x] Layer 3 变更相关：mock（10 passed，含 2 新增验证 updates 构造：兜底 + 尊重显式）+ 集成（10 passed，含 2 新增端到端 DB 落库）✅
- [x] 对称回归保护：`test_completed_still_writes_end_time` 确保 end_time 补全不被破坏 ✅

Closes #5424