### PR TITLE
fix(#5433): test_print_to_glog 增 AST 语法校验抓坏替换 SyntaxError

### DIFF
--- a/tests/unit/core/test_print_to_glog.py
+++ b/tests/unit/core/test_print_to_glog.py
@@ -1,5 +1,6 @@
 # Structural test: verifies bare print() replaced with GLOG
 # Issue #3871 - print() → GLOG migration
+import ast
 import os
 import re
 import pytest
@@ -57,6 +58,21 @@ def _find_bare_prints(src_dir="src/ginkgo"):
     return results
 
 
+def _check_syntax(path):
+    """Return SyntaxError if ``path`` fails to parse, else None.
+
+    Issue #5433: grep 级检查抓不到 print→GLOG 坏替换引入的语法错误。
+    此 helper 用 ast.parse 兜底，正/反测试共用。
+    """
+    with open(path) as fh:
+        source = fh.read()
+    try:
+        ast.parse(source, filename=path)
+    except SyntaxError as exc:
+        return exc
+    return None
+
+
 class TestBarePrintReplaced:
     """Bare print() should be replaced with GLOG except in allowed files."""
 
@@ -70,4 +86,52 @@ class TestBarePrintReplaced:
         assert len(violations) == 0, (
             f"{len(violations)} bare print() calls should use GLOG:\n"
             + "\n".join(f"  {v}" for v in violations[:30])
+        )
+
+
+class TestReplacedFilesHaveValidSyntax:
+    """print→GLOG 替换后文件必须仍是合法 Python 语法（Issue #5433）。
+
+    grep 级检查只能确认 ``print(`` 消失，无法发现替换引入的 SyntaxError
+    （历史 commit 5a69aadf 把 ``def print(string):`` 误替换为
+    ``GLOG.INFO(string):)`` 多冒号，8 个测试全绿）。这里用 ast.parse 兜底。
+    """
+
+    def test_syntax_check_catches_injected_syntaxerror(self, tmp_path):
+        """反向：注入坏替换产生的 SyntaxError，helper 必须检出。
+
+        样本复刻 issue 真实坏替换 ``GLOG.INFO(...):)``（多余右括号/冒号）。
+        helper 返回 SyntaxError 实例 → 非 None；证明校验非空转。
+        """
+        bad = tmp_path / "bad_replace.py"
+        bad.write_text('GLOG.INFO("colon"):)\n')  # 多余 ): 致 SyntaxError
+        result = _check_syntax(str(bad))
+        assert result is not None, "注入 SyntaxError 的文件应被检出"
+        assert isinstance(result, SyntaxError)
+
+    def test_scanned_source_files_parse_cleanly(self):
+        """正向：所有被 print→GLOG 迁移覆盖的源文件必须 ast.parse 通过。
+
+        扫描范围与 ``_find_bare_prints`` 一致（src/ginkgo 下 *.py，排除
+        client/ 与 __pycache__）。任一文件 SyntaxError 立即失败，并报文件
+        名+行号，定位到坏替换。
+        """
+        src_dir = "src/ginkgo"
+        broken = []
+        for root, dirs, files in os.walk(src_dir):
+            if "__pycache__" in root or ".ipynb_checkpoints" in root:
+                continue
+            for f in files:
+                if not f.endswith(".py"):
+                    continue
+                path = os.path.join(root, f)
+                rel = path.replace(src_dir + "/", "")
+                if rel.startswith("client/"):
+                    continue
+                exc = _check_syntax(path)
+                if exc is not None:
+                    broken.append(f"{rel}:{exc.lineno}  {exc.msg}")
+        assert broken == [], (
+            f"{len(broken)} 个源文件含 SyntaxError（疑似迁移坏替换）：\n"
+            + "\n".join(f"  {b}" for b in broken[:30])
         )


### PR DESCRIPTION
## Summary

修复 #5433：`test_print_to_glog` 仅 grep 级检查 `print(` 消失，无法发现 print→GLOG 坏替换引入的 SyntaxError（历史 commit 5a69aadf 把 `def print(string):` 误替换为 `GLOG.INFO(string):)` 多冒号，8 个测试全绿漏检）。

新增 `_check_syntax(path)` helper（`ast.parse` 兜底），并补两个测试：

- **反向** `test_syntax_check_catches_injected_syntaxerror`：注入 issue 真实坏替换 `GLOG.INFO("colon"):)`，断言 helper 检出 SyntaxError —— 证明校验非空转。
- **正向** `test_scanned_source_files_parse_cleanly`：对 `src/ginkgo` 全扫描范围（与 `_find_bare_prints` 同 scope）逐文件 `ast.parse`，SyntaxError 立即报文件名+行号，定位到坏替换。

## 范围说明

纯测试增强，无生产代码变更。仅 `tests/unit/core/test_print_to_glog.py`。

## ⚠️ 预存失败（非本 PR 引入，超范围）

`test_bare_print_replaced_with_glog` 在 master 上**已失败**（14 处违规：`config.py` 启动诊断 `print(...,file=sys.stderr)` 未加白名单 + `notification_worker.py` doctest `>>> print(...)` 未跳过）。验证：`git stash` 本 PR 改动后该测试仍失败 —— 与本 PR 正交，属 bare-print 迁移（#3871/#3868 范畴），不在 #5433（语法校验）范围内。本 PR 的 2 个新测试独立通过。

## Test plan

- [x] `pytest tests/unit/core/test_print_to_glog.py::TestReplacedFilesHaveValidSyntax` —— 2 新测试绿
- [x] Layer 1 py_compile（src+api）通过
- [x] Layer 2 启动 smoke（test_user_crud_mock + test_containers + test_user_cli，29 测试）全绿
- [x] 反向测试注入 SyntaxError 被检出（acceptance #2）
- [x] `ast.parse` 校验落地（acceptance #1）

Closes #5433