### PR TITLE
fix(#4760): 模板渲染语法错附带 template_id 上下文与位置

### DIFF
--- a/src/ginkgo/notifier/core/template_engine.py
+++ b/src/ginkgo/notifier/core/template_engine.py
@@ -21,6 +21,32 @@ from ginkgo.data.models import MNotificationTemplate
 from ginkgo.libs import GLOG
 
 
+class TemplateRenderError(ValueError):
+    """模板渲染失败时抛出，携带 template_id 上下文与位置信息（issue #4760）。
+
+    继承 ValueError 以保持向后兼容（现有 `except ValueError` 调用方仍能捕获）。
+    底层 `render()` 抛出的 ValueError 不含 template_id；本类在
+    `render_from_template_id`/`preview_template` 等"知道 template_id 的入口"
+    处包装底层错误，让用户能定位是哪个模板出错。
+    """
+
+    def __init__(
+        self,
+        message: str,
+        template_id: Optional[str] = None,
+        lineno: Optional[int] = None,
+    ) -> None:
+        self.template_id = template_id
+        self.lineno = lineno
+        parts = []
+        if template_id:
+            parts.append(f"template {template_id!r}")
+        if lineno is not None:
+            parts.append(f"line {lineno}")
+        prefix = f"Template render error ({', '.join(parts)}): " if parts else "Template render error: "
+        super().__init__(prefix + message)
+
+
 class TemplateEngine:
     """
     模板渲染引擎
@@ -91,7 +117,11 @@ class TemplateEngine:
 
         except TemplateSyntaxError as e:
             GLOG.ERROR(f"Template syntax error: {e}")
-            raise ValueError(f"Template syntax error at line {e.lineno}: {e.message}")
+            # 附加 lineno 属性供上层（render_from_template_id/preview_template）
+            # 包装成 TemplateRenderError 时结构化读取（issue #4760）
+            err = ValueError(f"Template syntax error at line {e.lineno}: {e.message}")
+            err.lineno = e.lineno
+            raise err
 
         except (UndefinedError, TemplateError) as e:
             GLOG.ERROR(f"Template rendering error: {e}")
@@ -134,11 +164,17 @@ class TemplateEngine:
             raise ValueError(f"Template is not active: {template_id}")
 
         # 渲染模板
-        return self.render(
-            template_content=template.content,
-            context=context,
-            strict=strict
-        )
+        try:
+            return self.render(
+                template_content=template.content,
+                context=context,
+                strict=strict
+            )
+        except ValueError as e:
+            # 底层 render 抛的 ValueError 不含 template_id 上下文；
+            # 此处知道 template_id，包装成 TemplateRenderError 让用户能定位是哪个模板出错（issue #4760）
+            lineno = getattr(e, "lineno", None)
+            raise TemplateRenderError(str(e), template_id=template_id, lineno=lineno) from e
 
     def validate_template(self, template_content: str) -> Dict[str, Any]:
         """
@@ -269,7 +305,13 @@ class TemplateEngine:
             context = {var: f"<{var}>" for var in variables}
 
         # 渲染模板
-        rendered = self.render(template.content, context)
+        try:
+            rendered = self.render(template.content, context)
+        except ValueError as e:
+            # 底层 render 抛的 ValueError 不含 template_id 上下文；
+            # 此处知道 template_id，包装成 TemplateRenderError（issue #4760）
+            lineno = getattr(e, "lineno", None)
+            raise TemplateRenderError(str(e), template_id=template_id, lineno=lineno) from e
 
         return {
             "template_id": template.template_id,

--- a/tests/unit/client/test_templates_cli_render.py
+++ b/tests/unit/client/test_templates_cli_render.py
@@ -1,0 +1,62 @@
+"""templates_cli render 命令的端到端友好错误测试（issue #4760）。
+
+验证 TemplateEngine 层的友好错误（含 template_id + 位置）能透传到
+用户在终端看到的命令输出，而非裸 Jinja2 traceback。
+"""
+
+import pytest
+from typer.testing import CliRunner
+from unittest.mock import patch, MagicMock
+
+from ginkgo.client.templates_cli import app
+from ginkgo.data.models.model_notification_template import MNotificationTemplate
+
+
+@pytest.mark.unit
+class TestTemplatesCliRenderFriendlyError:
+    """render 命令在模板含语法错时输出含 template_id 的可读错误。"""
+
+    def _make_bad_template(self) -> MNotificationTemplate:
+        return MNotificationTemplate(
+            template_id="live_signal",
+            template_name="Live Signal",
+            content="# {{ title }\nSymbol: {{ symbol }}",  # 第一行缺闭合 → 语法错
+            is_active=True,
+        )
+
+    def test_render_preview_syntax_error_shows_template_id(self):
+        """--preview 路径：错误输出含 template_id（issue #4760 验收点）"""
+        runner = CliRunner()
+        mock_crud = MagicMock()
+        mock_crud.get_by_template_id.return_value = self._make_bad_template()
+
+        with patch(
+            "ginkgo.data.containers.container.notification_template_crud",
+            return_value=mock_crud,
+        ):
+            result = runner.invoke(app, ["render", "--id", "live_signal", "--preview"])
+
+        # 友好错误：exit_code=1，stdout 含 template_id，非裸 traceback
+        assert result.exit_code == 1
+        assert "live_signal" in result.output
+        # 不应把 Python traceback 暴露给用户
+        assert "Traceback" not in result.output
+
+    def test_render_full_syntax_error_shows_template_id(self):
+        """完整渲染路径：错误输出含 template_id"""
+        runner = CliRunner()
+        mock_crud = MagicMock()
+        mock_crud.get_by_template_id.return_value = self._make_bad_template()
+
+        with patch(
+            "ginkgo.data.containers.container.notification_template_crud",
+            return_value=mock_crud,
+        ):
+            result = runner.invoke(
+                app,
+                ["render", "--id", "live_signal", "--var", "title=X", "--var", "symbol=AAPL"],
+            )
+
+        assert result.exit_code == 1
+        assert "live_signal" in result.output
+        assert "Traceback" not in result.output

--- a/tests/unit/notifier/core/test_template_engine.py
+++ b/tests/unit/notifier/core/test_template_engine.py
@@ -195,6 +195,32 @@ class TestTemplateEngineRenderFromTemplateId:
         with pytest.raises(ValueError, match="template_crud is not initialized"):
             engine.render_from_template_id("test", {})
 
+    def test_render_from_template_id_syntax_error_includes_template_id(self):
+        """语法错时错误信息含 template_id（issue #4760：友好错误标注哪个模板）"""
+        mock_crud = Mock()
+        template = MNotificationTemplate(
+            template_id="live_signal",
+            template_name="Live Signal",
+            content="Hello, {{ name }!",  # 缺少闭合括号 → Jinja2 TemplateSyntaxError
+            is_active=True
+        )
+        mock_crud.get_by_template_id.return_value = template
+
+        engine = TemplateEngine(template_crud=mock_crud)
+
+        with pytest.raises(ValueError) as exc_info:
+            engine.render_from_template_id("live_signal", {"name": "X"})
+
+        # 错误信息必须指出是哪个 template_id，且仍是 ValueError 子类（向后兼容）
+        assert "live_signal" in str(exc_info.value)
+        # 仍含位置/原因信息
+        assert "syntax" in str(exc_info.value).lower()
+
+        # issue #4760 brief: "可读错误含模板名 + 转义位置"——位置结构化暴露
+        err = exc_info.value
+        assert getattr(err, "template_id", None) == "live_signal"
+        assert getattr(err, "lineno", None) == 1
+
 
 @pytest.mark.unit
 class TestTemplateEngineValidate:
@@ -306,6 +332,25 @@ class TestTemplateEnginePreview:
 
         assert "Hello, Alice!" in result["rendered"]
         assert result["context_used"]["name"] == "Alice"
+
+    def test_preview_template_syntax_error_includes_template_id(self):
+        """预览语法错时错误信息含 template_id（issue #4760：preview 路径同样友好标注）"""
+        mock_crud = Mock()
+        template = MNotificationTemplate(
+            template_id="live_signal",
+            template_name="Live Signal",
+            content="# {{ title }\nSymbol: {{ symbol }}",  # 第一行缺闭合 → TemplateSyntaxError
+            is_active=True
+        )
+        mock_crud.get_by_template_id.return_value = template
+
+        engine = TemplateEngine(template_crud=mock_crud)
+
+        with pytest.raises(ValueError) as exc_info:
+            engine.preview_template("live_signal")
+
+        assert "live_signal" in str(exc_info.value)
+        assert "syntax" in str(exc_info.value).lower()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

修复 issue #4760：`ginkgo templates render --id <X> --preview` 在模板含语法错时抛裸 Jinja2 错误，用户/运维无法定位是哪个模板出错。

**根因**：`TemplateEngine.render()` 在 `TemplateSyntaxError` 分支抛 `ValueError(f"Template syntax error at line {lineno}: {msg}")`，丢失 `template_id` 上下文。而知道 `template_id` 的入口 `render_from_template_id` / `preview_template` 没在异常链里补回。

**修复**（纯代码层，不依赖 MongoDB 状态——issue triage 复核已确认种子数据里 live_signal 早已移除，本修复聚焦"渲染失败时的友好错误"这条对所有模板普适的代码层缺口）：

1. 新增 `TemplateRenderError(ValueError)` 异常类，结构化携带 `template_id` + `lineno`。继承 `ValueError` 保持向后兼容（现有 `except ValueError` 调用方仍能捕获）。
2. `render_from_template_id` / `preview_template` 两个"知道 template_id 的入口"包装底层 `ValueError` 为 `TemplateRenderError`，附加 `template_id` 与 `lineno`。
3. `render()` 的 `TemplateSyntaxError` 分支在抛出的 `ValueError` 上附加 `lineno` 属性，供上层结构化读取。

**修复前后对比**：
- 修前：`Template error: Template syntax error at line 1: unexpected ''}'`（不知是哪个模板）
- 修后：`Template error: Template render error (template 'live_signal', line 1): Template syntax error at line 1: unexpected ''}'`（含模板名 + 行号）

## Test plan

三层 smoke（对齐 `.github/workflows/ci.yml`）全绿：
- Layer 1 py_compile：src+api 全量通过
- Layer 2 启动路径：`test_user_crud_mock` + `test_containers` + `test_user_cli` (29 passed)
- Layer 3 变更相关：`test_template_engine` + `test_templates_cli_render` (27 passed)

新增测试：
- `test_render_from_template_id_syntax_error_includes_template_id` — 渲染入口含 template_id + lineno 属性
- `test_preview_template_syntax_error_includes_template_id` — preview 入口含 template_id
- `test_render_preview_syntax_error_shows_template_id` — CLI `--preview` 端到端契约（含 template_id，无 Traceback）
- `test_render_full_syntax_error_shows_template_id` — CLI 完整渲染端到端契约

既有 25 个 template_engine 测试全部回归通过。

## Notes

- issue triage 复核（2026-06-20）已确认种子数据 presets 中无 `live_signal`（仅 long_signal/short_signal 等 8 个），故本修复采用 brief 验收标准的"或"分支——失败时输出可读错误含模板名 + 位置，而非改种子数据。
- 不涉及数据库 schema、外部密钥、实盘交易逻辑。

Closes #4760