### PR TITLE
fix(#5091): dev jupyter 用 shutil.which 兜底+缺失友好提示

### DIFF
--- a/src/ginkgo/client/dev_cli.py
+++ b/src/ginkgo/client/dev_cli.py
@@ -85,13 +85,28 @@ def dev_jupyter(
     :notebook: Launch Jupyter Lab server for interactive data analysis.
     """
     import os
+    import shutil
     import subprocess
     from ginkgo.libs import GCONF
-    
+
     if daemon:
         GLOG.WARN("Daemon mode is not supported for jupyter yet.")
 
-    jupyter_path = os.path.join(os.path.dirname(GCONF.PYTHONPATH), "jupyter")
+    # #5091: 动态查找 jupyter，缺失时友好提示而非 FileNotFoundError。
+    # 优先 PATH 查找（shutil.which），回退 venv bin 推断（兼容非标准 PATH）。
+    jupyter_path = shutil.which("jupyter")
+    if not jupyter_path:
+        venv_jupyter = os.path.join(os.path.dirname(GCONF.PYTHONPATH), "jupyter")
+        if os.path.exists(venv_jupyter):
+            jupyter_path = venv_jupyter
+
+    if not jupyter_path:
+        console.print(
+            ":warning: [yellow]未找到 jupyter，请先安装：[/yellow] "
+            "[bold]pip install jupyterlab[/bold]"
+        )
+        return
+
     subprocess.run([jupyter_path, "lab"])
 
 

--- a/tests/unit/client/test_dev_cli.py
+++ b/tests/unit/client/test_dev_cli.py
@@ -99,3 +99,46 @@ class TestDevProfileUsesSysExecutable:
         with pytest.raises(typer.Exit) as exc_info:
             dev_profile(script="foo.py", output="profile.stats")
         assert exc_info.value.exit_code == 2
+
+
+class TestDevJupyterMissingInstall:
+    """dev jupyter 在 jupyter 未安装时应友好提示并正常退出（#5091）"""
+
+    @patch("subprocess.run")
+    @patch("os.path.exists", return_value=False)
+    @patch("shutil.which", return_value=None)
+    @patch("ginkgo.libs.GCONF")
+    def test_missing_jupyter_no_traceback(
+        self, mock_gconf, mock_which, mock_exists, mock_run, capsys):
+        """#5091: which 找不到 + venv 路径也不存在 → 不调 subprocess.run、不抛异常"""
+        mock_gconf.PYTHONPATH = "/home/x/.venv/bin/python"
+        from ginkgo.client.dev_cli import dev_jupyter
+        # 不应抛 FileNotFoundError
+        dev_jupyter()
+        # jupyter 缺失时不应尝试启动子进程
+        assert not mock_run.called, "#5091: jupyter 缺失时不应调 subprocess.run"
+        # 应输出安装提示（含 jupyter 关键词）
+        captured = capsys.readouterr()
+        assert "jupyter" in (captured.out + captured.err).lower(), \
+            "#5091: 缺失时应提示安装 jupyter"
+
+
+class TestDevJupyterLaunch:
+    """dev jupyter 在 jupyter 可用时应正常启动（#5091 回归守护）"""
+
+    @patch("subprocess.run")
+    @patch("os.path.exists", return_value=True)  # venv 也有，但应被 which 优先覆盖
+    @patch("shutil.which", return_value="/usr/bin/jupyter")
+    @patch("ginkgo.libs.GCONF")
+    def test_which_finds_jupyter_launches_lab(
+        self, mock_gconf, mock_which, mock_exists, mock_run):
+        """#5091: shutil.which 找到 jupyter 时启动 lab，且优先用 which 结果而非 venv 推断"""
+        mock_gconf.PYTHONPATH = "/home/x/.venv/bin/python"
+        from ginkgo.client.dev_cli import dev_jupyter
+        dev_jupyter()
+
+        assert mock_run.called, "找到 jupyter 时应启动 lab"
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == "/usr/bin/jupyter", \
+            f"#5091: 应优先用 shutil.which 结果而非 venv 推断, cmd={cmd}"
+        assert "lab" in cmd, f"应启动 lab 子命令, cmd={cmd}"


### PR DESCRIPTION
## Summary

修复 `ginkgo dev jupyter` 在 jupyter 未安装时的崩溃问题（#5091）。

**根因**：`dev_cli.py` 的 `dev_jupyter` 硬编码 `os.path.join(os.path.dirname(GCONF.PYTHONPATH), "jupyter")`，假设 jupyter 必装在 venv `bin/`。jupyter 缺失时 `subprocess.run` 抛 `FileNotFoundError`，命令以 traceback 退出。

**修复**：
1. 优先 `shutil.which("jupyter")` 跨 `$PATH` 查找（覆盖系统安装/用户 bin/venv 三种场景）
2. 回退 venv `bin/jupyter` 推断（兼容非标准 PATH）
3. 二者皆无 → 友好提示 `pip install jupyterlab` 并正常 `return`，不抛异常

## Test plan

- [x] 新增 `TestDevJupyterMissingInstall`：which=None + venv 不存在 → 不调 subprocess.run、不抛异常、输出含 jupyter 安装提示
- [x] 新增 `TestDevJupyterLaunch`：which 找到 → 启动 lab，且优先用 which 结果而非 venv 推断
- [x] 既有 `TestDevTestCommandTargetsTestsDir` / `TestDevLintCommandTargetsTestsDir` 未回归
- [x] Layer1 py_compile 全量通过
- [x] Layer2 启动路径 smoke 29 passed
- [x] Layer3 test_dev_cli.py 5 passed

## 验收对照（agent brief）

- ✅ 无 jupyter 时 `ginkgo dev jupyter` 输出安装提示并正常退出，不抛 FileNotFoundError

Closes #5091