### PR TITLE
fix(#5310): 实现 kafka consumer-groups 命令真实 broker 查询

### DIFF
--- a/src/ginkgo/client/kafka_cli.py
+++ b/src/ginkgo/client/kafka_cli.py
@@ -572,13 +572,75 @@ def _run_health_check():
         console.print(f"[red]{traceback.format_exc()}[/]")
 
 
-def _list_consumer_groups():
-    """列出Consumer Groups - 伪函数"""
-    # TODO: 实现Consumer Groups列表
-    # - 获取所有Consumer Groups
-    # - 显示状态和lag信息
-    # - 格式化表格输出
-    pass
+def _list_consumer_groups(timeout_seconds: float = 15.0):
+    """列出 broker 端所有 Consumer Groups
+
+    走 KafkaService.list_consumer_groups → KafkaCRUD.list_broker_consumer_groups
+    真实查询 broker。外层 daemon 线程 + queue 硬超时（默认 15s）兜底，防止 broker
+    不可达时 KafkaAdminClient 构造/连接阻塞（呼应 kafka_crud._test_connection 的 TODO）；
+    daemon 线程保证超时后不阻塞进程退出。
+
+    Args:
+        timeout_seconds: 硬超时秒数；超时打印友好提示而非挂死。
+    """
+    try:
+        import queue as _queue
+        import threading as _threading
+        from ginkgo.data.containers import container
+        from rich.table import Table
+
+        result_box: "_queue.Queue" = _queue.Queue()
+
+        def _fetch():
+            try:
+                service = container.kafka_service()
+                result_box.put(service.list_consumer_groups())
+            except Exception as e:  # 把异常也塞进队列，统一在主线程处理
+                result_box.put(e)
+
+        worker = _threading.Thread(target=_fetch, daemon=True)
+        worker.start()
+        try:
+            outcome = result_box.get(timeout=timeout_seconds)
+        except _queue.Empty:
+            console.print(
+                "[bold yellow]:hourglass: Listing consumer groups timed out "
+                f"(>{timeout_seconds}s). Check Kafka connectivity (ginkgo kafka status).[/]"
+            )
+            return
+
+        if isinstance(outcome, Exception):
+            console.print(f"[bold red]:x: Error listing consumer groups: {outcome}[/]")
+            return
+
+        result = outcome
+        if not result.success:
+            console.print(f"[bold red]:x: Failed to list consumer groups: {result.message}[/]")
+            return
+
+        groups = result.data or []
+        if not groups:
+            console.print("[bold yellow]:information: No active consumer groups found.[/]")
+            return
+
+        table = Table(title="Kafka Consumer Groups")
+        table.add_column("Group", style="cyan", no_wrap=True)
+        table.add_column("State", style="green")
+        table.add_column("Protocol", style="blue")
+        table.add_column("Type", style="yellow")
+        for group in groups:
+            table.add_row(
+                str(group.get("name", "")),
+                str(group.get("state", "")),
+                str(group.get("protocol_type", "")),
+                str(group.get("type", "")),
+            )
+        console.print(table)
+
+    except Exception as e:
+        console.print(f"[bold red]:x: Error listing consumer groups: {e}[/]")
+        import traceback
+        console.print(f"[red]{traceback.format_exc()}[/]")
 
 
 def _reset_consumer_offsets(group_id: str, strategy: str):

--- a/src/ginkgo/data/crud/kafka_crud.py
+++ b/src/ginkgo/data/crud/kafka_crud.py
@@ -21,6 +21,7 @@ import threading
 import time
 
 from ginkgo.libs import GLOG, time_logger, retry
+from ginkgo.libs.core.config import GCONF
 from ginkgo.data.drivers import GinkgoProducer, GinkgoConsumer, kafka_topic_llen
 
 
@@ -419,8 +420,60 @@ class KafkaCRUD:
             topic_name, group_id = consumer_key.rsplit('_', 1)
             if topic is None or topic_name == topic:
                 groups.add(group_id)
-        
+
         return list(groups)
+
+    def list_broker_consumer_groups(self, request_timeout_ms: int = 10000) -> List[Dict[str, str]]:
+        """
+        列出 broker 端所有 consumer groups（真实管理查询）
+
+        与 ``list_consumer_groups``（读本地内存缓存）不同，本方法通过
+        ``KafkaAdminClient.list_groups`` 查询 broker 已注册的所有消费组。
+
+        Args:
+            request_timeout_ms: 单次请求超时（毫秒），防止 broker 不可达时阻塞
+
+        Returns:
+            List[Dict[str, str]]: 归一化消费组列表，每项含
+            ``name`` / ``state`` / ``protocol_type`` / ``type``；
+            查询失败时返回空列表并记录错误（不向上抛）。
+        """
+        admin_client = None
+        try:
+            from kafka.admin import KafkaAdminClient
+
+            admin_client = KafkaAdminClient(
+                bootstrap_servers=[f"{GCONF.KAFKAHOST}:{GCONF.KAFKAPORT}"],
+                client_id="ginkgo-admin",
+                request_timeout_ms=request_timeout_ms,
+            )
+            raw_groups = admin_client.list_groups()
+            normalized: List[Dict[str, str]] = []
+            for group in raw_groups:
+                # kafka-python 3.x 返回 dict；旧版本可能是 namedtuple/tuple，统一兜底
+                if hasattr(group, "to_dict"):
+                    data = group.to_dict()
+                elif isinstance(group, dict):
+                    data = group
+                else:
+                    data = {"group_id": group[0] if len(group) > 0 else "",
+                            "protocol_type": group[1] if len(group) > 1 else ""}
+                normalized.append({
+                    "name": data.get("group_id") or data.get("name") or data.get("group") or "",
+                    "state": data.get("group_state") or data.get("state") or "",
+                    "protocol_type": data.get("protocol_type") or data.get("protocol") or "",
+                    "type": data.get("group_type") or data.get("type") or "",
+                })
+            return normalized
+        except Exception as e:
+            GLOG.ERROR(f"Failed to list broker consumer groups: {e}")
+            return []
+        finally:
+            if admin_client is not None:
+                try:
+                    admin_client.close()
+                except Exception as close_err:
+                    GLOG.DEBUG(f"Error closing KafkaAdminClient: {close_err}")
     
     # ==================== 监控和状态 ====================
     

--- a/src/ginkgo/data/services/kafka_service.py
+++ b/src/ginkgo/data/services/kafka_service.py
@@ -557,6 +557,22 @@ class KafkaService(BaseService):
             self._logger.ERROR(f"Failed to list active subscriptions: {e}")
             return ServiceResult.error(f"Failed to list active subscriptions: {str(e)}")
     
+    def list_consumer_groups(self) -> ServiceResult:
+        """
+        列出 broker 端所有 consumer groups
+
+        走 CRUD ``list_broker_consumer_groups`` 真实查询 broker（非本地缓存）。
+
+        Returns:
+            ServiceResult: data 为消费组列表（每项含 name/state/protocol_type/type）
+        """
+        try:
+            groups = self._crud_repo.list_broker_consumer_groups()
+            return ServiceResult.success(groups, f"Listed {len(groups)} consumer groups")
+        except Exception as e:
+            self._logger.ERROR(f"Failed to list consumer groups: {e}")
+            return ServiceResult.error(f"Failed to list consumer groups: {str(e)}")
+
     def unsubscribe_topic(self, topic: str) -> ServiceResult:
         """
         取消订阅主题

--- a/tests/unit/client/test_kafka_cli.py
+++ b/tests/unit/client/test_kafka_cli.py
@@ -198,10 +198,76 @@ class TestHealth:
 class TestConsumerGroups:
     """Tests for the 'consumer-groups' command."""
 
-    def test_consumer_groups_stub(self, cli_runner):
-        result = cli_runner.invoke(kafka_cli.app, ["consumer-groups"])
-        # _list_consumer_groups is a stub (pass), so no error expected
-        assert result.exit_code == 0
+    def test_consumer_groups_lists_broker_groups(self, cli_runner):
+        """consumer-groups 命令走 service 列出 broker 端 consumer groups 并渲染表格。
+
+        回归 #5310：原 `_list_consumer_groups` 是 pass 桩函数，命令打印标题后无输出。
+        """
+        mock_service = MagicMock()
+        mock_service.list_consumer_groups.return_value = ServiceResult.success(data=[
+            {"name": "ginkgo_data_worker", "state": "Stable", "protocol_type": "consumer", "type": "classic"},
+            {"name": "ginkgo_backtest_worker", "state": "Empty", "protocol_type": "consumer", "type": "classic"},
+        ])
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.kafka_service.return_value = mock_service
+            result = cli_runner.invoke(kafka_cli.app, ["consumer-groups"])
+
+        assert result.exit_code == 0, result.output
+        mock_service.list_consumer_groups.assert_called_once()
+        assert "ginkgo_data_worker" in result.output
+        assert "ginkgo_backtest_worker" in result.output
+
+    def test_consumer_groups_empty(self, cli_runner):
+        """service 返回空列表时打印友好提示，不渲染空表。"""
+        mock_service = MagicMock()
+        mock_service.list_consumer_groups.return_value = ServiceResult.success(data=[])
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.kafka_service.return_value = mock_service
+            result = cli_runner.invoke(kafka_cli.app, ["consumer-groups"])
+
+        assert result.exit_code == 0, result.output
+        assert "No active consumer groups" in result.output
+
+    def test_consumer_groups_service_error(self, cli_runner):
+        """service 返回 error 时打印错误信息、不挂死（回归 #5310 友好退出）。"""
+        mock_service = MagicMock()
+        mock_service.list_consumer_groups.return_value = ServiceResult.error("connection refused")
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.kafka_service.return_value = mock_service
+            result = cli_runner.invoke(kafka_cli.app, ["consumer-groups"])
+
+        assert result.exit_code == 0, result.output
+        assert "Failed to list consumer groups" in result.output
+        assert "connection refused" in result.output
+
+    def test_consumer_groups_timeout_friendly_exit(self, cli_runner):
+        """service 阻塞超过硬超时时打印友好提示、不挂死（回归 #5310「挂住」核心诉求）。
+
+        直接调用底层函数（绕过 typer），用极小 timeout 触发超时分支；
+        断言函数在远小于 service sleep 的时长内返回（即未挂等 service）。
+        """
+        import time as _time
+
+        service_sleep = 5.0  # 模拟 broker 不可达阻塞
+        max_wait = 2.0       # 远小于 service_sleep；超过即说明挂死
+
+        def _slow_service():
+            _time.sleep(service_sleep)
+            return ServiceResult.success(data=[])
+
+        slow_service = MagicMock()
+        slow_service.list_consumer_groups.side_effect = _slow_service
+
+        start = _time.monotonic()
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.kafka_service.return_value = slow_service
+            kafka_cli._list_consumer_groups(timeout_seconds=0.2)
+        elapsed = _time.monotonic() - start
+
+        assert elapsed < max_wait, f"命令挂等 service（elapsed={elapsed:.1f}s），超时安全网失效"
 
 
 @pytest.mark.unit

--- a/tests/unit/data/crud/test_kafka_crud_mock.py
+++ b/tests/unit/data/crud/test_kafka_crud_mock.py
@@ -191,3 +191,67 @@ class TestKafkaCRUDTopicManagement:
             result = kafka_crud.get_kafka_status()
 
         assert result["connected"] is False
+
+
+# ============================================================
+# broker 端 consumer groups 查询（list_broker_consumer_groups）
+# ============================================================
+
+
+class TestKafkaCRUDBrokerConsumerGroups:
+    """list_broker_consumer_groups 走 KafkaAdminClient 真实查询 broker。
+
+    回归 #5310：CLI `consumer-groups` 命令原依赖桩函数，本方法补齐 broker 端查询。
+    """
+
+    @pytest.mark.unit
+    def test_returns_normalized_groups(self, kafka_crud):
+        """list_groups 返回的 dict 被归一化为 name/state/protocol_type/type。"""
+        mock_admin = MagicMock()
+        # kafka-python 3.x: list_groups 返回 ListedGroup.to_dict() 后的 dict 列表
+        mock_admin.list_groups.return_value = [
+            {"group_id": "ginkgo_data_worker", "group_state": "Stable",
+             "protocol_type": "consumer", "group_type": "classic"},
+            {"group_id": "backtest_worker", "group_state": "Empty",
+             "protocol_type": "consumer", "group_type": "classic"},
+        ]
+
+        with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin):
+            result = kafka_crud.list_broker_consumer_groups()
+
+        assert len(result) == 2
+        assert result[0] == {
+            "name": "ginkgo_data_worker", "state": "Stable",
+            "protocol_type": "consumer", "type": "classic",
+        }
+        assert result[1]["name"] == "backtest_worker"
+        mock_admin.close.assert_called_once()
+
+    @pytest.mark.unit
+    def test_admin_error_returns_empty_no_raise(self, kafka_crud):
+        """admin client 抛异常时返回空列表且不向上抛（CLI 层友好看待连接失败）。"""
+        mock_admin = MagicMock()
+        mock_admin.list_groups.side_effect = Exception("broker unreachable")
+        mock_logger = MagicMock()
+
+        with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin), \
+             patch("ginkgo.data.crud.kafka_crud.GLOG", mock_logger):
+            result = kafka_crud.list_broker_consumer_groups()
+
+        assert result == []
+        mock_admin.close.assert_called_once()
+        mock_logger.ERROR.assert_called_once()
+
+    @pytest.mark.unit
+    def test_namedtuple_fallback_normalizes(self, kafka_crud):
+        """旧版 kafka-python 返回 namedtuple/tuple 时归一化兜底仍生效。"""
+        mock_admin = MagicMock()
+        # 模拟旧版 (group_id, protocol_type) 二元组
+        mock_admin.list_groups.return_value = [("legacy_group", "consumer")]
+
+        with patch("kafka.admin.KafkaAdminClient", return_value=mock_admin):
+            result = kafka_crud.list_broker_consumer_groups()
+
+        assert len(result) == 1
+        assert result[0]["name"] == "legacy_group"
+        assert result[0]["protocol_type"] == "consumer"

--- a/tests/unit/data/services/test_kafka_service.py
+++ b/tests/unit/data/services/test_kafka_service.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from datetime import datetime
 from uuid import uuid4
 import time
+from unittest.mock import MagicMock
 
 # 添加项目路径
 project_root = Path(__file__).parent.parent.parent.parent
@@ -365,3 +366,37 @@ class TestKafkaServiceEdgeCases:
                 # 尝试发布消息
                 publish_result = kafka_service.publish_message(topic, {"test": "data"})
                 assert publish_result is not None
+
+
+# ============================================================================
+# broker 端 consumer groups facade（list_consumer_groups）
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestKafkaServiceListConsumerGroups:
+    """list_consumer_groups 走 CRUD.list_broker_consumer_groups 的 facade 契约。
+
+    回归 #5310：service 层补齐 broker 端查询入口（非本地缓存语义）。
+    """
+
+    def test_success_wraps_crud_groups(self, kafka_service):
+        """CRUD 正常返回时，service 包成 ServiceResult.success(data=groups)。"""
+        sample = [{"name": "g1", "state": "Stable", "protocol_type": "consumer", "type": "classic"}]
+        kafka_service._crud_repo.list_broker_consumer_groups = MagicMock(return_value=sample)
+
+        result = kafka_service.list_consumer_groups()
+
+        assert result.success
+        assert result.data == sample
+
+    def test_crud_error_returns_service_error(self, kafka_service):
+        """CRUD 抛异常时返回 ServiceResult.error，不向上抛。"""
+        kafka_service._crud_repo.list_broker_consumer_groups = MagicMock(
+            side_effect=Exception("broker down")
+        )
+
+        result = kafka_service.list_consumer_groups()
+
+        assert not result.success
+        assert "broker down" in result.message


### PR DESCRIPTION
## Summary

修复 `ginkgo kafka consumer-groups` 命令原 `_list_consumer_groups` 为 `pass`+TODO 桩函数、打印标题后无输出（#5310 报"挂住"）的问题。

分层实现 `CLI → Service → CRUD` 真实 broker 查询：

| 层 | 方法 | 职责 |
|---|---|---|
| CRUD | `KafkaCRUD.list_broker_consumer_groups` | 短生命周期 `KafkaAdminClient.list_groups`（带 `request_timeout_ms` 防阻塞），归一化为 `name`/`state`/`protocol_type`/`type`；admin 异常返回空列表 + 记录错误，不向上抛 |
| Service | `KafkaService.list_consumer_groups` | facade 包 `ServiceResult.success/error` |
| CLI | `_list_consumer_groups` | 渲染 Rich 表；daemon 线程 + queue 硬超时（15s）兜底防 broker 不可达阻塞，超时/错误友好退出而非挂死 |

**与 `KafkaCRUD.list_consumer_groups(topic)` 区别**：后者只读本地内存 `_consumers` 缓存（被 `get_topic_info` 依赖，语义不变）；新方法 `list_broker_consumer_groups` 走 broker 管理接口查真实消费组。

## Test plan

三层单测（mock kafka client，覆盖成功/空/错误/超时四象限）：
- CLI 4：`tests/unit/client/test_kafka_cli.py::TestConsumerGroups`（含超时安全网计时断言）
- CRUD 3：`tests/unit/data/crud/test_kafka_crud_mock.py::TestKafkaCRUDBrokerConsumerGroups`（含 namedtuple 旧版兜底）
- Service 2：`tests/unit/data/services/test_kafka_service.py::TestKafkaServiceListConsumerGroups`

本地冒烟三层全绿（py_compile + 启动路径点名 + 变更相关测试，65 passed）。

Closes #5310

🤖 Generated with [Claude Code](https://claude.com/claude-code)