### PR TITLE
fix(#4969): MCP Server 版本号与 CLI 同源

### DIFF
--- a/mcp_server/__init__.py
+++ b/mcp_server/__init__.py
@@ -11,4 +11,4 @@ Ginkgo MCP Server
     GINKGO_ACCOUNT_ID=xxx ginkgo serve mcp
 """
 
-__version__ = "0.2.0"
+from ginkgo.config.package import VERSION as __version__  # 跟随主版本（#4969）

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -45,6 +45,7 @@ from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 from mcp.types import TextContent
 
 from ginkgo.libs import GLOG
+from ginkgo.config.package import VERSION  # 与 CLI `ginkgo version` 同源（#4969）
 
 # contextvars: 为 Streamable HTTP 多会话隔离不同的 API Key 工具实例
 _current_tools: contextvars.ContextVar = contextvars.ContextVar('current_tools')
@@ -348,7 +349,7 @@ class GinkgoMCPServer:
                 json.dumps({
                     "status": "ok",
                     "server": "ginkgo-okx",
-                    "version": "0.2.0",
+                    "version": VERSION,
                     "transports": ["stdio", "sse", "streamable_http"],
                     "endpoints": {
                         "/mcp": "Streamable HTTP (MCP 2025-03-26, recommended)",
@@ -365,7 +366,7 @@ class GinkgoMCPServer:
             return Response(
                 json.dumps({
                     "name": "Ginkgo OKX MCP Server",
-                    "version": "0.2.0",
+                    "version": VERSION,
                     "transports": ["stdio", "sse", "streamable_http"],
                     "endpoints": {
                         "/mcp": "Streamable HTTP (recommended)",

--- a/tests/unit/test_mcp_server_version.py
+++ b/tests/unit/test_mcp_server_version.py
@@ -1,0 +1,63 @@
+"""MCP Server 版本一致性测试。
+
+验收（issue #4969）：MCP Server /health 与 / 返回的 version 必须与
+`ginkgo version`（即 config.package.VERSION）一致，不能再硬编码字面量。
+
+通过公共 ASGI 接口（Starlette TestClient）验证，不耦合 handler 内部实现。
+
+注意：测试文件平铺在 tests/unit/ 下而非 tests/unit/mcp_server/，避免测试包名
+遮蔽仓库根的真 `mcp_server` 包（sys.path 上 tests/unit/ 在前会先命中测试包）。
+"""
+import os
+import sys
+
+import pytest
+
+# mcp_server 是仓库根目录下的顶层包（不在 src/ginkgo 下），需把 repo root 加入 sys.path
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+@pytest.fixture
+def http_app():
+    """构建 MCP HTTP ASGI app（sse 模式，无需 API Key/DB）。"""
+    from mcp_server.server import GinkgoMCPServer
+    import asyncio
+    server = GinkgoMCPServer(transport="sse")
+    return asyncio.get_event_loop_policy().new_event_loop().run_until_complete(
+        server._build_http_app()
+    )
+
+
+def _get_version_truth():
+    from ginkgo.config.package import VERSION
+    return VERSION
+
+
+class TestMCPServerVersionConsistency:
+    """MCP Server 暴露的版本必须与 CLI 同源（config.package.VERSION）。"""
+
+    def test_health_endpoint_returns_canonical_version(self, http_app):
+        from starlette.testclient import TestClient
+        expected = _get_version_truth()
+        with TestClient(http_app) as client:
+            resp = client.get("/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "version" in body, f"/health 缺 version 字段: {body}"
+        assert body["version"] == expected, (
+            f"/health version={body['version']!r} 与 ginkgo version={expected!r} 不一致"
+        )
+
+    def test_root_endpoint_returns_canonical_version(self, http_app):
+        from starlette.testclient import TestClient
+        expected = _get_version_truth()
+        with TestClient(http_app) as client:
+            resp = client.get("/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "version" in body, f"/ 缺 version 字段: {body}"
+        assert body["version"] == expected, (
+            f"/ version={body['version']!r} 与 ginkgo version={expected!r} 不一致"
+        )


### PR DESCRIPTION
## Summary

修复 MCP Server `/health` 与 `/` 端点硬编码 `version: "0.2.0"`、与 CLI `ginkgo version`（当前 0.8.x）不一致的问题。

**根因**：`mcp_server/server.py` 的 `health_handler`/`root_handler` 写死字面量 `"0.2.0"`，未接版本源；`mcp_server/__init__.py` 的 `__version__` 同样写死。

**修复**：
- `mcp_server/server.py`：新增 `from ginkgo.config.package import VERSION`，两个 handler 的 `version` 字段改用 `VERSION`
- `mcp_server/__init__.py`：`__version__` 改为 `from ginkgo.config.package import VERSION as __version__`，跟随主版本
- 选 `config.package.VERSION` 与 CLI `ginkgo version` 完全同源（`importlib.metadata → pyproject.toml → 兜底`，见 `arch_package_version_metadata_layer`）

未动 `protocolVersion`（line 496）——那是 MCP 协议规范版本（`2025-03-26`），与 server 软件版本无关。

## Test plan

- [x] 新增 `tests/unit/test_mcp_server_version.py`：通过 Starlette `TestClient` 走公共 ASGI 接口，验证 `/health` 与 `/` 返回的 `version` 等于 `config.package.VERSION`（不耦合 handler 内部实现）
- [x] Layer 1 py_compile（mcp_server 全模块）
- [x] Layer 2 启动路径 smoke（test_user_crud_mock / test_containers / test_user_cli，29 passed）
- [x] Layer 3 变更相关测试（test_mcp_server_version，2 passed）

手动验证（reviewer）：
```bash
ginkgo serve mcp --transport sse --port 8001 &
curl http://localhost:8001/health | jq .version   # 应与 ginkgo version 一致
curl http://localhost:8001/       | jq .version
```

Closes #4969