### PR TITLE
fix(#5116): scheduler plan 输出完整 Portfolio ID，rich 列 fold 自适应

### DIFF
--- a/src/ginkgo/client/scheduler_cli.py
+++ b/src/ginkgo/client/scheduler_cli.py
@@ -234,18 +234,19 @@ def plan():
 
         # Create table
         table = Table(title=":calendar: Schedule Plan", show_header=True, header_style="bold magenta")
-        table.add_column("Portfolio ID", style="cyan", no_wrap=False)
+        # #5116: Portfolio ID 列 overflow="fold"——rich 默认 ellipsis 会用 … 截断长 UUID，
+        # 即使移除代码层截断终端用户也看不到完整 id；fold 折行完整显示，终端宽时单行、窄时多行。
+        # 对齐 #4719 deploy list 范式。
+        table.add_column("Portfolio ID", style="cyan", overflow="fold")
         table.add_column("ExecutionNode", style="green")
 
         for portfolio_id_bytes, node_id_bytes in plan_data.items():
             portfolio_id = portfolio_id_bytes.decode('utf-8')
             node_id = node_id_bytes.decode('utf-8')
 
-            # Shorten IDs for display
-            portfolio_short = portfolio_id[:8] + "..." if len(portfolio_id) > 11 else portfolio_id
-            node_short = node_id[:20] if len(node_id) > 20 else node_id
-
-            table.add_row(portfolio_short, node_short)
+            # #5116: 输出完整 Portfolio ID，运维可据此识别具体组合（不再 [:8]+"..." 截断）。
+            # node_id 通常为短名（node_1）无需截断；保留 node 全显与 deploy list 一致。
+            table.add_row(portfolio_id, node_id)
 
         console.print(table)
         console.print(f"\n:information: Total portfolios scheduled: [bold]{len(plan_data)}[/bold]")

--- a/tests/unit/client/test_scheduler_cli.py
+++ b/tests/unit/client/test_scheduler_cli.py
@@ -211,6 +211,27 @@ class TestSchedulerOutputEscape:
             f"plan 输出含字面 \\n: {repr(result.output[-120:])}"
         )
 
+    def test_plan_shows_full_portfolio_id_no_truncation(self, cli_runner):
+        """#5116: plan 输出完整 Portfolio ID（32hex 无横线），不截断为 8 位 + '...'。
+
+        生产 UUID 全 hex 无横线（32 字符），len > 11 必触发旧 `portfolio_id[:8]+"..."`
+        截断分支。修复后须全显，让运维能识别具体组合。对齐 #4719 deploy list 范式。
+        """
+        full_uuid = "0016f12fabcd1234ef5678abcd9012def"  # 32 hex，生产真实形态
+        mock_redis = MagicMock()
+        mock_redis.hgetall.return_value = {full_uuid.encode(): b"node-1"}
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = mock_redis
+            result = cli_runner.invoke(scheduler_cli.app, ["plan"])
+
+        assert result.exit_code == 0
+        assert full_uuid in result.output, (
+            f"plan 未输出完整 Portfolio ID（期望含 {full_uuid}）: {repr(result.output)}"
+        )
+        assert "..." not in result.output, (
+            f"plan 仍含 '...' 截断后缀: {repr(result.output)}"
+        )
+
     def test_reload_no_literal_backslash_n(self, cli_runner):
         """#6001: reload --force 输出 'Reload Plan' 不含字面 \\n。"""
         with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as MockProducer:


### PR DESCRIPTION
## Summary

`ginkgo scheduler plan` 把 Portfolio ID 截断为 8 位 + `...`（如 `0016f12f...`），40 个组合无法区分。本 PR 输出完整 UUID，让运维能识别具体组合。

**根因**：`scheduler_cli.py plan()` L245 `portfolio_id[:8]+"..."` 硬截断（UUID 32hex > 11 必触发）；且 Rich Table 默认 `ellipsis` 会用 `…` 二次截断，需显式 `overflow="fold"`。

**修法**（对齐 #4719 / PR #6528 deploy list 同款范式）：
- 移除 `portfolio_id[:8]+"..."` 与 `node_id[:20]` 截断，全显
- `add_column("Portfolio ID", overflow="fold")`：rich 默认 ellipsis 用 `…` 截断长 UUID，即使移除代码层截断终端用户仍看不到完整 id；fold 折行完整显示（终端宽时单行、窄时多行）

## Test plan

- [x] 新增 `test_plan_shows_full_portfolio_id_no_truncation`：32hex 真实 UUID 覆盖完整输出 + 无 `...` 截断后缀
- [x] `tests/unit/client/test_scheduler_cli.py` 全 9 项通过（无回归）
- [x] 三层冒烟：py_compile 全量 ✅ ｜ 启动路径（user_crud/containers/user_cli）✅ ｜ 变更相关 ✅（共 38 passed）

Closes #5116

🤖 Generated with [Claude Code](https://claude.com/claude-code)