### PR TITLE
fix(#4992): scheduler plan 加 --node 过滤 + 分页

### DIFF
--- a/src/ginkgo/client/scheduler_cli.py
+++ b/src/ginkgo/client/scheduler_cli.py
@@ -211,12 +211,40 @@ def status():
 
 
 @app.command()
-def plan():
+def plan(
+    node: Optional[str] = typer.Option(
+        None, "--node", "-n",
+        help="Filter by ExecutionNode ID (only show portfolios mapped to this node).",
+    ),
+    page: int = typer.Option(
+        1, "--page", "-p",
+        help="Page number (1-based). Ignored when --page-size=0.",
+    ),
+    page_size: int = typer.Option(
+        50, "--page-size", "-s",
+        help="Entries per page. Set to 0 to show all (no pagination).",
+    ),
+):
     """
     :clipboard: Show current schedule plan.
 
-    Display Portfolio to ExecutionNode assignments.
+    Display Portfolio to ExecutionNode assignments, with optional
+    --node filter and --page/--page-size pagination (default 50 per page).
+
+    Examples:
+      ginkgo scheduler plan
+      ginkgo scheduler plan --node 3640219e75b6
+      ginkgo scheduler plan --page 2 --page-size 20
+      ginkgo scheduler plan --page-size 0        # show all
     """
+    # Validate pagination params (page_size=0 means unlimited)
+    if page < 1:
+        console.print("[red]:x: --page must be >= 1[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size must be >= 0 (0 = unlimited)[/red]")
+        raise typer.Exit(1)
+
     console.print(":information: Current schedule plan")
 
     try:
@@ -232,24 +260,69 @@ def plan():
             console.print("[yellow]:warning: No schedule plan found[/yellow]")
             return
 
+        # Decode + filter by node
+        entries = []
+        for portfolio_id_bytes, node_id_bytes in plan_data.items():
+            portfolio_id = portfolio_id_bytes.decode('utf-8')
+            node_id = node_id_bytes.decode('utf-8')
+            if node is not None and node_id != node:
+                continue
+            entries.append((portfolio_id, node_id))
+
+        total = len(entries)
+        if total == 0:
+            if node is not None:
+                console.print(
+                    f"[yellow]:warning: No portfolios mapped to node {node}[/yellow]"
+                )
+            else:
+                console.print("[yellow]:warning: No schedule plan found[/yellow]")
+            return
+
+        # Apply pagination (page_size=0 = unlimited)
+        unlimited = page_size == 0
+        total_pages = 1 if unlimited else max(1, (total + page_size - 1) // page_size)
+        if unlimited:
+            start = 0
+            end = total
+        else:
+            if page > total_pages:
+                console.print(
+                    f"[yellow]:warning: Page {page} out of range "
+                    f"(total {total_pages} pages, {total} entries)[/yellow]"
+                )
+                return
+            start = (page - 1) * page_size
+            end = start + page_size
+
+        page_entries = entries[start:end]
+
         # Create table
         table = Table(title=":calendar: Schedule Plan", show_header=True, header_style="bold magenta")
         table.add_column("Portfolio ID", style="cyan", no_wrap=False)
         table.add_column("ExecutionNode", style="green")
 
-        for portfolio_id_bytes, node_id_bytes in plan_data.items():
-            portfolio_id = portfolio_id_bytes.decode('utf-8')
-            node_id = node_id_bytes.decode('utf-8')
-
+        for portfolio_id, node_id in page_entries:
             # Shorten IDs for display
             portfolio_short = portfolio_id[:8] + "..." if len(portfolio_id) > 11 else portfolio_id
             node_short = node_id[:20] if len(node_id) > 20 else node_id
-
             table.add_row(portfolio_short, node_short)
 
         console.print(table)
-        console.print(f"\n:information: Total portfolios scheduled: [bold]{len(plan_data)}[/bold]")
+        # 总数始终显示（过滤后语义：满足 --node 条件的 portfolio 总数）
+        console.print(
+            f"\n:information: Total portfolios scheduled: [bold]{total}[/bold]"
+        )
+        if not unlimited:
+            shown_from = start + 1
+            shown_to = min(end, total)
+            console.print(
+                f":information: Page [bold]{page}/{total_pages}[/bold] "
+                f"(showing {shown_from}-{shown_to}) — use --page to navigate, --page-size 0 for all"
+            )
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"[red]:x: Error getting schedule plan: {e}[/red]")
         raise typer.Exit(1)

--- a/tests/unit/client/test_scheduler_cli.py
+++ b/tests/unit/client/test_scheduler_cli.py
@@ -224,3 +224,109 @@ class TestSchedulerOutputEscape:
         assert "\\n" not in result.output, (
             f"reload 输出含字面 \\n: {repr(result.output[-120:])}"
         )
+
+
+# ===========================================================================
+# plan 分页与过滤（#4992）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSchedulerPlanFilter:
+    """#4992: scheduler plan 全量 hgetall 后无过滤/分页，组合多时刷屏。
+
+    修复后应支持 --node 过滤（仅显示映射到指定节点的 portfolio）和
+    --page/--page-size 分页（默认 page_size=50 防 OOM 刷屏）。
+    """
+
+    @staticmethod
+    def _multi_node_plan_redis(n_node1: int = 60, n_node2: int = 30):
+        """构造 RedisCRUD().redis 的 mock：返回 n_node1 条映射到 node-1 +
+        n_node2 条映射到 node-2 的 schedule:plan hash（超出默认 page_size=50）。
+        """
+        mock_redis = MagicMock()
+        plan = {}
+        for i in range(n_node1):
+            plan[f"port-{i:03d}".encode()] = b"node-1"
+        for i in range(n_node1, n_node1 + n_node2):
+            plan[f"port-{i:03d}".encode()] = b"node-2"
+        mock_redis.hgetall.return_value = plan
+        return mock_redis
+
+    def test_node_filter_returns_only_matching_node(self, cli_runner):
+        """#4992 tracer: `--node node-2` 只输出映射到 node-2 的 portfolio。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()
+            result = cli_runner.invoke(scheduler_cli.app, ["plan", "--node", "node-2"])
+
+        assert result.exit_code == 0
+        # 只剩 node-2 的 30 条（用 "scheduled: N" 文案锚定过滤后总数）
+        assert "node-2" in result.output
+        assert "node-1" not in result.output
+        assert "scheduled: 30" in result.output
+
+    def test_default_page_size_truncates_to_50(self, cli_runner):
+        """#4992: 默认 page_size=50，90 条映射只显示前 50（防 OOM 刷屏）。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()  # 60 + 30 = 90
+            result = cli_runner.invoke(scheduler_cli.app, ["plan"])
+
+        assert result.exit_code == 0
+        # 总数仍是 90（过滤后），但本页只展示 1-50
+        assert "scheduled: 90" in result.output
+        assert "Page 1/2" in result.output
+        assert "showing 1-50" in result.output
+
+    def test_page_2_shows_remaining(self, cli_runner):
+        """#4992: --page 2 显示第 51-90 条（90 条分 2 页：50+40）。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()
+            result = cli_runner.invoke(scheduler_cli.app, ["plan", "--page", "2"])
+
+        assert result.exit_code == 0
+        assert "Page 2/2" in result.output
+        assert "showing 51-90" in result.output
+
+    def test_page_size_0_shows_all(self, cli_runner):
+        """#4992: --page-size 0 关闭分页，全量展示（向后兼容逃生口）。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()
+            result = cli_runner.invoke(
+                scheduler_cli.app, ["plan", "--page-size", "0"]
+            )
+
+        assert result.exit_code == 0
+        # 无 "Page X/Y" 行（unlimited 模式只输出总数）
+        assert "Page" not in result.output
+        assert "scheduled: 90" in result.output
+
+    def test_node_filter_no_match_shows_friendly_message(self, cli_runner):
+        """#4992: --node 不匹配任何节点时友好提示，不输出空表。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()
+            result = cli_runner.invoke(
+                scheduler_cli.app, ["plan", "--node", "nonexistent-node"]
+            )
+
+        assert result.exit_code == 0
+        assert "No portfolios mapped to node nonexistent-node" in result.output
+
+    def test_invalid_page_rejected(self, cli_runner):
+        """#4992: --page 0 报错退出 1（page 必须 >= 1）。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()
+            result = cli_runner.invoke(scheduler_cli.app, ["plan", "--page", "0"])
+
+        assert result.exit_code == 1
+        assert "--page must be >= 1" in result.output
+
+    def test_invalid_page_size_rejected(self, cli_runner):
+        """#4992: --page-size -1 报错退出 1（page_size 必须 >= 0）。"""
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = self._multi_node_plan_redis()
+            result = cli_runner.invoke(
+                scheduler_cli.app, ["plan", "--page-size", "-1"]
+            )
+
+        assert result.exit_code == 1
+        assert "--page-size must be >= 0" in result.output


### PR DESCRIPTION
## Summary

修复 `ginkgo scheduler plan` 全量输出所有组合映射、无过滤/分页导致刷屏的问题（#4992）。

`plan()` 原签名零参数，全量 `hgetall("schedule:plan")` 后无过滤遍历建表，组合多时输出冗长。

### 改动
- `--node <id>` / `-n`：仅显示映射到指定 ExecutionNode 的 portfolio
- `--page <n>` / `-p`：页码（1-based，默认 1）
- `--page-size <n>` / `-s`：每页条数（默认 50，`0` 关闭分页=全量，向后兼容）
- 参数校验：`--page < 1` / `--page-size < 0` 报错 exit 1
- 过滤后为空 / page 越界 友好提示（不输出空表）
- 末尾显示 `Total portfolios scheduled: N` + 分页导航 `Page X/Y (showing a-b)`

### 示例
```bash
ginkgo scheduler plan                              # 默认前 50 条
ginkgo scheduler plan --node 3640219e75b6          # 仅该节点
ginkgo scheduler plan --page 2 --page-size 20      # 翻页
ginkgo scheduler plan --page-size 0                # 全量（旧行为）
```

## Test plan

新增 `TestSchedulerPlanFilter`（7 用例，覆盖过滤/默认分页/翻页/unlimited/空匹配/参数校验）+ 既有 8 用例无回归。

- [x] `pytest tests/unit/client/test_scheduler_cli.py` — 15 passed
- [x] Layer 1 py_compile（src+api）通过
- [x] Layer 2 启动路径 smoke（user_crud_mock + containers + user_cli）— 29 passed
- [x] 无 Kafka/Redis 真实 IO（纯 mock）

Closes #4992
