### PR TITLE
docs: find()/_parse_filters 补全 filters DSL 注释（标注 page_size=LIMIT）

### DIFF
--- a/src/ginkgo/data/__init__.py
+++ b/src/ginkgo/data/__init__.py
@@ -1,6 +1,7 @@
 # Upstream: 回测引擎, 策略模块, 分析器模块, CLI命令, Web UI, Worker系统
 # Downstream: containers(Container), seeding(数据初始化), utils(get_crud)
 # Role: 数据层包入口，暴露依赖注入容器container和工具函数，统一数据访问入口
+# Filters DSL: 各 CRUD 的 find(filters=...) 经 BaseCRUD._parse_filters 支持 __like/__or__/__gte 等操作符,page_size 即 SQL LIMIT;跨字段模糊匹配可在 DB 层一体化,无需 service 端 Python 切片反模式(见 crud/base_crud 与 issue #6572)
 # See #2715: 聚合导入改为 __getattr__ 懒加载，打断全量模块加载链
 # 注意: models/ 包因 SQLAlchemy relationship() 要求使用 eager import，是唯一的例外
 

--- a/src/ginkgo/data/crud/__init__.py
+++ b/src/ginkgo/data/crud/__init__.py
@@ -1,6 +1,7 @@
 # Upstream: 数据服务层(BaseService), API层, 回测引擎
 # Downstream: BaseCRUD, ClickHouse/MySQL/MongoDB/Redis数据库模型
 # Role: CRUD包入口，统一导出全部CRUD类(BarCRUD、OrderCRUD、PortfolioCRUD等40+个)，供服务层和容器注册使用
+# Filters DSL: BaseCRUD.find 的 filters 经 _parse_filters 支持 __gte/__lte/__gt/__lt/__in/__like 与 __or__ 组合(跨字段 OR),page_size 即 SQL LIMIT;跨字段模糊匹配可 DB 层一体化,勿误判"只支持等值"(见 base_crud.BaseCRUD.find 与 issue #6572)
 
 # See #2715: PEP 562 懒加载（models/ 包除外，见该目录注释）
 _LAZY_IMPORTS = {

--- a/src/ginkgo/data/crud/base_crud.py
+++ b/src/ginkgo/data/crud/base_crud.py
@@ -356,18 +356,32 @@ class _CoreCRUD(Generic[T], ABC):
     ) -> ModelList[T]:
         """
         Template method: Find items with enhanced filters and pagination.
-        Supports operator filters like field__gte, field__lte, field__in.
-        Subclasses should override _do_find() instead.
+        Supports operator filters via _parse_filters:
+        field__gte / __lte / __gt / __lt / __in / __like, and __or__ combinator
+        for cross-field OR (e.g. multi-field fuzzy match). Subclasses should
+        override _do_find() instead.
 
         Args:
-            filters: Dictionary of field -> value filters (supports operators)
-                    Examples: {"code": "000001.SZ", "timestamp__gte": "2023-01-01"}
+            filters: Dictionary of field -> value filters (supports operators).
+                无后缀键为等值匹配；带 __operator 后缀走对应比较；__or__ 值为
+                子 filter dict 列表，递归解析后用 OR 组合。
+                    Examples:
+                    {"code": "000001.SZ"}                                   # 等值
+                    {"timestamp__gte": "2023-01-01"}                        # 范围
+                    {"code__in": ["000001.SZ", "000002.SZ"]}                # IN
+                    {"name__like": "ali"}                                   # LIKE '%ali%'
+                    {"__or__": [                                            # 跨字段 OR+LIKE
+                        {"username__like": "ali"},
+                        {"display_name__like": "ali"},
+                    ]}
                     source 字段筛选运行模式（使用 SOURCE_TYPES 枚举的 value）：
                     {"source": SOURCE_TYPES.BACKTEST.value}     # 回测数据
                     {"source": SOURCE_TYPES.PAPER_REPLAY.value}  # 历史模拟数据
                     {"source": SOURCE_TYPES.PAPER_LIVE.value}    # 实盘模拟数据
             page: Page number (0-based)
-            page_size: Number of items per page
+            page_size: Number of items per page;底层即 SQL LIMIT（page 缺省时
+                等价 LIMIT page_size）。优先用此参数在 DB 层截断，避免取全量后
+                Python 切片（反模式，见 issue #6572 与 PR #6561 讨论）
             order_by: Field name to order by
             desc_order: Whether to use descending order
             distinct_field: Field name for DISTINCT query (returns unique values of this field)
@@ -892,12 +906,17 @@ class _CoreCRUD(Generic[T], ABC):
         """
         Parse enhanced filters with operator support.
         Supports operators: gte, lte, gt, lt, in, like, and __or__ combinator.
+        __like 自动在值两侧加 % 通配符（即 SQL LIKE '%value%'）。
         Uses _get_enum_mappings() for precise enum-to-integer conversion.
 
         Args:
             filters: Dictionary with field__operator keys
                    Examples: {"timestamp__gte": "2023-01-01", "volume__in": [100, 200]}
                    OR combinator: {"__or__": [{"code__like": "x"}, {"name__like": "x"}]}
+                   跨字段模糊 + DB 层截断（配合 find 的 page_size 即 SQL LIMIT）:
+                       crud.find(filters={"__or__": [{"username__like": "ali"},
+                                                     {"display_name__like": "ali"}]},
+                                 page_size=10)
 
         Returns:
             List of SQLAlchemy filter conditions


### PR DESCRIPTION
## 背景

调研 #6572（fuzzy_search DB 层 limit 化）时发现：`BaseCRUD.find` 的 docstring 只提 `__gte/__lte/__in`，**漏了 `__like/__gt/__lt/__or__`**，且 `page_size` 未明示=SQL LIMIT。这是 PR #6561 body 与 #6572 初稿误判「DB 层不支持跨字段模糊匹配」的根因——调用者看 `find` docstring 不看 `_parse_filters` 实现，入口 docstring 必须自包含完整能力清单。

## 改动（仅文档，零逻辑变更）

- `base_crud.BaseCRUD.find` docstring：操作符列表补全为 `__gte/__lte/__gt/__lt/__in/__like/__or__`；新增等值/范围/IN/LIKE/跨字段 OR 五类示例；`page_size` 明示=SQL LIMIT 并点名 Python 切片反模式
- `base_crud._parse_filters` docstring：补 `__like` 自动加 `%` 通配符说明 + 完整可运行的跨字段 OR+LIKE+page_size 示例
- `crud/__init__.py` / `data/__init__.py`：各加一行 `# Filters DSL` 指引，指向 BaseCRUD.find 与 _parse_filters

## 验证

- py_compile（base_crud.py + 两个 __init__.py）✅
- docstring 是 AST 字符串字面量，不进 bytecode 逻辑，零行为影响

## 关联

- 关联 #6572（fuzzy_search DB 层 limit 化）——本 PR 治「注释缺失致误判」的标，#6572 治「service 层 head 截断」的本
- 关联 PR #6561（其 body 关于 find 能力的两条论据需更正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
