### PR TITLE
fix(#4903): result segment-stability --help 示例前缀去除残留 'get'

### DIFF
--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -876,8 +876,8 @@ def segment_stability(
     """:bar_chart: Run segment stability validation.
 
     Examples:
-        ginkgo get result segment-stability --task-id abc123
-        ginkgo get result segment-stability -t abc123 -s 2,4 -m sharpe_ratio,win_rate
+        ginkgo result segment-stability --task-id abc123
+        ginkgo result segment-stability -t abc123 -s 2,4 -m sharpe_ratio,win_rate
     """
     from ginkgo.data.containers import container
     from ginkgo.data.services.validation_service import ANALYZER_LABELS

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -81,6 +81,18 @@ class TestHelp:
         assert "get" in result.output
         assert "show" in result.output
 
+    def test_result_segment_stability_help_prefix_correct(self, cli_runner):
+        """#4903: segment-stability --help 示例前缀不应残留已拍平的 'get' 子命令。
+
+        早期 CLI 把 `get result` 拍平为 `result` 子命令组，docstring 示例
+        需同步更新为 `ginkgo result segment-stability ...`，否则用户复制
+        会得到 'No such command'。
+        """
+        result = cli_runner.invoke(flat_cli.result_app, ["segment-stability", "--help"])
+        assert result.exit_code == 0
+        assert "ginkgo result segment-stability" in result.output
+        assert "ginkgo get result segment-stability" not in result.output
+
 
 # ============================================================================
 # 1b. result list -p short-option conflict (#4621)


### PR DESCRIPTION
## Summary

修 `ginkgo result segment-stability --help` 示例命令前缀错误。

早期 CLI 把 `get result` 拍平为 `result` 子命令组，但 `segment-stability` 的 docstring 示例未同步，仍残留 `ginkgo get result segment-stability`（多了 `get`）。用户按示例复制会得到 'No such command'。

**改动**：
- `src/ginkgo/client/flat_cli.py:879-880`：示例前缀 `ginkgo get result segment-stability` → `ginkgo result segment-stability`
- `tests/unit/client/test_flat_cli.py`：TestHelp 新增 `test_result_segment_stability_help_prefix_correct`，守护 help 输出前缀契约（含 `ginkgo result segment-stability`，不含 `ginkgo get result segment-stability`）

全仓 grep 确认仅此两行残留错误前缀，无其他同根因簇。

## Test plan

- [x] Layer 1 py_compile（src/api 全量）通过
- [x] Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）29 passed
- [x] Layer 3 变更相关：`TestHelp` 全 4 passed（含新增 #4903 守护测试）
- [x] `ginkgo result segment-stability --help` 输出前缀正确
- 注：`TestComponentCreate` 2 个测试在 origin/master 上即失败（pre-existing，与本 docstring 修复无关）

Closes #4903

🤖 Generated with [Claude Code](https://claude.com/claude-code)