### PR TITLE
refactor(#6572): fuzzy_search DB 层 limit 化

### DIFF
--- a/src/ginkgo/data/crud/backtest_task_crud.py
+++ b/src/ginkgo/data/crud/backtest_task_crud.py
@@ -220,7 +220,8 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
     def fuzzy_search(
         self,
         query: str,
-        fields: Optional[List[str]] = None
+        fields: Optional[List[str]] = None,
+        limit: Optional[int] = None,
     ) -> ModelList[MBacktestTask]:
         """
         模糊搜索回测任务，支持 UUID、名称、task_id 的部分匹配。
@@ -245,7 +246,7 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
 
         if 'uuid' in fields:
             try:
-                results = self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False})
+                results = self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False}, page_size=limit)
                 for item in results:
                     if hasattr(item, 'uuid') and item.uuid not in seen_uuids:
                         all_results.append(item)
@@ -255,7 +256,7 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
 
         if 'name' in fields:
             try:
-                results = self.find(filters={"name__like": f"%{query_lower}%", "is_del": False})
+                results = self.find(filters={"name__like": f"%{query_lower}%", "is_del": False}, page_size=limit)
                 for item in results:
                     if hasattr(item, 'uuid') and item.uuid not in seen_uuids:
                         all_results.append(item)
@@ -265,13 +266,17 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
 
         if 'task_id' in fields:
             try:
-                results = self.find(filters={"task_id__like": f"%{query_lower}%", "is_del": False})
+                results = self.find(filters={"task_id__like": f"%{query_lower}%", "is_del": False}, page_size=limit)
                 for item in results:
                     if hasattr(item, 'uuid') and item.uuid not in seen_uuids:
                         all_results.append(item)
                         seen_uuids.add(item.uuid)
             except Exception as e:
                 GLOG.WARN(f"Task ID fuzzy search failed: {e}")
+
+        # #6572: 多字段合并去重后按 limit 截断
+        if limit is not None:
+            all_results = all_results[:limit]
 
         return ModelList(all_results, self)
 

--- a/src/ginkgo/data/crud/engine_crud.py
+++ b/src/ginkgo/data/crud/engine_crud.py
@@ -232,7 +232,8 @@ class EngineCRUD(BaseCRUD[MEngine]):
     def fuzzy_search(
         self,
         query: str,
-        fields: Optional[List[str]] = None
+        fields: Optional[List[str]] = None,
+        limit: Optional[int] = None,
     ) -> ModelList[MEngine]:
         """
         Fuzzy search engines across multiple fields with OR logic.
@@ -270,7 +271,7 @@ class EngineCRUD(BaseCRUD[MEngine]):
         # UUID search - partial match
         if 'uuid' in fields:
             try:
-                results = self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False})
+                results = self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False}, page_size=limit)
                 if hasattr(results, '__iter__'):
                     for item in results:
                         if hasattr(item, 'uuid') and item.uuid not in seen_uuids:
@@ -282,7 +283,7 @@ class EngineCRUD(BaseCRUD[MEngine]):
         # Name search - partial match
         if 'name' in fields:
             try:
-                results = self.find(filters={"name__like": f"%{query_lower}%", "is_del": False})
+                results = self.find(filters={"name__like": f"%{query_lower}%", "is_del": False}, page_size=limit)
                 if hasattr(results, '__iter__'):
                     for item in results:
                         if hasattr(item, 'uuid') and item.uuid not in seen_uuids:
@@ -295,9 +296,9 @@ class EngineCRUD(BaseCRUD[MEngine]):
         if 'is_live' in fields:
             try:
                 if query_lower in ['live', 'real', 'production']:
-                    results = self.find(filters={"is_live": True, "is_del": False})
+                    results = self.find(filters={"is_live": True, "is_del": False}, page_size=limit)
                 elif query_lower in ['backtest', 'test', 'simulation', 'sim']:
-                    results = self.find(filters={"is_live": False, "is_del": False})
+                    results = self.find(filters={"is_live": False, "is_del": False}, page_size=limit)
                 else:
                     results = []
 
@@ -346,7 +347,7 @@ class EngineCRUD(BaseCRUD[MEngine]):
             if status_matches:
                 try:
                     # Use IN operator to search for multiple status values
-                    results = self.find(filters={"status__in": status_matches, "is_del": False})
+                    results = self.find(filters={"status__in": status_matches, "is_del": False}, page_size=limit)
                     if hasattr(results, '__iter__'):
                         for item in results:
                             if hasattr(item, 'uuid') and item.uuid not in seen_uuids:
@@ -354,6 +355,10 @@ class EngineCRUD(BaseCRUD[MEngine]):
                                 seen_uuids.add(item.uuid)
                 except Exception as e:
                     GLOG.WARN(f"Status fuzzy search failed: {e}")
+
+        # #6572: 多字段合并去重后按 limit 截断（跨字段去重只能在 Python 层）
+        if limit is not None:
+            all_results = all_results[:limit]
 
         # Return ModelList for consistency with other CRUD methods
         return ModelList(all_results, self)

--- a/src/ginkgo/data/crud/portfolio_crud.py
+++ b/src/ginkgo/data/crud/portfolio_crud.py
@@ -144,6 +144,7 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
         self,
         query: str,
         fields: Optional[List[str]] = None,
+        limit: Optional[int] = None,
     ) -> List[MPortfolio]:
         """#5995: 模糊搜索投资组合，支持 UUID 片段 / 名称部分匹配（去重）。
 
@@ -167,7 +168,7 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
 
         if 'uuid' in fields:
             try:
-                for item in self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False}):
+                for item in self.find(filters={"uuid__like": f"%{query_lower}%", "is_del": False}, page_size=limit):
                     uuid_val = getattr(item, 'uuid', None)
                     if uuid_val and uuid_val not in seen_uuids:
                         all_results.append(item)
@@ -177,13 +178,17 @@ class PortfolioCRUD(BaseCRUD[MPortfolio]):
 
         if 'name' in fields:
             try:
-                for item in self.find(filters={"name__like": f"%{query_lower}%", "is_del": False}):
+                for item in self.find(filters={"name__like": f"%{query_lower}%", "is_del": False}, page_size=limit):
                     uuid_val = getattr(item, 'uuid', None)
                     if uuid_val and uuid_val not in seen_uuids:
                         all_results.append(item)
                         seen_uuids.add(uuid_val)
             except Exception as e:
                 GLOG.WARN(f"Portfolio name fuzzy search failed: {e}")
+
+        # #6572: 多字段合并去重后按 limit 截断
+        if limit is not None:
+            all_results = all_results[:limit]
 
         return all_results
 

--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -313,7 +313,8 @@ class UserCRUD(BaseCRUD[MUser]):
 
     def fuzzy_search(
         self,
-        query: str
+        query: str,
+        limit: Optional[int] = None,
     ) -> ModelList[MUser]:
         """
         模糊搜索用户 - 在 uuid、username 和 display_name 字段中搜索
@@ -324,6 +325,7 @@ class UserCRUD(BaseCRUD[MUser]):
 
         Args:
             query: 搜索关键词（UUID或用户名）
+            limit: 最大返回条数，None 表示全量（SQL LIMIT 下推，避免全量拉回）
 
         Returns:
             ModelList[MUser]: 用户模型列表，支持 .to_dataframe() 转换
@@ -354,6 +356,10 @@ class UserCRUD(BaseCRUD[MUser]):
                         MUser.display_name.like(search_pattern)
                     )
                 )
+
+            # #6572: limit 下推到 SQL LIMIT，避免全量拉回
+            if limit is not None:
+                query_obj = query_obj.limit(limit)
 
             results = query_obj.all()
             # Detach objects from session

--- a/src/ginkgo/data/crud/user_group_crud.py
+++ b/src/ginkgo/data/crud/user_group_crud.py
@@ -118,7 +118,8 @@ class UserGroupCRUD(BaseCRUD[MUserGroup]):
 
     def fuzzy_search(
         self,
-        query: str
+        query: str,
+        limit: Optional[int] = None,
     ) -> ModelList[MUserGroup]:
         """
         模糊搜索用户组 - 在 uuid 和 name 字段中搜索
@@ -129,6 +130,7 @@ class UserGroupCRUD(BaseCRUD[MUserGroup]):
 
         Args:
             query: 搜索关键词（UUID或组名）
+            limit: 最大返回条数，None 表示全量（SQL LIMIT 下推，避免全量拉回）
 
         Returns:
             ModelList[MUserGroup]: 用户组模型列表，支持 .to_dataframe() 转换
@@ -158,6 +160,10 @@ class UserGroupCRUD(BaseCRUD[MUserGroup]):
                         MUserGroup.name.like(search_pattern)
                     )
                 )
+
+            # #6572: limit 下推到 SQL LIMIT，避免全量拉回
+            if limit is not None:
+                query_obj = query_obj.limit(limit)
 
             results = query_obj.all()
             # Detach objects from session

--- a/src/ginkgo/user/services/user_group_service.py
+++ b/src/ginkgo/user/services/user_group_service.py
@@ -545,11 +545,7 @@ class UserGroupService(BaseService):
             result = service.fuzzy_search("fbe6e147")
         """
         try:
-            groups = self.user_group_crud.fuzzy_search(query)
-
-            # Apply limit
-            if limit and len(groups) > limit:
-                groups = groups.head(limit)
+            groups = self.user_group_crud.fuzzy_search(query, limit=limit)
 
             group_list = []
             for group in groups:

--- a/src/ginkgo/user/services/user_service.py
+++ b/src/ginkgo/user/services/user_service.py
@@ -888,11 +888,7 @@ class UserService(BaseService):
             result = service.fuzzy_search("a2eaba95")
         """
         try:
-            users = self.user_crud.fuzzy_search(query)
-
-            # Apply limit
-            if limit and len(users) > limit:
-                users = users.head(limit)
+            users = self.user_crud.fuzzy_search(query, limit=limit)
 
             user_list = []
             for user in users:

--- a/tests/unit/data/crud/test_backtest_task_crud_mock.py
+++ b/tests/unit/data/crud/test_backtest_task_crud_mock.py
@@ -142,6 +142,28 @@ class TestBacktestTaskCRUDBusinessHelpers:
         assert call_kwargs["filters"]["is_del"] is False
         assert result is None
 
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_pushes_page_size(self, crud_instance):
+        """#6572: fuzzy_search 传 limit 时，每个字段查询都下推 page_size 到 find（SQL LIMIT）"""
+        crud_instance.find = MagicMock(return_value=[])
+
+        crud_instance.fuzzy_search("x", limit=5, fields=["uuid", "name"])
+
+        assert crud_instance.find.call_count >= 1
+        for call in crud_instance.find.call_args_list:
+            assert call.kwargs.get("page_size") == 5
+
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_truncates_merged_results(self, crud_instance):
+        """#6572: 多字段合并去重后按 limit 截断"""
+        mock_task = MagicMock()
+        mock_task.uuid = "u1"
+        crud_instance.find = MagicMock(return_value=[mock_task, mock_task, mock_task])
+
+        result = crud_instance.fuzzy_search("x", limit=2, fields=["uuid", "name"])
+
+        assert len(result) <= 2
+
 
 # ============================================================
 # 构造与类型检查测试

--- a/tests/unit/data/crud/test_engine_crud_mock.py
+++ b/tests/unit/data/crud/test_engine_crud_mock.py
@@ -193,6 +193,28 @@ class TestEngineCRUDBusinessHelpers:
         assert call_kwargs["desc_order"] is True
         assert call_kwargs["order_by"] == "update_at"
 
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_pushes_page_size(self, engine_crud):
+        """#6572: fuzzy_search 传 limit 时，每个字段查询都下推 page_size 到 find（SQL LIMIT）"""
+        engine_crud.find = MagicMock(return_value=[])
+
+        engine_crud.fuzzy_search("x", limit=5, fields=["uuid", "name"])
+
+        assert engine_crud.find.call_count >= 1
+        for call in engine_crud.find.call_args_list:
+            assert call.kwargs.get("page_size") == 5
+
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_truncates_merged_results(self, engine_crud):
+        """#6572: 多字段合并去重后按 limit 截断（跨字段去重必在 Python）"""
+        mock_engine = MagicMock()
+        mock_engine.uuid = "u1"
+        engine_crud.find = MagicMock(return_value=[mock_engine, mock_engine, mock_engine])
+
+        result = engine_crud.fuzzy_search("x", limit=2, fields=["uuid", "name"])
+
+        assert len(result) <= 2
+
 
 # ============================================================
 # 构造与类型检查测试

--- a/tests/unit/data/crud/test_portfolio_crud_mock.py
+++ b/tests/unit/data/crud/test_portfolio_crud_mock.py
@@ -175,6 +175,28 @@ class TestPortfolioCRUDBusinessHelpers:
         assert call_kwargs["desc_order"] is True
         assert call_kwargs["order_by"] == "update_at"
 
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_pushes_page_size(self, portfolio_crud):
+        """#6572: fuzzy_search 传 limit 时，每个字段查询都下推 page_size 到 find（SQL LIMIT）"""
+        portfolio_crud.find = MagicMock(return_value=[])
+
+        portfolio_crud.fuzzy_search("x", limit=5, fields=["uuid", "name"])
+
+        assert portfolio_crud.find.call_count >= 1
+        for call in portfolio_crud.find.call_args_list:
+            assert call.kwargs.get("page_size") == 5
+
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_truncates_merged_results(self, portfolio_crud):
+        """#6572: 多字段合并去重后按 limit 截断"""
+        mock_pf = MagicMock()
+        mock_pf.uuid = "u1"
+        portfolio_crud.find = MagicMock(return_value=[mock_pf, mock_pf, mock_pf])
+
+        result = portfolio_crud.fuzzy_search("x", limit=2, fields=["uuid", "name"])
+
+        assert len(result) <= 2
+
 
 # ============================================================
 # 构造与类型检查测试

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -154,6 +154,35 @@ class TestUserCRUDBusinessHelpers:
         crud_instance._get_connection.assert_called_once()
         mock_session.query.assert_called_once()
 
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_pushes_sql_limit(self, crud_instance):
+        """#6572: fuzzy_search 传 limit 时下推到 SQL LIMIT（非全量拉回）"""
+        mock_conn = MagicMock()
+        mock_session = MagicMock()
+        mock_conn.get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_conn.get_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.query.return_value.filter.return_value.limit.return_value.all.return_value = []
+        crud_instance._get_connection = MagicMock(return_value=mock_conn)
+
+        crud_instance.fuzzy_search("Alice", limit=5)
+
+        mock_session.query.return_value.filter.return_value.limit.assert_called_once_with(5)
+
+    @pytest.mark.unit
+    def test_fuzzy_search_no_limit_keeps_full_query(self, crud_instance):
+        """#6572: limit=None 保持全量返回（零破坏现有调用方）"""
+        mock_conn = MagicMock()
+        mock_session = MagicMock()
+        mock_conn.get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_conn.get_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+        crud_instance._get_connection = MagicMock(return_value=mock_conn)
+
+        crud_instance.fuzzy_search("Alice")
+
+        # limit 未传时不应在 query 链上调用 .limit()
+        mock_session.query.return_value.filter.return_value.limit.assert_not_called()
+
 
 # ============================================================
 # 构造与类型检查测试

--- a/tests/unit/data/crud/test_user_group_crud_mock.py
+++ b/tests/unit/data/crud/test_user_group_crud_mock.py
@@ -133,6 +133,34 @@ class TestUserGroupCRUDBusinessHelpers:
         call_kwargs = crud_instance.find.call_args[1]
         assert call_kwargs["filters"]["name__like"] == "%trader%"
 
+    @pytest.mark.unit
+    def test_fuzzy_search_limit_pushes_sql_limit(self, crud_instance):
+        """#6572: fuzzy_search 传 limit 时下推到 SQL LIMIT"""
+        mock_conn = MagicMock()
+        mock_session = MagicMock()
+        mock_conn.get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_conn.get_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.query.return_value.filter.return_value.limit.return_value.all.return_value = []
+        crud_instance._get_connection = MagicMock(return_value=mock_conn)
+
+        crud_instance.fuzzy_search("traders", limit=5)
+
+        mock_session.query.return_value.filter.return_value.limit.assert_called_once_with(5)
+
+    @pytest.mark.unit
+    def test_fuzzy_search_no_limit_keeps_full_query(self, crud_instance):
+        """#6572: limit=None 保持全量返回"""
+        mock_conn = MagicMock()
+        mock_session = MagicMock()
+        mock_conn.get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_conn.get_session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.query.return_value.filter.return_value.all.return_value = []
+        crud_instance._get_connection = MagicMock(return_value=mock_conn)
+
+        crud_instance.fuzzy_search("traders")
+
+        mock_session.query.return_value.filter.return_value.limit.assert_not_called()
+
 
 # ============================================================
 # 构造与类型检查测试

--- a/tests/unit/test_user_service_facade.py
+++ b/tests/unit/test_user_service_facade.py
@@ -121,3 +121,58 @@ class TestGetGroupMemberUuidsReturnsServiceResult:
 
         assert isinstance(result, ServiceResult)
         assert result.success is False
+
+
+class TestUserServiceFuzzySearchLimitPushDown:
+    """#6572: service.fuzzy_search 透传 limit 给 CRUD，删 head() Python 截断"""
+
+    def test_passes_limit_to_crud(self):
+        from ginkgo.data.crud.model_conversion import ModelList
+        svc = _mock_user_service()
+        svc.user_crud = MagicMock()
+        svc.user_crud.fuzzy_search.return_value = ModelList([], MagicMock())
+
+        svc.fuzzy_search("Alice", limit=5)
+
+        svc.user_crud.fuzzy_search.assert_called_once_with("Alice", limit=5)
+
+    def test_does_not_head_truncate_when_limit_given(self):
+        """limit 下推 CRUD 后，service 不再用 ModelList.head() 截断（DB 层已 limit）"""
+        from ginkgo.data.crud.model_conversion import ModelList
+        svc = _mock_user_service()
+        svc.user_crud = MagicMock()
+        # 3 条结果 + limit=1：当前实现会 head(1)，改后不调 head
+        svc.user_crud.fuzzy_search.return_value = ModelList([
+            MagicMock(user_type=0), MagicMock(user_type=0), MagicMock(user_type=0),
+        ], MagicMock())
+
+        with patch.object(ModelList, "head") as head_spy, \
+             patch("ginkgo.user.services.user_service.USER_TYPES"):
+            svc.fuzzy_search("Alice", limit=1)
+
+        head_spy.assert_not_called()
+
+
+class TestUserGroupServiceFuzzySearchLimitPushDown:
+    """#6572: user_group_service.fuzzy_search 透传 limit，删 head() 截断"""
+
+    def test_passes_limit_to_crud(self):
+        from ginkgo.data.crud.model_conversion import ModelList
+        svc = _mock_user_group_service()
+        svc.user_group_crud.fuzzy_search.return_value = ModelList([], MagicMock())
+
+        svc.fuzzy_search("traders", limit=5)
+
+        svc.user_group_crud.fuzzy_search.assert_called_once_with("traders", limit=5)
+
+    def test_does_not_head_truncate_when_limit_given(self):
+        from ginkgo.data.crud.model_conversion import ModelList
+        svc = _mock_user_group_service()
+        svc.user_group_crud.fuzzy_search.return_value = ModelList([
+            MagicMock(), MagicMock(), MagicMock(),
+        ], MagicMock())
+
+        with patch.object(ModelList, "head") as head_spy:
+            svc.fuzzy_search("traders", limit=1)
+
+        head_spy.assert_not_called()


### PR DESCRIPTION
## Summary

治本 #4948 / PR #6561 引出的 fuzzy_search 性能反模式治理。

**问题**：5 个 CRUD `fuzzy_search` 不接 limit、底层 `query_obj.all()` / `find()` 全量返回；`user_service`/`user_group_service` 收了 `limit` 却用 `ModelList.head()` Python 截断（假 DB 层化）。`notification_service.fuzzy_search(user_input, limit=1)` 表面 limit=1，实际全表 LIKE 扫描 + 全量拉回 + head(1)。

**修复**（CRUD 分两类实现）：
- **A 类**（`user_crud`/`user_group_crud`，直接 SQLAlchemy query）：加 `limit` 形参 → `query_obj.limit(limit)` 下推 SQL LIMIT
- **B 类**（`engine_crud`/`portfolio_crud`/`backtest_task_crud`，多字段 `find()` 合并去重）：每个字段查询 `find(page_size=limit)` 下推 SQL LIMIT；跨字段去重后 `all_results[:limit]` 截断（去重只能在 Python 层）
- **Service 层**：`user_service`/`user_group_service` 透传 `limit` 给 CRUD，删 `head()` 截断

**零破坏**：`limit: Optional[int] = None` 默认全量，现有调用方（engine_cli/portfolio_cli/backtest_cli 等不传 limit）行为不变。

## Test plan

- [x] `tests/unit/data/crud/test_user_crud_mock.py` — 2 新测试（limit 下推 SQL LIMIT / None 保持全量）
- [x] `tests/unit/data/crud/test_user_group_crud_mock.py` — 2 新测试
- [x] `tests/unit/data/crud/test_engine_crud_mock.py` — 2 新测试（page_size 下推 / 合并截断）
- [x] `tests/unit/data/crud/test_portfolio_crud_mock.py` — 2 新测试
- [x] `tests/unit/data/crud/test_backtest_task_crud_mock.py` — 2 新测试
- [x] `tests/unit/test_user_service_facade.py` — 4 新测试（user/user_group service 透传 limit + 不调 head）
- [x] Layer 1 py_compile 全变更文件通过
- [x] Layer 2 启动路径 smoke（user_crud_mock + containers + user_cli）31 passed
- [x] 全 fuzzy_search 相关测试 74 passed（既有 `update_mode` 缺失失败与本次无关，master 同款缺失）

Closes #6572