### PR TITLE
fix(#5830): account 创建返回补 status 字段

### DIFF
--- a/src/ginkgo/data/services/live_account_service.py
+++ b/src/ginkgo/data/services/live_account_service.py
@@ -143,6 +143,7 @@ class LiveAccountService(BaseService):
                 "success": True,
                 "data": {
                     "uuid": account.uuid,
+                    "status": account.status,
                     "validation_result": validation_result
                 },
                 "message": "Live account created successfully"

--- a/tests/unit/data/test_live_account_service_existing.py
+++ b/tests/unit/data/test_live_account_service_existing.py
@@ -54,6 +54,26 @@ class TestLiveAccountServiceCreation:
         assert result["data"]["uuid"] == "test-account-uuid"
         assert result["data"]["validation_result"] is None
 
+    def test_create_account_returns_status_field(self, live_account_service):
+        """create_account 返回的 data 应含非空 status 字段 (#5830)"""
+        # Mock(spec=MLiveAccount) 的 status 默认是 child mock，须显式设真值
+        live_account_service._crud.add_live_account.return_value.status = AccountStatusType.ENABLED
+
+        result = live_account_service.create_account(
+            user_id="test-user-123",
+            exchange=ExchangeType.OKX,
+            name="测试OKX账号",
+            api_key="test-api-key",
+            api_secret="test-api-secret",
+            passphrase="test-passphrase",
+            environment="testnet",
+            auto_validate=False
+        )
+
+        assert result["success"] is True
+        assert "status" in result["data"], "返回 data 应含 status 字段"
+        assert result["data"]["status"] == AccountStatusType.ENABLED
+
     def test_create_account_missing_user_id(self, live_account_service):
         """测试缺少user_id参数"""
         result = live_account_service.create_account(


### PR DESCRIPTION
## Summary

修复 #5830：`POST /api/v1/accounts` 创建成功返回 data 缺 `status` 字段。

**根因**：`LiveAccountService.create_account`（`src/ginkgo/data/services/live_account_service.py:142`）返回的 data dict 仅含 `uuid` + `validation_result`，漏 `status` 键。端点 `ok(data=result["data"])` 直传，故响应 data.status 为空。参考路径 `get_account_by_uuid` 走 `account.to_dict()` 已含 status，仅 create 路径手写 dict 漏字段。

**修复**：service 返回 data dict 补 `"status": account.status`。`AccountStatusType(str)` 继承 str，JSON 序列化为 `"enabled"` 等字符串，安全。

## Test plan

- [x] 新增 `test_create_account_returns_status_field`：mock add_live_account 返回对象显式设 status=ENABLED，断言返回 data 含 status 键且值为 ENABLED
- [x] `pytest tests/unit/data/test_live_account_service_existing.py` 38 passed（含新测试）
- [x] 三层 smoke 全绿：py_compile / 启动路径（user_crud+containers+user_cli 29 passed）/ 变更相关 38 passed
- [ ] reviewer 复核：POST /api/v1/accounts 实跑返回含非空 status（需真 OKX 凭证，留人工）

注：`tests/unit/data/crud/test_live_account_crud_mock.py::test_get_live_account_by_uuid`（KeyError: is_del）与 `tests/api/ -k account` 7 个失败为**既有失败**（stash 改动后 origin/master 代码同样失败，与本次改动无关）。

Closes #5830
