### PR TITLE
fix(#4954): cleanup_historic_records 改用 remove(filters=...) 替代不存在的 delete_filtered

### DIFF
--- a/src/ginkgo/trading/services/_assembly/data_preparer.py
+++ b/src/ginkgo/trading/services/_assembly/data_preparer.py
@@ -193,7 +193,7 @@ class DataPreparer:
         try:
             for portfolio_id in portfolio_configs.keys():
                 self._logger.DEBUG(f"Cleaning historic records for portfolio {portfolio_id}")
-                self._analyzer_record_crud.delete_filtered(portfolio_id=portfolio_id, engine_id=engine_id)
+                self._analyzer_record_crud.remove(filters={"portfolio_id": portfolio_id, "engine_id": engine_id})
 
         except Exception as e:
             self._logger.WARN(f"Failed to clean historic records: {e}")

--- a/tests/unit/services/smoke/test_data_preparer_smoke.py
+++ b/tests/unit/services/smoke/test_data_preparer_smoke.py
@@ -10,6 +10,12 @@ try:
 except ImportError:
     HAS_MODULE = False
 
+try:
+    from ginkgo.data.crud.analyzer_record_crud import AnalyzerRecordCRUD
+    HAS_CRUD = True
+except ImportError:
+    HAS_CRUD = False
+
 
 @pytest.mark.skipif(not HAS_MODULE, reason="ginkgo.trading.services._assembly.data_preparer not importable")
 class TestDataPreparerSmoke:
@@ -46,10 +52,38 @@ class TestDataPreparerSmoke:
     def test_cleanup_historic_records_callable(self):
         """cleanup_historic_records() 可调用"""
         with patch("ginkgo.trading.services._assembly.data_preparer.GLOG"):
-            mock_crud = MagicMock()
+            # spec=AnalyzerRecordCRUD 防止 MagicMock auto-create 掩盖缺失方法 (#4954)
+            mock_crud = MagicMock(spec=AnalyzerRecordCRUD) if HAS_CRUD else MagicMock()
             preparer = DataPreparer(analyzer_record_crud=mock_crud)
             # Should not crash
             preparer.cleanup_historic_records("engine-id", {"pf-1": {}, "pf-2": {}})
+
+    def test_cleanup_historic_records_calls_remove_with_filters(self):
+        """cleanup_historic_records() 必须对每个 portfolio 调 remove(filters=...) (#4954)
+
+        历史 bug: 调用了 CRUD 上不存在的 delete_filtered -> AttributeError 被
+        except 吞掉只 warn -> 旧记录不清理。spec= 让缺失方法在测试中真 raise，
+        断言 remove 调用让 except 吞异常也无法蒙混。
+        """
+        if not HAS_CRUD:
+            pytest.skip("AnalyzerRecordCRUD not importable")
+        with patch("ginkgo.trading.services._assembly.data_preparer.GLOG"):
+            mock_crud = MagicMock(spec=AnalyzerRecordCRUD)
+            preparer = DataPreparer(analyzer_record_crud=mock_crud)
+            preparer.cleanup_historic_records(
+                "engine-1", {"pf-1": {}, "pf-2": {}, "pf-3": {}}
+            )
+            # 每个 portfolio 应触发一次 remove
+            assert mock_crud.remove.call_count == 3
+            # 每次调用 filters 必须含 portfolio_id + engine_id
+            for call in mock_crud.remove.call_args_list:
+                filters = call.kwargs.get("filters") or (call.args[0] if call.args else None)
+                assert filters is not None
+                assert "portfolio_id" in filters
+                assert "engine_id" in filters
+                assert filters["engine_id"] == "engine-1"
+            # 确认 delete_filtered 这种不存在的方法未被调用（防回归）
+            assert not hasattr(mock_crud, "delete_filtered")
 
     def test_get_sample_config_callable(self):
         """get_sample_config() 可调用"""


### PR DESCRIPTION
## Summary

`DataPreparer.cleanup_historic_records` 调用了 `AnalyzerRecordCRUD` 上从未定义的 `delete_filtered` 方法。全仓 CRUD 删除约定统一为 `BaseCRUD.remove(filters=...)`（20+ CRUD 一致使用），`delete_filtered` 是唯一的非约定调用点。

原代码在运行时抛 `AttributeError`，被方法内的 `try/except` 吞掉只打 `WARN`，导致回测启动时历史 analyzer 记录清理**静默失败**——旧记录不清理、可能重复，每次回测都打印警告。

## 根因

- **调用链**：`DataPreparer.cleanup_historic_records` (data_preparer.py:196) → `AnalyzerRecordCRUD.delete_filtered()` 💥 AttributeError（方法从未存在）→ except 吞掉 → 仅 WARN
- **根因**：调用方使用了全仓唯一的非约定方法名；正确约定是 `self.remove(filters=...)`
- **为何长期未发现**：(1) `try/except` 吞异常只 warn；(2) 现有 smoke 测试用 `MagicMock()` 注入 CRUD，auto-create 任意方法属性，掩盖了缺失方法（[[feedback_magicmock_method_attr_mask]] 陷阱）

## 改动

- `src/ginkgo/trading/services/_assembly/data_preparer.py`：`delete_filtered(portfolio_id=..., engine_id=...)` → `remove(filters={"portfolio_id": ..., "engine_id": ...})`（1 行，对齐全仓约定，不动 CRUD/Base 类）
- `tests/unit/services/smoke/test_data_preparer_smoke.py`：
  - 强化 `test_cleanup_historic_records_callable`：mock 改用 `MagicMock(spec=AnalyzerRecordCRUD)`，让缺失方法在测试中真 raise
  - 新增 `test_cleanup_historic_records_calls_remove_with_filters`：断言 cleanup 对每个 portfolio 调 `remove`，且 filters 含 `portfolio_id`+`engine_id`；显式 `assert not hasattr(mock, "delete_filtered")` 防回归

## Test plan

- [x] Layer 1 py_compile：data_preparer.py + 测试文件 ✅
- [x] Layer 2 启动路径 smoke：`test_user_crud_mock.py` + `test_containers.py` + `test_user_cli.py` (29 passed) ✅
- [x] Layer 3 变更相关：`test_data_preparer_smoke.py` (7 passed) + `test_analyzer_record_crud_mock.py` (11 passed) ✅
- [x] 新测试 RED→GREEN 验证：原代码 RED（`remove.call_count == 0`），修复后 GREEN

## 验收对齐 agent brief

- [x] ~~单测 delete_filtered 按条件删除 analyzer 记录~~ → 采取 brief 备选方案 B：改 data_preparer 调用 `remove`+过滤参数（保持全仓约定一致性，不为唯一调用点新增非约定别名）
- [x] 回测清理历史记录不再抛 AttributeError

Closes #4954
