### PR TITLE
fix(#4853): 回测孤儿任务治理 — 派发期检查 send 返回值 + 孤儿扫描兜底

### DIFF
--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -373,7 +373,13 @@ class BacktestTaskService(BaseService):
         """
         try:
             running = self._crud_repo.get_running_tasks()
-            threshold = datetime.now(timezone.utc) - timedelta(minutes=timeout_minutes)
+            # 阈值语态绑死 worker 写入端：progress_tracker.py:218 写 naive local
+            # datetime.now()（宿主 Asia/Shanghai UTC+8）。两端必须同语态比较，
+            # 否则 naive 北京时间被 replace(tzinfo=utc) 当 UTC 解释会看起来年轻 8h，
+            # 30min timeout 实际变 ~8h30min（#4853 PR #6565 review 抓的 bug）。
+            # 治本（worker 改 aware UTC）属全仓 naive→UTC 迁移，超出本 PR 范围，
+            # 迁移完成时同步此行回 datetime.now(timezone.utc)。
+            threshold = datetime.now() - timedelta(minutes=timeout_minutes)
             cleaned = 0
 
             for task in running:
@@ -381,9 +387,6 @@ class BacktestTaskService(BaseService):
                 if st is None:
                     # start_time 残缺无法判定，跳过（不崩，留给下次或人工）。
                     continue
-                # 兼容历史 naive datetime（DateTime(timezone=True) 列可能存 naive 值）
-                if st.tzinfo is None:
-                    st = st.replace(tzinfo=timezone.utc)
 
                 if st < threshold:
                     self.update_status(

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -16,7 +16,7 @@ import time
 import json
 from typing import List, Union, Any, Optional, Dict
 import pandas as pd
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from ginkgo.libs import cache_with_expiration, retry, GLOG
 from ginkgo.libs.data.number import convert_to_float
@@ -353,6 +353,59 @@ class BacktestTaskService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"Failed to delete backtest task {uuid[:8]}...: {e}")
             return ServiceResult.error(f"Failed to delete backtest task: {str(e)}")
+
+    def cleanup_orphan_tasks(self, timeout_minutes: int = 30) -> ServiceResult:
+        """
+        清理孤儿回测任务（#4853）。
+
+        扫描 status=running 但 start_time 早于 timeout_minutes 的任务，标记为 failed。
+        处理两类孤儿：
+        - Worker 重启期间 Kafka 消息丢失（派发成功但 Worker 未消费）
+        - 派发期未被 send 返回值检查拦截的历史残留（本方法上线前的存量）
+
+        与 portfolio_service.reset_stale_running() 同构：状态机兜底，防永久 running。
+
+        Args:
+            timeout_minutes: running 状态超时阈值（分钟），默认 30。
+
+        Returns:
+            ServiceResult: data 含 cleaned（标记 failed 数量）与 total_running（扫描时 running 总数）。
+        """
+        try:
+            running = self._crud_repo.get_running_tasks()
+            threshold = datetime.now(timezone.utc) - timedelta(minutes=timeout_minutes)
+            cleaned = 0
+
+            for task in running:
+                st = task.start_time
+                if st is None:
+                    # start_time 残缺无法判定，跳过（不崩，留给下次或人工）。
+                    continue
+                # 兼容历史 naive datetime（DateTime(timezone=True) 列可能存 naive 值）
+                if st.tzinfo is None:
+                    st = st.replace(tzinfo=timezone.utc)
+
+                if st < threshold:
+                    self.update_status(
+                        task.uuid, status="failed",
+                        error_message=(
+                            f"Orphan task: running > {timeout_minutes}min without progress "
+                            "(worker lost Kafka message or crashed)"
+                        ),
+                    )
+                    cleaned += 1
+                    GLOG.INFO(f"Marked orphan backtest task {task.uuid[:8]}... as failed")
+
+            if cleaned > 0:
+                GLOG.INFO(f"Cleaned {cleaned}/{len(running)} orphan running backtest tasks")
+
+            return ServiceResult.success(
+                {"cleaned": cleaned, "total_running": len(running)},
+                f"清理 {cleaned} 个孤儿 running 任务",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"Failed to cleanup orphan backtest tasks: {e}")
+            return ServiceResult.error(f"Failed to cleanup orphan backtest tasks: {str(e)}")
 
     def get_statistics(self) -> ServiceResult:
         """
@@ -748,9 +801,22 @@ class BacktestTaskService(BaseService):
             except ValidationError as e:
                 return ServiceResult.error(f"Invalid backtest assignment config: {e}")
 
-            producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
+            # #4853：检查 send 返回值，失败即标 failed，避免永久 running 孤儿。
+            # GinkgoProducer.send 已装饰 @retry(max_try=3)，此处 False 表示重试耗尽仍未送达。
+            send_ok = producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
             producer.flush(timeout=2.0)
             producer.close()
+
+            if not send_ok:
+                self.update_status(
+                    real_uuid, status="failed",
+                    error_message="Kafka dispatch failed: message not delivered after retries",
+                )
+                GLOG.ERROR(f"Failed to dispatch backtest task {task_id}: Kafka send returned False")
+                return ServiceResult.error(
+                    f"Failed to dispatch backtest task to Kafka (task {task_id}): "
+                    "message not delivered. Task marked as failed."
+                )
 
             GLOG.INFO(f"Started backtest task with task_id: {task_id}")
             return ServiceResult.success({"uuid": real_uuid, "task_id": task_id}, "Backtest task started")

--- a/tests/unit/data/services/test_backtest_task_orphan.py
+++ b/tests/unit/data/services/test_backtest_task_orphan.py
@@ -12,7 +12,7 @@
 import sys
 import os
 import json
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 from contextlib import contextmanager
 
@@ -107,7 +107,8 @@ class TestCleanupOrphanTasks:
     @pytest.mark.unit
     def test_stale_running_marked_failed(self, service):
         """running + start_time 早于阈值 → 标 failed。"""
-        now = datetime.now(timezone.utc)
+        # naive local，与 worker progress_tracker.py 写入语态一致（#4853 review 契约）。
+        now = datetime.now()
         stale = _make_task(
             status="running",
             start_time=now - timedelta(minutes=60),
@@ -126,7 +127,8 @@ class TestCleanupOrphanTasks:
     @pytest.mark.unit
     def test_fresh_running_not_touched(self, service):
         """running + start_time 新鲜 → 不动。"""
-        now = datetime.now(timezone.utc)
+        # naive local，与 worker progress_tracker.py 写入语态一致（#4853 review 契约）。
+        now = datetime.now()
         fresh = _make_task(
             status="running",
             start_time=now - timedelta(minutes=5),
@@ -150,3 +152,32 @@ class TestCleanupOrphanTasks:
 
         assert result.is_success()
         service.update_status.assert_not_called()
+
+    @pytest.mark.unit
+    def test_naive_local_start_time_cleaned_within_real_timeout(self, service):
+        """回归守护（#4853 PR #6565 review 抓的 bug）。
+
+        worker progress_tracker.py 写 start_time=datetime.now() 是 naive local
+        （宿主 Asia/Shanghai UTC+8）。cleanup 阈值必须与 worker 写入同语态
+        （naive local），否则 naive 北京时间被 replace(tzinfo=utc) 当 UTC 解释，
+        task 看起来比实际年轻 8 小时，声明的 30min timeout 实际变 ~8h30min，
+        孤儿永久不被清理 —— issue #4853 痛点未被有效兜底。
+
+        构造 naive local start_time = now-35min（与 worker 写入语态一致），
+        timeout=30min → 必须触发 failed。
+        """
+        naive_local_now = datetime.now()  # 无 tzinfo，模拟 worker 写入
+        stale = _make_task(
+            status="running",
+            start_time=naive_local_now - timedelta(minutes=35),
+        )
+        stale.uuid = "stale-naive-local"
+        service._crud_repo.get_running_tasks.return_value = [stale]
+        service.update_status = MagicMock(return_value=ServiceResult.success({}, "ok"))
+
+        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+
+        assert result.is_success()
+        service.update_status.assert_called_once()
+        assert service.update_status.call_args.kwargs.get("status") == "failed"
+        assert service.update_status.call_args.args[0] == "stale-naive-local"

--- a/tests/unit/data/services/test_backtest_task_orphan.py
+++ b/tests/unit/data/services/test_backtest_task_orphan.py
@@ -1,0 +1,152 @@
+"""
+#4853：回测任务孤儿治理。
+
+两层防御：
+1. 派发期（防新增）：producer.send 返回 False → start_task 标 task failed 并报错，
+   不再 fire-and-forget 留下永久 running 孤儿。
+2. 兜底（清存量）：cleanup_orphan_tasks 扫描 running 超 N 分钟无进展的任务标 failed，
+   处理历史孤儿与 Worker 重启丢消息场景。
+
+参考既有 mock 模式：test_backtest_task_assignment_payload.py。
+"""
+import sys
+import os
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+
+import pytest
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_task(**overrides):
+    task = MagicMock()
+    task.uuid = "uuid-1234-5678"
+    task.task_id = "task-abc"
+    task.portfolio_id = "portfolio-001"
+    task.name = "test_backtest"
+    task.backtest_start_date = None
+    task.backtest_end_date = None
+    task.status = "completed"
+    task.config_snapshot = json.dumps({
+        "start_date": "2025-06-01",
+        "end_date": "2026-06-01",
+        "initial_cash": 200000.0,
+    })
+    task.start_time = None
+    for k, v in overrides.items():
+        setattr(task, k, v)
+    return task
+
+
+@contextmanager
+def _mock_kafka(send_return=True):
+    """Mock GinkgoProducer；send_return 控制 send() 返回值（True=送达，False=失败）。"""
+    mock_producer = MagicMock()
+    mock_producer.send.return_value = send_return
+    mock_container = MagicMock()
+    with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer), \
+         patch("ginkgo.data.containers.container", mock_container):
+        yield mock_producer
+
+
+@pytest.fixture
+def service():
+    crud = MagicMock()
+    return BacktestTaskService(crud_repo=crud)
+
+
+def _setup_task(service, task):
+    service._crud_repo.get_by_uuid.return_value = task
+    service._crud_repo.find.return_value = []
+    service.update_status = MagicMock(return_value=ServiceResult.success(task, "ok"))
+
+
+# ---------- 派发期：防新增孤儿 ----------
+
+class TestStartDispatchFailure:
+    """producer.send 返回 False 时，start_task 必须标记 task failed 并报错。"""
+
+    @pytest.mark.unit
+    def test_send_false_marks_task_failed(self, service):
+        """send=False → start_task 返回 error，update_status(failed) 被调。"""
+        task = _make_task()
+        _setup_task(service, task)
+        with _mock_kafka(send_return=False):
+            result = service.start_task(uuid="uuid-1234-5678")
+
+        assert not result.is_success()
+        statuses = [c.kwargs.get("status") for c in service.update_status.call_args_list]
+        assert "failed" in statuses
+
+    @pytest.mark.unit
+    def test_send_true_returns_success_no_failed(self, service):
+        """回归：send=True → start_task 成功，update_status 不含 failed（仅 pending）。"""
+        task = _make_task()
+        _setup_task(service, task)
+        with _mock_kafka(send_return=True):
+            result = service.start_task(uuid="uuid-1234-5678")
+
+        assert result.is_success()
+        statuses = [c.kwargs.get("status") for c in service.update_status.call_args_list]
+        assert "failed" not in statuses
+
+
+# ---------- 兜底：清存量孤儿 ----------
+
+class TestCleanupOrphanTasks:
+    """cleanup_orphan_tasks 扫描 running 超 N 分钟无进展的任务标 failed。"""
+
+    @pytest.mark.unit
+    def test_stale_running_marked_failed(self, service):
+        """running + start_time 早于阈值 → 标 failed。"""
+        now = datetime.now(timezone.utc)
+        stale = _make_task(
+            status="running",
+            start_time=now - timedelta(minutes=60),
+        )
+        stale.uuid = "stale-uuid"
+        service._crud_repo.get_running_tasks.return_value = [stale]
+        service.update_status = MagicMock(return_value=ServiceResult.success({}, "ok"))
+
+        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+
+        assert result.is_success()
+        service.update_status.assert_called_once()
+        assert service.update_status.call_args.kwargs.get("status") == "failed"
+        assert "stale-uuid" == service.update_status.call_args.args[0]
+
+    @pytest.mark.unit
+    def test_fresh_running_not_touched(self, service):
+        """running + start_time 新鲜 → 不动。"""
+        now = datetime.now(timezone.utc)
+        fresh = _make_task(
+            status="running",
+            start_time=now - timedelta(minutes=5),
+        )
+        service._crud_repo.get_running_tasks.return_value = [fresh]
+        service.update_status = MagicMock()
+
+        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+
+        assert result.is_success()
+        service.update_status.assert_not_called()
+
+    @pytest.mark.unit
+    def test_running_without_start_time_skipped(self, service):
+        """running 但 start_time=None（数据残缺）→ 跳过不崩。"""
+        no_time = _make_task(status="running", start_time=None)
+        service._crud_repo.get_running_tasks.return_value = [no_time]
+        service.update_status = MagicMock()
+
+        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+
+        assert result.is_success()
+        service.update_status.assert_not_called()


### PR DESCRIPTION
## Summary

修复回测任务成为孤儿（status=running 但 Worker 从未收到 Kafka 消息）永久卡死的问题。

**根因**：`backtest_task_service.py:751` `producer.send()` 是 fire-and-forget —— `GinkgoProducer.send` 返回 bool（True=送达确认，False=连接失败/超时），但返回值未被检查。send=False 时仍报 success，DB 留下永久 running 孤儿。

**两层防御**：

1. **派发期（防新增）**：`start_task` 检查 `producer.send` 返回值，False 时标 task=failed 并报错，不再留下永久 running 孤儿。
2. **兜底（清存量）**：新增 `cleanup_orphan_tasks(timeout_minutes=30)` 方法，扫描 status=running 且 start_time 早于阈值的任务标 failed。处理 Worker 重启期间 Kafka 消息丢失等历史孤儿。与 `portfolio_service.reset_stale_running()` 同构。

## 变更

- `src/ginkgo/data/services/backtest_task_service.py`
  - `start_task`：检查 send 返回值，失败标 failed
  - 新增 `cleanup_orphan_tasks()`：孤儿扫描（公共 service 方法，可被 API/CLI/worker 调用）
- `tests/unit/data/services/test_backtest_task_orphan.py`：5 个单测

## Test plan

- [x] `test_send_false_marks_task_failed`：send=False → 标 failed
- [x] `test_send_true_returns_success_no_failed`：send=True → 回归（行为不变）
- [x] `test_stale_running_marked_failed`：running + 老 start_time → failed
- [x] `test_fresh_running_not_touched`：running + 新 start_time → 不动
- [x] `test_running_without_start_time_skipped`：start_time=None → 跳过不崩
- [x] 既有派发测试全绿（23 passed，无回归）
- [x] py_compile + 启动路径 smoke 通过

## 范围说明

按 triage agent brief 严格收窄：本次只做核心逻辑 + 单测。issue body 建议的 worker 启动 hook、`ginkgo backtest retry <task_id>` CLI 子命令留作后续 issue（需独立验证 worker 启动时序与 CLI 注册）。

Closes #4853