### PR TITLE
fix(#4893): CNAllSelector 尊重传入 codes 形参

### DIFF
--- a/src/ginkgo/trading/selectors/cn_all_selector.py
+++ b/src/ginkgo/trading/selectors/cn_all_selector.py
@@ -1,13 +1,17 @@
 # Upstream: EngineAssemblyService, PortfolioBase
-# Downstream: BaseSelector, container.stockinfo_service
-# Role: 全A股选股器，从股票信息服务获取全部A股代码列表
+# Downstream: BaseSelector, container.stockinfo_service, ensure_list
+# Role: 全A股选股器，默认从股票信息服务获取全部A股代码列表；
+#       调用方可经 codes 形参（portfolio bind-component --param '1:[...]'）限定子集。
 
 
 
 
 
+
+from typing import List, Union
 
 from ginkgo.trading.bases.selector_base import SelectorBase as BaseSelector
+from ginkgo.libs.utils import ensure_list
 
 import datetime
 
@@ -20,11 +24,17 @@ class CNAllSelector(BaseSelector):
     def __init__(
         self,
         name: str = "CNAllSelector",
+        codes: Union[str, List[str]] = "",
         *args,
         **kwargs,
     ) -> None:
         super().__init__(name, *args, **kwargs)
-        self._interested = []
+        # #4893: 尊重调用方传入的 codes（component_loader 按 index 排序后位置绑定：
+        # index0=name, index1=codes）。codes 非空 → pick() 早返该子集，不查全库；
+        # codes 空（默认 ""）→ pick() 回退查全 A 股（cn_all 本意，无参 fallback 实例化
+        # 如 component_loader.py:337 / engine_assembly_service.py:311 依赖此行为）。
+        # 区别于 FixedSelector：此处空 codes 是合法默认（=全市场），不发空告警。
+        self._interested = ensure_list(codes)
 
     def pick(self, time: any = None, *args, **kwargs) -> list[str]:
         if len(self._interested) > 0:

--- a/tests/unit/trading/selectors/test_cn_all_selector.py
+++ b/tests/unit/trading/selectors/test_cn_all_selector.py
@@ -1,0 +1,92 @@
+"""TDD tests for #4893: CNAllSelector 忽略传入的股票列表参数。
+
+根因: cn_all_selector.py __init__(name, *args, **kwargs) 不接 codes 形参，
+且 *args 转发给 SelectorBase.__init__（只收 name）会 TypeError；pick() 固定查
+全 A 股 get_stockinfos_df() 填 _interested，调用方传入的 codes 被丢弃。
+修复: __init__ 加 codes 形参（mirror FixedSelector），ensure_list 归一化后存
+_interested。codes 非空 → pick() 早返该子集；codes 空（默认）→ 保留全市场回退
+（cn_all 本意，区别于 FixedSelector 的空告警）。
+"""
+from typing import List, Union
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from ginkgo.trading.selectors.cn_all_selector import CNAllSelector
+
+
+class TestCNAllSelectorRespectsCodes:
+    """#4893: 传入 codes 子集时 pick 返回该子集，非全 A 股。"""
+
+    def test_codes_subset_returned_not_full_market(self):
+        """tracer bullet: codes=['000001','600519','000858'] → pick 返回该子集。"""
+        sel = CNAllSelector("cn_all", codes=["000001", "600519", "000858"])
+        # 修复前: __init__ 不接 codes → TypeError；修复后: pick 早返 codes 子集
+        assert sel.pick() == ["000001", "600519", "000858"]
+
+    def test_codes_as_positional_arg_index1(self):
+        """component_loader 按 index 排序后 component_class(*params) 位置绑定：
+        index0=name, index1=codes。故第二位置参应被 codes 接收。"""
+        sel = CNAllSelector("cn_all", ["000001", "600519", "000858"])
+        assert sel.pick() == ["000001", "600519", "000858"]
+
+    def test_codes_as_json_string_normalized(self):
+        """ensure_list 契约: JSON 字符串 '["a","b"]' → ["a","b"]。"""
+        sel = CNAllSelector("cn_all", codes='["000001", "600519"]')
+        assert sel.pick() == ["000001", "600519"]
+
+    def test_codes_as_comma_string_normalized(self):
+        """ensure_list 契约: 逗号分隔字符串 → list。"""
+        sel = CNAllSelector("cn_all", codes="000001,600519,000858")
+        assert sel.pick() == ["000001", "600519", "000858"]
+
+    def test_single_code_string_wrapped_to_list(self):
+        """ensure_list 契约: 单值 → [val]。"""
+        sel = CNAllSelector("cn_all", codes="000001")
+        assert sel.pick() == ["000001"]
+
+
+class TestCNAllSelectorEmptyCodesFallsBackToMarket:
+    """#4893: codes 空（默认）须保留全市场查询——cn_all 的本意。
+    component_loader.py:337 / engine_assembly_service.py:311 无参实例化依赖此行为。
+    """
+
+    def test_default_codes_queries_stockinfo_service(self):
+        """无 codes → pick() 走全市场 get_stockinfos_df() 回退路径。"""
+        fake_df = MagicMock()
+        fake_df.empty = False
+        fake_df.__getitem__ = MagicMock(return_value=MagicMock(tolist=lambda: ["000001", "600519"]))
+        fake_result = MagicMock(success=True, data=fake_df)
+
+        with patch("ginkgo.data.containers.container.stockinfo_service") as mock_svc:
+            mock_svc.return_value.get_stockinfos_df.return_value = fake_result
+            sel = CNAllSelector()  # 无参，fallback 路径
+            result = sel.pick()
+
+        assert result == ["000001", "600519"]
+        mock_svc.return_value.get_stockinfos_df.assert_called_once()
+
+    def test_empty_string_codes_also_falls_back(self):
+        """显式 codes='' 等价默认，走全市场回退（不似 FixedSelector 那样恒空）。"""
+        fake_df = MagicMock()
+        fake_df.empty = False
+        fake_df.__getitem__ = MagicMock(return_value=MagicMock(tolist=lambda: ["900001"]))
+        fake_result = MagicMock(success=True, data=fake_df)
+
+        with patch("ginkgo.data.containers.container.stockinfo_service") as mock_svc:
+            mock_svc.return_value.get_stockinfos_df.return_value = fake_result
+            sel = CNAllSelector("cn_all", codes="")
+            result = sel.pick()
+
+        assert result == ["900001"]
+        mock_svc.return_value.get_stockinfos_df.assert_called_once()
+
+    def test_codes_set_does_not_query_db(self):
+        """有 codes 时 pick() 早返，不应触发全市场查询（性能 + 避免 #4893 脏 ticker）。"""
+        with patch("ginkgo.data.containers.container.stockinfo_service") as mock_svc:
+            mock_svc.return_value.get_stockinfos_df = MagicMock()  # 不应被调用
+            sel = CNAllSelector("cn_all", codes=["000001"])
+            result = sel.pick()
+
+        assert result == ["000001"]
+        mock_svc.return_value.get_stockinfos_df.assert_not_called()


### PR DESCRIPTION
## Summary

`CNAllSelector.__init__(name, *args, **kwargs)` 不接 `codes` 形参，`pick()` 固定查全 A 股 `get_stockinfos_df()`，导致 `portfolio bind-component --param '1:["000001",...]'` 传入的股票列表被丢弃：

- **关键字形式** `codes=[...]` → 落入 `**kwargs` 被转发给 `SelectorBase` 静默吞掉
- **位置形式**（component_loader 按 index 排序后 `component_class(*params)` 真实绑定路径）→ `TypeError: SelectorBase.__init__() takes from 1 to 2 positional arguments but 3 were given`

任一情况 codes 都不生效，回测退化为全市场查询，DB 脏 ticker（`T20260517203142xhibbz.SZ` 等）刷屏。

**修复** mirror `FixedSelector`：
- `__init__` 加 `codes: Union[str, List[str]] = ""` 第二位置形参（index0=name, index1=codes，对齐 component_loader 位置绑定）
- `ensure_list(codes)` 归一化存 `_interested`（支持 list / JSON 串 / 逗号串 / 单值）
- `pick()` **不动**：既有 `if len(self._interested) > 0: return self._interested` 早返逻辑天然处理两种语义
  - codes 非空 → 早返该子集，不查全库（修 #4893）
  - codes 空（默认 `""`）→ 回退查全 A 股（**cn_all 本意保留**，无参 fallback 实例化 `component_loader.py:337` / `engine_assembly_service.py:311` 依赖此行为）

**与 FixedSelector 的关键区别**：FixedSelector 空 codes 是错误（恒空致零信号，发 WARNING，#5363）；CNAllSelector 空 codes 是合法默认（=全市场），**不发告警**。

## 关联 / 不冲突说明

PR #6546（issue #5163）同改 `cn_all_selector.py`，但职责正交：#6546 加 WARN 去重 + `bar_service.get_available_codes()` 批量预过滤（性能优化），#4893 修 codes 形参语义。本 PR 不冲突，可独立合并（如遇上下文 hunk 冲突易手解）。

## Test plan

新增 `tests/unit/trading/selectors/test_cn_all_selector.py`（8 用例）：
- ✅ codes 子集（list）→ pick 返回子集（tracer bullet）
- ✅ codes 位置实参 index1 → 被 codes 形参接收（真实绑定路径）
- ✅ JSON 串 / 逗号串 / 单值 → ensure_list 归一化
- ✅ 空 codes（默认）→ pick 查 stockinfo_service（mock 验证全市场回退保留）
- ✅ codes 非空 → pick 不查 DB（性能 + 防脏 ticker）

三层 smoke 全绿：
- Layer 1 py_compile（src+api 全量）
- Layer 2 启动路径（test_user_crud_mock / test_containers / test_user_cli，29 passed）
- Layer 3 变更相关（test_cn_all_selector + 同模块 test_fixed_selector + test_selector_base，13 passed, 27 pre-existing skips）

Closes #4893