### PR TITLE
fix(#5280): data get stockinfo 非 TTY 跳过交互分页阻塞

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -177,8 +177,9 @@ def get(
                 # 按code排序
                 formatted_df = formatted_df.sort_values('code')
 
-                # 如果设置了page_size，使用交互式翻页
-                if page_size and page_size > 0:
+                # 交互式翻页仅在 TTY 下启用；非 TTY（CI/脚本/管道）退化为 limit 输出（#5280）
+                import sys
+                if page_size and page_size > 0 and sys.stdin.isatty():
                     console.print(f":information: Interactive mode enabled (page size: {page_size})")
                     console.print(":information: Single-key navigation: n=next, p=prev, q=quit")
 
@@ -256,8 +257,9 @@ def get(
                         except Exception:
                             break
                 else:
-                    # 非交互式模式，显示前50条，按code排序
-                    display_df = formatted_df.sort_values('code').head(50)
+                    # 非交互模式：按 page_size 限制输出（无 page_size 默认 50），#5280
+                    limit = page_size or 50
+                    display_df = formatted_df.sort_values('code').head(limit)
 
                     if display_df.empty:
                         console.print(":memo: No stock records found.")

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -211,6 +211,35 @@ class TestGetStockinfo:
         assert result.exit_code == 0
         assert "No matching records" in result.output
 
+    @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_pagesize_nontty_skips_interactive(self, mock_container, cli_runner, mock_stockinfo_df):
+        """非 TTY + --page-size 不进交互分页（#5280：CI/脚本/管道不阻塞）
+
+        CliRunner 注入的 stdin 非 TTY，模拟自动化场景。修复前守卫仅判
+        page_size>0 即进交互分支 Prompt.ask，非交互环境阻塞/污染输出。
+        """
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--page-size", "5"])
+        assert result.exit_code == 0
+        # 不进入交互分支（无 Prompt 标记）
+        assert "Interactive mode enabled" not in result.output
+        assert "n/p/q" not in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_pagesize_nontty_limits_output(self, mock_container, cli_runner, mock_stockinfo_df):
+        """非 TTY + --page-size N 退化为 head(N) 输出，size 生效（#5280）"""
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--page-size", "2"])
+        assert result.exit_code == 0
+        # mock_stockinfo_df 共 3 条，page_size=2 退化 head(2)
+        assert "Showing first 2 of 3 records" in result.output
+
 
 # ============================================================================
 # 3. get 其他数据类型测试


### PR DESCRIPTION
## Summary

`ginkgo data get stockinfo --page-size 5` 在非 TTY 环境（CI/脚本/管道）进入交互式分页 `Prompt.ask`，进程阻塞等待输入。

**根因**：`src/ginkgo/client/data_cli.py` stockinfo 分支的交互守卫仅判断 `page_size > 0`，未检测 `sys.stdin.isatty()`，导致自动化场景也进交互分支。

**为何只有 stockinfo**：bars/tick/adjustfactor 分支用 `page_size` 当 `limit`（非交互输出前 N 条），只有 stockinfo 把 `page_size` 当交互翻页触发器。

**修复**：
- 守卫加 `sys.stdin.isatty()`：`if page_size > 0 and sys.stdin.isatty()` —— 仅 TTY 启用交互
- 非 TTY 退化路径 `else` 把 `page_size` 当 `limit`（`limit = page_size or 50`），语义连续（`--page-size 5` 在脚本里显示前 5 条），与 tick 分支惯用法对齐
- TTY 行为完全不变

## Test plan

新增 2 个单测（`tests/unit/client/test_data_cli.py::TestGetStockinfo`）：
- `test_get_stockinfo_pagesize_nontty_skips_interactive`：CliRunner（非 TTY）+ `--page-size 5` 不打印 "Interactive mode enabled" / "n/p/q"
- `test_get_stockinfo_pagesize_nontty_limits_output`：非 TTY + `--page-size 2` 输出 "Showing first 2 of 3 records"

三层冒烟（对齐 `.github/workflows/ci.yml`）：
- Layer 1 py_compile：`data_cli.py` 语法通过
- Layer 2 启动路径：`test_user_crud_mock.py` + `test_containers.py` + `test_user_cli.py` 全绿（29 passed）
- Layer 3 变更相关：`tests/unit/client/test_data_cli.py` 全绿（49 passed）

TTY 回归说明：CliRunner 本质非 TTY，`patch(sys.stdin.isatty)` 在 invoke 期间被 stdin 替换覆盖（mock 静默失效），故 TTY 行为靠代码审查保证——守卫 `and sys.stdin.isatty()` 仅在 True 时走原交互分支，逻辑未变。

Closes #5280
