### PR TITLE
fix(#4774): worker 完成回调灌入 ClickHouse 日志

### DIFF
--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -114,6 +114,7 @@ class BacktestProcessor(Thread):
             self.task.result = result.data
 
             self.progress_tracker.report_completed(self.task, None)
+            self._ingest_task_logs()
             GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
 
         except Exception as e:
@@ -302,6 +303,25 @@ class BacktestProcessor(Thread):
             self.task, progress, current_date,
             total_pnl=total_pnl, total_orders=total_orders, total_signals=total_signals
         )
+
+    def _ingest_task_logs(self):
+        """灌入回测运行日志到 ClickHouse（静默降级）。
+
+        与 ``backtest_cli.py`` 本地同步路径（L287-296）对齐：worker 派发的回测
+        完成后也须灌入日志，否则 ``ginkgo logging logs/errors --task <id>``
+        永远空查询（#4774）。灌入失败非致命——回测已完成，日志缺失不应回滚状态。
+        """
+        try:
+            from ginkgo.services.logging.log_ingester import LogIngester
+            ingester = LogIngester()
+            ingest_result = ingester.ingest_task_logs(self.task.task_uuid)
+            if ingest_result.inserted > 0:
+                GLOG.INFO(
+                    f"[{self.task.task_uuid[:8]}] Logs ingested: "
+                    f"{ingest_result.inserted} records"
+                )
+        except Exception as e:
+            GLOG.WARN(f"[{self.task.task_uuid[:8]}] Log ingest failed: {e}")
 
     def _calculate_result(self, engine_result: Dict[str, Any]) -> Dict[str, Any]:
         """计算回测结果"""

--- a/tests/unit/workers/test_task_processor_log_ingest.py
+++ b/tests/unit/workers/test_task_processor_log_ingest.py
@@ -1,0 +1,108 @@
+"""Tests for BacktestProcessor log ingestion after completion -- #4774.
+
+worker（Kafka→BacktestWorker）派发的回测完成后，必须把运行日志灌入 ClickHouse，
+否则 ``ginkgo logging logs/errors --task <id>`` 永远空查询。
+
+灌入职责与 ``backtest_cli.py`` 本地同步路径（L287-296）对齐：worker 完成回调
+``run()`` 在 ``report_completed`` 之后调用 ``_ingest_task_logs``，静默降级
+（灌入失败不影响已完成状态）。
+"""
+import importlib
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _ingester_module():
+    """ginkgo.services.logging 是 DynamicContainer（非真包），属性访问触发
+    __getattr__ 找服务提供者而非子模块。须走 importlib.import_module
+    拿到真实模块对象再 patch。见 [[arch_service_dict_wrapped_return]]。"""
+    return importlib.import_module("ginkgo.services.logging.log_ingester")
+
+try:
+    from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
+    from ginkgo.workers.backtest_worker.models import BacktestTask, BacktestConfig
+
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+def _full_backtest_config(start: str = "2025-01-01", end: str = "2025-06-01") -> BacktestConfig:
+    """ADR-018：BacktestConfig 删默认值后，进程内构造须显式传全 11 字段。"""
+    return BacktestConfig(
+        start_date=start,
+        end_date=end,
+        initial_cash=100000.0,
+        commission_rate=0.0003,
+        slippage_rate=0.0001,
+        benchmark_return=0.0,
+        max_position_ratio=0.3,
+        stop_loss_ratio=0.05,
+        take_profit_ratio=0.15,
+        frequency="DAY",
+        analyzers=[],
+    )
+
+
+def _make_processor(task) -> BacktestProcessor:
+    """构造最小可测处理器：跳过 __init__ 的 service 容器装配。"""
+    proc = BacktestProcessor.__new__(BacktestProcessor)
+    proc.task = task
+    proc.worker_id = "w-test"
+    proc.progress_tracker = MagicMock()
+    proc._stop_event = Event()
+    proc._engine = None
+    proc._exception = None
+    proc._result = {}
+    return proc
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+@pytest.mark.tdd
+class TestIngestTaskLogsOnCompletion:
+    """#4774: worker 完成回调必须灌入日志到 ClickHouse。"""
+
+    def test_calls_ingest_task_logs_with_task_uuid(self, monkeypatch):
+        """完成回调触发 LogIngester.ingest_task_logs(task_uuid)。"""
+        cfg = _full_backtest_config()
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+
+        calls = []
+
+        class FakeResult:
+            inserted = 3
+            skipped = 0
+            errors = 0
+
+        class FakeIngester:
+            def __init__(self_inner):
+                pass
+
+            def ingest_task_logs(self_inner, task_uuid):
+                calls.append(task_uuid)
+                return FakeResult()
+
+        monkeypatch.setattr(_ingester_module(), "LogIngester", FakeIngester)
+
+        proc._ingest_task_logs()
+
+        assert len(calls) == 1, f"expected one ingest call, got {calls}"
+        assert calls[0] == task.task_uuid
+
+    def test_ingest_failure_does_not_raise(self, monkeypatch):
+        """灌入异常必须静默降级（不影响已完成的回测状态）。"""
+        cfg = _full_backtest_config()
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+
+        class BoomIngester:
+            def __init__(self_inner):
+                raise RuntimeError("boom-ingest")
+
+        monkeypatch.setattr(_ingester_module(), "LogIngester", BoomIngester)
+
+        # 不得抛出——回测已完成，日志灌入失败非致命
+        proc._ingest_task_logs()


### PR DESCRIPTION
## Summary

worker（Kafka→BacktestWorker）派发的回测完成后未调用 `ingest_task_logs`，导致 `ginkgo logging logs/errors --task <id>` 查 ClickHouse 永远空查询（#4774）。

`ingest_task_logs` 此前仅在 `backtest_cli.py:291` 本地同步 `run_task` 路径调用；worker 全链路无 ingest。

**修复**：在 `task_processor.run()` 的 `report_completed` 之后调用新增的 `_ingest_task_logs()`，与本地同步路径（L287-296）行为对齐：
- 读 LOGGING_PATH 下 `bt_<prefix>_*.log` 灌入 ClickHouse
- 静默降级（灌入失败只 WARN，不回滚已完成状态——回测本身已成功）
- 走 worker 完成回调，避免在 `logging logs` 命令做懒触发引入并发/重复灌入

## 根因（调用链）

```
worker Kafka 消费 → task_processor.run() → orchestrator.run() (回测执行)
                                          → report_completed()  [更新 DB 状态]
                                          → ❌ 缺 ingest_task_logs
本地同步: backtest_cli run_task → orchestrator.run()
                                  → service.update_progress(FINALIZING)
                                  → ✅ ingest_task_logs (L287-296)
```

## Test plan

- [x] 新增单测 `test_task_processor_log_ingest.py`：
  - `_ingest_task_logs` 调用 `LogIngester.ingest_task_logs(task_uuid)` 且传入正确 uuid
  - 灌入异常静默降级（不抛出，不影响已完成状态）
- [x] 既有 task_processor / progress_tracker 测试回归全过（7 passed）
- [x] workers 全目录冒烟 46 passed（排除已知 paper_trading_worker hang/失败）
- [x] Layer 2 启动路径冒烟（test_user_crud_mock / test_containers / test_user_cli）29 passed
- [x] py_compile 通过
- [ ] worker 跑完一个回测后 `ginkgo logging logs <backtest_id>` 返回非空（运行时验证，需部署后实测）

## 备注

- mock 路径走 `importlib.import_module` 拿真实模块对象，绕开 Ginkgo DynamicContainer 的 `__getattr__`（`ginkgo.services.logging` 是容器非真包，属性访问触发服务查找）
- 未触碰 `backtest_cli.py` 本地同步路径（验收：行为不变）

Closes #4774

🤖 Generated with [Claude Code](https://claude.com/claude-code)