### PR TITLE
fix(#4751): test validate/run --database 修正过时 test.database import

### DIFF
--- a/src/ginkgo/client/test_cli.py
+++ b/src/ginkgo/client/test_cli.py
@@ -230,7 +230,8 @@ def validate():
     """
     :mag: Validate test environment configuration and safety settings.
     """
-    from test.database.test_isolation import validate_test_database_config
+    # #4751: test_isolation 实际位于 tests/unit/database/（历史 test/ 重构后未同步）
+    from tests.unit.database.test_isolation import validate_test_database_config
     
     console.print(":mag: [bold blue]Test Environment Validation[/bold blue]")
     console.print()
@@ -378,7 +379,8 @@ def run(
     if database:
         # Special handling for database tests with safety checks
         if not force:
-            from test.database.test_isolation import validate_test_database_config, print_database_test_warning
+            # #4751: test_isolation 实际位于 tests/unit/database/（与 validate 命令同源修复）
+            from tests.unit.database.test_isolation import validate_test_database_config, print_database_test_warning
             
             # Validate environment
             is_safe, issues = validate_test_database_config()

--- a/tests/unit/client/test_test_cli_validate.py
+++ b/tests/unit/client/test_test_cli_validate.py
@@ -1,0 +1,43 @@
+"""
+#4751: ginkgo test validate 不应崩 ModuleNotFoundError。
+
+根因：test_cli.py:233 ``from test.database.test_isolation import ...`` 用了过时的
+顶层 ``test`` 包路径（仓库已重构为 ``tests/unit/``），Python 找不到 ``test`` 包
+→ ModuleNotFoundError。同样过时的 import 还存在于 ``run --database`` 分支（:381）。
+
+测试策略：
+  - CliRunner.invoke catch_exceptions=True 会把异常吞进 result.exception
+    （见 feedback_test_cli_assertion_channel），故断言走 isinstance(result.exception)
+    而非 output 字面量
+  - validate_test_database_config 内部 try/except 兜底，不会因缺 DB 配置崩，
+    只会返回 issues，所以 validate 命令能跑完
+"""
+from typer.testing import CliRunner
+
+from ginkgo.client.test_cli import app
+
+
+def test_validate_does_not_raise_module_not_found():
+    """validate 命令不再因 ``from test.database...`` 过时 import 崩 ModuleNotFoundError。"""
+    runner = CliRunner()
+    result = runner.invoke(app, ["validate"], catch_exceptions=True)
+    # catch_exceptions=True 吞异常进 result.exception；不抛 ModuleNotFoundError 是关键
+    assert not isinstance(result.exception, ModuleNotFoundError), (
+        f"validate 不应崩 ModuleNotFoundError，got: {result.exception!r}"
+    )
+    assert result.exit_code == 0
+    # 命令真正执行（不是被 import 错挡在第一行）
+    assert "Test Environment Validation" in result.output
+
+
+def test_run_database_does_not_raise_module_not_found():
+    """``run --database``（无 --force）触发同源 import（:381），同样不应崩。
+
+    import 修好后，``validate_test_database_config`` 在测试环境（debug 未开）返回
+    ``(False, issues)``，命令早退 return，不会调 pytest.main，无副作用。
+    """
+    runner = CliRunner()
+    result = runner.invoke(app, ["run", "--database"], catch_exceptions=True)
+    assert not isinstance(result.exception, ModuleNotFoundError), (
+        f"run --database 不应崩 ModuleNotFoundError，got: {result.exception!r}"
+    )


### PR DESCRIPTION
## Summary

`ginkgo test validate` 崩 `ModuleNotFoundError: No module named 'test'`。

**根因**：`test_cli.py:233`（validate 命令）和 `:381`（run --database 分支）仍用 `from test.database.test_isolation import ...`，但仓库历史 `test/` 顶层目录已重构为 `tests/unit/`，过时 import 未同步。

**修复**：两处 import 改为 `from tests.unit.database.test_isolation import ...`，对齐实际模块位置（与 #6408 修复 list 命令 WORKING_PATH 的对称修复）。`run --database` 是同源 import，一并修否则仍会崩。

## Test plan

- [x] 新增 `tests/unit/client/test_test_cli_validate.py`
  - `test_validate_does_not_raise_module_not_found`：validate 不再 ModuleNotFoundError + 输出含 "Test Environment Validation"
  - `test_run_database_does_not_raise_module_not_found`：run --database 同源 import 覆盖
- [x] `tests/unit/client/test_test_cli_list.py` 回归（#6408 修复不破坏）：5 passed
- [x] 启动路径 smoke（test_user_crud_mock + test_containers + test_user_cli）：29 passed
- [x] py_compile 通过

Closes #4751

🤖 Generated with [Claude Code](https://claude.com/claude-code)