### PR TITLE
test(#6110): deviation 测试 mock 校准 get→get_cache + ServiceResult 形状

### DIFF
--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -17,6 +17,8 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch, call
 import pytest
 
+from ginkgo.data.services.base_service import ServiceResult
+
 
 class TestConstruction:
     """构造和初始化测试"""
@@ -844,10 +846,11 @@ class TestGetBaseline:
     def test_returns_cached_baseline_from_redis(self):
         """Redis 有缓存时应直接返回，不查 ClickHouse"""
         worker = self._make_worker()
-        cached_baseline = {"slice_period_days": 30, "baseline_stats": {"sharpe_ratio": {"mean": 1.5}}}
+        cached_json = '{"slice_period_days": 30}'
 
         mock_redis = MagicMock()
-        mock_redis.get.return_value = '{"slice_period_days": 30}'
+        # 实现层调 redis_svc.get_cache()，返回 ServiceResult（.data 为 JSON 字符串）
+        mock_redis.get_cache.return_value = ServiceResult.success(data=cached_json)
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.redis_service.return_value = mock_redis
@@ -874,7 +877,8 @@ class TestGetBaseline:
         worker = self._make_worker()
 
         mock_redis = MagicMock()
-        mock_redis.get.return_value = None
+        # baseline 与 source 缓存均 miss（get_cache 返回 ServiceResult，.data=None）
+        mock_redis.get_cache.return_value = ServiceResult.success(data=None)
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.redis_service.return_value = mock_redis
@@ -887,7 +891,10 @@ class TestGetBaseline:
         worker = self._make_worker()
 
         mock_redis = MagicMock()
-        mock_redis.get.side_effect = lambda key: "source_uuid" if "source" in key else None
+        # baseline miss、source hit（get_cache 返回 ServiceResult）
+        mock_redis.get_cache.side_effect = lambda key: ServiceResult.success(
+            data="source_uuid" if "source" in key else None
+        )
 
         mock_task_svc = MagicMock()
         mock_task_svc.list.return_value = MagicMock(is_success=True, data=[])
@@ -910,7 +917,8 @@ class TestGetDeviationConfig:
         worker = PaperTradingWorker(worker_id="test-1")
 
         mock_redis = MagicMock()
-        mock_redis.get.return_value = None
+        # 配置缓存 miss（get_cache 返回 ServiceResult，.data=None）→ 返回默认配置
+        mock_redis.get_cache.return_value = ServiceResult.success(data=None)
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.redis_service.return_value = mock_redis
@@ -927,7 +935,10 @@ class TestGetDeviationConfig:
         worker = PaperTradingWorker(worker_id="test-1")
 
         mock_redis = MagicMock()
-        mock_redis.get.return_value = '{"auto_takedown": true, "slice_period_days": 14}'
+        # 实现层调 redis_svc.get_cache()，返回 ServiceResult（.data 为 JSON 字符串）
+        mock_redis.get_cache.return_value = ServiceResult.success(
+            data='{"auto_takedown": true, "slice_period_days": 14}'
+        )
 
         with patch("ginkgo.services", create=True) as mock_services:
             mock_services.data.redis_service.return_value = mock_redis


### PR DESCRIPTION
## Summary

修 #6110：`tests/unit/workers/test_paper_trading_worker.py` 中 `TestGetBaseline::test_returns_cached_baseline_from_redis` 与 `TestGetDeviationConfig::test_returns_config_from_redis` 2 用例失败。

**根因**：实现层 `deviation_checker.py:34/98` 调 `redis_svc.get_cache()` 返回 `ServiceResult`（`.data` / `.is_success()`），测试却 mock 旧 CRUD 层 `mock_redis.get`（错方法），未配 `get_cache` 的 Result 形状 → `json.loads(MagicMock)` 抛 `TypeError` 被实现的 `try/except + GLOG.WARNING` 吞 → 断言拿到默认配置。**生产无 bug**（实现有兜底），仅测试侧缺陷。

**修复**：校准 5 个用例的 mock 接口，**不改生产代码**：
- `mock_redis.get` → `mock_redis.get_cache`
- 返回 `ServiceResult.success(data=<JSON 字符串 | None>)` 匹配实现契约
- 2 个 hit 用例转绿；3 个 miss 用例（原本靠真实 `BacktestEvaluator` 评估失败兜底才"凑巧通过"）同步校准，去除脆弱性

## Test plan

- [x] 两原失败用例转绿
- [x] `pytest tests/unit/workers/test_paper_trading_worker.py -k "deviation or baseline or get_deviation or get_baseline"` → **16 passed**
- [x] Layer 1 py_compile（src/api/tests）全通过
- [x] Layer 2 启动路径 smoke（`test_user_crud_mock` + `test_containers` + `test_user_cli`）→ **29 passed**
- [x] 生产代码无变更（仅 1 个测试文件，17 增 6 删）

Closes #6110