### PR TITLE
fix(#4982): deploy info 支持按 portfolio_id 反查部署记录

### DIFF
--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -67,14 +67,26 @@ def deploy(
 
 @app.command("info")
 def info(
-    deployment_id: Annotated[str, typer.Argument(help="部署记录 ID (Deployment ID)")],
+    deployment_id: Annotated[str, typer.Argument(help="部署记录 ID 或 Portfolio ID（按部署 UUID / 源组合 / 目标组合 任一反查）")],
 ):
-    """查看部署详情"""
+    """查看部署详情（#4982：支持按部署 UUID 或 portfolio_id 反查）"""
     try:
         from ginkgo.trading.containers import trading_container
 
         svc = trading_container.deployment_service()
         result = svc.get_deployment_by_id(deployment_id)
+
+        # #4982: 按 deployment UUID 查无记录时，回退到 source/target portfolio_id 反查。
+        # find_by_* 返回 list[dict]，取最近一条归一为单 dict，
+        # 复用同一 ServiceResult 让后续展示逻辑与 get_deployment_by_id 形状对齐。
+        if not result.success:
+            for finder in (svc.find_by_source_portfolio, svc.find_by_target_portfolio):
+                fb = finder(deployment_id)
+                if fb.success and fb.data:
+                    records = fb.data if isinstance(fb.data, list) else [fb.data]
+                    fb.data = records[0]
+                    result = fb
+                    break
 
         if result.success:
             data = result.data

--- a/src/ginkgo/data/crud/deployment_crud.py
+++ b/src/ginkgo/data/crud/deployment_crud.py
@@ -15,16 +15,24 @@ class DeploymentCRUD(BaseCRUD):
         super().__init__(MDeployment)
 
     def get_by_target_portfolio(self, portfolio_id: str):
-        """根据目标Portfolio ID查询部署记录"""
-        return self.find(filters={"target_portfolio_id": portfolio_id})
+        """根据目标Portfolio ID查询部署记录（#4982：按 create_at 降序，最近优先）"""
+        return self.find(
+            filters={"target_portfolio_id": portfolio_id},
+            order_by="create_at",
+            desc_order=True,
+        )
 
     def get_by_source_task(self, task_id: str):
         """根据源回测任务ID查询部署记录"""
         return self.find(filters={"source_task_id": task_id})
 
     def get_by_source_portfolio(self, portfolio_id: str):
-        """根据源Portfolio ID查询部署记录"""
-        return self.find(filters={"source_portfolio_id": portfolio_id})
+        """根据源Portfolio ID查询部署记录（#4982：按 create_at 降序，最近优先）"""
+        return self.find(
+            filters={"source_portfolio_id": portfolio_id},
+            order_by="create_at",
+            desc_order=True,
+        )
 
     def get_by_uuid(self, deployment_id: str):
         """根据部署记录 UUID 查询（#5335：deploy info 按 deployment_id 查）"""

--- a/tests/unit/client/test_deploy_cli_info.py
+++ b/tests/unit/client/test_deploy_cli_info.py
@@ -54,3 +54,94 @@ class TestDeployInfoByDeploymentId:
         assert "src-port-1234" in plain or "tgt-port-5678" in plain, (
             f"应显示源/目标 portfolio，实际：{plain!r}"
         )
+
+
+class TestDeployInfoBySourcePortfolio:
+    """#4982 deploy info 按源组合ID 查找部署记录"""
+
+    @patch("ginkgo.trading.containers.trading_container")
+    def test_info_falls_back_to_source_portfolio(self, mock_container):
+        """#4982 当按 UUID 查无记录时，info<source_id> 应 fallback find_by_source_portfolio 并展示"""
+        from ginkgo.client.deploy_cli import app
+
+        mock_svc = MagicMock()
+        mock_container.deployment_service.return_value = mock_svc
+
+        # UUID 查无记录（输入是 portfolio_id 而非 deployment UUID）
+        not_found = MagicMock()
+        not_found.success = False
+        not_found.error = "未找到部署记录"
+        mock_svc.get_deployment_by_id.return_value = not_found
+
+        # source 查到记录（find_by_source_portfolio 返回 list）
+        record = {
+            "deployment_id": "d90b32ab6b5149f49802754ce0c1f0ef",
+            "source_task_id": "task-1",
+            "source_portfolio_id": "9c7a58eb080d47baa98412c38728d9a8",
+            "target_portfolio_id": "tgt-port-5678",
+            "mode": 1,
+            "account_id": "acc-1",
+            "status": "running",
+            "create_at": "2025-01-01",
+        }
+        found = MagicMock()
+        found.success = True
+        found.data = [record]
+        mock_svc.find_by_source_portfolio.return_value = found
+
+        source_portfolio_id = "9c7a58eb080d47baa98412c38728d9a8"
+        result = runner.invoke(app, ["info", source_portfolio_id])
+        assert result.exit_code == 0, f"info 应成功：{result.output}"
+
+        # UUID 路径先尝试（保 #5335 优先级）
+        mock_svc.get_deployment_by_id.assert_called_once_with(source_portfolio_id)
+        # fallback 到 source
+        mock_svc.find_by_source_portfolio.assert_called_once_with(source_portfolio_id)
+
+        plain = _strip_ansi(result.output)
+        assert "tgt-port-5678" in plain, f"应展示目标 portfolio，实际：{plain!r}"
+
+    @patch("ginkgo.trading.containers.trading_container")
+    def test_info_falls_back_to_target_portfolio(self, mock_container):
+        """#4982 当 UUID 与 source 均查无记录时，info<target_id> 应 fallback find_by_target_portfolio"""
+        from ginkgo.client.deploy_cli import app
+
+        mock_svc = MagicMock()
+        mock_container.deployment_service.return_value = mock_svc
+
+        # UUID 查无
+        not_found = MagicMock()
+        not_found.success = False
+        not_found.error = "未找到部署记录"
+        mock_svc.get_deployment_by_id.return_value = not_found
+
+        # source 查无（空列表）
+        src_empty = MagicMock()
+        src_empty.success = True
+        src_empty.data = []
+        mock_svc.find_by_source_portfolio.return_value = src_empty
+
+        # target 查到
+        record = {
+            "deployment_id": "d90b32ab6b5149f49802754ce0c1f0ef",
+            "source_task_id": "task-1",
+            "source_portfolio_id": "src-port-1234",
+            "target_portfolio_id": "aabbccddeeff00112233445566778899",
+            "mode": 1,
+            "account_id": "acc-1",
+            "status": "running",
+            "create_at": "2025-01-01",
+        }
+        tgt_found = MagicMock()
+        tgt_found.success = True
+        tgt_found.data = [record]
+        mock_svc.find_by_target_portfolio.return_value = tgt_found
+
+        target_portfolio_id = "aabbccddeeff00112233445566778899"
+        result = runner.invoke(app, ["info", target_portfolio_id])
+        assert result.exit_code == 0, f"info 应成功：{result.output}"
+
+        mock_svc.find_by_target_portfolio.assert_called_once_with(target_portfolio_id)
+
+        plain = _strip_ansi(result.output)
+        assert "src-port-1234" in plain, f"应展示源 portfolio，实际：{plain!r}"

--- a/tests/unit/data/crud/test_deployment_crud_mock.py
+++ b/tests/unit/data/crud/test_deployment_crud_mock.py
@@ -72,14 +72,16 @@ class TestDeploymentCRUDBusinessHelpers:
 
     @pytest.mark.unit
     def test_get_by_target_portfolio(self, deployment_crud, fake_deployment):
-        """根据目标 Portfolio ID 查询部署记录"""
+        """根据目标 Portfolio ID 查询部署记录（#4982：含 create_at 降序契约）"""
         deployment_crud.find = MagicMock(return_value=[fake_deployment])
 
         result = deployment_crud.get_by_target_portfolio("portfolio_001")
 
         assert result == [fake_deployment]
         deployment_crud.find.assert_called_once_with(
-            filters={"target_portfolio_id": "portfolio_001"}
+            filters={"target_portfolio_id": "portfolio_001"},
+            order_by="create_at",
+            desc_order=True,
         )
 
     @pytest.mark.unit
@@ -133,3 +135,35 @@ class TestDeploymentCRUDBusinessHelpers:
         call_args = deployment_crud.find.call_args[1]
         assert "source_task_id" in call_args["filters"]
         assert call_args["filters"]["source_task_id"] == "task_xyz"
+
+    @pytest.mark.unit
+    def test_get_by_source_portfolio_orders_recent_first(self, deployment_crud):
+        """#4982 多次部署同组合，get_by_source_portfolio 应按 create_at 降序，
+        records[0] = 最近一条部署（review PR #6549：原 find 未传 order_by 致取最旧）"""
+        deployment_crud.find = MagicMock(return_value=[])
+
+        deployment_crud.get_by_source_portfolio("portfolio_src")
+
+        call_kwargs = deployment_crud.find.call_args[1]
+        assert call_kwargs.get("order_by") == "create_at", (
+            f"应按 create_at 排序取最近部署，实际 find 参数：{call_kwargs}"
+        )
+        assert call_kwargs.get("desc_order") is True, (
+            f"应降序（最近优先），实际 find 参数：{call_kwargs}"
+        )
+
+    @pytest.mark.unit
+    def test_get_by_target_portfolio_orders_recent_first(self, deployment_crud):
+        """#4982 get_by_target_portfolio 同样按 create_at 降序（一处修三处：
+        get_deployment_info records[0] / list_deployments 顺序 / CLI fallback records[0]）"""
+        deployment_crud.find = MagicMock(return_value=[])
+
+        deployment_crud.get_by_target_portfolio("portfolio_tgt")
+
+        call_kwargs = deployment_crud.find.call_args[1]
+        assert call_kwargs.get("order_by") == "create_at", (
+            f"应按 create_at 排序取最近部署，实际 find 参数：{call_kwargs}"
+        )
+        assert call_kwargs.get("desc_order") is True, (
+            f"应降序（最近优先），实际 find 参数：{call_kwargs}"
+        )


### PR DESCRIPTION
## Summary

修复 `ginkgo deploy info <portfolio_id>` 报"未找到部署记录"的问题。

**根因**：`info` 命令参数硬编码为 `deployment_id`，仅调 `get_deployment_by_id`（按部署 UUID 查）。当用户传入源/目标 portfolio_id 时查不到记录。service 层 `find_by_source_portfolio` / `find_by_target_portfolio` 能力齐备但 CLI 未接线。

**改动**：`info` 命令改为多路分发（按优先级）：
1. `get_deployment_by_id(identifier)` —— 保 #5335 契约（deployment UUID 优先）
2. 失败 fallback `find_by_source_portfolio(identifier)` —— 覆盖 issue 主场景（源组合 ID）
3. 再失败 fallback `find_by_target_portfolio(identifier)` —— 覆盖目标组合 ID

`find_by_*` 返回 `list[dict]`，取最近一条（`records[0]`）归一为单 dict，复用既有展示逻辑（控制流零改动）。

## Test plan

- [x] `tests/unit/client/test_deploy_cli_info.py` 全绿（3 测试）
  - #5335 `info <deployment_id>` 仍走 UUID 路径（不破坏既有契约）
  - #4982 `info <source_id>` fallback `find_by_source_portfolio`
  - #4982 `info <target_id>` fallback `find_by_target_portfolio`
- [x] Layer 1 py_compile 全量通过
- [x] Layer 2 启动路径 smoke（user_crud / containers / user_cli）29 passed
- [x] Layer 3 变更相关（service 层 4 文件 + cli_info）26 passed

## Notes

- `tests/unit/client/test_deploy_cli.py::TestDeployInfoStatusDisplay` 在 master 上即失败（#5335 改 info 调用路径后 #6285 的 mock 未同步），非本 PR 引入的回归。本 PR 改动行为等价（truthy MagicMock 仍走主分支），不恶化该测试。

Closes #4982