### PR TITLE
fix(#4896): validate 对 StrategyDataMixin 合规方法加白名单防 false positive

### DIFF
--- a/src/ginkgo/trading/evaluation/rules/logical_rules.py
+++ b/src/ginkgo/trading/evaluation/rules/logical_rules.py
@@ -422,6 +422,23 @@ class ForbiddenOperationsRule(ASTBasedRule):
     severity = EvaluationSeverity.WARNING
     level = EvaluationLevel.STANDARD
 
+    # StrategyDataMixin 提供的合规数据访问方法（内部走 self.data_feeder，
+    # 已受 BacktestFeeder 时间边界保护）。这些方法名是 forbidden_patterns
+    # 子串黑名单的合规豁免集——按精确方法名匹配，避免 "get_bars" 子串误伤
+    # "get_bars_cached" 等 mixin 封装（issue #4896）。
+    # 漂移风险：mixin 新增公开数据访问方法时须同步本集合。
+    # 来源：src/ginkgo/trading/interfaces/mixins/strategy_data_mixin.py
+    _ALLOWED_MIXIN_METHODS = frozenset({
+        "get_bars_cached",
+        "get_current_price",
+        "get_price_series",
+        "get_ohlcv_data",
+        "clear_data_cache",
+        "set_cache_ttl",
+        "get_data_statistics",
+        "reset_data_statistics",
+    })
+
     def check_ast(self, tree: ast.Module, file_path: Path, source_code: str) -> Optional["EvaluationIssue"]:
         """Check for forbidden operations in cal() method."""
         for node in ast.walk(tree):
@@ -477,6 +494,11 @@ class ForbiddenOperationsRule(ASTBasedRule):
             ]
 
             if call_str:
+                # StrategyDataMixin 合规封装方法（如 self.get_bars_cached）
+                # 按精确方法名豁免，不进子串黑名单判定（issue #4896）。
+                method_name = call_str.rsplit(".", 1)[-1]
+                if method_name in self._ALLOWED_MIXIN_METHODS:
+                    return None
                 for pattern, desc in forbidden_patterns:
                     if pattern in call_str and "data_feeder" not in call_str:
                         return self.get_issue(

--- a/tests/unit/trading/evaluation/test_forbidden_operations_rule.py
+++ b/tests/unit/trading/evaluation/test_forbidden_operations_rule.py
@@ -1,0 +1,73 @@
+"""ForbiddenOperationsRule 行为测试。
+
+验证规则对 StrategyDataMixin 合规方法与真正违规操作的判定边界。
+Issue #4896: 之前 self.get_bars_cached() 因子串命中 get_bars 黑名单被误报 database。
+"""
+
+import ast
+from pathlib import Path
+
+from ginkgo.trading.evaluation.rules.logical_rules import ForbiddenOperationsRule
+
+
+def _check(source: str):
+    """对给定策略源码跑 ForbiddenOperationsRule，返回 EvaluationIssue 或 None。"""
+    tree = ast.parse(source)
+    rule = ForbiddenOperationsRule()
+    return rule.check_ast(tree, Path("fake_strategy.py"), source)
+
+
+STRATEGY_USING_MIXIN = '''
+class FooStrategy:
+    def cal(self, portfolio_info, event):
+        bars = self.get_bars_cached(symbol="000001", count=50, frequency="1d", use_cache=True)
+        return []
+'''
+
+STRATEGY_USING_DATA_FEEDER = '''
+class FooStrategy:
+    def cal(self, portfolio_info, event):
+        bars = self.data_feeder.get_bars(code="000001")
+        return []
+'''
+
+STRATEGY_USING_CRUD = '''
+class FooStrategy:
+    def cal(self, portfolio_info, event):
+        rows = self.crud.get_bar(code="000001")
+        return []
+'''
+
+STRATEGY_USING_REQUESTS = '''
+class FooStrategy:
+    def cal(self, portfolio_info, event):
+        resp = requests.get("http://example.com")
+        return []
+'''
+
+
+def test_mixin_get_bars_cached_not_flagged():
+    """self.get_bars_cached(...) 是 StrategyDataMixin 合规方法，不应报 database。"""
+    issue = _check(STRATEGY_USING_MIXIN)
+    assert issue is None, f"期望不报，但得到: {issue}"
+
+
+def test_data_feeder_direct_access_still_allowed():
+    """self.data_feeder.get_bars() 是合规直接访问，不应报（原有豁免保持）。"""
+    issue = _check(STRATEGY_USING_DATA_FEEDER)
+    assert issue is None, f"期望不报，但得到: {issue}"
+
+
+def test_crud_access_still_flagged():
+    """self.crud.xxx 仍应报 database（回归：白名单未放宽 crud. 拦截）。"""
+    issue = _check(STRATEGY_USING_CRUD)
+    assert issue is not None, "期望报 database，但未报"
+    assert "database" in issue.message
+
+
+def test_requests_still_flagged():
+    """requests.get(...) 仍应报 network（回归：白名单未放宽 network 拦截）。"""
+    issue = _check(STRATEGY_USING_REQUESTS)
+    assert issue is not None, "期望报 network，但未报"
+    assert "network" in issue.message
+


### PR DESCRIPTION
## Summary

`ForbiddenOperationsRule` 用子串黑名单 `("get_bars","database")` 匹配 `call_str`，但 `"get_bars"` 是 `"get_bars_cached"` 的子串，导致使用 `StrategyDataMixin.get_bars_cached()` 的策略（如 mean_reversion）被误报 `forbidden operation: database`。

`StrategyDataMixin` 是框架推荐的策略数据访问封装（内部走 `self.data_feeder`，已受 BacktestFeeder 时间边界保护），与 `ForbiddenDirectDataAccessRule` docstring 标注的 ALLOWED 一致。该 false positive 削弱验证器可信度——研究员会习惯性忽略警告，真正违规反被漏过。

### 修复
- 加 `_ALLOWED_MIXIN_METHODS` 白名单（StrategyDataMixin 全部公开数据访问方法，按精确方法名匹配）
- `call_str` 命中黑名单前先提取末段方法名，若属 mixin 合规封装则豁免
- 原 `data_feeder` 直接调用豁免、`crud.`/`requests.` 拦截保持不变

## Test plan
- [x] 新增 `tests/unit/trading/evaluation/test_forbidden_operations_rule.py`（4 测试）
  - `get_bars_cached` 不报（核心修复）
  - `self.data_feeder.get_bars()` 直接调用仍合规（回归）
  - `self.crud.xxx` 仍报 database（回归）
  - `requests.get(...)` 仍报 network（回归）
- [x] 端到端：真实 `mean_reversion.py` 源码喂 rule，false positive 消失
- [x] Layer 1 py_compile 全过
- [x] Layer 2 启动路径 smoke（user_crud_mock + containers + user_cli）29 passed
- [x] Layer 3 变更相关测试（含既有 evaluation_cli）13 passed 无回归

## 变更树
```
src/ginkgo/trading/evaluation/rules/logical_rules.py   (修: +白名单 +豁免)
tests/unit/trading/evaluation/__init__.py              (新, 空)
tests/unit/trading/evaluation/test_forbidden_operations_rule.py (新, 4 测试)
```

Closes #4896
