### PR TITLE
fix(#4634): result list 命令实现, 复用 BacktestTaskService

### DIFF
--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -612,17 +612,76 @@ def priority(
 # Result 相关命令
 @result_app.command()
 def list(
-    backtest_id: Optional[str] = typer.Option(None, "--backtest", "-b", help="Filter by backtest ID"),
+    task_id: Optional[str] = typer.Option(None, "--task-id", help=":mag: 按任务ID过滤 (uuid 或 task_id)"),
     portfolio: Optional[str] = typer.Option(None, "--portfolio", "-p", help="Filter by portfolio ID"),
-    page: int = typer.Option(20, "--page", "-P", help="Page size"),
+    status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (pending/running/completed/failed)"),
+    page: int = typer.Option(0, "--page", "-P", help="Page number"),
+    page_size: int = typer.Option(20, "--page-size", help="Items per page"),
 ):
     """
     :clipboard: List all backtest results.
     """
-    console.print(":clipboard: Listing results...")
+    from ginkgo.data.containers import container
 
-    # TODO: Implement actual result listing
-    console.print(":information: Result listing not yet implemented")
+    service = container.backtest_task_service()
+
+    # --task-id: 复用 result get 查询路径(ADR-016 task_id 主键), 单条展示
+    if task_id:
+        result = service.get_by_id(task_id)
+        if not result.is_success() or result.data is None:
+            console.print(f":x: [red]未找到回测任务: {task_id}[/red]")
+            raise typer.Exit(1)
+        tasks = [result.data]
+        total = 1
+    else:
+        result = service.list(
+            page=page, page_size=page_size, portfolio_id=portfolio, status=status
+        )
+        if not result.is_success():
+            console.print(f":x: {result.error}")
+            raise typer.Exit(1)
+        # service 返回 dict 包装({"data":[...],"total":N}); 兼容直接返回 list
+        data = result.data or {}
+        if isinstance(data, dict):
+            tasks = data.get("data", [])
+            total = data.get("total", 0)
+        else:
+            tasks = data or []
+            total = len(tasks)
+
+    if not tasks:
+        console.print(":memo: No backtest results found.")
+        return
+
+    table = Table(title=":chart_with_upwards_trend: Backtest Results")
+    table.add_column("UUID", style="dim", width=12)
+    table.add_column("Name", style="bold", width=20)
+    table.add_column("Portfolio", width=12)
+    table.add_column("Status", width=12)
+    table.add_column("Created", width=19)
+
+    for task in tasks:
+        uuid_str = task.uuid[:12] if hasattr(task, "uuid") else str(task.get("uuid", ""))[:12]
+        name = task.name if hasattr(task, "name") else task.get("name", "")
+        portfolio_id = (
+            task.portfolio_id[:12] if hasattr(task, "portfolio_id")
+            else str(task.get("portfolio_id", ""))[:12]
+        )
+        status_val = task.status if hasattr(task, "status") else task.get("status", "")
+        created = str(task.create_at)[:19] if hasattr(task, "create_at") else ""
+        status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(
+            status_val, "white"
+        )
+        table.add_row(
+            uuid_str,
+            name[:20],
+            portfolio_id,
+            f"[{status_style}]{status_val}[/{status_style}]",
+            created,
+        )
+
+    console.print(table)
+    console.print(f"\n  Total: {total} results (Page {page}, size {page_size})")
 
 
 @result_app.command()

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -113,9 +113,18 @@ class TestResultListParamConflict:
         """--portfolio and --page must each parse independently without the
         duplicate-short-option warning, regardless of order."""
         import warnings
+        from ginkgo.data.services.base_service import ServiceResult
 
+        # #4634: result list 已实现, 会调 backtest_task_service.list;
+        # 此测试聚焦参数解析, mock service 隔离 DB
+        mock_service = MagicMock()
+        mock_service.list.return_value = ServiceResult.success(
+            data={"data": [], "total": 0, "page": 0, "page_size": 20}
+        )
         for argv in (["list", "--portfolio", "abc123"], ["list", "--page", "2"]):
-            with warnings.catch_warnings(record=True) as caught:
+            with patch("ginkgo.data.containers.container") as mock_container, \
+                 warnings.catch_warnings(record=True) as caught:
+                mock_container.backtest_task_service.return_value = mock_service
                 warnings.simplefilter("always")
                 result = cli_runner.invoke(flat_cli.result_app, argv)
             assert result.exit_code == 0, f"failed for {argv}: {result.output}"
@@ -267,10 +276,73 @@ class TestMappingCommands:
 class TestResultCommands:
     """Tests for result sub-app commands."""
 
-    def test_result_list_shows_not_implemented(self, cli_runner):
-        result = cli_runner.invoke(flat_cli.result_app, ["list"])
-        assert result.exit_code == 0
-        assert "not yet implemented" in result.output
+    def test_result_list_returns_tasks(self, cli_runner):
+        """#4634: result list 应调 backtest_task_service.list 返回任务表格，
+        而非 'not yet implemented' 占位。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        task = MagicMock()
+        task.uuid = "abc123def456"
+        task.name = "TestBacktest"
+        task.portfolio_id = "port12345678"
+        task.status = "completed"
+        task.progress = 100
+        task.create_at = datetime(2025, 1, 1)
+        mock_service = MagicMock()
+        mock_service.list.return_value = ServiceResult.success(
+            data={"data": [task], "total": 1, "page": 0, "page_size": 20}
+        )
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = mock_service
+            result = cli_runner.invoke(flat_cli.result_app, ["list"])
+        assert result.exit_code == 0, result.output
+        assert "TestBacktest" in result.output
+        assert "not yet implemented" not in result.output
+        mock_service.list.assert_called_once()
+
+    def test_result_list_with_task_id_calls_get_by_id(self, cli_runner):
+        """#4634: --task-id 应复用 result get 查询路径(get_by_id), 单条展示。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        task = MagicMock()
+        task.uuid = "task-uuid-12345"
+        task.name = "SingleBT"
+        task.portfolio_id = "port-abc12345"
+        task.status = "completed"
+        task.create_at = datetime(2025, 6, 1)
+        mock_service = MagicMock()
+        mock_service.get_by_id.return_value = ServiceResult.success(data=task)
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = mock_service
+            result = cli_runner.invoke(
+                flat_cli.result_app, ["list", "--task-id", "task-uuid-12345"]
+            )
+        assert result.exit_code == 0, result.output
+        assert "SingleBT" in result.output
+        mock_service.get_by_id.assert_called_once_with("task-uuid-12345")
+        mock_service.list.assert_not_called()
+
+    def test_result_list_empty_shows_no_results(self, cli_runner):
+        """#4634: 空结果应优雅提示, 非 crash。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_service = MagicMock()
+        mock_service.list.return_value = ServiceResult.success(
+            data={"data": [], "total": 0, "page": 0, "page_size": 20}
+        )
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = mock_service
+            result = cli_runner.invoke(flat_cli.result_app, ["list"])
+        assert result.exit_code == 0, result.output
+        assert "No backtest results" in result.output
+
+    def test_result_list_service_error_exits_nonzero(self, cli_runner):
+        """#4634: service 失败应 exit 1 + 显示错误, 非 crash。"""
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_service = MagicMock()
+        mock_service.list.return_value = ServiceResult.error("DB down")
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = mock_service
+            result = cli_runner.invoke(flat_cli.result_app, ["list"])
+        assert result.exit_code == 1, result.output
+        assert "DB down" in result.output
 
     # #5957: 旧 test_result_get_* 断言已删除的假数据("Sharpe Ratio"/"Trade History")，
     # 新契约(真实 service + task_id 参数)由 TestResultGetRealData 覆盖，故移除。


### PR DESCRIPTION
## Summary

实现 `ginkgo result list` 命令，替换 `flat_cli.py` 中的 TODO stub（原输出 "Result listing not yet implemented"）。

- **无 `--task-id`**：调用 `backtest_task_service.list(page, page_size, portfolio_id, status)` 分页返回回测任务表格
- **`--task-id <id>`**：复用 `result get` 的查询路径（`get_by_id`），按 ADR-016 task_id 主键单条展示
- 保留 `--portfolio/-p` `--page/-P`（#4621 守护的短选项），新增 `--status/-s` `--page-size`
- 空结果优雅提示（exit 0），service 失败 exit 1 + 显示错误

## 根因

`flat_cli.py` 的 `result list` 是 TODO stub，未接 BacktestTaskService。同模块 `result get` 已实现可用，故复用其查询路径。

## Test plan

- [x] `test_result_list_returns_tasks`：mock service.list，断言返回任务表格（非 stub 占位）
- [x] `test_result_list_with_task_id_calls_get_by_id`：--task-id 走 get_by_id 单条路径
- [x] `test_result_list_empty_shows_no_results`：空结果优雅提示
- [x] `test_result_list_service_error_exits_nonzero`：service 失败 exit 1
- [x] #4621 参数冲突测试加固 mock（保持断言语义，隔离 service）
- [x] 三层冒烟：py_compile ✅ ｜ 启动路径 smoke (user_crud/containers/user_cli) 29 passed ✅ ｜ test_flat_cli.py 34 passed（2 个 TestComponentCreate 失败为 master baseline 既有，非本次回归）

Closes #4634
