### PR TITLE
fix(#5659): 新增 file 适配路由对接前端 file.ts 5 端点

### DIFF
--- a/api/api/file.py
+++ b/api/api/file.py
@@ -1,0 +1,201 @@
+"""文件管理 flat 适配路由 (#5659)
+
+前端 web-ui/src/api/modules/file.ts 调用的 /api/v1/file_list、/api/v1/file、
+/api/v1/update_file、/api/v1/file/{id} 等 flat 端点在后端无对应路由（全 404）。
+FileService 能力完整，但只通过 /components（组件视角）、
+/node-graphs/{uuid}/files（portfolio 绑定视角）暴露。本 router 提供面向
+"全局文件管理"语义的 flat 适配端点，薄委托 FileService 既有方法，不改 service 核心。
+"""
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel
+from typing import Optional
+
+from ginkgo.data.containers import container
+from ginkgo.enums import FILE_TYPES
+from core.logging import logger
+from core.response import ok, paginated
+
+router = APIRouter()
+
+
+def get_file_service():
+    """获取 FileService 实例（与 components.py 同源容器注入）"""
+    return container.file_service()
+
+
+@router.get("/file_list")
+async def list_files(
+    query: str = "",
+    page: int = Query(1, ge=1),
+    size: int = Query(100, ge=1, le=500),
+    type: Optional[int] = None,
+):
+    """获取文件列表（flat 适配路由，薄委托 FileService.list_components）
+
+    与 GET /api/v1/components 等价，提供前端 file.ts 期望的 flat 命名。
+    page 为 1-based（前端约定），下推 service 时转 0-based。
+    """
+    try:
+        file_service = get_file_service()
+        file_types = [FILE_TYPES.from_int(type)] if type is not None else None
+        result = file_service.list_components(
+            file_types=file_types,
+            keyword=query or None,
+            is_del=False,
+            page=page - 1,
+            page_size=size,
+        )
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=result.message or "Failed to list files",
+            )
+        result_data = result.data or {}
+        items = result_data.get("data", [])
+        total = result_data.get("total", 0)
+        return paginated(items=items, total=total, page=page, page_size=size)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error listing files: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list files",
+        )
+
+
+class FileCreate(BaseModel):
+    """前端 file.ts create(name, type, content) 的请求体"""
+
+    name: str
+    type: int
+    content: str = ""
+
+
+class FileUpdate(BaseModel):
+    """前端 file.ts update(file_id, content) 的请求体"""
+
+    file_id: str
+    content: str
+
+
+@router.get("/file/{file_id}")
+async def get_file(file_id: str):
+    """获取单个文件（flat 适配路由，薄委托 FileService.get_by_uuid）"""
+    try:
+        file_service = get_file_service()
+        result = file_service.get_by_uuid(file_id)
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=result.message or "Failed to get file",
+            )
+        data = result.data or {}
+        if not data.get("exists"):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"File not found: {file_id}",
+            )
+        return ok(data=data.get("file"))
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error getting file {file_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get file",
+        )
+
+
+@router.post("/file", status_code=status.HTTP_201_CREATED)
+async def create_file(data: FileCreate):
+    """创建文件（flat 适配路由，薄委托 FileService.add）
+
+    从 FileService.add 返回的 {"file_info": {"uuid": ...}} 嵌套结构提取 uuid
+    （#5885 同款陷阱：直接 result.data.get("uuid") 取到 None）。
+    """
+    try:
+        file_service = get_file_service()
+        file_type = FILE_TYPES.from_int(data.type)
+        result = file_service.add(
+            name=data.name,
+            file_type=file_type,
+            data=data.content.encode("utf-8") if data.content else b"",
+        )
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=result.message or "Failed to create file",
+            )
+        file_info = (result.data or {}).get("file_info") or {}
+        uuid = file_info.get("uuid")
+        if not uuid:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to get created file UUID",
+            )
+        return ok(data={"uuid": uuid, "name": data.name}, message="File created")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error creating file: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create file",
+        )
+
+
+@router.post("/update_file")
+async def update_file(data: FileUpdate):
+    """更新文件内容（flat 适配路由，薄委托 FileService.update）
+
+    content 字符串编码为 bytes 下推（FileService.update.data 参数要求 bytes）。
+    """
+    try:
+        file_service = get_file_service()
+        exists = file_service.get_by_uuid(data.file_id)
+        if not (exists.is_success() and (exists.data or {}).get("exists")):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"File not found: {data.file_id}",
+            )
+        result = file_service.update(
+            file_id=data.file_id,
+            data=data.content.encode("utf-8") if data.content else b"",
+        )
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=result.message or "Failed to update file",
+            )
+        return ok(message="File updated")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating file {data.file_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to update file",
+        )
+
+
+@router.delete("/file/{file_id}")
+async def delete_file(file_id: str):
+    """删除文件（flat 适配路由，薄委托 FileService.soft_delete）"""
+    try:
+        file_service = get_file_service()
+        result = file_service.soft_delete(file_id)
+        if not result.is_success():
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=result.message or "Failed to delete file",
+            )
+        return ok(message="File deleted")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error deleting file {file_id}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete file",
+        )

--- a/api/api/file.py
+++ b/api/api/file.py
@@ -23,6 +23,29 @@ def get_file_service():
     return container.file_service()
 
 
+def _file_to_dict(file_record):
+    """ORM MFile → JSON 可序列化 dict（#5659 review 修复）
+
+    FileService.list_components/get_by_uuid 返 MFile ORM 实例（ADR-010: file_crud
+    hook 为 identity，直接返 ORM 不转 entity）。早期实现把 ORM 对象直接塞进
+    paginated()/ok()，端到端必 `TypeError: MFile not JSON serializable`。
+    参照同目录 components.py:137-158 的转换模式：datetime 调 isoformat()。
+    """
+    if file_record is None:
+        return None
+    created_at = file_record.create_at if hasattr(file_record, "create_at") else None
+    updated_at = file_record.update_at if hasattr(file_record, "update_at") else None
+    is_del = file_record.is_del if hasattr(file_record, "is_del") else False
+    return {
+        "uuid": file_record.uuid,
+        "name": file_record.name,
+        "type": file_record.type if hasattr(file_record, "type") else 0,
+        "created_at": created_at.isoformat() if created_at else None,
+        "updated_at": updated_at.isoformat() if updated_at else None,
+        "is_active": not is_del,
+    }
+
+
 @router.get("/file_list")
 async def list_files(
     query: str = "",
@@ -51,7 +74,8 @@ async def list_files(
                 detail=result.message or "Failed to list files",
             )
         result_data = result.data or {}
-        items = result_data.get("data", [])
+        # ORM MFile → dict（service 返 ModelList，直接塞 paginated 会序列化崩）
+        items = [_file_to_dict(f) for f in result_data.get("data", [])]
         total = result_data.get("total", 0)
         return paginated(items=items, total=total, page=page, page_size=size)
     except HTTPException:
@@ -96,7 +120,8 @@ async def get_file(file_id: str):
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"File not found: {file_id}",
             )
-        return ok(data=data.get("file"))
+        # ORM MFile → dict（service 返 ORM 单对象，直接塞 ok 会序列化崩）
+        return ok(data=_file_to_dict(data.get("file")))
     except HTTPException:
         raise
     except Exception as e:

--- a/api/main.py
+++ b/api/main.py
@@ -126,6 +126,7 @@ async def health_check_api():
 
 # 路由注册 - 统一使用 /api/v1 前缀
 from api import auth, dashboard, portfolio, backtest, components, data, arena, node_graph, accounts, trading, validation, deployment
+from api import file as file_router  # #5659: 文件管理 flat 适配路由（薄委托 FileService）
 from api import signals as signal_router
 from api import settings as settings_router
 from api import system as system_router
@@ -136,6 +137,8 @@ app.include_router(dashboard.router, prefix=f"{API_PREFIX}/dashboards", tags=["d
 app.include_router(portfolio.router, prefix=f"{API_PREFIX}/portfolios", tags=["portfolio"])
 app.include_router(backtest.router, prefix=f"{API_PREFIX}/backtests", tags=["backtest"])
 app.include_router(components.router, prefix=f"{API_PREFIX}/components", tags=["components"])
+# #5659: file 适配路由 flat 挂载在 /api/v1 下（/file_list、/file、/update_file、/file/{id}）
+app.include_router(file_router.router, prefix=API_PREFIX, tags=["files"])
 app.include_router(data.router, prefix=f"{API_PREFIX}/data", tags=["data"])
 app.include_router(arena.router, prefix=f"{API_PREFIX}/arena", tags=["arena"])
 app.include_router(settings_router.router, prefix=f"{API_PREFIX}/settings", tags=["settings"])

--- a/tests/api/test_file_router.py
+++ b/tests/api/test_file_router.py
@@ -1,0 +1,176 @@
+# #5659 — file.ts 前端文件管理 5 端点全 404，后端缺 flat 适配路由
+# Upstream: api.api.file (新建适配层 router)
+# Downstream: FileService.list_components / get_by_uuid / add / update / soft_delete
+# Role: 验证 /api/v1/file_list、/api/v1/file/{id}、/api/v1/file、/api/v1/update_file
+#       五个 flat 适配路由薄委托 FileService，对接前端 file.ts 语义
+
+"""
+文件管理 flat 适配路由测试
+
+后端 FileService 能力完整但只通过 /components、/node-graphs/{uuid}/files 暴露；
+前端 web-ui/src/api/modules/file.ts 调的 /api/v1/file_list 等 flat 端点无对应路由（全 404）。
+本测试验证新建的 api.file router 提供 5 个 flat 端点，薄委托 FileService 既有方法。
+"""
+
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from fastapi import HTTPException
+from ginkgo.enums import FILE_TYPES
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def make_mock_result(data=None, success=True, message="ok"):
+    result = MagicMock()
+    result.is_success.return_value = success
+    result.data = data
+    result.message = message
+    return result
+
+
+class TestListFiles:
+    """GET /api/v1/file_list — 薄委托 FileService.list_components"""
+
+    def test_delegates_to_list_components_with_pagination(self):
+        """list_files 应将 page(1-based)→page(0-based) 下推，size 下推，返回 paginated。"""
+        mock_service = MagicMock()
+        mock_service.list_components.return_value = make_mock_result(
+            data={"data": [{"uuid": "f1", "name": "s.py"}], "total": 1}
+        )
+
+        from api.file import list_files
+
+        with patch("api.file.get_file_service", return_value=mock_service):
+            resp = run_async(list_files(query="", page=1, size=100, type=None))
+
+        mock_service.list_components.assert_called_once()
+        _, kwargs = mock_service.list_components.call_args
+        assert kwargs["page"] == 0          # 1-based → 0-based
+        assert kwargs["page_size"] == 100
+        assert kwargs["is_del"] is False
+        assert resp["meta"]["total"] == 1
+        assert resp["data"][0]["uuid"] == "f1"
+
+    def test_passes_keyword_when_query_nonempty(self):
+        """非空 query 应作为 keyword 下推到 service。"""
+        mock_service = MagicMock()
+        mock_service.list_components.return_value = make_mock_result(
+            data={"data": [], "total": 0}
+        )
+
+        from api.file import list_files
+
+        with patch("api.file.get_file_service", return_value=mock_service):
+            run_async(list_files(query="momentum", page=1, size=50, type=None))
+
+        _, kwargs = mock_service.list_components.call_args
+        assert kwargs["keyword"] == "momentum"
+
+
+class TestGetFile:
+    """GET /api/v1/file/{file_id} — 薄委托 FileService.get_by_uuid"""
+
+    def test_delegates_to_get_by_uuid(self):
+        mock = MagicMock()
+        mock.get_by_uuid.return_value = make_mock_result(
+            data={"file": {"uuid": "f1", "name": "s.py"}, "exists": True}
+        )
+
+        from api.file import get_file
+
+        with patch("api.file.get_file_service", return_value=mock):
+            resp = run_async(get_file("f1"))
+
+        mock.get_by_uuid.assert_called_once_with("f1")
+        assert resp["data"]["uuid"] == "f1"
+
+    def test_404_when_not_exists(self):
+        mock = MagicMock()
+        mock.get_by_uuid.return_value = make_mock_result(
+            data={"file": None, "exists": False}
+        )
+
+        from api.file import get_file
+
+        with patch("api.file.get_file_service", return_value=mock):
+            with pytest.raises(HTTPException) as exc:
+                run_async(get_file("missing"))
+
+        assert exc.value.status_code == 404
+
+
+class TestCreateFile:
+    """POST /api/v1/file — 薄委托 FileService.add，提取 file_info.uuid"""
+
+    def test_delegates_to_add_and_returns_uuid(self):
+        mock = MagicMock()
+        mock.add.return_value = make_mock_result(
+            data={"file_info": {"uuid": "new-uuid", "name": "s.py"}}
+        )
+
+        from api.file import create_file, FileCreate
+
+        body = FileCreate(name="s.py", type=6, content="print(1)")
+        with patch("api.file.get_file_service", return_value=mock):
+            resp = run_async(create_file(body))
+
+        mock.add.assert_called_once()
+        _, kwargs = mock.add.call_args
+        assert kwargs["name"] == "s.py"
+        assert kwargs["file_type"] == FILE_TYPES.STRATEGY
+        assert kwargs["data"] == b"print(1)"
+        assert resp["data"]["uuid"] == "new-uuid"
+
+
+class TestUpdateFile:
+    """POST /api/v1/update_file — 薄委托 FileService.update，content 编码为 bytes"""
+
+    def test_delegates_to_update_with_encoded_content(self):
+        mock = MagicMock()
+        mock.get_by_uuid.return_value = make_mock_result(
+            data={"file": {"uuid": "f1"}, "exists": True}
+        )
+        mock.update.return_value = make_mock_result()
+
+        from api.file import update_file, FileUpdate
+
+        body = FileUpdate(file_id="f1", content="new code")
+        with patch("api.file.get_file_service", return_value=mock):
+            resp = run_async(update_file(body))
+
+        mock.update.assert_called_once_with(file_id="f1", data=b"new code")
+
+    def test_404_when_file_not_exists(self):
+        mock = MagicMock()
+        mock.get_by_uuid.return_value = make_mock_result(
+            data={"file": None, "exists": False}
+        )
+
+        from api.file import update_file, FileUpdate
+
+        body = FileUpdate(file_id="missing", content="x")
+        with patch("api.file.get_file_service", return_value=mock):
+            with pytest.raises(HTTPException) as exc:
+                run_async(update_file(body))
+
+        assert exc.value.status_code == 404
+        mock.update.assert_not_called()
+
+
+class TestDeleteFile:
+    """DELETE /api/v1/file/{file_id} — 薄委托 FileService.soft_delete"""
+
+    def test_delegates_to_soft_delete(self):
+        mock = MagicMock()
+        mock.soft_delete.return_value = make_mock_result()
+
+        from api.file import delete_file
+
+        with patch("api.file.get_file_service", return_value=mock):
+            resp = run_async(delete_file("f1"))
+
+        mock.soft_delete.assert_called_once_with("f1")

--- a/tests/api/test_file_router.py
+++ b/tests/api/test_file_router.py
@@ -32,14 +32,36 @@ def make_mock_result(data=None, success=True, message="ok"):
     return result
 
 
+def make_mock_file(uuid="f1", name="s.py", file_type=6, is_del=False):
+    """构造 ORM-like MFile 对象（#5659 review 修复）
+
+    FileService.list_components/get_by_uuid 返真实 MFile ORM 实例（ADR-010: file_crud
+    hook 为 identity）。早期测试用 dict mock 绕过了 ORM 路径，掩盖了端点缺 ORM→dict
+    转换层的 bug（端到端 TypeError: MFile not JSON serializable）。本 helper 用
+    MagicMock 设 ORM 属性，精确还原 service 真实返回形状。
+    """
+    import datetime
+    f = MagicMock()
+    f.uuid = uuid
+    f.name = name
+    f.type = file_type
+    f.is_del = is_del
+    f.create_at = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    f.update_at = datetime.datetime(2026, 1, 2, 12, 0, 0)
+    return f
+
+
 class TestListFiles:
     """GET /api/v1/file_list — 薄委托 FileService.list_components"""
 
     def test_delegates_to_list_components_with_pagination(self):
-        """list_files 应将 page(1-based)→page(0-based) 下推，size 下推，返回 paginated。"""
+        """list_files 应将 page(1-based)→page(0-based) 下推，size 下推，返回 paginated。
+
+        service 返 MFile ORM 列表（非 dict），端点必须转 dict + isoformat() 才能序列化。
+        """
         mock_service = MagicMock()
         mock_service.list_components.return_value = make_mock_result(
-            data={"data": [{"uuid": "f1", "name": "s.py"}], "total": 1}
+            data={"data": [make_mock_file(uuid="f1", name="s.py")], "total": 1}
         )
 
         from api.file import list_files
@@ -53,7 +75,14 @@ class TestListFiles:
         assert kwargs["page_size"] == 100
         assert kwargs["is_del"] is False
         assert resp["meta"]["total"] == 1
-        assert resp["data"][0]["uuid"] == "f1"
+        # ORM→dict 转换层产出可 JSON 序列化的 dict（非 MagicMock）
+        item = resp["data"][0]
+        assert isinstance(item, dict)
+        assert item["uuid"] == "f1"
+        assert item["name"] == "s.py"
+        # datetime 必须 isoformat() 否则端到端序列化崩
+        assert item["created_at"] == "2026-01-01T12:00:00"
+        assert item["updated_at"] == "2026-01-02T12:00:00"
 
     def test_passes_keyword_when_query_nonempty(self):
         """非空 query 应作为 keyword 下推到 service。"""
@@ -75,9 +104,10 @@ class TestGetFile:
     """GET /api/v1/file/{file_id} — 薄委托 FileService.get_by_uuid"""
 
     def test_delegates_to_get_by_uuid(self):
+        """service 返 MFile ORM 单对象（非 dict），端点必须转 dict + isoformat()。"""
         mock = MagicMock()
         mock.get_by_uuid.return_value = make_mock_result(
-            data={"file": {"uuid": "f1", "name": "s.py"}, "exists": True}
+            data={"file": make_mock_file(uuid="f1", name="s.py"), "exists": True}
         )
 
         from api.file import get_file
@@ -86,7 +116,11 @@ class TestGetFile:
             resp = run_async(get_file("f1"))
 
         mock.get_by_uuid.assert_called_once_with("f1")
-        assert resp["data"]["uuid"] == "f1"
+        data = resp["data"]
+        assert isinstance(data, dict)
+        assert data["uuid"] == "f1"
+        assert data["name"] == "s.py"
+        assert data["created_at"] == "2026-01-01T12:00:00"
 
     def test_404_when_not_exists(self):
         mock = MagicMock()

--- a/web-ui/src/api/modules/file.ts
+++ b/web-ui/src/api/modules/file.ts
@@ -12,25 +12,28 @@ export interface FileItem {
 export const fileApi = {
   /**
    * 获取文件列表
+   * 后端 GET /api/v1/file_list → { code, data: FileItem[], meta: { total, ... } }
+   * request 拦截器已 return response.data（HTTP body），故 res 即 { code, data, meta }。
    */
   async list(query: string = '', page: number = 1, size: number = 100, type?: number): Promise<FileItem[]> {
     const res = await request.get<FileItem[]>('/api/v1/file_list', {
       params: { query, page, size, type }
     })
-    // request 拦截器已经返回 response.data，所以 res 就是数据
-    return (res as any) || []
+    return (res as any)?.data || []
   },
 
   /**
    * 获取单个文件
+   * 后端 GET /api/v1/file/{id} → { code, data: FileItem }
    */
   async get(fileId: string): Promise<FileItem> {
-    const res = await request.get<FileItem>(`/v1/file/${fileId}`)
-    return res as any
+    const res = await request.get<FileItem>(`/api/v1/file/${fileId}`)
+    return (res as any)?.data
   },
 
   /**
    * 创建文件
+   * 后端 POST /api/v1/file { name, type, content } → { code, data: { uuid, name } }
    */
   async create(name: string, type: number, content: string = ''): Promise<{ status: string; uuid: string; name: string }> {
     const res = await request.post('/api/v1/file', {
@@ -38,25 +41,28 @@ export const fileApi = {
       type,
       content
     })
-    return res as any
+    const data = (res as any)?.data || {}
+    return { status: 'success', uuid: data.uuid, name: data.name }
   },
 
   /**
    * 更新文件内容
+   * 后端 POST /api/v1/update_file { file_id, content } → { code, message }
    */
   async update(fileId: string, content: string): Promise<{ status: string }> {
-    const res = await request.post('/api/v1/update_file', {
+    await request.post('/api/v1/update_file', {
       file_id: fileId,
       content
     })
-    return res as any
+    return { status: 'success' }
   },
 
   /**
    * 删除文件
+   * 后端 DELETE /api/v1/file/{id} → { code, message }
    */
   async delete(fileId: string): Promise<{ status: string }> {
-    const res = await request.delete(`/v1/file/${fileId}`)
-    return res as any
+    await request.delete(`/api/v1/file/${fileId}`)
+    return { status: 'success' }
   }
 }


### PR DESCRIPTION
## Summary

修复 #5659：前端 `web-ui/src/api/modules/file.ts` 调用的 5 个文件管理端点（`/api/v1/file_list`、`/api/v1/file/{id}`、`/api/v1/file`、`/api/v1/update_file`、`DELETE /api/v1/file/{id}`）后端无对应路由，全 404。

**根因**：后端 `FileService` 能力完整（add/update/soft_delete/get_by_uuid/list_components），但只通过 `/components`（组件视角）、`/node-graphs/{uuid}/files`（portfolio 绑定视角）暴露，缺面向"全局文件管理"语义的 flat 适配路由。另外 file.ts 的 get/delete 还漏了 `/api` 前缀。

**改动**：
- 新增 `api/api/file.py`：5 个 flat 适配路由，薄委托 FileService 既有方法（不新增 service 逻辑、不改 node_graph 核心）
- `api/main.py`：挂载 file router（`prefix=/api/v1`，flat 命名）
- `web-ui/src/api/modules/file.ts`：补 get/delete 的 `/api` 前缀；修正字段提取（request 拦截器返回 ok() 整体，原 list 误以为返数组）

## ⚠️ 范围说明（诚实）

前端组件 `CodeEditor.vue:49` / `ComponentList.vue:115` 当前用的是**本地 mock stub**（注释"简化的API，实际项目中需要导入真实的API"），并未 import `file.ts` 的 fileApi——即 **file.ts 当前无消费方**。本 PR：
- ✅ 让后端 5 个 flat 端点就位（消除 404，round-trip 可用）
- ✅ 让 file.ts 逻辑正确（路径 + 字段对齐后端契约），未来组件 import 即可用
- ⏳ 前端组件从 mock 切到真实 fileApi 是**后续工作**（涉及 UI 交互调整，超出 brief "file 路由对接" 范围）

## Test plan

- [x] `tests/api/test_file_router.py`：5 端点薄委托契约（list 委托+分页转换、get 404、create uuid 提取、update content 编码+404、delete 委托）— 8 passed
- [x] Layer 1 py_compile：src api 全量语法 OK
- [x] Layer 2 启动路径冒烟：test_user_crud_mock + test_containers + test_user_cli — 29 passed（确认 main.py 挂载不破坏启动）
- [x] Layer 3 变更相关 + components 回归：test_file_router + test_components_pagination + test_components_create_uuid — 13 passed（无回归）

Closes #5659
