### PR TITLE
fix(#5112): engine bind-portfolio 校验 portfolio mode 与 engine type 兼容

### DIFF
--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -849,7 +849,9 @@ def bind_portfolio(
             console.print(f"  • Engine: {engine_name} ({resolved_engine_uuid[:8]}...)")
             console.print(f"  • Portfolio: {portfolio_name} ({resolved_portfolio_uuid[:8]}...)")
         else:
-            console.print(f":white_check_mark: {result.message}")
+            # #5112: service 守卫拒绝（如模式不兼容）→ 显示错误并以非 0 退出
+            console.print(f":x: {result.error or result.message}")
+            raise typer.Exit(1)
 
     except Exception as e:
         console.print(f":x: Error: {e}")

--- a/src/ginkgo/data/services/mapping_service.py
+++ b/src/ginkgo/data/services/mapping_service.py
@@ -293,6 +293,27 @@ class MappingService(BaseService):
                                        engine_name: str = None, portfolio_name: str = None) -> ServiceResult:
         """创建Engine-Portfolio映射关系"""
         try:
+            # #5112: 守卫——校验 engine.is_live 与 portfolio.mode 兼容
+            # 引擎只分 BACKTEST/LIVE（arch-engine-unification）：
+            #   BACKTEST engine (is_live=False) 只能绑 BACKTEST portfolio (mode=0)
+            #   LIVE engine (is_live=True) 只能绑 PAPER/LIVE portfolio (mode>=1)
+            # 查不到实体时跳过（保持原存在性行为，mode 校验仅在新绑定时生效）
+            from ginkgo.data.crud.engine_crud import EngineCRUD
+            from ginkgo.data.crud.portfolio_crud import PortfolioCRUD
+            from ginkgo.enums import PORTFOLIO_MODE_TYPES
+
+            engines = EngineCRUD().find_by_uuid(engine_uuid)
+            portfolios = PortfolioCRUD().find_by_uuid(portfolio_uuid)
+            if engines and portfolios:
+                engine_is_live = bool(engines[0].is_live)
+                portfolio_is_live = portfolios[0].mode is not None and portfolios[0].mode >= PORTFOLIO_MODE_TYPES.PAPER.value
+                if engine_is_live != portfolio_is_live:
+                    eng_type = "LIVE" if engine_is_live else "BACKTEST"
+                    port_type = "PAPER/LIVE" if portfolio_is_live else "BACKTEST"
+                    return ServiceResult.error(
+                        f"模式不兼容: {eng_type} engine 不能绑定 {port_type} portfolio"
+                    )
+
             # 检查是否已存在
             existing = self._engine_portfolio_mapping_crud.find(
                 filters={"engine_id": engine_uuid, "portfolio_id": portfolio_uuid}

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -616,6 +616,49 @@ class TestBindPortfolio:
         assert result.exit_code == 1
         assert "not found" in result.output
 
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_bind_mode_mismatch_shows_error(self, cli_runner):
+        """#5112: service 返回模式不兼容错误时，CLI 显示错误（非 ✅）且退出码非 0"""
+        mock_portfolio = MagicMock()
+        mock_portfolio.uuid = "port-uuid"
+        mock_portfolio.name = "TestPortfolio"
+
+        port_model_list = MagicMock()
+        port_model_list.__len__ = MagicMock(return_value=1)
+        port_model_list.__getitem__ = MagicMock(return_value=mock_portfolio)
+
+        eng_model_list = MagicMock()
+        eng_model_list.__len__ = MagicMock(return_value=1)
+        eng_model_list.__getitem__ = MagicMock(return_value=_make_engine_model())
+
+        portfolio_svc = MagicMock()
+        portfolio_svc.get.return_value = ServiceResult.success(data=port_model_list)
+        engine_svc = MagicMock()
+        engine_svc.get.return_value = ServiceResult.success(data=eng_model_list)
+
+        mapping_svc = MagicMock()
+        mapping_svc.get_engine_portfolio_mapping.return_value = ServiceResult.success(data=[])
+        mapping_svc.create_engine_portfolio_mapping.return_value = ServiceResult.error(
+            "模式不兼容: BACKTEST engine 不能绑定 PAPER/LIVE portfolio"
+        )
+
+        container = _mock_container(
+            engine_service=engine_svc,
+            portfolio_service=portfolio_svc,
+            mapping_service=mapping_svc,
+        )
+
+        with patch("ginkgo.data.containers.container", container), \
+             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+            result = cli_runner.invoke(
+                engine_cli.app,
+                ["bind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid"],
+            )
+        assert result.exit_code == 1, f"模式不兼容应非 0 退出: {result.output}"
+        assert "模式不兼容" in result.output, f"输出应含错误信息: {result.output}"
+        assert "binding created successfully" not in result.output.lower()
+
 
 class TestUnbindPortfolio:
     """Tests for the 'unbind-portfolio' command."""

--- a/tests/unit/data/services/test_mapping_service_mode_validation.py
+++ b/tests/unit/data/services/test_mapping_service_mode_validation.py
@@ -1,0 +1,135 @@
+"""
+#5112 — create_engine_portfolio_mapping 必须校验 engine.is_live 与 portfolio.mode 兼容。
+
+表象：ginkgo engine bind-portfolio <live_engine> <backtest_portfolio> 静默成功，运行时才报错。
+根因：MappingService.create_engine_portfolio_mapping 直接落库 MEnginePortfolioMapping，
+      不校验 engine.is_live vs portfolio.mode 是否兼容。
+契约（引擎只分 BACKTEST/LIVE，见 arch-engine-unification）：
+  - BACKTEST engine (is_live=False) + BACKTEST portfolio (mode=0)         → 兼容，创建成功
+  - LIVE   engine (is_live=True)  + PAPER/LIVE portfolio (mode>=1)        → 兼容，创建成功
+  - BACKTEST engine + PAPER/LIVE portfolio                                → 拒绝，不落库
+  - LIVE   engine + BACKTEST portfolio                                    → 拒绝，不落库
+"""
+from unittest.mock import MagicMock, patch
+
+from ginkgo.data.services.mapping_service import MappingService
+
+
+def _make_svc():
+    mock_ep_mapping = MagicMock()
+    mock_pf_mapping = MagicMock()
+    mock_eh_mapping = MagicMock()
+    mock_param = MagicMock()
+    svc = MappingService(
+        engine_portfolio_mapping_crud=mock_ep_mapping,
+        portfolio_file_mapping_crud=mock_pf_mapping,
+        engine_handler_mapping_crud=mock_eh_mapping,
+        param_crud=mock_param,
+    )
+    return svc, mock_ep_mapping
+
+
+def _engine(is_live: bool):
+    e = MagicMock()
+    e.is_live = is_live
+    return e
+
+
+def _portfolio(mode: int):
+    p = MagicMock()
+    p.mode = mode
+    return p
+
+
+class TestCreateEnginePortfolioMappingModeValidation:
+    """bind-portfolio 必须校验 engine.is_live 与 portfolio.mode 兼容。"""
+
+    @patch("ginkgo.data.crud.engine_crud.EngineCRUD")
+    @patch("ginkgo.data.crud.portfolio_crud.PortfolioCRUD")
+    def test_backtest_engine_live_portfolio_rejected(self, mock_pf_crud_cls, mock_eng_crud_cls):
+        """BACKTEST engine + LIVE portfolio → 拒绝，不创建 mapping（tracer bullet）"""
+        svc, mock_ep_mapping = _make_svc()
+        mock_eng_crud_cls.return_value.find_by_uuid.return_value = [_engine(is_live=False)]
+        mock_pf_crud_cls.return_value.find_by_uuid.return_value = [_portfolio(mode=2)]  # LIVE
+
+        result = svc.create_engine_portfolio_mapping(
+            engine_uuid="eng-1",
+            portfolio_uuid="port-1",
+            engine_name="E",
+            portfolio_name="P",
+        )
+
+        assert not result.success, "BACKTEST engine + LIVE portfolio 应被拒绝"
+        mock_ep_mapping.add_batch.assert_not_called()
+
+    @patch("ginkgo.data.crud.engine_crud.EngineCRUD")
+    @patch("ginkgo.data.crud.portfolio_crud.PortfolioCRUD")
+    def test_live_engine_backtest_portfolio_rejected(self, mock_pf_crud_cls, mock_eng_crud_cls):
+        """LIVE engine + BACKTEST portfolio → 拒绝，不创建 mapping"""
+        svc, mock_ep_mapping = _make_svc()
+        mock_eng_crud_cls.return_value.find_by_uuid.return_value = [_engine(is_live=True)]
+        mock_pf_crud_cls.return_value.find_by_uuid.return_value = [_portfolio(mode=0)]  # BACKTEST
+
+        result = svc.create_engine_portfolio_mapping(
+            engine_uuid="eng-1", portfolio_uuid="port-1",
+            engine_name="E", portfolio_name="P",
+        )
+
+        assert not result.success, "LIVE engine + BACKTEST portfolio 应被拒绝"
+        mock_ep_mapping.add_batch.assert_not_called()
+
+    @patch("ginkgo.data.crud.engine_crud.EngineCRUD")
+    @patch("ginkgo.data.crud.portfolio_crud.PortfolioCRUD")
+    def test_backtest_engine_backtest_portfolio_accepted(self, mock_pf_crud_cls, mock_eng_crud_cls):
+        """BACKTEST engine + BACKTEST portfolio → 兼容，创建 mapping"""
+        svc, mock_ep_mapping = _make_svc()
+        mock_eng_crud_cls.return_value.find_by_uuid.return_value = [_engine(is_live=False)]
+        mock_pf_crud_cls.return_value.find_by_uuid.return_value = [_portfolio(mode=0)]  # BACKTEST
+        mock_ep_mapping.find.return_value = []  # 无重复
+        created = MagicMock()
+        mock_ep_mapping.add_batch.return_value = [created]
+
+        result = svc.create_engine_portfolio_mapping(
+            engine_uuid="eng-1", portfolio_uuid="port-1",
+            engine_name="E", portfolio_name="P",
+        )
+
+        assert result.success, "BACKTEST engine + BACKTEST portfolio 应创建成功"
+        mock_ep_mapping.add_batch.assert_called_once()
+
+    @patch("ginkgo.data.crud.engine_crud.EngineCRUD")
+    @patch("ginkgo.data.crud.portfolio_crud.PortfolioCRUD")
+    def test_live_engine_paper_portfolio_accepted(self, mock_pf_crud_cls, mock_eng_crud_cls):
+        """LIVE engine + PAPER portfolio → 兼容，创建 mapping"""
+        svc, mock_ep_mapping = _make_svc()
+        mock_eng_crud_cls.return_value.find_by_uuid.return_value = [_engine(is_live=True)]
+        mock_pf_crud_cls.return_value.find_by_uuid.return_value = [_portfolio(mode=1)]  # PAPER
+        mock_ep_mapping.find.return_value = []
+        created = MagicMock()
+        mock_ep_mapping.add_batch.return_value = [created]
+
+        result = svc.create_engine_portfolio_mapping(
+            engine_uuid="eng-1", portfolio_uuid="port-1",
+            engine_name="E", portfolio_name="P",
+        )
+
+        assert result.success, "LIVE engine + PAPER portfolio 应创建成功"
+        mock_ep_mapping.add_batch.assert_called_once()
+
+    @patch("ginkgo.data.crud.engine_crud.EngineCRUD")
+    @patch("ginkgo.data.crud.portfolio_crud.PortfolioCRUD")
+    def test_engine_not_found_skips_guard(self, mock_pf_crud_cls, mock_eng_crud_cls):
+        """engine 查不到 → 跳过守卫（保持原存在性行为，不阻断其他调用方）"""
+        svc, mock_ep_mapping = _make_svc()
+        mock_eng_crud_cls.return_value.find_by_uuid.return_value = []  # engine 不存在
+        mock_pf_crud_cls.return_value.find_by_uuid.return_value = [_portfolio(mode=0)]
+        mock_ep_mapping.find.return_value = []
+        created = MagicMock()
+        mock_ep_mapping.add_batch.return_value = [created]
+
+        result = svc.create_engine_portfolio_mapping(
+            engine_uuid="eng-1", portfolio_uuid="port-1",
+            engine_name="E", portfolio_name="P",
+        )
+
+        assert result.success, "engine 查不到时应跳过守卫保持原行为"


### PR DESCRIPTION
## Summary

修复 #5112：`ginkgo engine bind-portfolio <live_engine> <backtest_portfolio>` 静默成功、运行时才报错的问题。

## 根因

`MappingService.create_engine_portfolio_mapping`（mapping_service.py:292）直接落库 `MEnginePortfolioMapping`，**无 `engine.is_live` 与 `portfolio.mode` 兼容校验**；CLI `bind_portfolio` 同样无校验。CLI error 分支还误用 ✅ emoji + `result.message`（error 时为空）。

## 改动

**Service 层守卫**（`mapping_service.py`）—— 权威入口，防 API/其他调用方绕过：
- 函数级 import `EngineCRUD/PortfolioCRUD`（照 `cleanup_orphaned_mappings` 模式，避免改构造函数影响容器注入）
- 比对 `engine.is_live` vs `portfolio.mode >= PORTFOLIO_MODE_TYPES.PAPER(1)`，不兼容返回 `ServiceResult.error` 且不落库
- 查不到实体时跳过（保持原存在性行为，mode 校验仅在新绑定时生效）

**CLI error 分支**（`engine_cli.py`）—— 顺手修 bug：
- `:white_check_mark:` → `:x:`，`result.message` → `result.error or result.message`，加 `raise typer.Exit(1)`

**兼容规则**（`arch-engine-unification`：引擎只分 BACKTEST/LIVE）：
| engine.is_live | 兼容 portfolio.mode |
|---|---|
| False (BACKTEST) | 0 BACKTEST |
| True (LIVE) | 1 PAPER / 2 LIVE |

## Test plan

- [x] `tests/unit/data/services/test_mapping_service_mode_validation.py`（新建，5 case：BACKTEST+LIVE 拒、LIVE+BACKTEST 拒、BACKTEST+BACKTEST 成、LIVE+PAPER 成、engine 查不到跳过守卫）
- [x] `tests/unit/client/test_engine_cli.py::TestBindPortfolio::test_bind_mode_mismatch_shows_error`（CLI 显示错误 + 非 0 退出）
- [x] 三层冒烟：py_compile / 启动路径 smoke (29 passed) / 变更相关 (50 passed)

Closes #5112
