### PR TITLE
fix(#4768): dev profile 用 sys.executable 替代硬编码 python + 友好错误

### DIFF
--- a/src/ginkgo/client/dev_cli.py
+++ b/src/ginkgo/client/dev_cli.py
@@ -270,11 +270,27 @@ def dev_profile(
     :stopwatch: Profile Python script performance.
     """
     import subprocess
-    
+    import sys
+
     console.print(f":stopwatch: [bold blue]Profiling {script}...[/bold blue]")
 
-    cmd = ["python", "-m", "cProfile", "-o", output, script]
+    # #4768: 用 sys.executable 而非硬编码 "python"——venv/uv/容器环境下
+    # 裸 "python" 可能不在 PATH 或指向不同版本，导致 cProfile 调用崩溃。
+    cmd = [sys.executable, "-m", "cProfile", "-o", output, script]
 
-    subprocess.run(cmd)
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        console.print(
+            f":x: [bold red]Profiling 失败[/bold red] cProfile 退出码 {e.returncode}。"
+        )
+        raise typer.Exit(code=e.returncode)
+    except FileNotFoundError:
+        console.print(
+            f":x: [bold red]Profiling 失败[/bold red] 找不到解释器或脚本: {sys.executable}。"
+            "请检查运行环境。"
+        )
+        raise typer.Exit(code=1)
+
     console.print(f":chart_with_upwards_trend: Profile results saved to {output}")
     console.print(f"View with: [bold]python -m pstats {output}[/bold]")

--- a/tests/unit/client/test_dev_cli.py
+++ b/tests/unit/client/test_dev_cli.py
@@ -58,3 +58,44 @@ class TestDevLintCommandTargetsTestsDir:
         for call in tool_calls:
             assert "tests/" in call, f"#6020: {call[0]} 未含 tests/: {call}"
             assert "test/" not in call, f"#6020: {call[0]} 仍含 test/: {call}"
+
+
+class TestDevProfileUsesSysExecutable:
+    """#4768 — dev profile 应调用当前解释器 (sys.executable) 而非硬编码 'python'"""
+
+    @patch("subprocess.run")
+    def test_dev_profile_cmd_uses_sys_executable(self, mock_run):
+        import sys
+        from ginkgo.client.dev_cli import dev_profile
+
+        dev_profile(script="foo.py", output="profile.stats")
+
+        assert mock_run.called, "dev_profile 未调用 subprocess.run"
+        cmd = mock_run.call_args[0][0]
+        assert cmd[0] == sys.executable, (
+            f"#4768: cmd 首元素应为 sys.executable ({sys.executable}), got {cmd[0]!r}"
+        )
+        assert "-m" in cmd and "cProfile" in cmd, f"cProfile 调用丢失: {cmd}"
+
+    @patch("subprocess.run")
+    def test_dev_profile_interpreter_missing_outputs_friendly_error(self, mock_run):
+        """#4768: 解释器/脚本缺失时应友好退出 (typer.Exit)，非裸 FileNotFoundError traceback"""
+        import typer
+        mock_run.side_effect = FileNotFoundError("python not found")
+        from ginkgo.client.dev_cli import dev_profile
+
+        with pytest.raises(typer.Exit) as exc_info:
+            dev_profile(script="foo.py", output="profile.stats")
+        assert exc_info.value.exit_code != 0, "失败时应以非零码退出"
+
+    @patch("subprocess.run")
+    def test_dev_profile_nonzero_exit_outputs_friendly_error(self, mock_run):
+        """#4768: cProfile 非零退出应友好提示并透传退出码，非裸 CalledProcessError"""
+        import typer
+        from subprocess import CalledProcessError
+        mock_run.side_effect = CalledProcessError(returncode=2, cmd=[])
+        from ginkgo.client.dev_cli import dev_profile
+
+        with pytest.raises(typer.Exit) as exc_info:
+            dev_profile(script="foo.py", output="profile.stats")
+        assert exc_info.value.exit_code == 2


### PR DESCRIPTION
## Summary

`ginkgo dev profile <script>` 通过 `subprocess.run(["python", "-m", "cProfile", ...])` 执行，但在 venv/uv/容器（Python 3.14）环境下，裸 `"python"` 可能不在 PATH 或解析到不同版本解释器，导致 cProfile 调用崩溃（#4768）。

修复 `src/ginkgo/client/dev_cli.py` 的 `dev_profile`：
- **`"python"` → `sys.executable`**：保证子进程使用与 ginkgo 相同的解释器，根除环境漂移。
- **`check=True` + try/except**：把 `subprocess.run` 的静默失败转为可处理异常，`FileNotFoundError` / `CalledProcessError` 包装为 `typer.Exit` 友好退出，透传退出码，不再裸 traceback。

## Test plan

新增 `tests/unit/client/test_dev_cli.py::TestDevProfileUsesSysExecutable`（3 个单测，mock `subprocess.run`）：
- ✅ `cmd[0] == sys.executable`（核心修复）
- ✅ 解释器缺失 → `typer.Exit` 非零退出（非裸 `FileNotFoundError`）
- ✅ cProfile 非零退出 → `typer.Exit` 透传退出码（非裸 `CalledProcessError`）

三层冒烟（对齐 ci.yml #6015）：
- Layer 1 py_compile 全扫 ✅
- Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）✅
- Layer 3 test_dev_cli.py 全 6 用例 ✅

Closes #4768