### PR TITLE
fix(#5177): execution list-portfolios 读 schedule:plan 实现

### DIFF
--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -169,15 +169,63 @@ def list_portfolios(
     """
     :clipboard: List all Portfolios loaded in ExecutionNode.
 
-    Display Portfolio IDs and their subscription status.
+    Display Portfolio IDs assigned to the given ExecutionNode.
+    Source of truth: schedule:plan Redis hash ({portfolio_id -> node_id}),
+    same key the scheduler inverts to map node -> portfolios.
+
+    Examples:
+      ginkgo execution list-portfolios
+      ginkgo execution list-portfolios --node-id node_1
     """
-    # STUB: Portfolio 热管理功能尚未实现
-    # See: https://github.com/Kaoruha/GinkGO/issues/4637
-    console.print(
-        f"[yellow]:warning: STUB: list_portfolios 尚未实现。[/yellow]\n"
-        f"[dim]Portfolio 热加载/卸载/列表功能待开发，参见 #4637。[/dim]"
-    )
-    return
+    try:
+        from ginkgo.data.crud import RedisCRUD
+        from ginkgo.data.redis_schema import RedisKeyBuilder
+
+        redis_client = RedisCRUD().redis
+
+        # schedule:plan hash: {portfolio_id -> node_id}
+        # (Scheduler.SCHEDULE_PLAN_KEY；CLI 沿用 status 命令既有先例直接引用键名)
+        plan = redis_client.hgetall("schedule:plan")
+
+        def _decode(v):
+            return v.decode("utf-8") if isinstance(v, bytes) else v
+
+        portfolios_on_node = [
+            _decode(pid)
+            for pid, assigned_node in plan.items()
+            if _decode(assigned_node) == node_id
+        ]
+
+        if not portfolios_on_node:
+            console.print(
+                f"[yellow]:information: No portfolios assigned to ExecutionNode '{node_id}'[/yellow]"
+            )
+            # 信息性心跳提示（不阻断；调度计划为空也可能是节点未启动）
+            heartbeat_ttl = redis_client.ttl(
+                RedisKeyBuilder.execution_node_heartbeat(node_id)
+            )
+            if heartbeat_ttl < 0:
+                console.print(
+                    f"[dim]  (node '{node_id}' 心跳未检出 — TTL={heartbeat_ttl}；"
+                    f"若节点未运行，调度计划自然为空)[/dim]"
+                )
+            return
+
+        table = Table(
+            title=f":clipboard: Portfolios on ExecutionNode '{node_id}' "
+            f"({len(portfolios_on_node)})",
+            show_header=True,
+        )
+        table.add_column("#", style="dim", no_wrap=True)
+        table.add_column("Portfolio ID", style="cyan")
+        for idx, pid in enumerate(portfolios_on_node, 1):
+            table.add_row(str(idx), pid)
+        console.print("\n")
+        console.print(table)
+
+    except Exception as e:
+        console.print(f"[red]:x: Error listing portfolios: {e}[/red]")
+        raise typer.Exit(1)
 
 
 @app.command()

--- a/tests/unit/client/test_execution_cli_list_portfolios.py
+++ b/tests/unit/client/test_execution_cli_list_portfolios.py
@@ -1,0 +1,93 @@
+# coding:utf-8
+"""execution_cli list-portfolios 命令单元测试 (#5177)。
+
+list-portfolios 从 schedule:plan Redis hash ({portfolio_id -> node_id})
+读取并反查指定节点已加载的 portfolio 列表。数据源与调度器反查节点
+portfolio 的同一来源 (scheduler.py _send_status_report)。
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client import execution_cli
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestExecutionListPortfolios:
+    """#5177 list-portfolios 读 schedule:plan hash 反查节点 portfolio。"""
+
+    def test_list_portfolios_filters_by_node_id(self, cli_runner):
+        """schedule:plan 含多节点分配时，--node-id 仅显示分配给该节点的 portfolio。"""
+        mock_redis = MagicMock()
+        # schedule:plan hash: {portfolio_id -> node_id} (redis-py 返回 bytes)
+        mock_redis.hgetall.return_value = {
+            b"portfolio_aaa": b"node_1",
+            b"portfolio_bbb": b"node_2",
+            b"portfolio_ccc": b"node_1",
+        }
+        # heartbeat 存活（TTL > 0 表示有心跳）
+        mock_redis.ttl.return_value = 25
+        mock_crud = MagicMock()
+        mock_crud.redis = mock_redis
+
+        with patch("ginkgo.data.crud.RedisCRUD", return_value=mock_crud):
+            result = cli_runner.invoke(
+                execution_cli.app, ["list-portfolios", "--node-id", "node_1"]
+            )
+
+        assert result.exit_code == 0
+        assert "portfolio_aaa" in result.output
+        assert "portfolio_ccc" in result.output
+        # portfolio_bbb 分配给 node_2，不应出现
+        assert "portfolio_bbb" not in result.output
+
+    def test_list_portfolios_empty_plan_friendly_message(self, cli_runner):
+        """schedule:plan 为空（无分配）时打印友好提示，exit 0（AC: 空列表提示）。"""
+        mock_redis = MagicMock()
+        mock_redis.hgetall.return_value = {}
+        mock_redis.ttl.return_value = 25  # 节点在线，只是无分配
+        mock_crud = MagicMock()
+        mock_crud.redis = mock_redis
+
+        with patch("ginkgo.data.crud.RedisCRUD", return_value=mock_crud):
+            result = cli_runner.invoke(
+                execution_cli.app, ["list-portfolios", "--node-id", "node_1"]
+            )
+
+        assert result.exit_code == 0
+        # 友好提示包含节点 id 与"No portfolios"
+        assert "node_1" in result.output
+        assert "No portfolios" in result.output
+        # 不应崩溃成 traceback
+        assert "Traceback" not in result.output
+
+    def test_list_portfolios_node_offline_shows_heartbeat_hint(self, cli_runner):
+        """节点无心跳（TTL<0）且无分配时，额外提示心跳未检出（信息性，不阻断）。"""
+        mock_redis = MagicMock()
+        mock_redis.hgetall.return_value = {}
+        # TTL=-2 表示心跳键不存在（节点未运行）
+        mock_redis.ttl.return_value = -2
+        mock_crud = MagicMock()
+        mock_crud.redis = mock_redis
+
+        with patch("ginkgo.data.crud.RedisCRUD", return_value=mock_crud):
+            result = cli_runner.invoke(
+                execution_cli.app, ["list-portfolios", "--node-id", "ghost_node"]
+            )
+
+        assert result.exit_code == 0
+        assert "No portfolios" in result.output
+        # 信息性心跳提示
+        assert "ghost_node" in result.output
+        assert "心跳" in result.output


### PR DESCRIPTION
## Summary

实现 `ginkgo execution list-portfolios --node-id <id>`，替换原 stub。

**数据源**：Redis `schedule:plan` hash（`{portfolio_id -> node_id}`）——这是调度器维护的节点↔portfolio 权威映射，调度器自身在 `_send_status_report` 中用它反查节点 portfolio（scheduler.py:438-441）。CLI 是独立进程，无法访问 ExecutionNode 进程内 `node.portfolios`，`schedule:plan` 是无需 RPC 的最佳可用真相源。

**行为**：
- 节点有分配 → 表格输出 portfolio ID 列表
- 无分配 → 友好提示 `No portfolios assigned to ExecutionNode '<id>'`
- 节点心跳未检出（TTL<0）→ 信息性提示（不阻断，调度计划为空也可能是节点未启动）

**范围**：仅 `list-portfolios`。`load`/`unload` 热管理需生命周期设计，超出本 brief（triage 已收窄），跟踪 #4637 另立。

## Test plan

三层冒烟全绿（对齐 `.github/workflows/ci.yml` #6015）：
- Layer 1: `py_compile` (src + api) ✅
- Layer 2: 启动路径 smoke（`test_user_crud_mock` + `test_containers` + `test_user_cli`，29 tests）✅
- Layer 3: `test_execution_cli_list_portfolios.py`（新增 3 tests）+ `test_execution_cli_status.py` + `test_execution_cli_cleanup.py`（11 tests，无回归）✅

新增测试覆盖：按 `--node-id` 过滤、空调度计划友好提示、节点离线心跳提示。

Closes #5177

🤖 Generated with [Claude Code](https://claude.com/claude-code)