### PR TITLE
fix(#5714): OpenAPI 注入 Bearer securityScheme，受保护端点标注 auth

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -158,6 +158,18 @@ app.add_websocket_route("/ws/portfolio", portfolio_handler.websocket_endpoint)
 app.add_websocket_route("/ws/system", system_handler.websocket_endpoint)
 
 
+# 自定义 OpenAPI schema：注入 Bearer JWT securityScheme（#5714）
+# 鉴权仍由 JWTAuthMiddleware 运行时负责，此处只补 spec 契约
+from openapi_schema import build_openapi_schema
+
+
+def custom_openapi():
+    return build_openapi_schema(app)
+
+
+app.openapi = custom_openapi
+
+
 if __name__ == "__main__":
     import uvicorn
 

--- a/api/openapi_schema.py
+++ b/api/openapi_schema.py
@@ -1,0 +1,54 @@
+"""
+自定义 OpenAPI schema 生成 — #5714
+
+为 FastAPI app 注入 Bearer JWT securityScheme，受保护端点显式标注 security。
+
+背景：鉴权由 JWTAuthMiddleware（BaseHTTPMiddleware）实现，对 FastAPI 的 schema
+生成器不可见（get_openapi 只扫描路由 Depends/Security，不扫描 add_middleware）。
+故此处集中补全 spec 的 auth 契约，运行时鉴权行为仍由中间件负责，二者复用
+同一份 PUBLIC_PATHS 真相源避免漂移。
+"""
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+
+from middleware.auth import JWTAuthMiddleware
+
+BEARER_SCHEME_NAME = "bearerAuth"
+
+
+def build_openapi_schema(app: FastAPI) -> dict:
+    """构造含 securitySchemes 的 OpenAPI schema。
+
+    - 注入 bearerAuth (http/bearer/JWT)
+    - 受保护端点（path 不在 JWTAuthMiddleware.PUBLIC_PATHS）标注 security
+    - public 端点不标注（Swagger UI 显示为无需认证）
+    - 结果缓存于 app.openapi_schema（FastAPI 惯例，重复调用返回同一对象）
+    """
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    schema = get_openapi(
+        title=app.title,
+        version=app.version,
+        openapi_version=app.openapi_version,
+        description=app.description,
+        routes=app.routes,
+    )
+
+    schema.setdefault("components", {}).setdefault("securitySchemes", {})[BEARER_SCHEME_NAME] = {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+    }
+
+    public_paths = JWTAuthMiddleware.PUBLIC_PATHS
+    for path, methods in schema.get("paths", {}).items():
+        for _method, op in methods.items():
+            if not isinstance(op, dict):
+                continue
+            if path in public_paths:
+                continue
+            op["security"] = [{BEARER_SCHEME_NAME: []}]
+
+    app.openapi_schema = schema
+    return schema

--- a/tests/api/test_openapi_security_scheme.py
+++ b/tests/api/test_openapi_security_scheme.py
@@ -1,0 +1,81 @@
+# Issue: #5714
+# Upstream: api.openapi_schema, api.middleware.auth
+# Downstream: pytest
+# Role: OpenAPI spec securitySchemes 行为测试
+
+"""
+OpenAPI spec securitySchemes 测试 — #5714
+
+验证 build_openapi_schema 为 FastAPI app 注入 Bearer JWT securityScheme，
+受保护端点显式标注 security，public 端点（JWTAuthMiddleware.PUBLIC_PATHS）
+不标注。鉴权仍由中间件运行时负责，此处只补 spec 契约。
+"""
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def _make_app_with_routes():
+    """构造最小 FastAPI app（含 public + protected 路由），避免触发 containers。"""
+    from fastapi import FastAPI
+
+    app = FastAPI(title="test", version="0.0.1")
+
+    @app.get("/health")
+    def health():
+        return {"ok": 1}
+
+    @app.get("/api/v1/auth/login")
+    def login():
+        return {}
+
+    @app.get("/api/v1/portfolios")
+    def list_portfolios():
+        return []
+
+    return app
+
+
+def test_security_schemes_defines_bearer_jwt(api_modules):
+    """securitySchemes 含 bearerAuth: http/bearer/JWT。"""
+    from openapi_schema import build_openapi_schema
+
+    app = _make_app_with_routes()
+    schema = build_openapi_schema(app)
+    schemes = schema["components"]["securitySchemes"]
+    assert "bearerAuth" in schemes
+    bearer = schemes["bearerAuth"]
+    assert bearer["type"] == "http"
+    assert bearer["scheme"] == "bearer"
+    assert bearer["bearerFormat"] == "JWT"
+
+
+def test_protected_endpoint_has_bearer_security(api_modules):
+    """受保护端点标注 security: [{bearerAuth: []}]。"""
+    from openapi_schema import build_openapi_schema
+
+    app = _make_app_with_routes()
+    schema = build_openapi_schema(app)
+    op = schema["paths"]["/api/v1/portfolios"]["get"]
+    assert op.get("security") == [{"bearerAuth": []}]
+
+
+def test_public_endpoints_have_no_security(api_modules):
+    """public 端点（PUBLIC_PATHS）不标注 security。"""
+    from openapi_schema import build_openapi_schema
+
+    app = _make_app_with_routes()
+    schema = build_openapi_schema(app)
+    for public_path in ("/health", "/api/v1/auth/login"):
+        op = schema["paths"][public_path]["get"]
+        assert "security" not in op, f"{public_path} 应为 public 不带 security"
+
+
+def test_schema_cached_on_app(api_modules):
+    """重复调用复用缓存（FastAPI openapi_schema 惯例）。"""
+    from openapi_schema import build_openapi_schema
+
+    app = _make_app_with_routes()
+    s1 = build_openapi_schema(app)
+    s2 = build_openapi_schema(app)
+    assert s1 is s2


### PR DESCRIPTION
## Summary

`/openapi.json` 缺 securitySchemes，128 端点零 auth 标注。根因：鉴权由 `JWTAuthMiddleware`（BaseHTTPMiddleware）实现，对 FastAPI schema 生成器不可见（`get_openapi` 只扫描路由 `Depends`/`Security`，不扫描 `add_middleware`）。

修复（集中改动，运行时零风险）：
- 新增 `api/openapi_schema.py`：`build_openapi_schema(app)` 注入 `bearerAuth` (http/bearer/JWT) securityScheme，给受保护端点标注 `security`，public 端点（复用 `JWTAuthMiddleware.PUBLIC_PATHS` 单一真相源）不标注
- `api/main.py`：`app.openapi = custom_openapi` 接入（接线，逻辑全在被测模块）
- 不改任何 router 与中间件，运行时鉴权行为完全不变

## Test plan

- [x] `tests/api/test_openapi_security_scheme.py` 4 用例（securitySchemes 定义 / 受保护端点标注 / public 端点无标注 / 缓存）
- [x] Layer 1 py_compile (src api) 通过
- [x] Layer 2 启动路径 smoke（user_crud / containers / user_cli）29 passed
- [ ] 部署后 `GET /openapi.json` 校验 `components.securitySchemes.bearerAuth` 存在、Swagger UI 端点显锁标志（review 侧验证）

Closes #5714
