### PR TITLE
fix(#4706): ATRSizer 取数切 _data_feeder，缺数据 WARN 恢复可诊断性

### DIFF
--- a/src/ginkgo/trading/sizers/atr_sizer.py
+++ b/src/ginkgo/trading/sizers/atr_sizer.py
@@ -1,5 +1,5 @@
 # Upstream: PortfolioBase, ComponentFactoryService
-# Downstream: BaseSizer, Signal, Order, DIRECTION_TYPES, container, pandas
+# Downstream: BaseSizer, Signal, Order, DIRECTION_TYPES, pandas
 # Role: ATR仓位管理器，基于平均真实波幅计算波动率自适应的订单仓位
 
 
@@ -15,7 +15,6 @@ from ginkgo.entities import Signal
 from ginkgo.entities.mixins import LotAlignableMixin
 from ginkgo.libs import GLOG
 from ginkgo.trading.computation.technical.average_true_range import AverageTrueRange as ATR  # #3958 restored import
-from ginkgo.data.containers import container
 
 import datetime
 import pandas as pd
@@ -78,15 +77,26 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
             if self.now is None:
                 GLOG.WARN("ATRSizer: now is None, passing the signal")
                 return None
+            # #4706: LONG 取数走注入的 _data_feeder.get_historical_data()，对齐
+            # FixedSizer/RatioSizer 范式。原直查 container.bar_service() 是 sizer 中
+            # 旁路 feeder 的数据层穿透孤例：回测下常 result.success=False 致静默丢信号，
+            # 且绕过 feeder 的 validate_time 防未来数据泄露装饰器。
+            if self._data_feeder is None:
+                GLOG.ERROR(f"ATRSizer:{self.name} has no data_feeder bound")
+                return None
             start_date = self.now - datetime.timedelta(days=self.period + 7)
             end_date = self.now
-            result = container.bar_service().get(code=code, start_date=start_date, end_date=end_date)
-            if not result.success or not result.data:
+            df = self._data_feeder.get_historical_data(
+                symbols=[code],
+                start_time=start_date,
+                end_time=end_date,
+            )
+            if df is None or df.shape[0] == 0:
+                GLOG.WARN(f"ATRSizer: no bars for {code}, signal dropped")
                 return None
-            df = result.data.to_dataframe()
 
             # 检查数据是否足够
-            if df is None or len(df) < self.period + 1:
+            if len(df) < self.period + 1:
                 GLOG.WARN(f"ATRSizer: insufficient data for {code}, need {self.period + 1} bars")
                 return None
 
@@ -99,6 +109,7 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
             atr = ATR.cal(self.period, high_prices[-(self.period+1):], low_prices[-(self.period+1):], close_prices[-(self.period+1):]) * self.risk_ratio
 
             if atr == 0 or pd.isna(atr):
+                GLOG.WARN(f"ATRSizer: ATR is {atr} for {code}, signal dropped")
                 return None
             # #5490: floor ATR to a minimum fraction of close so a collapsed ATR
             # (halt / limit board / stale quotes) cannot inflate max_shares.

--- a/tests/unit/trading/sizers/test_atr_sizer.py
+++ b/tests/unit/trading/sizers/test_atr_sizer.py
@@ -1,8 +1,14 @@
 """
-Unit tests for ATRSizer near-zero ATR protection (#5490).
+Unit tests for ATRSizer.
 
-ATRSizer still uses container.bar_service() (not yet migrated to _data_feeder),
-so tests patch ginkgo.trading.sizers.atr_sizer.container.
+Covers:
+- #4706: LONG 取数走注入的 _data_feeder.get_historical_data()（对齐
+  FixedSizer/RatioSizer），缺数据时 WARN + return None 恢复可诊断性。
+- #5490: 近零 ATR 保护（floor）。
+- #6019: 不得以 INFO 输出完整 DataFrame。
+
+注：ATRSizer 经 portfolio_base.bind_data_feeder 注入 feeder（见 sizer_base），
+单测通过直接设置 sizer._data_feeder 模拟注入，走公共 cal() 接口验证行为。
 """
 import datetime
 from unittest.mock import MagicMock, patch
@@ -28,9 +34,9 @@ def _make_signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG):
 
 
 def _make_portfolio_info(cash=500000.0, positions=None):
-    # NOTE: cash as float — atr_sizer.py:88 does `cash * self.risk` with no
+    # NOTE: cash as float — atr_sizer.py does `cash * self.risk` with no
     # Decimal coercion, so Decimal cash raises TypeError. That is a separate
-    # pre-existing issue, out of scope for #5490 (near-zero ATR floor).
+    # pre-existing issue, out of scope here.
     return {"cash": cash, "positions": positions or {}}
 
 
@@ -43,6 +49,96 @@ def _bar_df(n, high, low, close):
     })
 
 
+def _bind_feeder(sizer, df):
+    """注入模拟 _data_feeder：get_historical_data 返回给定 DataFrame。
+
+    对齐 BacktestFeeder.get_historical_data 契约（返回 DataFrame，空数据返
+    空 DataFrame）。模拟 portfolio_base 在装配时调 bind_data_feeder 的结果。
+    """
+    feeder = MagicMock()
+    feeder.get_historical_data.return_value = df
+    sizer._data_feeder = feeder
+    return feeder
+
+
+class TestATRSizerDataFeederPath:
+    """#4706: LONG 取数走 _data_feeder.get_historical_data()，缺数据 WARN。"""
+
+    def test_normal_bars_via_feeder_returns_expected_volume(self, sizer):
+        """Tracer: 经 _data_feeder 注入正常 bar，产出预期 volume（与历史 mock 路径一致）。
+
+        TR=1 → ATR=1 → atr=2；max_money=5000，max_shares=int(5000/2/100)*100=2500。
+        验证迁移到 feeder 契约后 sizing 行为不变。
+        """
+        df = _bar_df(15, high=11.0, low=10.0, close=10.0)
+        _bind_feeder(sizer, df)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        order = sizer.cal(info, signal)
+
+        assert order is not None
+        assert order.volume == 2500
+        # 契约：经 _data_feeder.get_historical_data 取数（symbols/start_time/end_time）
+        assert sizer._data_feeder.get_historical_data.called
+
+    def test_feeder_unbound_logs_error_and_returns_none(self, sizer):
+        """#4706: _data_feeder 未注入（None）时 ERROR + return None（对齐 FixedSizer）。"""
+        assert sizer._data_feeder is None  # 默认未绑定
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog:
+            order = sizer.cal(info, signal)
+
+        assert order is None
+        mock_glog.ERROR.assert_called()
+
+    def test_no_bars_warns_and_returns_none(self, sizer):
+        """#4706 验收#1/#3: feeder 返回空 DataFrame → WARN 'no bars for {code}, signal dropped' + None。"""
+        _bind_feeder(sizer, pd.DataFrame())  # 空 DF
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog:
+            order = sizer.cal(info, signal)
+
+        assert order is None
+        # WARN 被调用，且消息含 code 与 "signal dropped"
+        warn_calls = [c.args[0] for c in mock_glog.WARN.call_args_list if c.args]
+        assert any("000001.SZ" in m and "signal dropped" in m for m in warn_calls), (
+            f"缺 bar 应 WARN 'no bars ... signal dropped'，实际 WARN: {warn_calls}"
+        )
+
+    def test_feeder_returns_none_warns_and_returns_none(self, sizer):
+        """#4706: feeder 返回 None（时间校验失败/未来数据泄露拦截）→ WARN + None。"""
+        _bind_feeder(sizer, None)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog:
+            order = sizer.cal(info, signal)
+
+        assert order is None
+        mock_glog.WARN.assert_called()
+
+    def test_zero_atr_warns_and_returns_none(self, sizer):
+        """#4706: 平盘 bar（TR=0 → ATR=0）→ WARN 'ATR is ...' + None（原静默分支恢复可诊断）。"""
+        df = _bar_df(15, high=10.0, low=10.0, close=10.0)  # 全平 → ATR=0
+        _bind_feeder(sizer, df)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = _make_portfolio_info(cash=500000.0)
+
+        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog:
+            order = sizer.cal(info, signal)
+
+        assert order is None
+        warn_calls = [c.args[0] for c in mock_glog.WARN.call_args_list if c.args]
+        assert any("ATR is" in m and "000001.SZ" in m for m in warn_calls), (
+            f"ATR=0 应 WARN，实际: {warn_calls}"
+        )
+
+
 class TestATRSizerNearZeroFloor:
     """#5490: ATR approaching zero must not produce oversized positions."""
 
@@ -50,21 +146,13 @@ class TestATRSizerNearZeroFloor:
         """Tracer: normal ATR (TR=1 → ATR=1 → atr=2) yields bounded volume.
 
         max_money=5000, atr=2 → max_shares=int(5000/2/100)*100=2500.
-        Establishes mock path + baseline before adding floor logic.
         """
         df = _bar_df(15, high=11.0, low=10.0, close=10.0)
+        _bind_feeder(sizer, df)
         signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
         info = _make_portfolio_info(cash=500000.0)
 
-        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-
-            order = sizer.cal(info, signal)
+        order = sizer.cal(info, signal)
 
         assert order is not None
         assert order.volume == 2500
@@ -73,101 +161,47 @@ class TestATRSizerNearZeroFloor:
         """#5490: tiny non-zero ATR (near-stagnant bar) must not explode volume.
 
         high=10.001/low=10.0/close=10.0 → TR=0.001 → ATR=0.001 → atr=0.002.
-        Without a floor: int(5000/0.002/100)*100 = 2,500,000 shares (oversized).
         Floor (close * min_atr_percent=0.005 → 0.05, since 0.002<0.05):
-        int(5000/0.05/100)*100 = 100,000 shares (bounded, 25x smaller).
+        int(5000/0.05/100)*100 = 100,000 shares (vs 2,500,000 unfloored).
         """
         df = _bar_df(15, high=10.001, low=10.0, close=10.0)
+        _bind_feeder(sizer, df)
         signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
         info = _make_portfolio_info(cash=500000.0)
 
-        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-
-            order = sizer.cal(info, signal)
+        order = sizer.cal(info, signal)
 
         assert order is not None
-        # 2,500,000 (unfloored) would mean ~25M CNY position on 500k cash.
         assert order.volume == 100000
-
-    def test_zero_atr_returns_none_not_floored(self, sizer):
-        """Regression: flat bar (TR=0 → ATR=0) must return None, not floor up.
-
-        The floor sits AFTER the atr==0 guard, so a true zero still declines
-        the signal. Without this ordering, floor would turn a dead market into
-        a max-size order.
-        """
-        df = _bar_df(15, high=10.0, low=10.0, close=10.0)
-        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
-        info = _make_portfolio_info(cash=500000.0)
-
-        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-
-            order = sizer.cal(info, signal)
-
-        assert order is None
 
     def test_min_atr_percent_configurable(self):
         """min_atr_percent raises the floor → smaller max_shares on near-zero ATR.
 
-        Same tiny-ATR bar as the floor test, but min_atr_percent=0.01 →
-        min_atr=0.1 (vs 0.05 default) → int(5000/0.1/100)*100 = 50,000.
+        Same tiny-ATR bar, min_atr_percent=0.01 → min_atr=0.1 → int(5000/0.1/100)*100=50,000.
         """
         s = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2, min_atr_percent=0.01)
         s.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
         df = _bar_df(15, high=10.001, low=10.0, close=10.0)
+        _bind_feeder(s, df)
         signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
         info = _make_portfolio_info(cash=500000.0)
 
-        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-
-            order = s.cal(info, signal)
+        order = s.cal(info, signal)
 
         assert order is not None
         assert order.volume == 50000
 
 
 class TestATRSizerDoesNotLogDataFrame:
-    """#6019: ATRSizer 不得以 INFO 级别输出完整 DataFrame（遗留调试日志）。
-
-    历史：原始 `print(df)` 调试代码被机械地替换为 `GLOG.INFO(df)`，
-    导致每次 cal() 都把完整行情 DataFrame（高/低/收 多行）写日志。
-    验收：cal() 执行后，GLOG.INFO 的所有调用参数中不得出现
-    pandas.DataFrame 实例（"Order Generated." 字符串、Order 对象等
-    正常业务日志不受影响）。
-    """
+    """#6019: ATRSizer 不得以 INFO 级别输出完整 DataFrame（遗留调试日志）。"""
 
     def test_cal_does_not_log_full_dataframe(self, sizer):
         df = _bar_df(15, high=11.0, low=10.0, close=10.0)
+        _bind_feeder(sizer, df)
         signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
         info = _make_portfolio_info(cash=500000.0)
 
-        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog, \
-             patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-
+        with patch("ginkgo.trading.sizers.atr_sizer.GLOG") as mock_glog:
             sizer.cal(info, signal)
 
         info_args = [c.args[0] for c in mock_glog.INFO.call_args_list if c.args]

--- a/tests/unit/trading/sizers/test_sizer_lot_size.py
+++ b/tests/unit/trading/sizers/test_sizer_lot_size.py
@@ -10,7 +10,7 @@ agent brief 已剔除 Claim #3，此处加守护测试防回归。
 """
 import datetime
 from decimal import Decimal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -147,8 +147,8 @@ class TestRatioSizerLotSize:
 class TestATRSizerLotSize:
     """ATRSizer 开仓路径 lot 对齐由 lot_size 决定（原硬编码 100 内联）。
 
-    ATRSizer 仍用 container.bar_service 取价（未迁 _data_feeder），故 patch
-    ginkgo.trading.sizers.atr_sizer.container（同 test_atr_sizer.py 范式）。
+    ATRSizer LONG 取数经注入的 _data_feeder.get_historical_data()（#4706），
+    模拟注入方式同 RatioSizer 测试（feeder.get_historical_data 返回 bar DF）。
     """
 
     @staticmethod
@@ -170,27 +170,19 @@ class TestATRSizerLotSize:
         # 默认 lot_size=100
         sizer_default = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2)
         sizer_default.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
-        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-            order_default = sizer_default.cal(info, signal)
+        feeder_default = MagicMock()
+        feeder_default.get_historical_data.return_value = df
+        sizer_default._data_feeder = feeder_default
+        order_default = sizer_default.cal(info, signal)
         assert order_default.volume == 1600
 
         # lot_size=50
         sizer_50 = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2, lot_size=50)
         sizer_50.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
-        with patch("ginkgo.trading.sizers.atr_sizer.container") as cm:
-            service = MagicMock()
-            result = MagicMock()
-            result.success = True
-            result.data.to_dataframe.return_value = df
-            service.get.return_value = result
-            cm.bar_service.return_value = service
-            order_50 = sizer_50.cal(info, signal)
+        feeder_50 = MagicMock()
+        feeder_50.get_historical_data.return_value = df
+        sizer_50._data_feeder = feeder_50
+        order_50 = sizer_50.cal(info, signal)
         assert order_50.volume == 1650
 
 


### PR DESCRIPTION
## Summary

**根因**（owner 控制实验已动态证实，见 issue #4706 评论）：
ATRSizer 是 sizer 中唯一旁路 `_data_feeder` 的孤例——LONG 路径直查
`container.bar_service().get()`，回测下 `result.success` 常为 False，
L79-80 静默 `return None` 丢光所有信号（复现：14 LONG 信号 → 0 订单）。
同组合换 FixedSizer（走 `self._data_feeder.get_historical_data()`）后
LONG 立即恢复出单。此外直查容器还绕过了 feeder 的 `validate_time`
防未来数据泄露装饰器。

## 改动

- **`atr_sizer.py` LONG 取数**：`container.bar_service().get()` →
  `self._data_feeder.get_historical_data(symbols=[code], start_time, end_time)`，
  对齐 FixedSizer/RatioSizer 范式；删除 `container` import。
- **可诊断性恢复**（agent brief 验收 #1）：
  - `_data_feeder` 未绑定 → `GLOG.ERROR` + None（对齐 FixedSizer 防御）
  - 无 bar / feeder 返回 None → `GLOG.WARN("ATRSizer: no bars for {code}, signal dropped")` + None
  - ATR==0/NaN → `GLOG.WARN("ATRSizer: ATR is {atr} for {code}, signal dropped")` + None
- **不动 sizing 公式**：#5490 near-zero ATR floor、lot 对齐、min_atr_percent 行为不变。

## 测试

- 新增 `TestATRSizerDataFeederPath`（5 测试）：feeder 正常出单 / feeder 未绑 ERROR /
  无 bar WARN / feeder 返回 None WARN / ATR==0 WARN。
- 迁移既有 `container` mock 到 feeder mock（test_atr_sizer.py、test_sizer_lot_size.py），
  sizing 行为断言（volume/floor/lot）全保留。

## Test plan

- [x] `pytest tests/unit/trading/sizers/` — 37 passed
- [x] py_compile 全绿
- [x] 启动路径 smoke（user_crud_mock / containers / user_cli）— 29 passed
- [ ] 回测端到端复测（owner 在 issue 评论里的复现组合 `loop_ma_mom_e2e`：
      ATRSizer 14 LONG → 应出单而非全 None；`ATRSizer WARN` 日志计数应 > 0 当缺 bar）

Closes #4706