### PR TITLE
fix(#5409): Portfolio 更新假回滚——success() 参数修正 + initial_capital 接入

### DIFF
--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -167,6 +167,7 @@ class PortfolioService(BaseService):
         mode: PORTFOLIO_MODE_TYPES = None,
         state: PORTFOLIO_RUNSTATE_TYPES = None,
         description: str = None,
+        initial_capital=None,
         cash=None,
         frozen=None,
         current_capital=None,
@@ -199,6 +200,7 @@ class PortfolioService(BaseService):
         _only_state = state is not None and all(
             v is None for k, v in [
                 ("name", name), ("mode", mode), ("description", description),
+                ("initial_capital", initial_capital),
                 ("cash", cash), ("frozen", frozen), ("current_capital", current_capital),
                 ("total_fee", total_fee), ("total_profit", total_profit),
             ]
@@ -232,6 +234,10 @@ class PortfolioService(BaseService):
             updates["desc"] = description
             updates_applied.append("description")
 
+        if initial_capital is not None:
+            updates["initial_capital"] = initial_capital
+            updates_applied.append("initial_capital")
+
         if cash is not None:
             updates["cash"] = cash
             updates_applied.append("cash")
@@ -257,7 +263,12 @@ class PortfolioService(BaseService):
             updates_applied.append("live_account_id")
 
         if not updates:
-            return ServiceResult.success({}, "No updates provided for portfolio update", warnings)
+            # #5409: ServiceResult.success() 只收 (data, message)；warnings 通过 add_warning 附加，
+            # 否则传第 3 个位置参会抛 TypeError，端点误报 "rolled back" 但实际未回滚（假回滚）。
+            result = ServiceResult.success({}, "No updates provided for portfolio update")
+            for w in warnings:
+                result.add_warning(w)
+            return result
 
         # Check if name conflicts with existing portfolio (if name is being updated)
         if "name" in updates:

--- a/tests/unit/data/services/test_portfolio_update_noop_typeerror.py
+++ b/tests/unit/data/services/test_portfolio_update_noop_typeerror.py
@@ -1,0 +1,88 @@
+"""#5409: portfolio update 在无可更新字段时不应抛 TypeError。
+
+复现 issue：PUT /api/v1/portfolios/{id} 触发 saga.update_basic_info，
+当 saga 字段被 `**kwargs` 丢弃致 `updates` 空时，命中
+`ServiceResult.success({}, msg, warnings)` 第 3 个位置参数 → TypeError
+（success 签名只收 data/message 两参），端点误报 "rolled back"。
+
+隔离单测：mock crud，不连库。
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+_src = str(project_root / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from ginkgo.data.services.portfolio_service import PortfolioService
+
+
+@pytest.fixture
+def noop_portfolio_service():
+    """PortfolioService with mocked collaborators (no DB)."""
+    svc = PortfolioService(crud_repo=MagicMock(), portfolio_file_mapping_crud=MagicMock())
+    return svc
+
+
+class TestPortfolioUpdateNoopNoTypeerror:
+    """#5409 regression: update 无可更新字段路径。"""
+
+    def test_update_with_no_fields_returns_success_not_typeerror(self, noop_portfolio_service):
+        """仅传 portfolio_id（无可更新字段）应返回 success，不抛 TypeError。"""
+        with patch.object(noop_portfolio_service, "is_portfolio_frozen", return_value=False):
+            # 修复前：line 260 ServiceResult.success({}, msg, warnings) → TypeError
+            result = noop_portfolio_service.update(portfolio_id="some-uuid")
+
+        assert result.is_success(), f"expected success, got error={result.error!r}"
+
+    def test_update_with_no_fields_message_indicates_noop(self, noop_portfolio_service):
+        """无字段更新应通过 message（而非抛异常）告知调用方是 no-op。"""
+        with patch.object(noop_portfolio_service, "is_portfolio_frozen", return_value=False):
+            result = noop_portfolio_service.update(portfolio_id="some-uuid")
+
+        assert result.is_success()
+        text = (result.message or "").lower()
+        assert "no update" in text, f"message should mention no-update, got {result.message!r}"
+
+    def test_update_with_only_unknown_kwarg_no_typeerror(self, noop_portfolio_service):
+        """saga 路径：initial_capital 不在 update 签名，被 **kwargs 丢弃致 updates 空。
+
+        调用方（saga.update_basic_info）传 update(portfolio_uuid, initial_capital=X)，
+        update 内部 kwargs 接收但不处理 → updates 空 → 应返回 success(no-op)，
+        不应抛 TypeError。
+        """
+        with patch.object(noop_portfolio_service, "is_portfolio_frozen", return_value=False):
+            result = noop_portfolio_service.update(
+                portfolio_id="some-uuid", initial_capital=100000.0
+            )
+
+        assert result.is_success(), f"expected success, got error={result.error!r}"
+
+
+class TestPortfolioUpdateInitialCapitalPersisted:
+    """#5409 第二半：saga 转发 initial_cash -> update(initial_capital=X) 应真正写入 DB。
+
+    Portfolio model 有 initial_capital 字段，但 update() 历史签名未暴露，
+    saga 传入被 **kwargs 静默丢弃 → updates 空 → 即便修了 TypeError 也只是 no-op，
+    用户改 initial_cash 会"静默不生效"。update 应显式处理 initial_capital。
+    """
+
+    def test_update_initial_capital_is_persisted(self, noop_portfolio_service):
+        """update(portfolio_id, initial_capital=X) 应把 initial_capital 写入 updates。"""
+        noop_portfolio_service._crud_repo.modify = MagicMock()
+        with patch.object(noop_portfolio_service, "is_portfolio_frozen", return_value=False):
+            result = noop_portfolio_service.update(
+                portfolio_id="some-uuid", initial_capital=500000.0
+            )
+
+        assert result.is_success(), f"expected success, got error={result.error!r}"
+        noop_portfolio_service._crud_repo.modify.assert_called_once()
+        updates = noop_portfolio_service._crud_repo.modify.call_args.kwargs.get("updates")
+        assert updates is not None, "modify should be called with updates dict"
+        assert updates.get("initial_capital") == 500000.0, \
+            f"initial_capital should be in updates, got {updates!r}"
+


### PR DESCRIPTION
## Summary

修复 `PUT /api/v1/portfolios/{id}` 报错 "Transaction has been rolled back" 但数据实际已变更（假回滚）。两处同源 bug：

### 根因链
端点 → `PortfolioSagaFactory.update_portfolio_saga` → 步骤 `update_basic_info`：
```python
portfolio_service.update(portfolio_uuid, name=name)                      # name 先改成功
portfolio_service.update(portfolio_uuid, initial_capital=initial_cash)   # ← 触发崩
```

**Bug 1**：`portfolio_service.py:260` `ServiceResult.success({}, msg, warnings)` 传第 3 个位置参，但 `success(cls, data=None, message="")` 只收两参 → `TypeError`。

**Bug 2**：`update()` 签名未暴露 `initial_capital`（Portfolio model 有此字段），saga 转发的 `initial_capital=X` 被 `**kwargs` 静默丢弃 → `updates` 空 → 命中 Bug 1。

用户同时传 name + initial_cash 时：name 先改成功，initial_capital 路径抛 TypeError，saga 报 "rolled back" 但 name 未回滚 = 假回滚。

### 修复
1. **Bug 1**：`success({}, msg)` 后用 `result.add_warning(w)` 附加 warnings（保持语义，签名不破）。
2. **Bug 2**：`update()` 加 `initial_capital` 参数（对齐 model 字段），`_only_state` 冻结豁免列表 + `updates` 构建同步纳入。saga 调用真正生效。

### 影响面
Bug 1 还波及 `update(mode=X)` 路径（mode 被 line 220-225 转成 warning 不进 updates，单传 mode 时 updates 空 → 同样 TypeError）。本修复一并消除。

## Test plan

新增隔离单测 `tests/unit/data/services/test_portfolio_update_noop_typeerror.py`（4 例，mock crud 不连库）：
- noop（无可更新字段）不抛 TypeError
- noop 返回 message 含 "no update"
- 仅传 `initial_capital`（saga 字段名）不抛 TypeError
- `initial_capital` 真正写入 `modify(updates=...)`

三层冒烟（对齐 `.github/workflows/ci.yml`）：
- ✅ Layer 1 py_compile（src + api 全量）
- ✅ Layer 2 启动路径 smoke：user_crud_mock + containers + user_cli（29 passed）
- ✅ Layer 3 变更相关：新测试 4 passed；`test_portfolio_update_validation.py` 6 passed

既有失败（与本 PR 无关，stash baseline 同样失败）：
- `test_portfolio_service.py` 5 例 mode/state：line 220-225 设计决策明确禁止 mode 修改（提示用 deploy），测试期望 mode 改变 → 矛盾；本 PR 把 TypeError 崩溃降级为明确断言失败。
- `test_saga_transaction.py::test_update_portfolio_saga_structure`：patch 模块级 `container`，但 saga_transaction.py 是函数内 import container（见 ADR arch_api_containers_module_level_import）。

Closes #5409