### PR TITLE
fix(#5366): dev chat 非 TTY/无 Ollama 时友好退出而非崩溃

### DIFF
--- a/src/ginkgo/client/dev_cli.py
+++ b/src/ginkgo/client/dev_cli.py
@@ -95,14 +95,51 @@ def dev_jupyter(
     subprocess.run([jupyter_path, "lab"])
 
 
+def _check_ollama_reachable(timeout: float = 2.0) -> bool:
+    """#5366: 轻量探活 Ollama 服务（GET /api/tags）。
+
+    返回 True 表示可连通且 HTTP 200；False 表示连不上或超时。
+    仅吞 requests 层的连接/超时异常（这正是要友好处理的场景），
+    其它异常原样抛出（避免静默掩盖编程错误，参见归因纪律）。
+    """
+    import requests
+    from ginkgo.libs import GCONF
+
+    url = f"{GCONF.OLLAMA_HOST}:{GCONF.OLLAMA_PORT}/api/tags"
+    try:
+        resp = requests.get(url, timeout=timeout)
+        return resp.status_code == 200
+    except requests.exceptions.RequestException:
+        # ConnectionError / Timeout / 等连接层问题 → 友好提示而非 traceback
+        return False
+
+
 @app.command("chat")
 def dev_chat():
     """
     :speech_balloon: Launch interactive command-line interface.
     """
+    # #5366: 前置守卫——非交互终端 / Ollama 不可用时友好退出而非崩溃。
+    # 守卫必须早于 os.system("clear") 与重 import，保证非 TTY 快速失败。
+    import sys
+
+    if not sys.stdin.isatty():
+        console.print(
+            ":warning: [yellow]检测到非交互终端。"
+            "请在交互式终端中运行 [bold]ginkgo dev chat[/bold]。[/yellow]"
+        )
+        raise typer.Exit(1)
+
+    if not _check_ollama_reachable():
+        console.print(
+            ":warning: [yellow]无法连接 Ollama 服务。"
+            "请确认已安装并启动 Ollama（默认 http://localhost:11434）。[/yellow]"
+        )
+        raise typer.Exit(1)
+
     import os
     from ginkgo.client.interactive_cli import MyPrompt
-    
+
     os.system("clear")
     p = MyPrompt()
     p.cmdloop()

--- a/src/ginkgo/client/dev_cli.py
+++ b/src/ginkgo/client/dev_cli.py
@@ -99,18 +99,20 @@ def _check_ollama_reachable(timeout: float = 2.0) -> bool:
     """#5366: 轻量探活 Ollama 服务（GET /api/tags）。
 
     返回 True 表示可连通且 HTTP 200；False 表示连不上或超时。
-    仅吞 requests 层的连接/超时异常（这正是要友好处理的场景），
-    其它异常原样抛出（避免静默掩盖编程错误，参见归因纪律）。
+    仅吞连接/超时异常（这正是要友好处理的场景），schema 类异常
+    （InvalidSchema/MissingSchema/InvalidURL）原样抛出——它们是配置 bug，
+    吞掉会把「host 缺 scheme」伪装成「Ollama 没启动」，违背归因纪律。
     """
     import requests
     from ginkgo.libs import GCONF
+    from ginkgo.client.interactive_cli import _normalize_ollama_url
 
-    url = f"{GCONF.OLLAMA_HOST}:{GCONF.OLLAMA_PORT}/api/tags"
+    url = _normalize_ollama_url(GCONF.OLLAMA_HOST, GCONF.OLLAMA_PORT, "/api/tags")
     try:
         resp = requests.get(url, timeout=timeout)
         return resp.status_code == 200
-    except requests.exceptions.RequestException:
-        # ConnectionError / Timeout / 等连接层问题 → 友好提示而非 traceback
+    except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        # 连接层问题（服务未启动/网络不通/超时）→ 友好提示而非 traceback
         return False
 
 

--- a/src/ginkgo/client/interactive_cli.py
+++ b/src/ginkgo/client/interactive_cli.py
@@ -80,11 +80,23 @@ def chunk_print(response):
     sys.stdout.write("\n")
 
 
+def _normalize_ollama_url(host: str, port: str, path: str) -> str:
+    """#5366: 归一化 Ollama URL，给裸 host 补 http:// scheme。
+
+    GCONF.OLLAMA_HOST 默认 "localhost"（无 scheme），裸拼出的 URL 会让
+    requests 抛 InvalidSchema（No connection adapters）。统一在此补 scheme，
+    dev_cli 启动守卫与 ask_ollama 运行时复用，避免两份裸 URL 各自维护。
+    """
+    if not host.startswith(("http://", "https://")):
+        host = f"http://{host}"
+    return f"{host}:{port}{path}"
+
+
 def ask_ollama(msg: str):
     global mem
     mem += msg
     from ginkgo.libs import GCONF
-    url = f"{GCONF.OLLAMA_HOST}:{GCONF.OLLAMA_PORT}/api/generate"
+    url = _normalize_ollama_url(GCONF.OLLAMA_HOST, GCONF.OLLAMA_PORT, "/api/generate")
     payload = {"model": "mistral:latest", "prompt": mem}
     headers = {"Content-Type": "application/json"}
     response = requests.post(url, json=payload, headers=headers, stream=True)

--- a/tests/unit/client/test_dev_cli.py
+++ b/tests/unit/client/test_dev_cli.py
@@ -1,9 +1,12 @@
 # #6020 — dev test/lint 引用错误目录 test/ 应为 tests/
+# #5366 — dev chat 非 TTY / 无 Ollama 时应友好退出而非崩溃
 """
 验证 ginkgo dev test / dev lint 命令指向真实存在的 tests/ 目录，
 而非不存在的 test/（项目测试目录统一为 tests/，见 CLAUDE.md）。
+另验证 dev chat 在非交互终端或 Ollama 不可用时给出友好提示退出（#5366）。
 """
 import pytest
+import typer
 from unittest.mock import patch, MagicMock
 
 
@@ -58,3 +61,56 @@ class TestDevLintCommandTargetsTestsDir:
         for call in tool_calls:
             assert "tests/" in call, f"#6020: {call[0]} 未含 tests/: {call}"
             assert "test/" not in call, f"#6020: {call[0]} 仍含 test/: {call}"
+
+
+class TestDevChatNonTTYGuard:
+    """#5366: 非 TTY 环境应友好提示退出，不进入交互循环"""
+
+    def test_non_tty_exits_without_cmdloop(self):
+        """非交互终端调用 dev_chat 应 raise typer.Exit 且不进入 cmdloop"""
+        from ginkgo.client.dev_cli import dev_chat
+
+        with patch("sys.stdin.isatty", return_value=False), \
+             patch("ginkgo.client.interactive_cli.MyPrompt") as mock_prompt:
+            with pytest.raises(typer.Exit):
+                dev_chat()
+
+        # 守卫触发后绝不能构造 MyPrompt / 进入 cmdloop
+        assert not mock_prompt.called, "非 TTY 不应构造 MyPrompt"
+
+
+class TestDevChatOllamaUnreachableGuard:
+    """#5366: Ollama 不可用时应给出安装/启动提示而非 ConnectionError 堆栈"""
+
+    def test_ollama_unreachable_exits_without_cmdloop(self):
+        """TTY 正常但连不上 Ollama 应 raise typer.Exit 且不进入 cmdloop"""
+        import requests
+        from ginkgo.client.dev_cli import dev_chat
+
+        with patch("sys.stdin.isatty", return_value=True), \
+             patch("requests.get", side_effect=requests.exceptions.ConnectionError), \
+             patch("ginkgo.client.interactive_cli.MyPrompt") as mock_prompt:
+            with pytest.raises(typer.Exit):
+                dev_chat()
+
+        assert not mock_prompt.called, "Ollama 不可用时不应构造 MyPrompt"
+
+
+class TestDevChatHappyPathPreserved:
+    """#5366: TTY + Ollama 可用时，原有 cmdloop 行为必须保留"""
+
+    def test_tty_and_ollama_ok_enters_cmdloop(self):
+        """守卫不应误伤正常交互场景"""
+        from ginkgo.client.dev_cli import dev_chat
+
+        ok_resp = MagicMock(status_code=200)
+        with patch("sys.stdin.isatty", return_value=True), \
+             patch("requests.get", return_value=ok_resp), \
+             patch("ginkgo.client.interactive_cli.MyPrompt") as mock_prompt, \
+             patch("os.system") as mock_system:
+            dev_chat()
+
+        assert mock_prompt.called, "正常路径应构造 MyPrompt"
+        mock_prompt.return_value.cmdloop.assert_called_once(), "正常路径应进入 cmdloop"
+        # clear 仍在守卫之后执行
+        mock_system.assert_called_with("clear")

--- a/tests/unit/client/test_dev_cli.py
+++ b/tests/unit/client/test_dev_cli.py
@@ -105,7 +105,7 @@ class TestDevChatHappyPathPreserved:
 
         ok_resp = MagicMock(status_code=200)
         with patch("sys.stdin.isatty", return_value=True), \
-             patch("requests.get", return_value=ok_resp), \
+             patch("requests.get", return_value=ok_resp) as mock_get, \
              patch("ginkgo.client.interactive_cli.MyPrompt") as mock_prompt, \
              patch("os.system") as mock_system:
             dev_chat()
@@ -114,3 +114,79 @@ class TestDevChatHappyPathPreserved:
         mock_prompt.return_value.cmdloop.assert_called_once(), "正常路径应进入 cmdloop"
         # clear 仍在守卫之后执行
         mock_system.assert_called_with("clear")
+        # #5366 review: 校验传给 requests.get 的 URL 含 scheme
+        # （原 happy-path 用 MagicMock 整体替换 get，schema bug 测试不可见）
+        called_url = mock_get.call_args[0][0]
+        assert called_url.startswith(("http://", "https://")), \
+            f"URL 缺 scheme，默认配置会触发 InvalidSchema: {called_url}"
+        assert called_url.endswith("/api/tags"), f"URL 应指向 /api/tags: {called_url}"
+
+
+class TestCheckOllamaReachableSchemaException:
+    """#5366 review: except 收窄，schema 类异常（InvalidSchema/MissingSchema/InvalidURL）
+    必须原样抛出。宽 except RequestException 会把它们当「连不上」吞掉，
+    把配置 bug 伪装成「Ollama 没启动」，违背归因纪律。"""
+
+    def test_invalid_schema_propagates_not_swallowed(self):
+        """requests.get 抛 InvalidSchema 时应原样抛，不返 False"""
+        import requests
+        from ginkgo.client.dev_cli import _check_ollama_reachable
+
+        with patch("requests.get", side_effect=requests.exceptions.InvalidSchema("No connection adapters")):
+            with pytest.raises(requests.exceptions.InvalidSchema):
+                _check_ollama_reachable()
+
+    def test_connection_error_still_swallowed_friendly(self):
+        """真·连接错误仍应友好吞掉返 False（保留原 #5366 守卫语义）"""
+        import requests
+        from ginkgo.client.dev_cli import _check_ollama_reachable
+
+        with patch("requests.get", side_effect=requests.exceptions.ConnectionError):
+            assert _check_ollama_reachable() is False
+
+    def test_timeout_still_swallowed_friendly(self):
+        """超时仍应友好吞掉返 False"""
+        import requests
+        from ginkgo.client.dev_cli import _check_ollama_reachable
+
+        with patch("requests.get", side_effect=requests.exceptions.Timeout):
+            assert _check_ollama_reachable() is False
+
+
+class TestAskOllamaUsesNormalizedUrl:
+    """#5366 review: interactive_cli.ask_ollama 同款裸 URL（{OLLAMA_HOST}:{PORT}/api/generate），
+    守卫侥幸过了进 REPL 仍崩。必须复用归一化 helper。"""
+
+    def test_ask_ollama_url_contains_scheme(self):
+        """ask_ollama 传给 requests.post 的 URL 必须含 scheme"""
+        import ginkgo.client.interactive_cli as ic
+
+        with patch.object(ic, "mem", ""), \
+             patch.object(ic, "requests") as mock_requests, \
+             patch.object(ic, "chunk_print"):
+            ic.ask_ollama("hello")
+
+        called_url = mock_requests.post.call_args[0][0]
+        assert called_url.startswith(("http://", "https://")), \
+            f"ask_ollama URL 缺 scheme，进 REPL 仍会 InvalidSchema: {called_url}"
+        assert called_url.endswith("/api/generate"), \
+            f"URL 应指向 /api/generate: {called_url}"
+
+
+class TestNormalizeOllamaUrl:
+    """#5366 review: OLLAMA_HOST 默认裸 host（localhost），URL 必须归一化补 scheme，
+    否则 requests.get 抛 InvalidSchema 被宽 except 吞 → 守卫恒 False。"""
+
+    def test_bare_host_gets_http_scheme(self):
+        """裸 host（默认 localhost）应补 http:// 前缀"""
+        from ginkgo.client.interactive_cli import _normalize_ollama_url
+
+        url = _normalize_ollama_url("localhost", "11434", "/api/tags")
+        assert url == "http://localhost:11434/api/tags"
+
+    def test_host_with_scheme_preserved(self):
+        """用户显式配置 http:// 或 https:// 时不重复补 scheme"""
+        from ginkgo.client.interactive_cli import _normalize_ollama_url
+
+        assert _normalize_ollama_url("http://localhost", "11434", "/api/tags") == "http://localhost:11434/api/tags"
+        assert _normalize_ollama_url("https://ollama.example.com", "11434", "/api/tags") == "https://ollama.example.com:11434/api/tags"


### PR DESCRIPTION
## Summary

`ginkgo dev chat` 在非交互终端或 Ollama 不可用时直接崩溃：
- 非 TTY：`cmd.Cmd` 收到 EOF 后行为未定义，EOF 被当 prompt 发给 Ollama
- Ollama 未运行：`requests.post` 抛原始 `ConnectionError` traceback 给用户

`dev_chat` 入口加两段前置守卫（早于 `os.system("clear")` 与重 import，保证快速失败）：

1. **TTY 守卫**：`sys.stdin.isatty() == False` → 提示「请在交互式终端中运行」+ `typer.Exit(1)`
2. **Ollama 探活**：新增 `_check_ollama_reachable()` helper，`GET /api/tags`（2s 超时）失败 → 提示「无法连接 Ollama，请确认已安装并启动」+ `typer.Exit(1)`

Helper 仅吞 `requests.exceptions.RequestException`（连接/超时，正是要友好处理的场景），其它异常原样抛出，避免静默掩盖编程错误（参见 CLAUDE.md 归因纪律）。

正常路径（TTY + Ollama 可用）原有 `cmdloop()` 行为完全保留。

## Test plan

新增 3 个单元测试（`tests/unit/client/test_dev_cli.py`），覆盖三条路径：
- `TestDevChatNonTTYGuard` — 非 TTY → `typer.Exit` 且不构造 `MyPrompt`
- `TestDevChatOllamaUnreachableGuard` — Ollama 连不上 → `typer.Exit` 且不构造 `MyPrompt`
- `TestDevChatHappyPathPreserved` — TTY + Ollama 200 → 进入 `cmdloop`（守卫不误伤正常交互）

冒烟测试三层全绿：
- Layer 1：`py_compile`（src/ + api/ 全量）
- Layer 2：启动路径 smoke（user_crud_mock + containers + user_cli，29 passed）
- Layer 3：变更相关测试（test_dev_cli.py 全量 6 passed，含原有 dev_test/dev_lint 回归）

Closes #5366

🤖 Generated with [Claude Code](https://claude.com/claude-code)