### PR TITLE
fix(#5307): validate --show-trace 策略获取行情失败（bar_service 契约）

### DIFF
--- a/src/ginkgo/client/validation_cli.py
+++ b/src/ginkgo/client/validation_cli.py
@@ -524,6 +524,77 @@ def _batch_validate_database_strategies(
         raise typer.Exit(5)
 
 
+class _InMemoryBarService:
+    """
+    内存 BarService 包装器 (#5307)。
+
+    validate --show-tracing 预加载的 MBar models 经此类暴露为生产 BarService
+    契约：``get(code, start_date, end_date) -> ServiceResult``。
+    StrategyDataMixin.get_bars_cached 经 ``hasattr(feeder, 'bar_service')``
+    守卫并消费 ``result.success / result.data``；此处用内存数据满足该契约，
+    避免追踪环境重复查库，也修复原本静默 0 信号的问题。
+    """
+
+    def __init__(self, bars):
+        from collections import defaultdict
+
+        self._bars_by_code = defaultdict(list)
+        for bar in bars:
+            self._bars_by_code[bar.code].append(bar)
+
+    @staticmethod
+    def _to_date(value):
+        """归一化 date/datetime 为 date（mixin 传 ``.date()``，bar.timestamp 多为 datetime）。"""
+        if value is None:
+            return None
+        return value.date() if hasattr(value, "date") else value
+
+    def get(self, code, start_date=None, end_date=None):
+        from ginkgo.data.services.base_service import ServiceResult
+
+        start_d = self._to_date(start_date)
+        end_d = self._to_date(end_date)
+        matched = []
+        for bar in self._bars_by_code.get(code, []):
+            ts = self._to_date(bar.timestamp)
+            if start_d is not None and ts < start_d:
+                continue
+            if end_d is not None and ts > end_d:
+                continue
+            matched.append(bar)
+        return ServiceResult(success=True, data=matched)
+
+
+class SimpleDataFeeder:
+    """
+    validate --show-trace 的轻量 data_feeder (#5307)。
+
+    持有预加载的 MBar models，并按 feeder 契约暴露 ``bar_service``
+    (``_InMemoryBarService``)，使依赖 ``data_feeder.bar_service.get()``
+    的策略代码（如 ``StrategyDataMixin.get_bars_cached``）在追踪环境下
+    能正常取数，不再走 ``hasattr`` 守卫的 0 信号分支。
+    """
+
+    def __init__(self, bars, time_controller=None):
+        self.bars = bars
+        self.bars_by_code = {}
+        for bar in bars:
+            self.bars_by_code.setdefault(bar.code, []).append(bar)
+        self.bar_service = _InMemoryBarService(bars)
+        # feeder 契约：追踪时业务时间由 time_controller 提供（与 BacktestFeeder 一致），
+        # 使 StrategyDataMixin.get_bars_cached 用事件时间而非 wall clock 取数。
+        self.time_controller = time_controller
+
+    def get_bars(self, code, start_date=None, end_date=None):
+        """Get bars for a code within date range."""
+        bars = self.bars_by_code.get(code, [])
+        if start_date:
+            bars = [b for b in bars if b.timestamp >= start_date]
+        if end_date:
+            bars = [b for b in bars if b.timestamp <= end_date]
+        return bars
+
+
 def _run_signal_tracing(strategy_file, stock_code: str, max_events: int, verbose: bool, silent: bool = False):
     """
     Run runtime signal tracing on a strategy with database data.
@@ -590,25 +661,7 @@ def _run_signal_tracing(strategy_file, stock_code: str, max_events: int, verbose
 
         console.print(f":page_facing_up: Loaded {len(all_bars)} bar records from database")
 
-        # Create a simple data_feeder for the strategy
-        class SimpleDataFeeder:
-            def __init__(self, bars):
-                self.bars = bars
-                self.bars_by_code = {}
-                for bar in bars:
-                    if bar.code not in self.bars_by_code:
-                        self.bars_by_code[bar.code] = []
-                    self.bars_by_code[bar.code].append(bar)
-
-            def get_bars(self, code, start_date=None, end_date=None):
-                """Get bars for a code within date range."""
-                bars = self.bars_by_code.get(code, [])
-                if start_date:
-                    bars = [b for b in bars if b.timestamp >= start_date]
-                if end_date:
-                    bars = [b for b in bars if b.timestamp <= end_date]
-                return bars
-
+        # Use module-level SimpleDataFeeder (exposes bar_service contract, #5307)
         # Create a simple time_provider for the strategy
         class SimpleTimeProvider:
             def __init__(self, initial_time):
@@ -621,13 +674,18 @@ def _run_signal_tracing(strategy_file, stock_code: str, max_events: int, verbose
                 self.current_time = new_time
                 return True
 
-        # Create and initialize strategy with data_feeder and time_provider
-        strategy = strategy_class(name=f"trace_{strategy_class.__name__}")
-        strategy.bind_data_feeder(SimpleDataFeeder(all_bars))
-
-        # Create and set time_provider (reused across all events)
+        # Create and initialize strategy with data_feeder and time_provider.
+        # time_provider 同时作为 data_feeder.time_controller，使策略 get_bars_cached
+        # 按事件时间取数（#5307），与回测 BacktestFeeder 契约一致。
         if all_bars:
             time_provider = SimpleTimeProvider(all_bars[0].timestamp)
+        else:
+            time_provider = None
+
+        strategy = strategy_class(name=f"trace_{strategy_class.__name__}")
+        strategy.bind_data_feeder(SimpleDataFeeder(all_bars, time_controller=time_provider))
+
+        if time_provider is not None:
             strategy.set_time_provider(time_provider)
 
         # Limit events if requested (use last N bars for events)

--- a/tests/unit/client/test_validation_cli_signal_trace.py
+++ b/tests/unit/client/test_validation_cli_signal_trace.py
@@ -1,0 +1,122 @@
+"""
+validate --show-trace 行情获取链路测试 (#5307)
+
+根因：`_run_signal_tracing` 创建的 SimpleDataFeeder 仅暴露 bars/get_bars，
+缺少 feeder 契约要求的 `bar_service` 属性，导致 StrategyDataMixin.get_bars_cached
+走 hasattr 守卫失败 → INFO + return [] → 策略 0 信号。
+
+本测试验证 SimpleDataFeeder 遵守 feeder 契约（暴露 bar_service，
+.get() 返回 ServiceResult 兼容结构），使追踪环境下 get_bars_cached 能取到行情。
+"""
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_bar(code: str = "000001.SZ", timestamp=None, close: float = 10.0):
+    """构造 MBar model mock（对齐 src/ginkgo/data/models/model_bar.py 字段）"""
+    bar = MagicMock()
+    bar.code = code
+    bar.timestamp = timestamp or datetime(2026, 1, 1)
+    bar.open = close
+    bar.high = close
+    bar.low = close
+    bar.close = close
+    bar.volume = 1000
+    return bar
+
+
+class TestSimpleDataFeederBarServiceContract:
+    """SimpleDataFeeder 必须遵守 feeder 契约暴露 bar_service (#5307)"""
+
+    def test_feeder_exposes_bar_service_attribute(self):
+        """SimpleDataFeeder 实例应暴露 bar_service 属性（feeder 契约）"""
+        from ginkgo.client.validation_cli import SimpleDataFeeder
+
+        feeder = SimpleDataFeeder([_make_bar()])
+        assert hasattr(feeder, "bar_service"), "SimpleDataFeeder 缺 bar_service 属性"
+
+    def test_bar_service_get_returns_service_result_with_data(self):
+        """bar_service.get(code) 返回 ServiceResult 兼容结构 (success=True, data=[bars])"""
+        from ginkgo.client.validation_cli import SimpleDataFeeder
+
+        bars = [
+            _make_bar(timestamp=datetime(2026, 1, 1)),
+            _make_bar(timestamp=datetime(2026, 1, 2)),
+        ]
+        feeder = SimpleDataFeeder(bars)
+        result = feeder.bar_service.get(code="000001.SZ")
+
+        assert result.success is True
+        assert len(result.data) == 2
+
+    def test_bar_service_get_filters_by_date_range(self):
+        """bar_service.get 支持 start_date/end_date 过滤（mixin 传 date 对象）"""
+        from ginkgo.client.validation_cli import SimpleDataFeeder
+
+        bars = [
+            _make_bar(timestamp=datetime(2026, 1, 1)),
+            _make_bar(timestamp=datetime(2026, 2, 1)),
+            _make_bar(timestamp=datetime(2026, 3, 1)),
+        ]
+        feeder = SimpleDataFeeder(bars)
+        result = feeder.bar_service.get(
+            code="000001.SZ",
+            start_date=date(2026, 1, 15),
+            end_date=date(2026, 2, 15),
+        )
+
+        assert result.success is True
+        assert len(result.data) == 1
+
+    def test_bar_service_get_unknown_code_returns_empty_success(self):
+        """查未加载的 code 返回 success=True 但 data 空（graceful，不崩）"""
+        from ginkgo.client.validation_cli import SimpleDataFeeder
+
+        feeder = SimpleDataFeeder([_make_bar(code="000001.SZ")])
+        result = feeder.bar_service.get(code="999999.SZ")
+
+        assert result.success is True
+        assert result.data == []
+
+    def test_feeder_accepts_time_controller(self):
+        """SimpleDataFeeder 可注入 time_controller（追踪按事件时间取数，非 wall clock）"""
+        from ginkgo.client.validation_cli import SimpleDataFeeder
+
+        time_controller = MagicMock()
+        time_controller.now.return_value = datetime(2026, 1, 5)
+        feeder = SimpleDataFeeder([_make_bar()], time_controller=time_controller)
+
+        assert feeder.time_controller is time_controller
+
+
+class TestGetBarsCachedEndToEnd:
+    """端到端：SimpleDataFeeder + StrategyDataMixin → get_bars_cached 取到数据 (#5307)"""
+
+    def test_get_bars_cached_returns_data_via_simple_feeder(self, monkeypatch):
+        """修复后 get_bars_cached 不再走 bar_service 缺失的 0 信号分支"""
+        from ginkgo.client.validation_cli import SimpleDataFeeder
+        from ginkgo.trading.interfaces.mixins import strategy_data_mixin as mixin_mod
+        from ginkgo.trading.interfaces.mixins.strategy_data_mixin import StrategyDataMixin
+
+        # 追踪环境：事件时间作为 time_controller，避免 mixin 退回 wall clock 误过滤历史 bar
+        event_time = datetime(2026, 1, 10)
+        bars = [_make_bar(timestamp=datetime(2026, 1, 1) + timedelta(days=i)) for i in range(10)]
+        time_controller = MagicMock()
+        time_controller.now.return_value = event_time
+
+        class _TraceStrategy(StrategyDataMixin):
+            pass
+
+        strategy = _TraceStrategy()
+        strategy.data_feeder = SimpleDataFeeder(bars, time_controller=time_controller)
+
+        # 绕开 model→entity 转换（不在 #5307 修复范围，BarMapper 已被回测/实盘覆盖）
+        monkeypatch.setattr(
+            mixin_mod.BarMapper, "from_models", staticmethod(lambda models: list(models))
+        )
+
+        result = strategy.get_bars_cached("000001.SZ", count=10)
+        assert len(result) > 0, "get_bars_cached 在 SimpleDataFeeder 下返回空（#5307 根因未修）"
+


### PR DESCRIPTION
## Summary

修复 `ginkgo validate <策略> --show-trace` 时策略 `get_bars_cached()` 返回空、产生 0 信号的问题。

**根因**：`_run_signal_tracing` 创建的内嵌 `SimpleDataFeeder` 仅含 `bars`/`get_bars`，缺 feeder 契约要求的 `bar_service` 属性。`StrategyDataMixin.get_bars_cached` 经 `hasattr(data_feeder, "bar_service")` 守卫失败 → INFO 日志 + `return []` → 策略拿不到行情 → 0 信号。追踪看似通过实则策略没数据。

**调用链**：
```
_run_signal_tracing → SimpleDataFeeder(all_bars) [无 bar_service]
  → strategy.bind_data_feeder(...)
  → cal() → get_bars_cached()
  → mixin:130 hasattr(feeder, bar_service) == False  💥
  → INFO + return []  →  0 信号
```

**修复**（仅 `src/ginkgo/client/validation_cli.py`，不动 mixin/feeder 基类）：
- `SimpleDataFeeder` 与新增 `_InMemoryBarService` 从函数内嵌提升为模块级（可测试）
- `SimpleDataFeeder` 暴露 `bar_service`（包装预加载的 MBar models，`.get()` 返回 `ServiceResult`，满足 mixin 消费契约），不再走静默 0 信号分支
- `SimpleDataFeeder` 接受 `time_controller`（`_run_signal_tracing` 把 `SimpleTimeProvider` 同时注入为 `data_feeder.time_controller`），使追踪按事件时间取数，与回测 `BacktestFeeder` 契约一致，避免 wall clock 误过滤历史 bar

## Test plan

新增 `tests/unit/client/test_validation_cli_signal_trace.py`（6 例）：
- 4 个契约测试：feeder 暴露 bar_service / `.get()` 返回 ServiceResult(success, data) / start_date-end_date 过滤（含 date vs datetime 归一化）/ 未知 code graceful 空返回
- 1 个 time_controller 注入测试
- 1 个端到端：`StrategyDataMixin.get_bars_cached` 经 `SimpleDataFeeder` 返回非空（monkeypatch `BarMapper.from_models` 绕开 model→entity 转换）

冒烟三层（推送前已过）：
- Layer 1 py_compile（src/api 全量）✅
- Layer 2 启动路径 smoke（user_crud_mock + containers + user_cli，29 passed）✅
- Layer 3 变更相关（新 6 + 既有 test_validation_cli.py 17，共 23 passed，无回归）✅

手动验证（需 DB 数据，留给 review）：`ginkgo validate <含 get_bars_cached 的策略> --type strategy --show-trace --code 000001.SZ --events 5` 不再出现 `data_feeder 没有 bar_service 属性` / `Generated 0 signals`。

Closes #5307
