### PR TITLE
fix(#5431): AdjustFactor code 全空 + 按过滤返回 0 结果(根因:空 code 脏数据污染 order_by 分页)

### DIFF
--- a/src/ginkgo/data/crud/adjustfactor_crud.py
+++ b/src/ginkgo/data/crud/adjustfactor_crud.py
@@ -96,9 +96,17 @@ class AdjustfactorCRUD(BaseCRUD[MAdjustfactor]):
         Called by BaseCRUD.create() template method.
         Automatically gets @time_logger + @retry effects.
         """
+        code = kwargs.get("code")
+        # #5431: code 是 MergeTree order_by 首键,空值会污染默认分页排序。
+        # MAdjustfactor.code 声明 nullable=False,但 ClickHouse 不强制,需代码层兜底。
+        if not code:
+            raise ValueError(
+                f"AdjustfactorCRUD._create_from_params: code 不能为空(传入 {code!r}),"
+                f"空 code 会作为 order_by 首键污染查询分页"
+            )
         return MAdjustfactor(
             timestamp=datetime_normalize(kwargs.get("timestamp")),
-            code=kwargs.get("code"),
+            code=code,
             foreadjustfactor=to_decimal(kwargs.get("foreadjustfactor", 1.0)),
             backadjustfactor=to_decimal(kwargs.get("backadjustfactor", 1.0)),
             adjustfactor=to_decimal(kwargs.get("adjustfactor", 1.0)),
@@ -112,9 +120,14 @@ class AdjustfactorCRUD(BaseCRUD[MAdjustfactor]):
         Automatically gets @time_logger + @retry effects.
         """
         if hasattr(item, "timestamp") and hasattr(item, "code") and hasattr(item, "adjustfactor"):
+            code = getattr(item, "code")
+            # #5431: 空 code 跳过该行(返回 None),防 order_by 首键被空值污染默认分页。
+            # 批量入库跳过坏行 > 中断整批;None=跳过是本 hook 既有契约。
+            if not code:
+                return None
             return MAdjustfactor(
                 timestamp=datetime_normalize(getattr(item, "timestamp")),
-                code=getattr(item, "code"),
+                code=code,
                 foreadjustfactor=to_decimal(getattr(item, "foreadjustfactor", 1.0)),
                 backadjustfactor=to_decimal(getattr(item, "backadjustfactor", 1.0)),
                 adjustfactor=to_decimal(getattr(item, "adjustfactor", 1.0)),

--- a/tests/unit/data/crud/test_adjustfactor_crud_mock.py
+++ b/tests/unit/data/crud/test_adjustfactor_crud_mock.py
@@ -149,6 +149,12 @@ class TestAdjustfactorCRUDCreateFromParams:
             mock_normalize.assert_called_once_with("2024-06-01")
             assert model.timestamp == datetime(2024, 6, 1)
 
+    @pytest.mark.unit
+    def test_create_from_params_rejects_empty_code(self, adjustfactor_crud):
+        """code 为空字符串时 raise ValueError,防止空 code 脏数据入库(#5431)"""
+        with pytest.raises(ValueError, match="code"):
+            adjustfactor_crud._create_from_params(code="")
+
 
 # ============================================================
 # Business Helper 测试
@@ -203,4 +209,57 @@ class TestAdjustfactorCRUDConstruction:
         assert adjustfactor_crud.model_class is MAdjustfactor
         assert adjustfactor_crud._is_clickhouse is True
         assert adjustfactor_crud._is_mysql is False
+
+
+# ============================================================
+# _convert_input_item 测试
+# ============================================================
+
+
+class TestAdjustfactorCRUDConvertInputItem:
+    """_convert_input_item hook 测试(BaseCRUD.add_batch 入库路径)"""
+
+    @pytest.mark.unit
+    def test_convert_input_item_skips_empty_code(self, adjustfactor_crud):
+        """item.code 为空字符串时返回 None(跳过该行,防脏数据混入批量,#5431)"""
+        item = MagicMock()
+        item.timestamp = datetime(2024, 1, 1)
+        item.code = ""
+        item.foreadjustfactor = Decimal("1.0")
+        item.backadjustfactor = Decimal("1.0")
+        item.adjustfactor = Decimal("1.0")
+
+        result = adjustfactor_crud._convert_input_item(item)
+
+        assert result is None, "空 code 的 item 必须被跳过(返回 None),不得构造 MAdjustfactor"
+
+    @pytest.mark.unit
+    def test_convert_input_item_skips_none_code(self, adjustfactor_crud):
+        """item.code 为 None 时返回 None(同 #5431 防御)"""
+        item = MagicMock()
+        item.timestamp = datetime(2024, 1, 1)
+        item.code = None
+        item.foreadjustfactor = Decimal("1.0")
+        item.backadjustfactor = Decimal("1.0")
+        item.adjustfactor = Decimal("1.0")
+
+        result = adjustfactor_crud._convert_input_item(item)
+
+        assert result is None
+
+    @pytest.mark.unit
+    def test_convert_input_item_valid_code_returns_model(self, adjustfactor_crud):
+        """item.code 合法时正常转换(回归:防御不误伤合法路径)"""
+        item = MagicMock()
+        item.timestamp = datetime(2024, 1, 1)
+        item.code = "000001.SZ"
+        item.foreadjustfactor = Decimal("1.5")
+        item.backadjustfactor = Decimal("0.8")
+        item.adjustfactor = Decimal("1.2")
+
+        result = adjustfactor_crud._convert_input_item(item)
+
+        assert result is not None
+        assert result.code == "000001.SZ"
+        assert result.adjustfactor == Decimal("1.2")
 


### PR DESCRIPTION
## Summary

修复 #5431。

### 根因(两层叠加)

1. **数据层**:test 实例历史残留 43 行 `code=''` 脏数据(测试种子 source=-1 + 早期同步 source=7)。**master 实例实测 0 行脏数据(干净)**。
2. **机制层**:`MAdjustfactor` 表 MergeTree `order_by=("code","timestamp")`,空串排序优先 → 43 行脏数据霸占默认分页头部 → API 默认查询返回全空 code("全表空"错觉)。

**入库代码缺口**:`MAdjustfactor.code` 声明 `nullable=False`,但 ClickHouse 不强制该约束(与 MySQL 不同),CRUD hook 无非空校验 → 历史路径漏过空 code。

### 验收复核

- **AC1(默认查询 code 非空)**:清数据+校验后,test 实例默认分页前 5 行返回 `000858.SZ` ✅
- **AC2(按 code 过滤命中)**:`crud.find(filters={'code':'000858.SZ'})` 实测返回 74 行(filter 一直健康,symptom 2 是历史数据问题已自愈)✅

### 修复

**代码层(本 PR)**:
- `_create_from_params`:code 空 `raise ValueError`(单条显式构造→响亮报错)
- `_convert_input_item`:code 空返回 `None` 跳过(批量入库→复用 hook 既有 None=跳过契约,不中断整批)

两个 hook 不同拒绝策略反映调用语境,非一刀切。

**数据层(配套运维,已在 test 实例执行)**:清理 43 行 `code=''` 脏数据(`ALTER TABLE adjustfactor DELETE WHERE code=''`)。master 0 脏数据,无需清理。

## Test plan

- [x] TDD 4 新测试(RED→GREEN 垂直切片):`rejects_empty_code` / `skips_empty_code` / `skips_none_code` / `valid_code_returns_model`
- [x] Layer 1 py_compile(src+api)
- [x] Layer 2 启动路径 smoke(user_crud+containers+user_cli)29 passed
- [x] Layer 3 变更相关:crud mock 15 + api sync adjustfactor 3 + source tushare/tdx 19
- [x] 端到端:test 默认分页 code=`000858.SZ`,filter 命中 74 行

Closes #5431