### PR TITLE
fix(#5834): GET /settings/users/{uuid} 补单条详情路由

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -364,6 +364,39 @@ async def create_user(req: Request, data: UserCreate):
         )
 
 
+@router.get("/users/{uuid}")
+async def get_user_detail(req: Request, uuid: str):
+    """获取单个用户详情（basic + contacts + groups 聚合）。
+
+    #5834: 此前仅 list/POST/PUT{uuid}/DELETE{uuid}，缺 GET{uuid} 致 405。
+    service.get_user_full_info 已实现，端点仅装配 + 守卫，与 PUT/{uuid} 一致。
+    """
+    _require_admin(req)  # 与 list_users / update_user 一致（#5467）
+    try:
+        user_service = get_user_service()
+        result = user_service.get_user_full_info(uuid)
+        if not result.success:
+            if "not found" in (result.error or "").lower():
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="User not found",
+                )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to get user detail",
+            )
+        return ok(data=result.data)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting user detail {uuid}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get user detail",
+        )
+
+
 @router.put("/users/{uuid}")
 async def update_user(req: Request, uuid: str, data: UserUpdate):
     """更新用户"""

--- a/tests/api/test_settings_user_detail_5834.py
+++ b/tests/api/test_settings_user_detail_5834.py
@@ -1,0 +1,105 @@
+"""#5834: GET /settings/users/{uuid} 返回 405 Method Not Allowed。
+
+根因：api/api/settings.py 注册了 list/POST/PUT{uuid}/DELETE{uuid}，唯独缺
+GET /users/{uuid} 单条详情路由。Service 层 UserService.get_user_full_info 已实现
+（聚合 basic + contacts + groups）。本测试覆盖端点装配层：
+  - admin 守卫（_require_admin，与 PUT /users/{uuid} 一致）
+  - 调 service.get_user_full_info(uuid)
+  - not found → 404 错误码映射
+
+参考 [[arch_api_test_root_main_shadow]]：端点测试走 from api.settings import 纯函数，
+避开 api/main.py app 启动；sys.path.insert api/ 双层目录约定（同 test_settings_error_sanitization）。
+"""
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from ginkgo.data.services.base_service import ServiceResult
+
+_api_dir = str(Path(__file__).parent.parent.parent / "api")
+if _api_dir not in sys.path:
+    sys.path.insert(0, _api_dir)
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-jwt-security-tests")
+
+from api.settings import get_user_detail  # noqa: E402  端点（待实现）
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def _full_info(uuid_="u-1"):
+    return {
+        "uuid": uuid_,
+        "username": "admin",
+        "display_name": "Admin",
+        "email": "a@t.com",
+        "description": "",
+        "user_type": "ADMIN",
+        "is_active": True,
+        "source": "LOCAL",
+        "create_at": "2025-01-01T00:00:00",
+        "update_at": None,
+        "contacts": [],
+        "groups": [],
+    }
+
+
+class TestGetUserDetail:
+    """GET /settings/users/{uuid} 端点装配（#5834）"""
+
+    def test_returns_full_info_on_success(self):
+        """happy path: admin 请求已存在 uuid → 返 200 + full info dict，service 收到正确 uuid"""
+        mock_service = MagicMock()
+        # _require_admin → _resolve_is_admin → get_credential(is_admin=True)
+        mock_service.get_credential.return_value = MagicMock(is_admin=True)
+        full = _full_info("u-1")
+        mock_service.get_user_full_info.return_value = ServiceResult.success(data=full, message="ok")
+
+        req = MagicMock()
+        req.state.user_uuid = "u-admin"
+
+        with patch("api.settings.get_user_service", return_value=mock_service):
+            result = run_async(get_user_detail(req=req, uuid="u-1"))
+
+        mock_service.get_user_full_info.assert_called_once_with("u-1")
+        assert result["data"] == full
+
+    def test_not_found_returns_404(self):
+        """uuid 不存在 → service 返 error('User not found') → 端点 404"""
+        mock_service = MagicMock()
+        mock_service.get_credential.return_value = MagicMock(is_admin=True)
+        mock_service.get_user_full_info.return_value = ServiceResult.error(
+            "User not found: u-missing", message="User does not exist"
+        )
+
+        req = MagicMock()
+        req.state.user_uuid = "u-admin"
+
+        with patch("api.settings.get_user_service", return_value=mock_service):
+            with pytest.raises(HTTPException) as exc:
+                run_async(get_user_detail(req=req, uuid="u-missing"))
+
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "User not found"
+
+    def test_requires_admin(self):
+        """非 admin 请求 → _require_admin 抛 403，service.get_user_full_info 不被调用"""
+        mock_service = MagicMock()
+        # 当前用户非 admin（fail-closed）
+        mock_service.get_credential.return_value = MagicMock(is_admin=False)
+
+        req = MagicMock()
+        req.state.user_uuid = "u-ordinary"
+
+        with patch("api.settings.get_user_service", return_value=mock_service):
+            with pytest.raises(HTTPException) as exc:
+                run_async(get_user_detail(req=req, uuid="u-1"))
+
+        assert exc.value.status_code == 403
+        mock_service.get_user_full_info.assert_not_called()


### PR DESCRIPTION
## Summary

`GET /api/v1/settings/users/{uuid}` 此前返回 **405 Method Not Allowed**：该路径仅注册了 `PUT` / `DELETE` / `POST reset-password`，缺 `GET` 单条详情路由。Service 层 `UserService.get_user_full_info`（聚合 basic + contacts + groups）早已实现，端点只是漏了路由声明。

## 改动

- `api/api/settings.py`：新增 `@router.get("/users/{uuid}")` → `get_user_detail`，复用 `get_user_full_info`，装配与 `PUT /users/{uuid}` 完全一致：
  - `_require_admin(req)` 守卫（#5467，与 list/update 一致）
  - `except HTTPException: raise` 穿透链（避免被兜底 `except Exception` 吞成 500）
  - service error 含 "not found" → 404；其他失败 → 500

## Test plan

新增 `tests/api/test_settings_user_detail_5834.py`（3 个契约测试）：
- ✅ happy path：admin 请求已存在 uuid → 200 + full info，service 收到正确 uuid
- ✅ uuid 不存在 → 404
- ✅ 非 admin → 403，service 不被调用

本地三层冒烟（对齐 CI #6015）：
- Layer 1 py_compile（src+api）：✅
- Layer 2 启动路径 smoke（user_crud_mock + containers + user_cli，29 tests）：✅
- Layer 3 `tests/api -k user`（43 tests）：✅；`tests/unit -k user` 中 4 个失败为预存在（notify/analyzer 模块，已证伪：无 commit 的主仓库同样失败）

## Closes

Closes #5834
