### PR TITLE
fix(#5317): validate --show-trace 区分策略崩溃与合法空返回

### DIFF
--- a/src/ginkgo/client/validation_cli.py
+++ b/src/ginkgo/client/validation_cli.py
@@ -276,7 +276,8 @@ def _validate_single_strategy(
         source_info: Source description for report (T111)
         console: Rich console instance
     """
-    from ginkgo.trading.evaluation.core.enums import ComponentType, EvaluationLevel
+    from ginkgo.trading.evaluation.core.enums import ComponentType, EvaluationLevel, EvaluationSeverity
+    from ginkgo.trading.evaluation.core.evaluation_result import EvaluationIssue
     from ginkgo.libs import GLOG
     from ginkgo.trading.evaluation.evaluators.base_evaluator import SimpleEvaluator
     from ginkgo.trading.evaluation.rules.rule_registry import get_global_registry
@@ -334,7 +335,39 @@ def _validate_single_strategy(
         # the 5 best-practice STRICT rules registered above → regression).
         result = evaluator.evaluate(file_path, level=EvaluationLevel.STRICT)
 
-        # Generate report using selected format (T048)
+        # Runtime signal tracing (T109) — runs before report generation so that
+        # #5317 runtime crashes can be folded into `result` as ERROR issues and
+        # the report/verdict consistently show FAILED. A structurally-valid
+        # strategy that crashes at runtime is not a valid strategy.
+        tracer_report = None
+        if show_trace:
+            if result.passed:
+                tracer_report = _run_signal_tracing(file_path, code, events, verbose)
+            else:
+                console.print(":warning: [yellow]Skipping signal tracing - validation failed[/yellow]")
+
+        # #5317: 策略 cal() 运行时崩溃（_run_signal_tracing 捕获到 cal_exceptions）
+        # 记为 ERROR 级 EvaluationIssue，使 result.passed=False → 报告/最终判定
+        # 一致显示 FAILED，与"主动返回 []"（合法，仍 PASSED）区分开。
+        if tracer_report is not None and tracer_report.cal_exceptions:
+            crashes = tracer_report.cal_exceptions
+            first = crashes[0]
+            result.add_issue(EvaluationIssue(
+                severity=EvaluationSeverity.ERROR,
+                code="RUNTIME_CAL_CRASH",
+                message=(
+                    f"Strategy raised {first['exception_type']} during runtime tracing "
+                    f"({len(crashes)} event(s) crashed): {first['message']}"
+                ),
+                suggestion=(
+                    "Fix the runtime error in cal() — the strategy must execute "
+                    "without raising. Re-run with --verbose to see the full traceback."
+                ),
+                file_path=file_path,
+                context=first.get("traceback_str") if verbose else None,
+            ))
+
+        # Generate report using selected format (T048) — reflects runtime crashes
         report_content = _generate_report(result, report_format)
 
         # Determine output file
@@ -361,13 +394,6 @@ def _validate_single_strategy(
                 # Use console.print() for pre-formatted Rich content with ANSI codes
                 console.print()
                 console.print(report_content, end="")
-
-        # Runtime signal tracing (T109)
-        if show_trace:
-            if result.passed:
-                tracer_report = _run_signal_tracing(file_path, code, events, verbose)
-            else:
-                console.print(":warning: [yellow]Skipping signal tracing - validation failed[/yellow]")
 
         # Exit with appropriate code
         if result.passed:
@@ -671,6 +697,16 @@ def _run_signal_tracing(strategy_file, stock_code: str, max_events: int, verbose
                     try:
                         signals = strategy.cal(portfolio_info, event)
                     except Exception as cal_error:
+                        # #5317: 区分"主动空返回"(合法)与"运行时崩溃"(失败)。
+                        # 崩溃记录到 report.cal_exceptions，由 _validate_single_strategy
+                        # 据此翻转最终判定为 FAILED；此处仍吞掉异常以保证后续 event 继续跑。
+                        import traceback as _tb
+                        tracer.get_report().add_cal_exception(
+                            exception_type=type(cal_error).__name__,
+                            message=str(cal_error),
+                            traceback_str=_tb.format_exc(),
+                            timestamp=bar.timestamp,
+                        )
                         if verbose:
                             console.print(f"  [CAL ERROR] {cal_error}")
                         signals = []

--- a/src/ginkgo/trading/evaluation/core/evaluation_result.py
+++ b/src/ginkgo/trading/evaluation/core/evaluation_result.py
@@ -289,6 +289,9 @@ class SignalTraceReport:
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
+    # #5317: cal() 运行时崩溃记录。区分"主动返回 []"(合法)与"异常被吞后返回 []"(失败)。
+    # 每条: {"exception_type", "message", "traceback_str", "timestamp"}
+    cal_exceptions: List[Dict[str, Any]] = field(default_factory=list)
 
     @property
     def signal_count(self) -> int:
@@ -326,6 +329,27 @@ class SignalTraceReport:
         """Add a signal trace to the report."""
         self.traces.append(trace)
 
+    def add_cal_exception(
+        self,
+        exception_type: str,
+        message: str,
+        traceback_str: str,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
+        """#5317: Record a cal() runtime crash. Captured exceptions cause the
+        validation verdict to flip from PASSED to FAILED (a crashing strategy
+        is not a valid strategy), distinguishing a crash from a legitimate
+        empty-list return.
+        """
+        self.cal_exceptions.append(
+            {
+                "exception_type": exception_type,
+                "message": message,
+                "traceback_str": traceback_str,
+                "timestamp": (timestamp or datetime.now()).isoformat(),
+            }
+        )
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert report to dictionary representation."""
         return {
@@ -341,6 +365,8 @@ class SignalTraceReport:
             },
             "traces": [trace.to_dict() for trace in self.traces],
             "metadata": self.metadata,
+            # #5317: 暴露 cal() 运行时崩溃，JSON 消费方据此区分"主动空返回"与"崩溃"。
+            "cal_exceptions": self.cal_exceptions,
         }
 
     def to_csv_rows(self) -> List[Dict[str, Any]]:
@@ -386,5 +412,15 @@ class SignalTraceReport:
                 )
             if len(self.traces) > 20:
                 result.append(f"  ... and {len(self.traces) - 20} more")
+
+        # #5317: 在 trace 报告里显式列出 cal() 崩溃，避免"Total Signals: 0"被误读为合法空返回。
+        if self.cal_exceptions:
+            result.append(f"\nRuntime Crashes: {len(self.cal_exceptions)}")
+            for i, exc in enumerate(self.cal_exceptions[:5], 1):
+                result.append(
+                    f"  {i}. [{exc['exception_type']}] {exc['message']}"
+                )
+            if len(self.cal_exceptions) > 5:
+                result.append(f"  ... and {len(self.cal_exceptions) - 5} more")
 
         return "\n".join(result)

--- a/tests/unit/client/test_validation_cli.py
+++ b/tests/unit/client/test_validation_cli.py
@@ -276,3 +276,186 @@ class TestComponentNameUuidResolution:
         # name 未命中 → 用原始 uuid 输入加载
         mock_loader.load_by_file_id.assert_called_once_with("deadbeefdeadbeefdeadbeefdeadbeef")
         mock_validate.assert_called_once()
+
+
+# ============================================================================
+# 7. Runtime crash detection (#5317)
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestRuntimeCrashDetection:
+    """#5317: validate --show-trace must distinguish a strategy that crashes in
+    cal() (FAILED) from one that legitimately returns [] (PASSED).
+
+    Before: cal() exceptions were swallowed into signals=[] and only printed
+    under --verbose, so a crashing strategy reported 'Validation PASSED'.
+    """
+
+    def test_signal_trace_report_has_cal_exceptions_field(self):
+        """SignalTraceReport exposes a cal_exceptions list (default empty)."""
+        from ginkgo.trading.evaluation.core.evaluation_result import SignalTraceReport
+
+        report = SignalTraceReport(strategy_name="s", strategy_file="s.py")
+        assert report.cal_exceptions == []
+
+    def test_signal_trace_report_add_cal_exception(self):
+        """add_cal_exception appends a structured record (type/message/traceback)."""
+        from ginkgo.trading.evaluation.core.evaluation_result import SignalTraceReport
+
+        report = SignalTraceReport(strategy_name="s", strategy_file="s.py")
+        report.add_cal_exception(
+            exception_type="AttributeError",
+            message="'SimpleDataFeeder' has no get_historical_data",
+            traceback_str="Traceback ...",
+        )
+        assert len(report.cal_exceptions) == 1
+        rec = report.cal_exceptions[0]
+        assert rec["exception_type"] == "AttributeError"
+        assert "get_historical_data" in rec["message"]
+        assert rec["traceback_str"] == "Traceback ..."
+
+    def test_run_signal_tracing_captures_cal_exceptions(self, tmp_path):
+        """A strategy whose cal() raises → _run_signal_tracing records each
+        crash in report.cal_exceptions (previously swallowed silently)."""
+        from datetime import datetime
+        from decimal import Decimal
+
+        from ginkgo.data.models import MBar
+        from ginkgo.enums import FREQUENCY_TYPES
+
+        crash_file = tmp_path / "crash.py"
+        crash_file.write_text(
+            "from ginkgo.trading.strategies.strategy_base import BaseStrategy\n"
+            "class CrashStrategy(BaseStrategy):\n"
+            "    def cal(self, portfolio_info, event):\n"
+            "        raise AttributeError(\"'SimpleDataFeeder' object has no attribute 'get_historical_data'\")\n"
+        )
+
+        bar = MBar(
+            code="000001.SZ",
+            timestamp=datetime(2023, 1, 3, 9, 30),
+            open=Decimal("10.0"),
+            high=Decimal("10.5"),
+            low=Decimal("9.8"),
+            close=Decimal("10.2"),
+            volume=1000000,
+            amount=Decimal("10200000.0"),
+            frequency=FREQUENCY_TYPES.DAY,
+        )
+
+        mock_container = MagicMock()
+        mock_bar_service = MagicMock()
+        mock_bar_service.get.return_value = ServiceResult.success(
+            data=[bar], message="ok"
+        )
+        mock_container.bar_service.return_value = mock_bar_service
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            report = validation_cli._run_signal_tracing(
+                crash_file, "000001.SZ", 0, verbose=False
+            )
+
+        assert report is not None
+        assert len(report.cal_exceptions) >= 1
+        rec = report.cal_exceptions[0]
+        assert rec["exception_type"] == "AttributeError"
+        assert "get_historical_data" in rec["message"]
+        assert "Traceback" in rec["traceback_str"]
+
+    def test_validate_crashing_strategy_reports_failed(self, cli_runner, tmp_path):
+        """#5317 验收: ginkgo validate --show-trace on a crashing strategy must
+        exit non-zero and print FAILED + exception info (previously: PASSED)."""
+        from datetime import datetime
+        from decimal import Decimal
+
+        from ginkgo.data.models import MBar
+        from ginkgo.enums import FREQUENCY_TYPES
+
+        crash_file = tmp_path / "crash.py"
+        crash_file.write_text(
+            "from ginkgo.trading.strategies.strategy_base import BaseStrategy\n"
+            "class CrashStrategy(BaseStrategy):\n"
+            "    def cal(self, portfolio_info, event):\n"
+            "        if event:\n"
+            "            raise AttributeError(\"no get_historical_data\")\n"
+            "        return []\n"
+        )
+
+        bar = MBar(
+            code="000001.SZ",
+            timestamp=datetime(2023, 1, 3, 9, 30),
+            open=Decimal("10.0"),
+            high=Decimal("10.5"),
+            low=Decimal("9.8"),
+            close=Decimal("10.2"),
+            volume=1000000,
+            amount=Decimal("10200000.0"),
+            frequency=FREQUENCY_TYPES.DAY,
+        )
+
+        mock_container = MagicMock()
+        mock_bar_service = MagicMock()
+        mock_bar_service.get.return_value = ServiceResult.success(
+            data=[bar], message="ok"
+        )
+        mock_container.bar_service.return_value = mock_bar_service
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = cli_runner.invoke(
+                validation_cli.app,
+                [str(crash_file), "--show-trace"],
+            )
+
+        assert result.exit_code == 1, f"expected FAILED (exit 1), got {result.exit_code}\n{result.output}"
+        assert "FAILED" in result.output
+        assert "AttributeError" in result.output
+        assert "PASSED" not in result.output
+
+    def test_validate_legitimate_empty_strategy_still_passes(self, cli_runner, tmp_path):
+        """#5317 回归保护: 策略主动 return [] (无崩溃) → 仍 PASSED。
+        修复不能误伤合法的零信号策略。"""
+        from datetime import datetime
+        from decimal import Decimal
+
+        from ginkgo.data.models import MBar
+        from ginkgo.enums import FREQUENCY_TYPES
+
+        quiet_file = tmp_path / "quiet.py"
+        quiet_file.write_text(
+            "from ginkgo.trading.strategies.strategy_base import BaseStrategy\n"
+            "class QuietStrategy(BaseStrategy):\n"
+            "    def cal(self, portfolio_info, event):\n"
+            "        return []\n"
+        )
+
+        bar = MBar(
+            code="000001.SZ",
+            timestamp=datetime(2023, 1, 3, 9, 30),
+            open=Decimal("10.0"),
+            high=Decimal("10.5"),
+            low=Decimal("9.8"),
+            close=Decimal("10.2"),
+            volume=1000000,
+            amount=Decimal("10200000.0"),
+            frequency=FREQUENCY_TYPES.DAY,
+        )
+
+        mock_container = MagicMock()
+        mock_bar_service = MagicMock()
+        mock_bar_service.get.return_value = ServiceResult.success(
+            data=[bar], message="ok"
+        )
+        mock_container.bar_service.return_value = mock_bar_service
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = cli_runner.invoke(
+                validation_cli.app,
+                [str(quiet_file), "--show-trace"],
+            )
+
+        assert result.exit_code == 0, f"expected PASSED (exit 0), got {result.exit_code}\n{result.output}"
+        assert "PASSED" in result.output
+        assert "FAILED" not in result.output
+        assert "RUNTIME_CAL_CRASH" not in result.output


### PR DESCRIPTION
## Summary

`ginkgo validate --show-trace` 之前把 `strategy.cal()` 的运行时异常吞成 `signals=[]`，只在 `--verbose` 下打印一行 `[CAL ERROR]`。结果一个**崩溃的策略**和一个**主动返回 []` 的合法零信号策略**在判定上完全无法区分 —— 两者都报 `✅ Validation PASSED`。真实场景：DualThrust 调用不存在的 `feeder.get_historical_data`，validate 照样 PASSED。

### 根因
`_run_signal_tracing` 的 except 块把异常吞进 `signals=[]`，但 `tracer_report` 返回值在 `_validate_single_strategy` 里被丢弃，最终判定只用结构化 `result.passed`（结构化 evaluator 看不到运行时行为）。

### 修复
- **`SignalTraceReport` 新增 `cal_exceptions: List[Dict]` 字段 + `add_cal_exception()` 方法**，结构化记录每次 cal() 崩溃（异常类型/message/traceback/时间戳）。
- **`_run_signal_tracing`** 把 cal() 异常捕获进报告（不再静默丢弃），`--verbose` 时仍打印 `[CAL ERROR]`。
- **`_validate_single_strategy`** 在结构化校验通过后跑 trace，若 `cal_exceptions` 非空，用 **ERROR 级 `EvaluationIssue` (`RUNTIME_CAL_CRASH`)** 丰富 `result` —— 这样结构化报告**和**最终判定**一致报 FAILED**，而不是另开一个 verdict override 变量（保持单一判定源）。
- **`SignalTraceReport.to_dict()` / `__str__()`** 暴露 `cal_exceptions`，JSON 消费方和 `--show-trace` 报告都能看到崩溃明细，不再误读 "Total Signals: 0"。

### 行为对比
| 场景 | 修复前 | 修复后 |
|---|---|---|
| 策略主动 `return []` | PASSED | PASSED（回归保护） |
| 策略 cal() 抛 AttributeError | PASSED（误报） | **FAILED + exit 1 + AttributeError 详情** |

## Test plan

`tests/unit/client/test_validation_cli.py` 新增 `TestRuntimeCrashDetection` 5 个用例：
1. `SignalTraceReport.cal_exceptions` 默认空列表
2. `add_cal_exception()` 追加结构化记录
3. `_run_signal_tracing` 直接调用 → 捕获崩溃（含 traceback）
4. **验收**：CliRunner 跑崩溃策略 → exit 1 + "FAILED" + "AttributeError" + 无 "PASSED"
5. **回归**：合法空返回策略 → exit 0 + "PASSED" + 无 "RUNTIME_CAL_CRASH"

三层 smoke 全绿：
- py_compile (src + api 全量)
- 启动路径点名 (user_crud_mock + containers + user_cli, 29 项)
- 变更相关 (validation_cli + evaluation_cli + evaluation_glog, 35 项)

本地实跑验收用例 #4 输出（节选）：
```
❌ Validation FAILED: 1 error(s), 0 warning(s)
...
RUNTIME_CAL_CRASH (ERROR): Strategy raised AttributeError during runtime tracing
  (1 event(s) crashed): no get_historical_data
```

Closes #5317

🤖 Generated with [Claude Code](https://claude.com/claude-code)