### PR TITLE
fix(#4723): init 链路拷贝 task_timer.yml 模板，修 tasktimer validate 缺文件

### DIFF
--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -261,6 +261,20 @@ class GinkgoConfig(object):
         else:
             self._has_local_secure = True  # ✅ 文件已存在
 
+        # 处理 task_timer.yml (#4723)
+        # 与 config.yml/secure.yml 对称：init 链路（GCONF 初始化）幂等拷贝
+        # src/ginkgo/config/task_timer.yml → 目标目录，避免用户首次
+        # `ginkgo tasktimer validate` 因缺文件报 INVALID。已存在则保留用户自定义（不覆盖）。
+        task_timer_path = os.path.join(path, "task_timer.yml")
+        if not os.path.exists(task_timer_path):
+            origin_path = os.path.join(current_path, "src/ginkgo/config/task_timer.yml")
+            if os.path.exists(origin_path):
+                os.makedirs(path, exist_ok=True)
+                shutil.copy(origin_path, task_timer_path)
+                print(f"[GCONF] Copy task_timer.yml from {origin_path} to {task_timer_path}", file=sys.stderr)
+            # 源模板缺失时不阻塞（task_timer.yml 非启动核心依赖，缺失由
+            # TaskTimer._load_config 运行时降级兜底），故不引入 _has_local_task_timer 缓存。
+
     def _read_config(self) -> dict:
         self.generate_config_file()
         # 如果缓存标记为无本地文件，直接返回空字典

--- a/tests/unit/client/test_tasktimer_cli.py
+++ b/tests/unit/client/test_tasktimer_cli.py
@@ -126,3 +126,54 @@ class TestHeartbeatCommand:
         assert "json-node" in result.output
         assert "iso-node" in result.output
         assert "Failed to parse" not in result.output
+
+
+# ============================================================================
+# init 链路拷贝 task_timer.yml — #4723
+#   ginkgo init → GCONF.generate_config_file 未安装 task_timer.yml，
+#   用户首次 tasktimer validate 即报 INVALID。修复：与 config.yml/secure.yml
+#   对称，幂等拷贝 src/ginkgo/config/task_timer.yml → 目标目录。
+# ============================================================================
+
+
+@pytest.fixture
+def isolated_gconf(monkeypatch):
+    """隔离 GCONF 单例状态 + 重定向 GINKGO_DIR 到临时目录，避免污染其他测试"""
+    from ginkgo.libs.core.config import GCONF
+
+    saved = {
+        "_has_local_config": GCONF._has_local_config,
+        "_has_local_secure": GCONF._has_local_secure,
+    }
+    yield GCONF
+    # 恢复单例状态，防 _has_local_* 残留污染后续测试
+    GCONF._has_local_config = saved["_has_local_config"]
+    GCONF._has_local_secure = saved["_has_local_secure"]
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestTaskTimerInitConfig:
+    """ginkgo init 链路（GCONF.generate_config_file）拷贝 task_timer.yml 模板 (#4723)"""
+
+    def test_init_installs_task_timer_template(self, tmp_path, isolated_gconf):
+        """generate_config_file 后目标目录存在 task_timer.yml（从 src 模板拷贝）"""
+        isolated_gconf.generate_config_file(str(tmp_path))
+        installed = tmp_path / "task_timer.yml"
+        assert installed.exists(), "task_timer.yml 未被 init 链路拷贝"
+        assert installed.is_file()
+
+    def test_init_does_not_overwrite_existing_task_timer(self, tmp_path, isolated_gconf):
+        """已存在 task_timer.yml（用户自定义）→ init 链路不覆盖，保留用户配置"""
+        custom = tmp_path / "task_timer.yml"
+        custom.write_text("user-customized: true\n")
+        isolated_gconf.generate_config_file(str(tmp_path))
+        assert custom.read_text() == "user-customized: true\n", "init 覆盖了用户自定义 task_timer.yml"
+
+    def test_installed_task_timer_passes_validate(self, tmp_path, isolated_gconf):
+        """init 拷贝的 task_timer.yml 能通过 TaskTimer.validate_config (#4723 验收2)"""
+        from ginkgo.livecore.task_timer import TaskTimer
+        isolated_gconf.generate_config_file(str(tmp_path))
+        installed = str(tmp_path / "task_timer.yml")
+        timer = TaskTimer(config_path=installed)
+        assert timer.validate_config() is True, "拷贝的模板未通过 validate_config"


### PR DESCRIPTION
## Summary

`ginkgo tasktimer validate` 在 `~/.ginkgo/task_timer.yml` 缺失时报 `Config file not found` → INVALID。根因：`ginkgo init`（经 GCONF 初始化）从未拷贝 task_timer.yml 模板，默认模板 `src/ginkgo/config/task_timer.yml` 存在但无安装链路。

## 修复

在 `GCONF.generate_config_file()`（src/ginkgo/libs/core/config.py）增加 task_timer.yml 拷贝，与既有 config.yml / secure.yml **对称、幂等**：

- 源：`src/ginkgo/config/task_timer.yml`（仓库内已存在，2422B，含 5 个合法 scheduled_tasks）
- 目标：`<GINKGO_DIR>/task_timer.yml`（默认 `~/.ginkgo/task_timer.yml`）
- 已存在则**保留用户自定义不覆盖**
- ginkgo init 触发 GCONF 初始化 → `_read_config` → `generate_config_file`，自动触达

> 注：`validate_config()` 对缺文件严格返回 False 是**有意的**（validate 本职即校验文件，区别于运行时 `_load_config` 缺文件降级用默认）。根因在 init 未安装模板，非 validate 严格性。

## 验收对照（brief #4723）

1. ✅ init 后目标目录存在 task_timer.yml — `test_init_installs_task_timer_template`
2. ✅ 拷贝的模板通过 `TaskTimer.validate_config()` — `test_installed_task_timer_passes_validate`
3. ✅ 单测断言（init 后文件存在 + validate 通过）
4. ✅ `pytest tests/unit/client -k "init or tasktimer"` 绿（18 passed）
5. ✅ 幂等：已存在不覆盖 — `test_init_does_not_overwrite_existing_task_timer`

## Test plan

- [x] `pytest tests/unit/client/test_tasktimer_cli.py` — 10 passed
- [x] `pytest tests/unit/client -k "init or tasktimer"` — 18 passed
- [x] py_compile（src+api 全量）通过
- [x] 启动路径点名 smoke（user_crud_mock / containers / user_cli）— 29 passed
- [x] 端到端：GCONF.generate_config_file(tmp) → task_timer.yml 存在 + validate_config True

Closes #4723