### PR TITLE
fix(#4702): eval --level strict 真正跑 STRICT 规则(注册+level过滤)

### DIFF
--- a/src/ginkgo/client/evaluation_cli.py
+++ b/src/ginkgo/client/evaluation_cli.py
@@ -66,6 +66,13 @@ def evaluate_strategy(
         TimeProviderUsageRule,
         ForbiddenOperationsRule,
     )
+    from ginkgo.trading.evaluation.rules.best_practice_rules import (
+        DecoratorUsageRule,
+        ExceptionHandlingRule,
+        LoggingRule,
+        ResetStateRule,
+        ParameterValidationRule,
+    )
 
     # Validate level parameter
     level_map = {
@@ -129,6 +136,28 @@ def evaluate_strategy(
     )
     registry.register_rule_class(
         ForbiddenOperationsRule,
+        ComponentType.STRATEGY,
+    )
+
+    # Strict level rules (best-practice checks; only run at --level strict)
+    registry.register_rule_class(
+        DecoratorUsageRule,
+        ComponentType.STRATEGY,
+    )
+    registry.register_rule_class(
+        ExceptionHandlingRule,
+        ComponentType.STRATEGY,
+    )
+    registry.register_rule_class(
+        LoggingRule,
+        ComponentType.STRATEGY,
+    )
+    registry.register_rule_class(
+        ResetStateRule,
+        ComponentType.STRATEGY,
+    )
+    registry.register_rule_class(
+        ParameterValidationRule,
         ComponentType.STRATEGY,
     )
 

--- a/src/ginkgo/client/validation_cli.py
+++ b/src/ginkgo/client/validation_cli.py
@@ -328,7 +328,11 @@ def _validate_single_strategy(
         console.print(f":information: Source: {source_info}")
 
     try:
-        result = evaluator.evaluate(file_path)
+        # #4702: SimpleEvaluator.evaluate now filters rules by level. `validate`
+        # has no --level flag and historically runs ALL registered rules (14),
+        # so pin STRICT to preserve full-check semantics (STANDARD would drop
+        # the 5 best-practice STRICT rules registered above → regression).
+        result = evaluator.evaluate(file_path, level=EvaluationLevel.STRICT)
 
         # Generate report using selected format (T048)
         report_content = _generate_report(result, report_format)

--- a/src/ginkgo/trading/evaluation/evaluators/base_evaluator.py
+++ b/src/ginkgo/trading/evaluation/evaluators/base_evaluator.py
@@ -273,7 +273,11 @@ class SimpleEvaluator(BaseEvaluator):
 
             # Get applicable rules first
             rules = self.registry.get_rules(self.component_type)
-            GLOG.DEBUG(f"Applying {len(rules)} rules")
+            # #4702: filter by evaluation level via base_rule.is_applicable (uses
+            # EvaluationLevel.includes). Without this, basic/standard/strict run
+            # identical rule sets and the level flag is display-only.
+            rules = [r for r in rules if r.is_applicable(level)]
+            GLOG.DEBUG(f"Applying {len(rules)} rules at {level.value} level")
 
             # T093: Lazy loading - only load component class if RuntimeRule exists
             component_class = None

--- a/tests/unit/client/test_evaluation_cli.py
+++ b/tests/unit/client/test_evaluation_cli.py
@@ -11,6 +11,8 @@ import json
 import re
 from pathlib import Path
 
+import pytest
+
 project_root = Path(__file__).parent.parent.parent.parent
 _path = str(project_root / "src")
 sys.path.insert(0, _path)
@@ -22,6 +24,7 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 from ginkgo.client.evaluation_cli import app  # noqa: E402
+from ginkgo.trading.evaluation.rules.rule_registry import get_global_registry  # noqa: E402
 
 # patch 源模块(命令体为函数级 import,每次执行从源模块取属性)
 _EVALUATOR_PATH = "ginkgo.trading.analysis.evaluation.backtest_evaluator.BacktestEvaluator"
@@ -187,3 +190,156 @@ def test_monitor_live_no_stub(tmp_path):
     out = _strip_ansi(result.output)
     assert "not yet implemented" not in out
     assert mock_evaluator.create_live_monitor.called
+
+
+# ---- eval strategy: level 分级 (#4702) ----
+# 背景:--level strict 与 basic 输出完全一致。根因双重:
+#   ① SimpleEvaluator.evaluate 不按 level 过滤规则(base_evaluator)
+#   ② CLI 从未注册 best_practice_rules 里的 5 条 STRICT 规则
+# 框架已有 base_rule.is_applicable(level) = enabled and level.includes(self.level),
+# 但 SimpleEvaluator 未调用它。本组测试经 CLI 公共接口验证三档分级正确。
+
+# best_practice_rules 里全部 STRICT 级规则 id
+_STRICT_RULE_IDS = (
+    "DECORATOR_USAGE",
+    "EXCEPTION_HANDLING",
+    "LOGGING_USAGE",
+    "PARAMETER_VALIDATION",
+    "RESET_STATE_CALL",
+)
+
+
+@pytest.fixture
+def clean_eval_registry():
+    """全局 registry 是单例;每次 eval-strategy 测试前清空,保证计数确定。"""
+    get_global_registry().clear()
+    yield
+    get_global_registry().clear()
+
+
+@pytest.fixture
+def best_practice_deficient_strategy(tmp_path):
+    """合法 BaseStrategy 子类,但缺最佳实践:无装饰器/无 try-except/无 GLOG/无参数校验。
+    会触发 STRICT 规则(DECORATOR_USAGE/EXCEPTION_HANDLING/LOGGING_USAGE/PARAMETER_VALIDATION)。"""
+    content = (
+        "from ginkgo.trading.strategies.strategy_base import BaseStrategy\n"
+        "\n"
+        "class DeficientStrategy(BaseStrategy):\n"
+        "    def cal(self, portfolio_info, event):\n"
+        "        return []\n"
+    )
+    p = tmp_path / "deficient.py"
+    p.write_text(content)
+    return p
+
+
+class TestEvalStrategyLevelFiltering:
+    """#4702: --level strict 必须比 --level basic 跑更多检查。"""
+
+    def test_strict_fires_best_practice_rules_basic_does_not(
+        self, clean_eval_registry, best_practice_deficient_strategy
+    ):
+        """STRICT 规则在 strict 档触发、在 basic 档不触发(tracer:驱动 Fix A 注册 + Fix B 过滤)。"""
+        r_strict = runner.invoke(
+            app,
+            ["strategy", str(best_practice_deficient_strategy), "--level", "strict"],
+        )
+        r_basic = runner.invoke(
+            app,
+            ["strategy", str(best_practice_deficient_strategy), "--level", "basic"],
+        )
+
+        out_strict = _strip_ansi(r_strict.output)
+        out_basic = _strip_ansi(r_basic.output)
+
+        strict_hit = {rid for rid in _STRICT_RULE_IDS if rid in out_strict}
+        basic_hit = {rid for rid in _STRICT_RULE_IDS if rid in out_basic}
+
+        assert r_strict.exit_code == 0, r_strict.output
+        assert r_basic.exit_code == 0, r_basic.output
+        assert strict_hit, (
+            f"strict 档应触发 STRICT 规则,实测均未触发。输出:\n{out_strict}"
+        )
+        assert not basic_hit, (
+            f"basic 档不得跑 STRICT 规则,实测触发了 {basic_hit}。输出:\n{out_basic}"
+        )
+
+    def test_strict_has_more_issues_than_basic(
+        self, clean_eval_registry, best_practice_deficient_strategy
+    ):
+        """#4702 字面验收:strict 档 issue 数须多于 basic 档(增量检查)。"""
+        counts = {}
+        for lvl in ("basic", "standard", "strict"):
+            # 每档前清空,避免单例 registry 跨调用累积重复注册
+            get_global_registry().clear()
+            res = runner.invoke(
+                app,
+                ["strategy", str(best_practice_deficient_strategy), "--level", lvl],
+            )
+            assert res.exit_code == 0, res.output
+            out = _strip_ansi(res.output)
+            # EvaluationResult repr 里每条 issue 形如 code='DECORATOR_USAGE'
+            codes = re.findall(r"code='([A-Z_]+)'", out)
+            counts[lvl] = len(codes)
+
+        # 三档非递减,且 strict 严格多于 basic(修复前两者均为 0,完全一致)
+        assert counts["basic"] <= counts["standard"] <= counts["strict"]
+        assert counts["strict"] > counts["basic"], (
+            f"strict issue 数({counts['strict']})应多于 basic({counts['basic']})"
+        )
+
+
+class TestSimpleEvaluatorLevelFiltering:
+    """#4702 根因守护:SimpleEvaluator.evaluate 须按 level 过滤规则(独立于 CLI)。
+
+    直接对 SimpleEvaluator 注入独立 RuleRegistry(隔离全局单例累积),
+    验证 base_rule.is_applicable(level) 真的被 evaluate 调用。"""
+
+    def test_evaluate_filters_rules_by_level(self, tmp_path):
+        from ginkgo.trading.evaluation.core.enums import (
+            ComponentType,
+            EvaluationLevel,
+        )
+        from ginkgo.trading.evaluation.evaluators.base_evaluator import SimpleEvaluator
+        from ginkgo.trading.evaluation.rules.rule_registry import RuleRegistry
+        from ginkgo.trading.evaluation.rules.structural_rules import (
+            StrategyBaseInheritanceRule,
+        )
+        from ginkgo.trading.evaluation.rules.logical_rules import (
+            ReturnStatementRule,
+        )
+        from ginkgo.trading.evaluation.rules.best_practice_rules import (
+            DecoratorUsageRule,
+        )
+
+        # 独立 registry,各取一条 BASIC/STANDARD/STRICT 规则
+        registry = RuleRegistry()
+        registry.register_rule_class(StrategyBaseInheritanceRule, ComponentType.STRATEGY)
+        registry.register_rule_class(ReturnStatementRule, ComponentType.STRATEGY)
+        registry.register_rule_class(DecoratorUsageRule, ComponentType.STRATEGY)
+
+        strategy = tmp_path / "s.py"
+        strategy.write_text(
+            "from ginkgo.trading.strategies.strategy_base import BaseStrategy\n"
+            "class S(BaseStrategy):\n"
+            "    def cal(self, portfolio_info, event):\n"
+            "        return []\n"
+        )
+
+        evaluator = SimpleEvaluator(ComponentType.STRATEGY, registry=registry)
+
+        # BASIC 档:STANDARD/STRICT 规则不得运行
+        result_basic = evaluator.evaluate(strategy, level=EvaluationLevel.BASIC)
+        basic_codes = {i.code for i in result_basic.issues}
+        assert "DECORATOR_USAGE" not in basic_codes, "STRICT 规则在 BASIC 档不应运行"
+        assert "RETURN_STATEMENT" not in basic_codes, "STANDARD 规则在 BASIC 档不应运行"
+
+        # STRICT 档:全部规则运行,STRICT 规则须触发
+        result_strict = evaluator.evaluate(strategy, level=EvaluationLevel.STRICT)
+        strict_codes = {i.code for i in result_strict.issues}
+        assert "DECORATOR_USAGE" in strict_codes, "STRICT 规则在 STRICT 档应触发"
+
+        # STANDARD 档:STRICT 规则仍不得运行
+        result_std = evaluator.evaluate(strategy, level=EvaluationLevel.STANDARD)
+        std_codes = {i.code for i in result_std.issues}
+        assert "DECORATOR_USAGE" not in std_codes, "STRICT 规则在 STANDARD 档不应运行"


### PR DESCRIPTION
## Summary

`ginkgo eval strategy <file> --level strict` 与 `--level basic` 输出完全一致 —— strict 档的增量检查(信号逻辑/风险覆盖/参数合理性等最佳实践)从未执行。根因是**双重缺陷**:

### 根因 1:SimpleEvaluator.evaluate 不按 level 过滤
框架早已备好级别过滤原语 `base_rule.is_applicable(level) = enabled and level.includes(self.level)`,但编排器 `SimpleEvaluator.evaluate` 取规则后**直接全跑,从未调用 is_applicable**。结果三档 level 形同摆设,注册了什么就全跑什么。

**修复** (`base_evaluator.py:279`):取规则后追加过滤
```python
rules = [r for r in rules if r.is_applicable(level)]
```

### 根因 2:CLI 从未注册 STRICT 规则
`best_practice_rules.py` 里有 5 条完整的 STRICT 级规则(DecoratorUsage / ExceptionHandling / Logging / ResetState / ParameterValidation),但 `evaluation_cli.py` 只注册了 9 条 BASIC+STANDARD 规则。即便根因 1 修好,strict 档也无 STRICT 规则可跑。

**修复** (`evaluation_cli.py`):补齐 5 条 import + register_rule_class。

### 防回归:validation_cli 显式 STRICT
`validation_cli._validate_single_strategy` 注册全部 14 条规则,但 `evaluate(file_path)` 走默认 STANDARD。根因 1 修复后,5 条 STRICT 规则会被过滤掉 → `ginkgo validate` 从「跑 14 条」退化为「跑 9 条」。

`validate` 语义是全面验证(无 --level 参数),显式传 `level=EvaluationLevel.STRICT` 保持原行为 (`validation_cli.py:331`)。

## 验证(修复前后对比)

 deficient 策略(无装饰器/无 try-except/无 GLOG/无参数校验):
- 修复前:basic=0, standard=0, strict=0(三档全一致,STRICT 规则未注册+未过滤)
- 修复后:basic=0, standard=0, **strict=4**(STRICT 规则触发:DECORATOR_USAGE/EXCEPTION_HANDLING/LOGGING_USAGE/PARAMETER_VALIDATION)

## Test plan

TDD 垂直切片(一测试一实现,非水平切片):

- [x] **T1** `test_strict_fires_best_practice_rules_basic_does_not`:经 CLI 公共接口验证 STRICT rule_id 在 strict 档触发、basic 档不触发(驱动 Fix A 注册 + Fix B 过滤)
- [x] **T2** `test_strict_has_more_issues_than_basic`:三档 issue 计数 `basic ≤ standard ≤ strict` 且 `strict > basic`(issue 字面验收标准)
- [x] **T3** `test_evaluate_filters_rules_by_level`:直接对 `SimpleEvaluator` 注入独立 `RuleRegistry`(隔离全局单例累积),验证 `is_applicable(level)` 被调用 —— **根因守护,独立于 CLI**
- [x] `test_validation_cli.py` 17 项全绿(确认 Fix C 无回归)
- [x] 三层冒烟:py_compile(src+api) + 启动路径(user_crud/containers/user_cli 29 项) + 变更相关测试

## 调用方影响审计

`SimpleEvaluator.evaluate` 全仓调用方:
- `evaluation_cli.py` — 想分级,已传 `--level` ✅
- `validation_cli.py` — 想全跑,已显式 STRICT ✅(本次修复)
- 无其他调用方

Closes #4702

🤖 Generated with [Claude Code](https://claude.com/claude-code)