### PR TITLE
fix(#4948): user list --limit 在 service 层生效（过滤后截断）

### DIFF
--- a/src/ginkgo/user/services/user_service.py
+++ b/src/ginkgo/user/services/user_service.py
@@ -576,6 +576,9 @@ class UserService(BaseService):
                 name_lower = name.lower()
                 users = [u for u in users if name_lower in u.username.lower() or (u.display_name and name_lower in u.display_name.lower())]
 
+            # #4948 应用 limit（在 Python 端过滤之后截断，保证 name/username 过滤语义不丢匹配）
+            users = users[:limit]
+
             # Batch-fetch credentials for is_admin enrichment
             credentials_map = self.get_all_credentials()
 

--- a/tests/unit/test_user_service_list_users.py
+++ b/tests/unit/test_user_service_list_users.py
@@ -1,0 +1,77 @@
+# See #4948: list_users(limit=N) 必须截断到 N 条，不能 dead parameter
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+pytestmark = pytest.mark.unit
+
+
+def _make_user(uuid, username="u", display_name=None, user_type=1):
+    """构造 mock user（user_type=1 → PERSON，USER_TYPES.from_int 可用）"""
+    return SimpleNamespace(
+        uuid=uuid,
+        username=username,
+        display_name=display_name,
+        description="",
+        user_type=user_type,
+        is_active=True,
+        create_at=None,
+    )
+
+
+def _mock_user_service():
+    from ginkgo.user.services.user_service import UserService
+    with patch.object(UserService, '__init__', lambda self: None):
+        svc = UserService()
+    svc.user_crud = MagicMock()
+    svc.user_contact_crud = MagicMock()
+    svc.user_contact_crud.find.return_value = []
+    svc.get_all_credentials = MagicMock(return_value={})
+    return svc
+
+
+class TestListUsersLimit:
+    def test_limit_truncates_results(self):
+        """list_users(limit=2) 当 DB 返回 5 用户时，只返回 2 条（#4948 核心）"""
+        svc = _mock_user_service()
+        svc.user_crud.find.return_value = [_make_user(i) for i in range(5)]
+
+        result = svc.list_users(limit=2)
+
+        assert isinstance(result, ServiceResult)
+        assert result.success is True
+        assert len(result.data["users"]) == 2
+        assert result.data["count"] == 2
+
+    def test_limit_applies_after_name_filter(self):
+        """先 name 过滤再 limit 截断——不能先截断后过滤（否则丢匹配）"""
+        svc = _mock_user_service()
+        svc.user_crud.find.return_value = [
+            _make_user(0, username="bob0"),
+            _make_user(1, username="alice1"),
+            _make_user(2, username="bob2"),
+            _make_user(3, username="alice3"),
+            _make_user(4, username="alice4"),
+        ]
+
+        result = svc.list_users(name="alice", limit=2)
+
+        assert result.success is True
+        # name=alice 匹配 3 个，limit=2 截断到 2 个（若先截断 2 再过滤只得 1 个，错）
+        assert len(result.data["users"]) == 2
+        usernames = [u["username"] for u in result.data["users"]]
+        assert all("alice" in u for u in usernames)
+
+    def test_default_limit_100(self):
+        """limit 默认 100，DB 返回 150 用户时只返回 100 条"""
+        svc = _mock_user_service()
+        svc.user_crud.find.return_value = [_make_user(i) for i in range(150)]
+
+        result = svc.list_users()  # 不传 limit，用默认 100
+
+        assert result.success is True
+        assert len(result.data["users"]) == 100


### PR DESCRIPTION
## Summary

`ginkgo user list --limit 3` 忽略 limit，始终返回全部 330 条记录。根因：`UserService.list_users` 签名收 `limit: int = 100` 但函数体零引用（dead parameter）——`user_crud.find()` 全量返回后，username/name 过滤、enrichment、返回全程无截断。

## 修复

`BaseCRUD.find` 不支持 limit 参数（只有 `page`/`page_size` 分页），且 service 在 Python 端做 name/username 过滤——若在 DB 层截断会破坏过滤语义（先截断后过滤丢匹配）。故在 Python 端过滤**之后**、enrichment 循环**之前**插入 `users = users[:limit]`：

```python
# 按 name 过滤 ...
# #4948 应用 limit（在 Python 端过滤之后截断，保证 name/username 过滤语义不丢匹配）
users = users[:limit]
# Batch-fetch credentials ...
```

放在 enrichment 前还顺带减少 enrichment 开销（不再对截断掉的 user 做 credentials/contacts 查询）。

## Test plan

新增 `tests/unit/test_user_service_list_users.py`（3 个行为测试）：
- `test_limit_truncates_results`：limit=2 + DB 5 用户 → 返回 2 条（核心）
- `test_limit_applies_after_name_filter`：name=alice（匹配 3）+ limit=2 → 返回 2 条 alice（语义守护：锁死"先过滤后截断"，防 DB 层截断优化破坏过滤）
- `test_default_limit_100`：默认 limit=100 + DB 150 用户 → 返回 100 条

冒烟三层全过：py_compile (src+api) ✅｜启动路径 smoke (user_crud_mock/containers/user_cli) + 变更相关 (list_users/facade) 共 41 passed ✅，无回归。

```bash
ginkgo user list --limit 5   # 期望 ≤5 条（原先显示全部 330）
```

Closes #4948

🤖 Generated with [Claude Code](https://claude.com/claude-code)