### PR TITLE
fix(#5188): notify history 支持 --page-size 对齐其他 list 命令

### DIFF
--- a/src/ginkgo/client/notify_cli.py
+++ b/src/ginkgo/client/notify_cli.py
@@ -332,98 +332,6 @@ def send_template_notification(
         raise typer.Exit(1)
 
 
-@app.command("history")
-def get_notification_history(
-    user_uuid: Optional[str] = typer.Option(None, "--user", "-u", help="User UUID"),
-    status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (pending/sent/failed)"),
-    limit: int = typer.Option(50, "--limit", "-l", help="Max results"),
-    failed: bool = typer.Option(False, "--failed", "-f", help="Show only failed notifications"),
-):
-    """
-    :bookmark_tabs: Show notification history.
-
-    Examples:
-      ginkgo notify history --user <uuid>
-      ginkgo notify history --failed
-      ginkgo notify history -l 20
-    """
-    try:
-        from ginkgo.data.containers import container
-        from ginkgo.enums import NOTIFICATION_STATUS_TYPES
-
-        # Get service from container
-        service = container.notification_service()
-
-        # Get history
-        if failed:
-            result = service.get_failed_notifications(limit=limit)
-        elif user_uuid:
-            status_filter = None
-            if status:
-                status_map = {
-                    "pending": NOTIFICATION_STATUS_TYPES.PENDING.value,
-                    "sent": NOTIFICATION_STATUS_TYPES.SENT.value,
-                    "failed": NOTIFICATION_STATUS_TYPES.FAILED.value
-                }
-                status_filter = status_map.get(status.lower())
-
-            result = service.get_notification_history(
-                user_uuid=user_uuid,
-                limit=limit,
-                status=status_filter
-            )
-        else:
-            console.print("[yellow]:warning: Please specify --user or use --failed[/yellow]")
-            raise typer.Exit(1)
-
-        if result.is_success():
-            data = result.data
-            records = data.get("records", [])
-            count = data.get("count", 0)
-
-            if count == 0:
-                console.print(":memo: No notification records found.")
-                return
-
-            table = Table(title=f":bell: Notification History ({count} records)")
-            table.add_column("Message ID", style="cyan", max_width=20)
-            table.add_column("Status", style="yellow")
-            table.add_column("Channels", style="green")
-            table.add_column("Content", style="white", max_width=30)
-            table.add_column("Created", style="dim")
-
-            for rec in records[:limit]:
-                content = rec.get("content", "")[:30] + "..." if len(rec.get("content", "")) > 30 else rec.get("content", "")
-
-                status_val = rec.get("status", 0)
-                status_map = {
-                    0: "[dim]PENDING[/dim]",
-                    1: "[green]SENT[/green]",
-                    2: "[red]FAILED[/red]"
-                }
-                status_str = status_map.get(status_val, str(status_val))
-
-                channels = ", ".join(rec.get("channels", []))
-                created = str(rec.get("create_at", ""))[:16] if rec.get("create_at") else "N/A"
-
-                table.add_row(
-                    rec.get("message_id", "")[:18] + "...",
-                    status_str,
-                    channels,
-                    content,
-                    created
-                )
-
-            console.print(table)
-        else:
-            console.print(f"[red]:x: Failed to get history: {result.message}[/red]")
-            raise typer.Exit(1)
-
-    except Exception as e:
-        console.print(f"[red]:x: Error getting history: {e}[/red]")
-        raise typer.Exit(1)
-
-
 @app.command("search")
 def search_recipients(
     keyword: str = typer.Argument(..., help="Search keyword (user name or group name)"),
@@ -516,18 +424,17 @@ def search_recipients(
 @app.command("history")
 def notification_history(
     user: Optional[str] = typer.Option(None, "--user", "-u", help="Filter by user UUID or name"),
-    limit: int = typer.Option(50, "--limit", "-l", help="Maximum number of records to show", min=1, max=500),
+    page_size: int = typer.Option(20, "--page-size", help="Items per page", min=1, max=500),
     status: Optional[int] = typer.Option(None, "--status", "-s", help="Filter by status (0=pending, 1=sent, 2=failed)"),
-    offset: int = typer.Option(0, "--offset", "-o", help="Offset for pagination", min=0),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw JSON data"),
 ):
     """
     :book: Query notification history records.
 
     Examples:
-      ginkgo notify history                    # Show recent 50 records
+      ginkgo notify history                    # Show recent 20 records
       ginkgo notify history --user "Alice"     # Show records for user Alice
-      ginkgo notify history -u <uuid> -l 100   # Show last 100 records for user
+      ginkgo notify history -u <uuid> --page-size 100   # Show last 100 records for user
       ginkgo notify history --status 1         # Show only sent notifications
       ginkgo notify history --raw              # Output JSON format
     """
@@ -549,7 +456,7 @@ def notification_history(
         if user_uuid:
             result = service.get_notification_history(
                 user_uuid=user_uuid,
-                limit=limit,
+                limit=page_size,
                 status=status
             )
         else:

--- a/tests/unit/client/test_notify_cli.py
+++ b/tests/unit/client/test_notify_cli.py
@@ -357,3 +357,74 @@ class TestNotifyCLIExceptions:
 
         # list_recipients catches exceptions and raises typer.Exit(1)
         assert result.exit_code != 0
+
+
+# ============================================================================
+# 5. History command (--page-size alignment, #5188)
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestNotifyHistoryPageSize:
+    """history 命令支持 --page-size，与其他 list 命令一致（#5188）。"""
+
+    def _patch_notifier(self, mock_service):
+        """直接 patch service_hub.notifier 为返回 mock_service 的 mock_notifier。
+
+        注：模块内的 _patch_notifier_service 用 PropertyMock patch 实例属性，
+        但 ServiceHub.notifier 是 __getattr__ 懒加载的实例属性（非类级 property），
+        PropertyMock 作为实例属性不会触发描述符协议——故此处用普通 MagicMock。
+        """
+        mock_notifier = MagicMock()
+        mock_notifier.notification_service.return_value = mock_service
+        return patch.object(service_hub_module, "notifier", mock_notifier)
+
+    def _mock_history_service(self):
+        """mock notification_service，get_notification_history 返回成功空列表。"""
+        mock_service = MagicMock()
+        mock_service._resolve_user_uuid.return_value = "user-uuid-001"
+        mock_service.get_notification_history.return_value = MagicMock(
+            is_success=lambda: True,
+            data={"records": [], "count": 0},
+        )
+        return mock_service
+
+    def test_history_supports_page_size_option(self, cli_runner):
+        """tracer: --page-size 不再报 'No such option'，命令 exit 0。"""
+        with self._patch_notifier(self._mock_history_service()):
+            result = cli_runner.invoke(
+                notify_cli.app, ["history", "-u", "Alice", "--page-size", "5"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "No such option" not in result.output
+
+    def test_page_size_passed_to_service_as_limit(self, cli_runner):
+        """--page-size 5 映射到 service.get_notification_history(limit=5)。"""
+        mock_service = self._mock_history_service()
+        with self._patch_notifier(mock_service):
+            cli_runner.invoke(
+                notify_cli.app, ["history", "-u", "Alice", "--page-size", "5"]
+            )
+        mock_service.get_notification_history.assert_called_once()
+        call_kwargs = mock_service.get_notification_history.call_args.kwargs
+        assert call_kwargs["limit"] == 5
+
+    def test_default_page_size_is_20(self, cli_runner):
+        """默认 page-size=20（对齐 backtest_cli/logging_cli 约定）。"""
+        mock_service = self._mock_history_service()
+        with self._patch_notifier(mock_service):
+            cli_runner.invoke(notify_cli.app, ["history", "-u", "Alice"])
+        call_kwargs = mock_service.get_notification_history.call_args.kwargs
+        assert call_kwargs["limit"] == 20
+
+    def test_history_help_lists_page_size_option(self, cli_runner):
+        """history --help 列出 --page-size（验收：用户可见该选项）。"""
+        result = cli_runner.invoke(notify_cli.app, ["history", "--help"])
+        assert result.exit_code == 0
+        assert "--page-size" in result.output
+
+    def test_only_one_history_command_registered(self, cli_runner):
+        """验收：commands 中 history 唯一，无重名冲突（#5188 根因）。"""
+        history_cmds = [c for c in notify_cli.app.registered_commands if c.name == "history"]
+        assert len(history_cmds) == 1, f"expected 1 history command, got {len(history_cmds)}"


### PR DESCRIPTION
## Summary

修复 `ginkgo notify history --page-size` 报 `No such option: --page-size` 的问题（#5188），对齐 `backtest_cli`/`logging_cli`/`account_cli` 等其他 list 命令的 `--page-size` 约定。

### 根因
`notify_cli.py` 注册了**两个** `@app.command("history")`：
- `:335 get_notification_history`（用 `container`，含 `--failed`）
- `:516 notification_history`（用 `service_hub.notifier`，含 `--offset --raw`）

typer 按命令名注册到 dict，同名静默覆盖，无任何警告。实际生效的命令无 `--page-size`。此外 `:516` 的 `--offset` 是**死参数**（声明了但从未传入 service）。

### 修复（单文件 `src/ginkgo/client/notify_cli.py`）
1. **删除 `:335 get_notification_history` 死代码**（消除命令名冲突）。其 `--failed` 便利功能由 `:516` 的 `--status 2`（0=pending/1=sent/2=failed）等效替代。
2. **重构 `:516 notification_history`**：`--limit`/`--offset` → `--page-size`（默认 20，对齐 `backtest_cli`），映射到 `service.get_notification_history(limit=page_size)`。

### 测试
新增 `TestNotifyHistoryPageSize` 5 个测试：
- ✅ `--page-size` 不再报 No such option
- ✅ `--page-size 5` 映射 service `limit=5`
- ✅ 默认 `limit=20`
- ✅ `history --help` 列出 `--page-size`
- ✅ commands 中 `history` 唯一（无重名冲突）

**测试基础设施发现**：模块内既有 `_patch_notifier_service` helper 用 `PropertyMock` patch `ServiceHub` 实例属性，但 `notifier` 是 `__getattr__` 懒加载的实例属性（非类级 property），描述符协议不生效 → mock 不命中。既有 3 个 `send` 测试因此**假阳性**（断言松散，auto-mock 恰好产出含 "Success" 的 exit-0 输出）。新 history 测试改用普通 `MagicMock` patch 才真正命中。这 3 个 send 失败在 master 上预存在（与本次无关），建议后续单独修。

## Test plan
- [x] Layer 1 py_compile 全通过
- [x] Layer 2 启动路径 smoke（user_crud/containers/user_cli）通过
- [x] Layer 3 `tests/unit/client/test_notify_cli.py` 新增 5 测试全通过
- [x] `ginkgo notify history --page-size 5` 不再报 No such option
- [x] `ginkgo notify history --help` 仅一个 history 命令、列出 `--page-size`

Closes #5188