### PR TITLE
fix(#4719): deploy list 输出完整 UUID（rich Table id 列 fold 自适应）

### DIFF
--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -112,19 +112,22 @@ def list_deployments(
 
         if result.success and result.data:
             table = Table(title="部署记录")
-            table.add_column("Deployment ID", style="cyan")
+            # #4719: id 列 overflow="fold"——rich 默认 ellipsis 会用 … 截断长 UUID，
+            # 导致终端用户也看不到完整 id；fold 折行完整显示，终端宽时单行、窄时多行
+            table.add_column("Deployment ID", style="cyan", overflow="fold")
             table.add_column("源任务")
-            table.add_column("目标Portfolio")
+            table.add_column("目标Portfolio", overflow="fold")
             table.add_column("模式")
             table.add_column("状态")
             table.add_column("创建时间")
 
             for d in result.data:
                 mode_str = "纸上" if d["mode"] == 1 else "实盘"
+                # #4719: 输出完整 UUID，list→info round-trip 可直接复制；rich Table 自适应列宽
                 table.add_row(
-                    d["deployment_id"][:8] + "...",
+                    d["deployment_id"],
                     d["source_task_id"],
-                    d["target_portfolio_id"][:8] + "...",
+                    d["target_portfolio_id"],
                     mode_str,
                     str(d["status"]),
                     d.get("create_at", "")[:19] if d.get("create_at") else "",

--- a/tests/unit/client/test_deploy_cli_list.py
+++ b/tests/unit/client/test_deploy_cli_list.py
@@ -1,0 +1,117 @@
+"""
+#4719 deploy list ID 截断修复
+- list 输出的 deployment_id / target_portfolio_id 必须完整（不再 [:8]+"..."）
+- list 输出的 id 可直接被 info 消费（round-trip 契约的生产者侧）
+"""
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+from typer.testing import CliRunner
+
+from ginkgo.client import deploy_cli
+from ginkgo.data.services.base_service import ServiceResult
+
+# 32 字符 hex UUID（与库内存储格式一致：hex 无横线，见 arch_uuid_storage_no_dashes）
+DEPLOY_ID = "4f08f8a1" + "0" * 24  # 32 chars
+TGT_PORTFOLIO_ID = "816f2559" + "a" * 24  # 32 chars
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _wide_terminal(monkeypatch):
+    """rich Console 非 tty 时读 COLUMNS 环境变量定宽。
+    模拟现代宽终端（120+），让 32 字符 UUID 单行完整渲染——这是真实用户体验，
+    不被 CliRunner 默认 80 列的 fold artefact 干扰。"""
+    monkeypatch.setenv("COLUMNS", "200")
+
+
+def _compact(s: str) -> str:
+    """去所有空白——免疫 rich Table 渲染细节，只验数据完整性"""
+    return "".join(s.split())
+
+
+def _mock_svc_with_list():
+    svc = MagicMock()
+    svc.list_deployments.return_value = ServiceResult(
+        success=True,
+        data=[
+            {
+                "deployment_id": DEPLOY_ID,
+                "source_task_id": "bt_task_777",
+                "target_portfolio_id": TGT_PORTFOLIO_ID,
+                "mode": 1,
+                "status": 1,
+                "status_name": "DEPLOYED",
+                "create_at": "2026-07-03 10:00:00",
+            }
+        ],
+    )
+    return svc
+
+
+class TestDeployListFullId:
+    """#4719: list 输出完整 ID，不截断"""
+
+    def test_list_shows_full_deployment_id(self, cli_runner):
+        # RED: 当前代码 d["deployment_id"][:8]+"..." 截断，完整 id 不会出现
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=_mock_svc_with_list(),
+        ):
+            result = cli_runner.invoke(deploy_cli.app, ["list"])
+
+        assert result.exit_code == 0, result.output
+        # 完整 32 字符 deployment_id 出现在输出中（可复制喂给 deploy info）
+        assert DEPLOY_ID in _compact(result.output)
+        # 截断标记不应附着在 deployment_id 列（确保不是 [:8]+"..."）
+        assert DEPLOY_ID[:8] + "..." not in result.output
+
+    def test_list_shows_full_target_portfolio_id(self, cli_runner):
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=_mock_svc_with_list(),
+        ):
+            result = cli_runner.invoke(deploy_cli.app, ["list"])
+
+        assert result.exit_code == 0, result.output
+        assert TGT_PORTFOLIO_ID in _compact(result.output)
+        assert TGT_PORTFOLIO_ID[:8] + "..." not in result.output
+
+    def test_list_id_round_trips_to_info(self, cli_runner):
+        """list 输出的 deployment_id 可直接传给 info（round-trip 契约）"""
+        svc = MagicMock()
+        svc.list_deployments.return_value = _mock_svc_with_list().list_deployments.return_value
+        svc.get_deployment_by_id.return_value = ServiceResult(
+            success=True,
+            data={
+                "deployment_id": DEPLOY_ID,
+                "source_task_id": "bt_task_777",
+                "source_portfolio_id": "src_pid",
+                "target_portfolio_id": TGT_PORTFOLIO_ID,
+                "mode": 1,
+                "account_id": None,
+                "status": 1,
+                "status_name": "DEPLOYED",
+                "create_at": "2026-07-03 10:00:00",
+            },
+        )
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=svc,
+        ):
+            list_result = cli_runner.invoke(deploy_cli.app, ["list"])
+            assert list_result.exit_code == 0, list_result.output
+            # 从 list 输出取完整 deployment_id（出现在 output 即为可复制）
+            assert DEPLOY_ID in _compact(list_result.output)
+
+            info_result = cli_runner.invoke(deploy_cli.app, ["info", DEPLOY_ID])
+            assert info_result.exit_code == 0, info_result.output
+            svc.get_deployment_by_id.assert_called_once_with(DEPLOY_ID)


### PR DESCRIPTION
## Summary

`ginkgo deploy list` 输出的 deployment_id / target_portfolio_id 被截断为 `[:8]+"..."`，用户无法复制完整 UUID 喂给 `deploy info <id>`（#4719）。

**根因有两层截断**：
1. **代码层**：`deploy_cli.py:125,127` 硬编码 `d["deployment_id"][:8]+"..."` 截断 → 已移除
2. **渲染层**（隐蔽）：rich `Table.add_column()` 默认 `overflow="ellipsis"`，即使移除代码截断，32 字符 UUID 仍被 rich 用 `…` 截断显示 → 给 id 列加 `overflow="fold"`，折行完整渲染

## 改动

- `src/ginkgo/client/deploy_cli.py`
  - 移除 `deployment_id` / `target_portfolio_id` 的 `[:8]+"..."` 截断
  - 两个 id 列 `add_column(..., overflow="fold")`
- `tests/unit/client/test_deploy_cli_list.py`（新增）
  - `test_list_shows_full_deployment_id`：完整 deployment_id 出现在输出
  - `test_list_shows_full_target_portfolio_id`：完整 target_portfolio_id 出现
  - `test_list_id_round_trips_to_info`：list 输出的 id 可直接被 info 消费（round-trip 契约）

## Test plan

三层冒烟（对齐 `.github/workflows/ci.yml` #6015）：
- ✅ Layer 1 py_compile：`src/`+`api/` 全量语法通过
- ✅ Layer 2 启动路径点名：`test_user_crud_mock` + `test_containers` + `test_user_cli`（29 passed）
- ✅ Layer 3 变更相关：`test_deploy_cli_list` + `test_deploy_cli_info`（4 passed）

> 注：`tests/unit/client/test_deploy_cli.py::test_info_shows_status_name_not_raw_int` 是 **pre-existing 既有失败**（mock 用旧方法名 `get_deployment_info`，而 info 命令调 `get_deployment_by_id`，方法名漂移致 MagicMock 渲染报错），与本 PR 无关——stash 本 PR 改动后 master 上同样失败。属于另一 issue 范畴。

Closes #4719