### PR TITLE
fix(#5163): cn_all 宽 universe 回测无数据 code 性能优化（WARN 去重 + 批量预过滤）

### DIFF
--- a/src/ginkgo/trading/feeders/backtest_feeder.py
+++ b/src/ginkgo/trading/feeders/backtest_feeder.py
@@ -63,6 +63,10 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
 
         # 兴趣集（通过EventInterestUpdate动态更新）
         self._interested_codes: List[str] = []
+
+        # 无数据 code 去重集合（#5163）：同 code 仅 WARN 一次，避免宽 universe
+        # 回测时逐日刷屏（5000 股 × 60 日 ≈ 30 万次 WARN）
+        self._warned_no_data: set = set()
         
     # === IDataFeeder 基础接口实现 ===
 
@@ -235,7 +239,10 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
             )
 
             if not result.success or not result.data:
-                GLOG.WARN(f"BacktestFeeder: No bar data for {code} at {target_time.date()}")
+                # #5163: 同 code 仅 WARN 一次，避免宽 universe 逐日刷屏
+                if code not in self._warned_no_data:
+                    self._warned_no_data.add(code)
+                    GLOG.WARN(f"BacktestFeeder: No bar data for {code} at {target_time.date()}")
                 return events
 
             # 转换ModelList → 业务对象列表（ADR-010: 走 Mapper 层，不再经 to_entities 懒转换）

--- a/src/ginkgo/trading/selectors/cn_all_selector.py
+++ b/src/ginkgo/trading/selectors/cn_all_selector.py
@@ -1,13 +1,12 @@
 # Upstream: EngineAssemblyService, PortfolioBase
-# Downstream: BaseSelector, container.stockinfo_service
-# Role: 全A股选股器，从股票信息服务获取全部A股代码列表
-
-
+# Downstream: BaseSelector, container.stockinfo_service, container.bar_service
+# Role: 全A股选股器，从股票信息服务获取全部A股代码列表，剔除 DB 无 bar 数据的 code（#5163）
 
 
 
 
 from ginkgo.trading.bases.selector_base import SelectorBase as BaseSelector
+from ginkgo.libs import GLOG
 
 import datetime
 
@@ -33,7 +32,37 @@ class CNAllSelector(BaseSelector):
         from ginkgo.data.containers import container
         result = container.stockinfo_service().get_stockinfos_df()
         if result.success and not result.data.empty:
-            self._interested = result.data["code"].tolist()
+            market_codes = result.data["code"].tolist()
+        else:
+            market_codes = []
+
+        # #5163: 批量预过滤——剔除 DB 中无 bar 数据的 code，避免 feeder 每日
+        # 对全市场逐股 N+1 查询 + 逐日刷屏 WARN。get_available_codes 一次 distinct
+        # 查询返回所有有 bar 的 code。
+        if market_codes:
+            market_set = set(market_codes)
+            try:
+                bar_result = container.bar_service().get_available_codes()
+            except Exception as e:
+                GLOG.WARN(
+                    f"CNAllSelector: bar_service.get_available_codes failed ({e}), "
+                    f"skip prefilter (fail-open, return all {len(market_set)} codes)"
+                )
+                bar_result = None
+
+            if bar_result is not None and bar_result.success and bar_result.data:
+                available = set(bar_result.data)
+                filtered = [c for c in market_codes if c in available]
+                dropped = len(market_set) - len(filtered)
+                if dropped > 0:
+                    GLOG.INFO(
+                        f"CNAllSelector: prefilter dropped {dropped}/{len(market_set)} "
+                        f"codes without bar data, {len(filtered)} remaining"
+                    )
+                self._interested = filtered
+            else:
+                # 预过滤失败/空 → fail-open，返回全市场（不阻断回测）
+                self._interested = market_codes
         else:
             self._interested = []
         return self._interested

--- a/tests/unit/trading/engines/test_backtest_feeder.py
+++ b/tests/unit/trading/engines/test_backtest_feeder.py
@@ -937,3 +937,73 @@ class TestHistoricalDataAccess:
         assert isinstance(result, pd.DataFrame)
         assert result.empty
         assert len(result) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.backtest
+class TestBacktestFeederNoDataDedup:
+    """BacktestFeeder 无数据警告去重（#5163）
+
+    宽 universe（cn_all）回测时，无数据 code 逐日逐票刷屏 WARN 拖慢性能。
+    验收：同一 code 的 'No bar data' WARN 至多一条。
+    """
+
+    def test_same_code_warns_at_most_once_across_days(self, monkeypatch):
+        """同一 code 跨多日无数据 → 'No bar data' WARN 至多一次（tracer bullet）"""
+        from unittest.mock import Mock
+        from ginkgo.trading.feeders import backtest_feeder as feeder_module
+        from ginkgo.data.services.base_service import ServiceResult
+
+        feeder = BacktestFeeder()
+        # bar_service.get 始终返回无数据
+        feeder.bar_service = Mock()
+        feeder.bar_service.get = Mock(
+            return_value=ServiceResult.error(error="no data")
+        )
+
+        warn_calls = []
+        monkeypatch.setattr(
+            feeder_module.GLOG, "WARN",
+            lambda msg, *a, **kw: warn_calls.append(msg),
+        )
+
+        day1 = datetime(2026, 1, 5, 9, 30, 0)
+        day2 = datetime(2026, 1, 6, 9, 30, 0)
+        day3 = datetime(2026, 1, 7, 9, 30, 0)
+
+        # 同一 code 跨三日重复调用
+        feeder._generate_price_events("NODATA.SZ", day1)
+        feeder._generate_price_events("NODATA.SZ", day2)
+        feeder._generate_price_events("NODATA.SZ", day3)
+
+        no_data_warns = [w for w in warn_calls if "No bar data" in str(w)]
+        assert len(no_data_warns) <= 1, (
+            f"同 code 应只 WARN 一次, 实际 {len(no_data_warns)}: {no_data_warns}"
+        )
+
+    def test_different_codes_each_warn_once(self, monkeypatch):
+        """不同无数据 code 各 WARN 一次（去重粒度=code，非全局静默）"""
+        from unittest.mock import Mock
+        from ginkgo.trading.feeders import backtest_feeder as feeder_module
+        from ginkgo.data.services.base_service import ServiceResult
+
+        feeder = BacktestFeeder()
+        feeder.bar_service = Mock()
+        feeder.bar_service.get = Mock(
+            return_value=ServiceResult.error(error="no data")
+        )
+
+        warn_calls = []
+        monkeypatch.setattr(
+            feeder_module.GLOG, "WARN",
+            lambda msg, *a, **kw: warn_calls.append(msg),
+        )
+
+        day = datetime(2026, 1, 5, 9, 30, 0)
+        feeder._generate_price_events("NODATA_A.SZ", day)
+        feeder._generate_price_events("NODATA_B.SZ", day)
+
+        no_data_warns = [w for w in warn_calls if "No bar data" in str(w)]
+        assert len(no_data_warns) == 2, (
+            f"两个不同 code 应各 WARN 一次, 实际 {len(no_data_warns)}: {no_data_warns}"
+        )

--- a/tests/unit/trading/selectors/test_cn_all_selector.py
+++ b/tests/unit/trading/selectors/test_cn_all_selector.py
@@ -1,0 +1,94 @@
+"""TDD tests for #5163: CNAllSelector 回测宽 universe 时无数据 code 逐日刷屏 WARN + N+1 查询。
+
+根因: cn_all_selector.pick 直接返回 stockinfo 全市场 codes，不剔除 DB 无 bar 的 code，
+feeder 每日对全市场逐股 bar_service.get() N+1 查询。
+修复: pick 拿到全市场 codes 后，调 bar_service.get_available_codes() 一次性剔除无数据 code。
+"""
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+import pytest
+
+from ginkgo.trading.selectors.cn_all_selector import CNAllSelector
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_stockinfo_df(codes):
+    return pd.DataFrame({"code": codes})
+
+
+class TestCNAllSelectorPrefilterNoData:
+    """#5163: pick 应剔除 DB 中无 bar 数据的 code（批量预过滤）。"""
+
+    def test_pick_filters_out_codes_without_bar_data(self):
+        """全市场 [A,B,C] 但 DB 仅有 [A,B] → pick 返回 [A,B]（C 被剔除）"""
+        sel = CNAllSelector(name="test")
+        mock_stockinfo = MagicMock()
+        mock_stockinfo.get_stockinfos_df.return_value = ServiceResult.success(
+            data=_make_stockinfo_df(["A.SZ", "B.SZ", "C.SZ"])
+        )
+        mock_bar = MagicMock()
+        mock_bar.get_available_codes.return_value = ServiceResult.success(
+            data=["A.SZ", "B.SZ"]
+        )
+        with patch(
+            "ginkgo.data.containers.container.stockinfo_service",
+            return_value=mock_stockinfo,
+        ), patch(
+            "ginkgo.data.containers.container.bar_service",
+            return_value=mock_bar,
+        ):
+            result = sel.pick()
+        assert "C.SZ" not in result, "无数据的 C.SZ 应被预过滤剔除 #5163"
+        assert set(result) == {"A.SZ", "B.SZ"}
+
+    def test_pick_returns_all_when_bar_service_fails(self):
+        """bar_service.get_available_codes 失败 → 降级返回全市场（不阻断回测）"""
+        sel = CNAllSelector(name="test")
+        mock_stockinfo = MagicMock()
+        mock_stockinfo.get_stockinfos_df.return_value = ServiceResult.success(
+            data=_make_stockinfo_df(["A.SZ", "B.SZ", "C.SZ"])
+        )
+        mock_bar = MagicMock()
+        mock_bar.get_available_codes.return_value = ServiceResult.error(error="db down")
+        with patch(
+            "ginkgo.data.containers.container.stockinfo_service",
+            return_value=mock_stockinfo,
+        ), patch(
+            "ginkgo.data.containers.container.bar_service",
+            return_value=mock_bar,
+        ):
+            result = sel.pick()
+        # 必须实际调用了预过滤（否则是未实现）
+        mock_bar.get_available_codes.assert_called_once()
+        # 降级：不剔除，返回全市场（fail-open，不因预过滤失败阻断）
+        assert set(result) == {"A.SZ", "B.SZ", "C.SZ"}
+
+    def test_pick_logs_filtered_count(self):
+        """剔除时应 INFO 一次被过滤数量（便于诊断，非逐股刷屏）"""
+        sel = CNAllSelector(name="test")
+        mock_stockinfo = MagicMock()
+        mock_stockinfo.get_stockinfos_df.return_value = ServiceResult.success(
+            data=_make_stockinfo_df(["A.SZ", "B.SZ", "C.SZ", "D.SZ"])
+        )
+        mock_bar = MagicMock()
+        mock_bar.get_available_codes.return_value = ServiceResult.success(
+            data=["A.SZ"]
+        )
+        with patch(
+            "ginkgo.data.containers.container.stockinfo_service",
+            return_value=mock_stockinfo,
+        ), patch(
+            "ginkgo.data.containers.container.bar_service",
+            return_value=mock_bar,
+        ), patch("ginkgo.trading.selectors.cn_all_selector.GLOG") as mock_glog:
+            result = sel.pick()
+        assert set(result) == {"A.SZ"}
+        # 应有一次 INFO/WARNING 记录被剔除的数量
+        info_msgs = (
+            [c[0][0] for c in mock_glog.INFO.call_args_list]
+            + [c[0][0] for c in mock_glog.WARNING.call_args_list]
+        )
+        assert any("3" in m and ("filter" in m.lower() or "过滤" in m or "剔除" in m) for m in info_msgs), (
+            f"应记录被剔除数量(3), 实际 INFO/WARN: {info_msgs}"
+        )


### PR DESCRIPTION
## Summary

修复 `cn_all_selector` 宽 universe 回测时无数据股票逐日刷屏 WARN + N+1 查询致回测 10+ 分钟未完成（#5163）。

### 根因
- `BacktestFeeder._generate_price_events:238` 同一无数据 code 在每日循环都 `GLOG.WARN("No bar data for {code} at {date}")`，无去重 → O(N×T) 日志爆炸
- `CNAllSelector.pick` 直接返回 stockinfo 全市场 codes，不剔除 DB 无 bar 的 code → feeder 每日对全市场逐股 `bar_service.get()` N+1 查询

### 改动
1. **feeder WARN 按 code 去重**（`backtest_feeder.py`）：`__init__` 加 `self._warned_no_data: set`，`_generate_price_events` 内 code 首次无数据 WARN 一次后加入 set，后续跳过。日志从 O(N×T) 降到 O(N)
2. **selector 批量预过滤**（`cn_all_selector.py`）：`pick` 拿到全市场 codes 后调 `bar_service.get_available_codes()` 一次 distinct 查询剔除无数据 code。N+1 查询降到 1 次预查。预过滤失败时 fail-open 返回全市场，不阻断回测

## Test plan

- [x] `test_same_code_warns_at_most_once_across_days`：同 code 跨三日无数据 → WARN 至多 1 次（修复前 3 次）
- [x] `test_different_codes_each_warn_once`：去重粒度 = code，不同 code 各 WARN 一次
- [x] `test_pick_filters_out_codes_without_bar_data`：全市场 [A,B,C] + DB 仅 [A,B] → pick 返回 [A,B]
- [x] `test_pick_returns_all_when_bar_service_fails`：预过滤失败 → fail-open 返回全市场
- [x] `test_pick_logs_filtered_count`：剔除时 INFO 一次被过滤数量
- [x] 三层 smoke 全绿：py_compile + 启动路径 smoke (29 passed) + 变更相关 (52 passed)
- [x] 既有 `test_backtest_feeder.py` / `test_fixed_selector.py` 等无回归

## 备注

issue body 第 3 项期望「显示回测进度（已处理日期/总日期）」未在本 PR 实现：总日数只在 `backtest_task` 调用方（不在 engine/feeder），需改主推进循环，侵入性超出本 issue 的 agent brief 验收范围（验收只含「No bar data 每 code 至多一条 + 回测耗时下降」）。建议作为独立 enhancement issue 后续处理。

Closes #5163

🤖 Generated with [Claude Code](https://claude.com/claude-code)