### PR TITLE
fix(#5282): status 区分 Data Workers 与 Exec Nodes 口径

### DIFF
--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -50,6 +50,24 @@ class ComponentType(str, Enum):
     SIZERS = "sizers"
     ANALYZERS = "analyzers"
 
+def _get_exec_node_count():
+    """统计活跃 ExecutionNode 数量（#5282）。
+
+    Workers 字段只查 GTM data_worker 进程池（Redis SET ginkgo:dataworker_pool），
+    不含实盘 ExecutionNode；后者通过 Redis 心跳键 heartbeat:node:*（TTL=30s）注册，
+    由 Scheduler 监控。此 helper 走 Service 层（与 scheduler nodes 同源）补全口径，
+    任一环节异常（Redis 不可用 / services 未就绪）返回 "N/A"，不破坏 status 其余字段。
+    """
+    try:
+        from ginkgo import services
+        result = services.data.redis_service().get_execution_node_status()
+        if result.is_success() and result.data is not None:
+            return len(result.data)
+        return 0
+    except Exception:
+        return "N/A"
+
+
 def status():
     """
     :bar_chart: Display system status (simplified from 'system status').
@@ -68,7 +86,8 @@ def status():
         console.print(f"Main Ctrl  : [medium_spring_green]{GTM.main_status}[/]")
         console.print(f"Watch Dog  : [medium_spring_green]{GTM.watch_dog_status}[/]")
         console.print(f"CPU Limit  : {GCONF.CPURATIO*100}%")
-        console.print(f"Workers    : {GTM.get_worker_count()}")
+        console.print(f"Data Workers : {GTM.get_worker_count()}")
+        console.print(f"Exec Nodes : {_get_exec_node_count()}")
         console.print(f"Log Path   : {GCONF.LOGGING_PATH}")
         console.print(f"Work Dir   : {GCONF.WORKING_PATH}")
         

--- a/tests/unit/client/test_core_cli.py
+++ b/tests/unit/client/test_core_cli.py
@@ -137,6 +137,98 @@ class TestStatus:
 
 
 # ===========================================================================
+# 2b. status command — ExecutionNode 口径 (#5282)
+# ===========================================================================
+
+class TestStatusExecNodes:
+    """status 命令应反映 ExecutionNode 心跳数（#5282）。
+
+    原先 Workers 字段只查 GTM data_worker 进程池（Redis SET ginkgo:dataworker_pool），
+    完全忽略 ExecutionNode 心跳（Redis key heartbeat:node:*），导致实盘节点运行时
+    Workers 误显 0。新增 Exec Nodes 行，复用 redis_service.get_execution_node_status()
+    走 Service 层（与 scheduler_cli.nodes() 同源，不直连 Redis）。
+    """
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_shows_exec_nodes_count_when_heartbeat_present(self, cli_runner, mock_gconf, mock_gtm):
+        """#5282 tracer: ExecutionNode 心跳非空 → status 输出 Exec Nodes 行且计数≠0。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_services = MagicMock()
+        mock_services.data.redis_service.return_value.get_execution_node_status.return_value = ServiceResult.success(
+            data=[{"node_id": "node_a"}, {"node_id": "node_b"}, {"node_id": "node_c"}],
+        )
+        with patch("ginkgo.libs.GCONF", mock_gconf), \
+             patch("ginkgo.libs.GTM", mock_gtm), \
+             patch("ginkgo.services", mock_services):
+            result = cli_runner.invoke(_get_main_app(), ["status"])
+
+        assert result.exit_code == 0
+        assert "Exec Nodes" in result.output
+        exec_line = next(l for l in result.output.splitlines() if "Exec Nodes" in l)
+        assert "3" in exec_line
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_shows_zero_exec_nodes_when_no_heartbeat(self, cli_runner, mock_gconf, mock_gtm):
+        """#5282: 无 ExecutionNode 心跳 → Exec Nodes 显示 0（与 Workers 字段口径并列，不崩）。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_services = MagicMock()
+        mock_services.data.redis_service.return_value.get_execution_node_status.return_value = ServiceResult.success(
+            data=[],
+        )
+        with patch("ginkgo.libs.GCONF", mock_gconf), \
+             patch("ginkgo.libs.GTM", mock_gtm), \
+             patch("ginkgo.services", mock_services):
+            result = cli_runner.invoke(_get_main_app(), ["status"])
+
+        assert result.exit_code == 0
+        exec_line = next(l for l in result.output.splitlines() if "Exec Nodes" in l)
+        assert "0" in exec_line
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_shows_na_when_redis_service_raises(self, cli_runner, mock_gconf, mock_gtm):
+        """#5282: redis_service 异常（Redis 不可用）→ Exec Nodes 显示 N/A，status 其余字段照常输出。"""
+        mock_services = MagicMock()
+        mock_services.data.redis_service.side_effect = RuntimeError("redis down")
+        with patch("ginkgo.libs.GCONF", mock_gconf), \
+             patch("ginkgo.libs.GTM", mock_gtm), \
+             patch("ginkgo.services", mock_services):
+            result = cli_runner.invoke(_get_main_app(), ["status"])
+
+        assert result.exit_code == 0
+        # status 其余字段不受影响
+        assert "System Status" in result.output
+        exec_line = next(l for l in result.output.splitlines() if "Exec Nodes" in l)
+        assert "N/A" in exec_line
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_worker_fields_distinct_labels(self, cli_runner, mock_gconf, mock_gtm):
+        """#5282 AC: 字段文案明确区分两类——Data Workers（GTM 进程池）与 Exec Nodes（心跳）并列。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_services = MagicMock()
+        mock_services.data.redis_service.return_value.get_execution_node_status.return_value = ServiceResult.success(
+            data=[{"node_id": "n1"}],
+        )
+        mock_gtm.get_worker_count.return_value = 2
+        with patch("ginkgo.libs.GCONF", mock_gconf), \
+             patch("ginkgo.libs.GTM", mock_gtm), \
+             patch("ginkgo.services", mock_services):
+            result = cli_runner.invoke(_get_main_app(), ["status"])
+
+        assert result.exit_code == 0
+        lines = result.output.splitlines()
+        # Data Workers 行（GTM data_worker 进程池口径）
+        dw_line = next(l for l in lines if "Data Workers" in l)
+        assert "2" in dw_line
+        # Exec Nodes 行（ExecutionNode 心跳口径，与 scheduler nodes 同源）
+        en_line = next(l for l in lines if "Exec Nodes" in l)
+        assert "1" in en_line
+
+
+# ===========================================================================
 # 3. debug command
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

修复 `ginkgo status` 的 Workers 字段误显 0（#5282）。

**根因**：两个字段查的是两套**独立**的 Redis 存储：
- `ginkgo status` Workers → `GTM.get_worker_count()` → Redis SET `ginkgo:dataworker_pool`（DataWorker 进程 PID 注册表）
- `ginkgo scheduler nodes` → Redis keys `heartbeat:node:*`（ExecutionNode 心跳，TTL=30s）

实盘 ExecutionNode 运行时不往 `data_worker` 进程池注册 PID，故 Workers 恒 0，与 scheduler 实跑节点数严重不一致。仅显示层问题，不影响调度/执行。

**修复**：
- `core_cli.status()` 新增 `Exec Nodes` 行，复用已有的 `redis_service.get_execution_node_status()`（`redis_service.py:985`）——与 `ginkgo scheduler nodes` 同源，走 Service 层不直连 Redis
- `Workers` 字段改名 `Data Workers`，明确该字段只统计 GTM data_worker 进程池口径
- 新增 `_get_exec_node_count()` helper：Redis 不可用 / services 未就绪时降级返回 `N/A`，不破坏 status 其余字段

## Test plan

- [x] Layer 1 py_compile 全量通过
- [x] Layer 2 启动路径 smoke（test_user_crud_mock + test_containers + test_user_cli，29 passed）
- [x] Layer 3 变更相关（test_core_cli + test_scheduler_cli，42 passed）
- [x] 新增 4 个单测覆盖：心跳非空计数 / 空列表 0 / redis 异常 N/A / 两类字段标签并列
- [x] 既有 status 测试无回归（`Workers: 0` → `Data Workers: 0` 语义一致）

## 行为对照

修复前：
```
Workers    : 0          ← 实盘节点在跑，却显示 0
Log Path   : ...
```

修复后：
```
Data Workers : 0         ← 明确这是 data_worker 进程池口径
Exec Nodes   : 3         ← ExecutionNode 心跳数（与 scheduler nodes 同源）
Log Path     : ...
```

Closes #5282

🤖 Generated with [Claude Code](https://claude.com/claude-code)