### PR TITLE
fix(#4945): execution cleanup 删前检查心跳活跃，活跃节点拒绝清理除非 --force

### DIFF
--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -478,13 +478,18 @@ def _display_single_node_status(node_id: str, heartbeat_ttl: int, metrics: dict)
 def _is_node_active(redis_client, node_id: str) -> bool:
     """判断节点是否活跃（运行中，不应清理）（#4945 deep module）。
 
-    判活口径（三处对齐：本函数 / status 命令 / heartbeat_manager._check_node_id_in_use）：
+    判活阈值 _STALE_HEARTBEAT_TTL_THRESHOLD=5 与 status 命令（L361 的 ``< 5``）一致：
+    避免 status 说活跃、cleanup 却清掉同一节点的数据。
     - heartbeat 不存在 → 不活跃（可清理）。
-    - TTL ≥ 阈值 → 活跃（fresh heartbeat，运行中）。
-    - TTL < 阈值且 ≥ 0 → stale（即将过期），不活跃（可清理）。
-    - TTL < 0（key 存在但永不过期，异常情况）→ 保守判活（拒绝清理，需 --force）。
-      与 heartbeat_manager._check_node_id_in_use 一致：永不过期的 heartbeat 视为
-      "被占用=有实例运行"，避免清掉可能的活跃节点导致调度器误判离线（#4945 review）。
+    - TTL ≥ 5 → 活跃（fresh heartbeat，运行中）。
+    - 0 ≤ TTL < 5 → stale（即将过期），不活跃（可清理）。
+    - TTL < 0（key 存在但永不过期，异常）→ 保守判活（拒绝清理，需 --force）。
+
+    注意：heartbeat_manager.is_node_id_in_use（节点启动时判 node_id 是否被占用）
+    用更宽松的阈值 10 秒（TTL<10 视为残留数据、允许抢占启动），与本函数的 5 秒口径
+    不同——目的不同：cleanup 问"清掉是否误杀运行节点"，is_node_id_in_use 问"能否用
+    此 node_id 启动"。仅 TTL<0 永不过期分支语义一致（都保守拒绝：拒绝清理/拒绝启动）
+    （#4945 review docstring 订正：方法名 + 阈值口径）。
     """
     from ginkgo.data.redis_schema import RedisKeyBuilder
 

--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -26,6 +26,10 @@ from ginkgo.interfaces.kafka_topics import KafkaTopics
 app = typer.Typer(help=":execution: ExecutionNode - Portfolio Execution Engine", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
 
+# #4945: heartbeat TTL < 此阈值视为 stale（节点即将离线/已停），可安全清理。
+# 与 status 命令 (L352-360) 的 stale 判定阈值一致，避免 status 说活跃、cleanup 却清掉。
+_STALE_HEARTBEAT_TTL_THRESHOLD = 5
+
 
 @app.command()
 def start(
@@ -471,13 +475,35 @@ def _display_single_node_status(node_id: str, heartbeat_ttl: int, metrics: dict)
     console.print(f"  :chart_with_upwards_trend: Total Events: {total_events}")
 
 
-def _cleanup_node(redis_client, node_id: str) -> tuple:
-    """清理单个 ExecutionNode 的 heartbeat + metrics（#5980 deep module）。
+def _is_node_active(redis_client, node_id: str) -> bool:
+    """判断节点是否活跃（运行中，不应清理）（#4945 deep module）。
 
-    返回 (heartbeat_deleted, metrics_deleted)，调用方据此决定输出与计数。
-    抽出此纯逻辑使 cleanup 命令能在「指定节点」与「扫描所有节点」两路径复用。
+    复用 status 命令的判活口径：heartbeat 存在且 TTL ≥ 阈值 = 活跃；
+    TTL < 阈值（即将过期）或无 heartbeat = stale/已停，可清理。
     """
     from ginkgo.data.redis_schema import RedisKeyBuilder
+
+    heartbeat_key = RedisKeyBuilder.execution_node_heartbeat(node_id)
+    if not redis_client.exists(heartbeat_key):
+        return False
+    heartbeat_ttl = redis_client.ttl(heartbeat_key)
+    return heartbeat_ttl >= _STALE_HEARTBEAT_TTL_THRESHOLD
+
+
+def _cleanup_node(redis_client, node_id: str, force: bool = False) -> tuple:
+    """清理单个 ExecutionNode 的 heartbeat + metrics（#5980 deep module，#4945 加活跃守卫）。
+
+    返回 (skipped_active, heartbeat_deleted, metrics_deleted)：
+    - skipped_active=True：节点活跃（fresh heartbeat）且非 force，已拒绝清理，调用方应警告用户。
+    - 其余情况按 key 是否存在删除，返回删除标志，供调用方统计/输出。
+
+    force=True 跳过活跃守卫，强制清理（用于运维明确知道要清的场景）。
+    """
+    from ginkgo.data.redis_schema import RedisKeyBuilder
+
+    # #4945: 活跃守卫——fresh heartbeat 表示节点在运行，删它会让调度器误判离线。
+    if not force and _is_node_active(redis_client, node_id):
+        return (True, False, False)
 
     heartbeat_key = RedisKeyBuilder.execution_node_heartbeat(node_id)
     metrics_key = f"node:metrics:{node_id}"
@@ -487,12 +513,13 @@ def _cleanup_node(redis_client, node_id: str) -> tuple:
         redis_client.delete(heartbeat_key)
     if metrics_exists:
         redis_client.delete(metrics_key)
-    return bool(heartbeat_exists), bool(metrics_exists)
+    return (False, bool(heartbeat_exists), bool(metrics_exists))
 
 
 @app.command()
 def cleanup(
     node_id: Optional[str] = typer.Option(None, "--node-id", "-n", help="ExecutionNode ID to cleanup (default: scan all nodes from heartbeats)"),
+    force: bool = typer.Option(False, "--force", help="Force cleanup even if heartbeat is still fresh (node appears running). Use only for stuck/zombie nodes."),
 ):
     """
     :broom: Cleanup stale data for an ExecutionNode.
@@ -500,12 +527,18 @@ def cleanup(
     Remove heartbeat and metrics data from Redis for a node that has stopped.
     Useful when a process exits abnormally and leaves stale data.
 
-    Without --node-id, scans all heartbeat keys and cleans every node
-    (consistent with `execution status`). With --node-id, cleans only that node.
+    #4945: Refuses to clean a node whose heartbeat is still fresh (running) unless
+    --force is given, since deleting a live heartbeat makes the scheduler mark the
+    node offline while it is actually still running.
+
+    Without --node-id, scans all heartbeat keys and cleans every stale node
+    (consistent with `execution status`); running nodes are skipped.
+    With --node-id, cleans only that node (also guarded by --force).
 
     Examples:
       ginkgo execution cleanup                      # Clean all stale nodes
       ginkgo execution cleanup --node-id node_1     # Clean specific node only
+      ginkgo execution cleanup --node-id node_1 --force  # Force clean a running node
     """
     try:
         from ginkgo.data.crud import RedisCRUD
@@ -535,23 +568,50 @@ def cleanup(
 
             total_hb = 0
             total_mt = 0
+            total_skipped = 0
             for nid in node_ids:
-                hb_deleted, mt_deleted = _cleanup_node(redis_client, nid)
+                # #4945: 三元组 (skipped_active, hb_deleted, mt_deleted)
+                skipped, hb_deleted, mt_deleted = _cleanup_node(redis_client, nid, force=force)
+                if skipped:
+                    total_skipped += 1
+                    console.print(
+                        f"[yellow]:warning: ExecutionNode '{nid}' still running (fresh heartbeat). "
+                        f"Skipped. Use --force to clean anyway.[/yellow]"
+                    )
+                    continue
                 if hb_deleted:
                     total_hb += 1
                 if mt_deleted:
                     total_mt += 1
                 console.print(f":white_check_mark: [green]Cleaned ExecutionNode '{nid}'[/green]")
 
+            cleaned_count = len(node_ids) - total_skipped
             console.print(
                 f"\n:information: Cleanup completed: {total_hb} heartbeat(s), "
-                f"{total_mt} metrics removed across {len(node_ids)} node(s)"
+                f"{total_mt} metrics removed across {cleaned_count} node(s)"
             )
-            console.print("[dim]Scheduler will detect these nodes as offline on next schedule loop[/dim]")
+            if total_skipped:
+                console.print(
+                    f"[yellow]:warning: {total_skipped} running node(s) skipped "
+                    f"(fresh heartbeat). Re-run with --force to clean them.[/yellow]"
+                )
+            # 仅在确实清理了 stale 节点时才提示调度器将判定离线（语义对这些节点成立）
+            if cleaned_count:
+                console.print("[dim]Scheduler will detect cleaned nodes as offline on next schedule loop[/dim]")
         else:
             console.print(f":information: Cleaning up data for ExecutionNode '{node_id}'...")
 
-            hb_deleted, mt_deleted = _cleanup_node(redis_client, node_id)
+            # #4945: 三元组 (skipped_active, hb_deleted, mt_deleted)
+            skipped, hb_deleted, mt_deleted = _cleanup_node(redis_client, node_id, force=force)
+
+            if skipped:
+                # 节点仍在运行——拒绝清理，绝不声称"调度器会判定它离线"（那正是 bug 表象）
+                console.print(
+                    f"[yellow]:warning: ExecutionNode '{node_id}' still has a fresh heartbeat "
+                    f"(it is running). Cleanup refused to avoid the scheduler falsely marking it offline.[/yellow]"
+                )
+                console.print(f"[dim]Re-run with --force if the node is genuinely stuck/zombie.[/dim]")
+                return
 
             if not hb_deleted and not mt_deleted:
                 console.print(f"[dim]:information: No data found for ExecutionNode '{node_id}'[/dim]")

--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -478,8 +478,13 @@ def _display_single_node_status(node_id: str, heartbeat_ttl: int, metrics: dict)
 def _is_node_active(redis_client, node_id: str) -> bool:
     """判断节点是否活跃（运行中，不应清理）（#4945 deep module）。
 
-    复用 status 命令的判活口径：heartbeat 存在且 TTL ≥ 阈值 = 活跃；
-    TTL < 阈值（即将过期）或无 heartbeat = stale/已停，可清理。
+    判活口径（三处对齐：本函数 / status 命令 / heartbeat_manager._check_node_id_in_use）：
+    - heartbeat 不存在 → 不活跃（可清理）。
+    - TTL ≥ 阈值 → 活跃（fresh heartbeat，运行中）。
+    - TTL < 阈值且 ≥ 0 → stale（即将过期），不活跃（可清理）。
+    - TTL < 0（key 存在但永不过期，异常情况）→ 保守判活（拒绝清理，需 --force）。
+      与 heartbeat_manager._check_node_id_in_use 一致：永不过期的 heartbeat 视为
+      "被占用=有实例运行"，避免清掉可能的活跃节点导致调度器误判离线（#4945 review）。
     """
     from ginkgo.data.redis_schema import RedisKeyBuilder
 
@@ -487,6 +492,9 @@ def _is_node_active(redis_client, node_id: str) -> bool:
     if not redis_client.exists(heartbeat_key):
         return False
     heartbeat_ttl = redis_client.ttl(heartbeat_key)
+    if heartbeat_ttl < 0:
+        # 永不过期（异常情况），保守判活
+        return True
     return heartbeat_ttl >= _STALE_HEARTBEAT_TTL_THRESHOLD
 
 

--- a/tests/unit/client/test_execution_cli_cleanup.py
+++ b/tests/unit/client/test_execution_cli_cleanup.py
@@ -19,7 +19,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from typer.testing import CliRunner
 
-from ginkgo.client.execution_cli import _cleanup_node, app
+from ginkgo.client.execution_cli import _cleanup_node, _is_node_active, app
 from ginkgo.data.redis_schema import (
     RedisKeyPattern,
     RedisKeyPrefix,
@@ -39,31 +39,69 @@ def cli_runner():
 @pytest.mark.unit
 @pytest.mark.cli
 class TestCleanupNode:
-    """_cleanup_node：清单个节点的 heartbeat + metrics，返回删除标志。"""
+    """_cleanup_node：清单个节点的 heartbeat + metrics。
 
-    def test_deletes_heartbeat_and_metrics_when_exist(self):
+    返回三元组 (skipped_active, hb_deleted, mt_deleted)：
+    - 活跃节点（fresh heartbeat）默认拒绝（skipped_active=True），除非 force=True。
+    - stale/无数据节点正常处理（skipped_active=False）。
+    """
+
+    @staticmethod
+    def _make_exists(hb: int, mt: int):
+        """key-aware exists side_effect：按 key 名区分 heartbeat/metrics，不依赖调用顺序。"""
+        def fake(key):
+            k = key.decode() if isinstance(key, bytes) else key
+            return hb if "heartbeat" in k else mt
+        return fake
+
+    def test_stale_node_deletes_heartbeat_and_metrics(self):
+        """stale 节点（heartbeat 存在但 TTL 已很小）→ 正常删除 heartbeat + metrics"""
         redis = MagicMock()
-        redis.exists.return_value = 1  # heartbeat 与 metrics 两次 exists 均命中
-        hb_deleted, mt_deleted = _cleanup_node(redis, "node-a")
-        assert hb_deleted is True
-        assert mt_deleted is True
+        redis.exists.side_effect = self._make_exists(hb=1, mt=1)
+        redis.ttl.return_value = 0  # stale
+        skipped, hb_deleted, mt_deleted = _cleanup_node(redis, "node-a")
+        assert skipped is False
+        assert hb_deleted is True and mt_deleted is True
         assert redis.delete.call_count == 2
 
     def test_no_data_returns_false_and_skips_delete(self):
+        """无任何数据 → 不删"""
         redis = MagicMock()
-        redis.exists.return_value = 0
-        hb_deleted, mt_deleted = _cleanup_node(redis, "node-x")
-        assert hb_deleted is False
-        assert mt_deleted is False
+        redis.exists.side_effect = self._make_exists(hb=0, mt=0)
+        skipped, hb_deleted, mt_deleted = _cleanup_node(redis, "node-x")
+        assert skipped is False
+        assert hb_deleted is False and mt_deleted is False
         redis.delete.assert_not_called()
 
-    def test_heartbeat_only_deletes_heartbeat(self):
+    def test_stale_node_heartbeat_only_deletes_heartbeat(self):
+        """stale 节点且只有 heartbeat → 只删 heartbeat"""
         redis = MagicMock()
-        redis.exists.side_effect = [1, 0]  # heartbeat 存在, metrics 不存在
-        hb_deleted, mt_deleted = _cleanup_node(redis, "node-hb")
-        assert hb_deleted is True
-        assert mt_deleted is False
+        redis.exists.side_effect = self._make_exists(hb=1, mt=0)
+        redis.ttl.return_value = 0  # stale
+        skipped, hb_deleted, mt_deleted = _cleanup_node(redis, "node-hb")
+        assert skipped is False
+        assert hb_deleted is True and mt_deleted is False
         assert redis.delete.call_count == 1
+
+    def test_active_node_rejected_without_force(self):
+        """#4945: 活跃节点（fresh heartbeat）默认拒绝清理，不删任何 key"""
+        redis = MagicMock()
+        redis.exists.side_effect = self._make_exists(hb=1, mt=1)
+        redis.ttl.return_value = 20  # 活跃（≥ 阈值 5）
+        skipped, hb_deleted, mt_deleted = _cleanup_node(redis, "node-a")
+        assert skipped is True
+        assert hb_deleted is False and mt_deleted is False
+        redis.delete.assert_not_called()
+
+    def test_active_node_force_overrides_guard(self):
+        """#4945: force=True 强制清理活跃节点"""
+        redis = MagicMock()
+        redis.exists.side_effect = self._make_exists(hb=1, mt=1)
+        redis.ttl.return_value = 20  # 活跃
+        skipped, hb_deleted, mt_deleted = _cleanup_node(redis, "node-a", force=True)
+        assert skipped is False
+        assert hb_deleted is True and mt_deleted is True
+        assert redis.delete.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -74,10 +112,10 @@ class TestCleanupNode:
 @pytest.mark.unit
 @pytest.mark.cli
 class TestCleanupCommand:
-    """cleanup 命令：不带 --node-id 扫描所有节点；指定 --node-id 只清该节点。"""
+    """cleanup 命令：扫描/指定节点清理 + #4945 活跃守卫。"""
 
-    def test_no_node_id_scans_all_nodes(self, cli_runner):
-        """#5980: 不带 --node-id 应扫描所有 heartbeat keys 逐个清理（非硬编码 execution_node_1）"""
+    def test_no_node_id_scans_all_stale_nodes(self, cli_runner):
+        """#5980: 不带 --node-id 应扫描所有 heartbeat keys 逐个清理（stale 节点）"""
         redis = MagicMock()
         prefix = f"{RedisKeyPrefix.EXECUTION_NODE_HEARTBEAT}:"
         redis.keys.return_value = [
@@ -85,6 +123,7 @@ class TestCleanupCommand:
             f"{prefix}node-b".encode(),
         ]
         redis.exists.return_value = 1  # 每节点 heartbeat+metrics 均存在
+        redis.ttl.return_value = 0  # stale，可清理
 
         with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
             MockCRUD.return_value.redis = redis
@@ -97,10 +136,11 @@ class TestCleanupCommand:
         assert "node-a" in result.output
         assert "node-b" in result.output
 
-    def test_with_node_id_cleans_only_specified(self, cli_runner):
-        """指定 --node-id 只清该节点，不扫描所有"""
+    def test_with_node_id_cleans_stale(self, cli_runner):
+        """指定 --node-id 清 stale 节点"""
         redis = MagicMock()
         redis.exists.return_value = 1
+        redis.ttl.return_value = 0  # stale
 
         with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
             MockCRUD.return_value.redis = redis
@@ -122,3 +162,97 @@ class TestCleanupCommand:
 
         assert result.exit_code == 0
         assert "No ExecutionNodes" in result.output or "no heartbeat" in result.output.lower()
+
+    # --- #4945: 活跃守卫命令级行为 ---
+
+    def test_active_node_with_id_refused_without_force(self, cli_runner):
+        """#4945: --node-id 指定活跃节点 → 拒绝清理，不删任何 key"""
+        redis = MagicMock()
+        redis.exists.return_value = 1
+        redis.ttl.return_value = 20  # 活跃
+
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = redis
+            result = cli_runner.invoke(app, ["cleanup", "--node-id", "live-host"])
+
+        assert result.exit_code == 0  # 拒绝但非错误退出
+        redis.delete.assert_not_called()
+        out = result.output.lower()
+        assert "running" in out or "fresh" in out  # 明确告知节点在运行
+        # #4945 表象：拒绝时绝不能出现"调度器会判定它离线"的误导语（那正是 bug）
+        assert "will detect" not in out and "detect this node as offline" not in out
+
+    def test_active_node_with_id_force_cleans(self, cli_runner):
+        """#4945: --force 强制清理活跃节点"""
+        redis = MagicMock()
+        redis.exists.return_value = 1
+        redis.ttl.return_value = 20  # 活跃
+
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = redis
+            result = cli_runner.invoke(app, ["cleanup", "--node-id", "live-host", "--force"])
+
+        assert result.exit_code == 0
+        assert redis.delete.call_count == 2  # force 跳过守卫，正常删
+        assert "live-host" in result.output
+
+    def test_scan_all_skips_active_and_cleans_stale(self, cli_runner):
+        """#4945: scan-all 混合场景——活跃节点跳过 + stale 节点清理 + 统计 skipped"""
+        redis = MagicMock()
+        prefix = f"{RedisKeyPrefix.EXECUTION_NODE_HEARTBEAT}:"
+        redis.keys.return_value = [
+            f"{prefix}stale-node".encode(),
+            f"{prefix}live-node".encode(),
+        ]
+        redis.exists.return_value = 1  # 所有 key 存在
+
+        def fake_ttl(key):
+            k = key.decode() if isinstance(key, bytes) else key
+            return 20 if "live" in k else 3  # live 活跃，stale 即将过期
+
+        redis.ttl.side_effect = fake_ttl
+
+        with patch("ginkgo.data.crud.RedisCRUD") as MockCRUD:
+            MockCRUD.return_value.redis = redis
+            result = cli_runner.invoke(app, ["cleanup"])
+
+        assert result.exit_code == 0
+        # stale-node: hb+mt = 2 delete；live-node: 0 delete
+        assert redis.delete.call_count == 2
+        out = result.output.lower()
+        assert "stale-node" in result.output
+        assert "live-node" in result.output
+        # 活跃跳过提示
+        assert "running" in out or "skipped" in out
+
+
+# ---------------------------------------------------------------------------
+# _is_node_active deep module (#4945：cleanup 删前必须判活)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestIsNodeActive:
+    """_is_node_active：查 heartbeat TTL 判断节点是否活跃（复用 status 命令阈值）。"""
+
+    def test_fresh_heartbeat_is_active(self):
+        """TTL ≥ 阈值 → 活跃（运行中，不应清理）"""
+        redis = MagicMock()
+        redis.exists.return_value = 1
+        redis.ttl.return_value = 20  # 30s TTL 还剩 20s，刚刷新
+        assert _is_node_active(redis, "node-a") is True
+
+    def test_stale_heartbeat_is_not_active(self):
+        """TTL < 阈值（即将过期）→ 不活跃（可清理）"""
+        redis = MagicMock()
+        redis.exists.return_value = 1
+        redis.ttl.return_value = 3  # < 5s 阈值，stale
+        assert _is_node_active(redis, "node-a") is False
+
+    def test_no_heartbeat_is_not_active(self):
+        """heartbeat 不存在 → 不活跃"""
+        redis = MagicMock()
+        redis.exists.return_value = 0
+        assert _is_node_active(redis, "node-a") is False
+        redis.ttl.assert_not_called()  # 短路，不查 TTL

--- a/tests/unit/client/test_execution_cli_cleanup.py
+++ b/tests/unit/client/test_execution_cli_cleanup.py
@@ -103,6 +103,16 @@ class TestCleanupNode:
         assert hb_deleted is True and mt_deleted is True
         assert redis.delete.call_count == 2
 
+    def test_never_expire_node_rejected_without_force(self):
+        """#4945 review: TTL=-1（永不过期异常 heartbeat）默认拒绝清理，与 heartbeat_manager 保守口径一致。"""
+        redis = MagicMock()
+        redis.exists.side_effect = self._make_exists(hb=1, mt=1)
+        redis.ttl.return_value = -1  # 永不过期（异常）
+        skipped, hb_deleted, mt_deleted = _cleanup_node(redis, "node-a")
+        assert skipped is True
+        assert hb_deleted is False and mt_deleted is False
+        redis.delete.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # cleanup 命令端到端（#5980：默认 node_id 应扫描所有节点，非硬编码 execution_node_1）
@@ -256,3 +266,14 @@ class TestIsNodeActive:
         redis.exists.return_value = 0
         assert _is_node_active(redis, "node-a") is False
         redis.ttl.assert_not_called()  # 短路，不查 TTL
+
+    def test_never_expire_heartbeat_is_active(self):
+        """TTL=-1（key 存在但永不过期，异常情况）→ 保守判活（#4945 review）。
+
+        与 heartbeat_manager._check_node_id_in_use 口径一致：永不过期的 heartbeat
+        视为"被占用=有实例运行"，cleanup 拒绝清理（需 --force），避免清掉可能的活跃节点。
+        """
+        redis = MagicMock()
+        redis.exists.return_value = 1
+        redis.ttl.return_value = -1  # Redis: key 存在但无过期时间
+        assert _is_node_active(redis, "node-a") is True


### PR DESCRIPTION
## Summary

`ginkgo execution cleanup` 直接 `redis.delete(heartbeat_key)`，不检查节点是否仍在运行。清理活跃节点会让调度器误判节点离线（issue 表象），且提示语错误声称 "Scheduler will detect this node as offline"。

### 修复
- 新增 `_is_node_active` deep module：复用 `status` 命令的 `TTL<5=stale` 口径判活（与 `execution_cli.py:352-360` 一致），避免 status 说活跃、cleanup 却清掉的语义分裂。
- `_cleanup_node` 加 `force` 参数，活跃节点（fresh heartbeat）默认拒绝（返回 `skipped_active=True`），签名从二元组改三元组。
- `cleanup` 命令加 `--force` 选项：
  - 单节点路径：活跃时拒绝 + 警告，不出现 "will detect offline" 误导语。
  - scan-all 路径：遇活跃跳过 + 统计 `skipped`，继续清 stale 节点；仅对实际清理的节点提示调度器将判定离线（对这些节点语义成立）。
- 阈值常量 `_STALE_HEARTBEAT_TTL_THRESHOLD = 5` 抽出，注释指向 status 命令同口径。

### 为什么是 deep module
`_is_node_active` 与 `_cleanup_node` 是 #5980 已抽的 deep module 层。在 deep module 加守卫，单节点/scan-all 两路径自动同时受益，无需在命令层重复校验。

## Test plan

三层冒烟（推送前已全绿，对齐 `.github/workflows/ci.yml` #6015）：
- ✅ Layer 1 `py_compile`（src/api 全量）
- ✅ Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）29 passed
- ✅ Layer 3 变更相关 `test_execution_cli_cleanup.py` 14 passed + `test_execution_cli_status.py` 2 passed（确认 status 未破坏）

新增/更新测试覆盖：
- `TestIsNodeActive`（3）：fresh=active / stale=not / 无 heartbeat=not（短路不查 TTL）
- `TestCleanupNode`（5）：stale 删双/stale 仅 hb/无数据/活跃拒绝/活跃+force 删除
- `TestCleanupCommand`（6）：scan stale / 指定 stale / 无节点警告 / 活跃拒绝（断言无 "will detect offline" 误导语）/ force 强制 / scan-all 混合（活跃跳过+stale 清理+统计）

Closes #4945

🤖 Generated with [Claude Code](https://claude.com/claude-code)