### PR TITLE
fix(#4882): user_cli contact set-primary/update 字面 \n 改真实换行

### DIFF
--- a/src/ginkgo/client/user_cli.py
+++ b/src/ginkgo/client/user_cli.py
@@ -457,11 +457,11 @@ def update_contact(
 
         if result.success:
             console.print(Panel.fit(
-                f"[green]:white_check_mark: Contact updated successfully![/green]\\n\\n"
-                f"[cyan]UUID:[/cyan] {result.data['uuid']}\\n"
-                f"[cyan]Type:[/cyan] {result.data['contact_type']}\\n"
-                f"[cyan]Address:[/cyan] {result.data['address']}\\n"
-                f"[cyan]Primary:[/cyan] {result.data['is_primary']}\\n"
+                f"[green]:white_check_mark: Contact updated successfully![/green]\n\n"
+                f"[cyan]UUID:[/cyan] {result.data['uuid']}\n"
+                f"[cyan]Type:[/cyan] {result.data['contact_type']}\n"
+                f"[cyan]Address:[/cyan] {result.data['address']}\n"
+                f"[cyan]Primary:[/cyan] {result.data['is_primary']}\n"
                 f"[cyan]Active:[/cyan] {result.data['is_active']}",
                 title="[bold green]Success[/bold green]",
                 border_style="green"
@@ -495,9 +495,9 @@ def set_primary_contact(
 
         if result.success:
             console.print(Panel.fit(
-                f"[green]:white_check_mark: Primary contact set successfully![/green]\\n\\n"
-                f"[cyan]UUID:[/cyan] {result.data['uuid']}\\n"
-                f"[cyan]User:[/cyan] {result.data['user_uuid']}\\n"
+                f"[green]:white_check_mark: Primary contact set successfully![/green]\n\n"
+                f"[cyan]UUID:[/cyan] {result.data['uuid']}\n"
+                f"[cyan]User:[/cyan] {result.data['user_uuid']}\n"
                 f"[cyan]Primary:[/cyan] {result.data['is_primary']}",
                 title="[bold green]Success[/bold green]",
                 border_style="green"

--- a/tests/unit/client/test_user_cli.py
+++ b/tests/unit/client/test_user_cli.py
@@ -214,6 +214,53 @@ class TestUserUpdate:
 
 
 # ============================================================================
+# 2b. contact 命令换行转义测试 (#4882)
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestUserContactNewlineEscape:
+    """contact set-primary/update 输出框中 \\n 应渲染为真实换行，非字面 \\n (#4882)"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_set_primary_renders_real_newline(self, mock_container, cli_runner, mock_user_service):
+        """set-primary 成功输出不应含字面反斜杠 n，应含真实换行"""
+        mock_container.user_service.return_value = mock_user_service
+        mock_user_service.set_primary.return_value = ServiceResult.success(
+            data={"uuid": "ct-001", "user_uuid": "user-001", "is_primary": True}
+        )
+        result = cli_runner.invoke(user_cli.app, ["contact", "set-primary", "ct-001"])
+        assert result.exit_code == 0
+        assert "Primary contact set successfully" in result.output
+        # 字面两字符序列 "\n" 不应出现（bug 状态：f-string \\n 渲染为字面）
+        assert "\\n" not in result.output
+        # 真实换行符应存在（Panel.fit 内多行内容）
+        assert "\n" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_update_contact_renders_real_newline(self, mock_container, cli_runner, mock_user_service):
+        """update 成功输出不应含字面反斜杠 n，应含真实换行"""
+        mock_container.user_service.return_value = mock_user_service
+        mock_user_service.update_contact.return_value = ServiceResult.success(
+            data={
+                "uuid": "ct-002",
+                "contact_type": "EMAIL",
+                "address": "new@x.com",
+                "is_primary": False,
+                "is_active": True,
+            }
+        )
+        result = cli_runner.invoke(
+            user_cli.app, ["contact", "update", "ct-002", "--address", "new@x.com"]
+        )
+        assert result.exit_code == 0
+        assert "Contact updated successfully" in result.output
+        assert "\\n" not in result.output
+        assert "\n" in result.output
+
+
+# ============================================================================
 # 3. 验证/错误测试
 # ============================================================================
 


### PR DESCRIPTION
## Summary

修复 `ginkgo user contact set-primary` / `update` 成功输出框中显示字面 `\n` 而非真实换行的 bug。

**根因**：`user_cli.py` 两处 `Panel.fit` 内 f-string 使用 `\\n`（双反斜杠 = 字面反斜杠 + n 两字符），Rich 把它当普通文本渲染为字面 `\n`，而非换行符。

**修复**：8 处 `\\n` → `\n`（单反斜杠 = 真实换行符）：
- `set-primary` 命令（user_cli.py:498-501，3 处）
- `update` 命令（user_cli.py:460-464，5 处）

## Test plan

新增 `TestUserContactNewlineEscape` 测试类（tests/unit/client/test_user_cli.py），两轮 TDD：
- `test_set_primary_renders_real_newline`：断言输出不含字面 `\n` 两字符序列、含真实换行
- `test_update_contact_renders_real_newline`：同款断言

冒烟三层全绿：
- py_compile（src+api 全量）✅
- 启动路径 smoke（user_crud_mock + containers + user_cli，31 passed）✅
- 变更相关测试（test_user_cli.py 全文件）✅

Closes #4882