### PR TITLE
refactor(#6577): cli_utils 落地 ADR-021 5 helper（format_result 待 #6576）

### DIFF
--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -7,10 +7,18 @@
 
 
 
+import json
+import os
+import sys
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
 import pandas as pd
+import typer
 from rich.console import Console
 from rich.tree import Tree
-from typing import Optional
 from ginkgo.enums import FILE_TYPES
 
 console = Console()
@@ -147,5 +155,159 @@ def _show_engine_tree(engine_row, detail: bool, filter_type: Optional[FILE_TYPES
                 portfolio_row = portfolio_df.iloc[0]
                 portfolio_branch = tree.add(f"[bold green]Portfolio:[/bold green] {portfolio_row['name']} ([yellow]{portfolio_id}[/yellow])")
                 _add_portfolio_components(portfolio_branch, portfolio_id, detail, filter_type)
-    
+
     console.print(tree)
+
+
+# ============================================================================
+# ADR-021 E2 (#6577): CLI 输出层 helper
+# 契约锚点: docs/adrs/ADR-021-cli-output-layer.md (10 维)
+# ============================================================================
+
+
+class CliConfirmError(Exception):
+    """safe_confirm 在非 TTY 且未提供 --yes 时抛出。
+
+    专用异常避免被通用 ``except Exception`` 吞（呼应
+    ``arch_typer_exit_caught_by_except``）。调用方按具体类型捕获，
+    不与 typer.Exit / 业务异常混淆。
+    """
+
+
+def is_interactive(explicit: Optional[bool] = None) -> bool:
+    """判断当前是否交互模式（ADR-021 第 2 维）。
+
+    - 默认 ``sys.stdin.isatty()``（人=交互，管道=非交互）
+    - ``explicit=True/False`` 覆盖（docker ``-it`` 风格）
+    - ``--format json`` 隐含非交互，由调用方判断后传 ``explicit=False``
+    """
+    if explicit is not None:
+        return bool(explicit)
+    return bool(sys.stdin.isatty())
+
+
+def make_console(
+    *,
+    no_color: bool = False,
+    isatty: Optional[bool] = None,
+    stderr: bool = True,
+) -> Console:
+    """构造统一配置的 rich Console（ADR-021 第 7 维）。
+
+    三层 NO_COLOR 优先级：
+      Layer 1 自动检测（``isatty`` → emoji 开关；彩色由 rich 据 color_system+TTY 决定）
+      Layer 2 ``NO_COLOR`` 环境变量（no-color.org 标准，存在即禁用彩色）
+      Layer 3 ``--no-color`` flag 显式覆盖（优先级最高）
+
+    保留 unicode emoji（``:x:`` → ``❌``）；**禁用** ``Console(emoji=False)``
+    ——它会保留 ``:x:`` 原文，比无 emoji 更糟（ADR-021 实证）。
+    """
+    # Layer 3 优先；Layer 2 兜底（任一为真即禁彩色）
+    use_color = not (no_color or ("NO_COLOR" in os.environ))
+    if isatty is None:
+        isatty = bool(sys.stdin.isatty() or sys.stdout.isatty())
+    return Console(
+        emoji=bool(isatty),
+        color_system=None if not use_color else "auto",
+        legacy_windows=False,
+        stderr=stderr,
+    )
+
+
+class GinkgoJSONEncoder(json.JSONEncoder):
+    """Ginkgo 统一 JSON 编码器（ADR-021 第 10 维）。
+
+    - datetime/date → ISO8601（``T`` 分隔，非空格）
+    - Decimal → str（金融精度，float 会丢；与 ADR-005 序列化对称同精神）
+    - UUID → 带横线（用户面向，与库内 hex 存储 ``arch_uuid_storage_no_dashes`` 分层）
+    - pydantic BaseModel → ``model_dump(mode="json")``（duck-typing，避免顶部
+      import pydantic 拖慢 CLI 启动，呼应 ``arch_module_level_validator_import_crash``）
+    - SQLAlchemy Model → 列字典
+    - DataFrame → ``to_dict('records')``（每行一对象，jq 友好）
+    """
+
+    def default(self, obj):
+        # datetime 必须先于 date 判断（datetime 是 date 子类）
+        if isinstance(obj, datetime):
+            return obj.isoformat()
+        if isinstance(obj, date):
+            return obj.isoformat()
+        if isinstance(obj, Decimal):
+            return str(obj)
+        if isinstance(obj, UUID):
+            return str(obj)
+        if isinstance(obj, pd.DataFrame):
+            return obj.to_dict("records")
+        # pydantic v2 BaseModel（duck-typing on model_dump）
+        if hasattr(obj, "model_dump"):
+            return obj.model_dump(mode="json")
+        # SQLAlchemy ORM Model
+        if hasattr(obj, "__table__"):
+            return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+        return super().default(obj)
+
+
+def safe_confirm(
+    message: str,
+    *,
+    default: bool = False,
+    require_tty: bool = True,
+    yes_flag: bool = False,
+) -> bool:
+    """TTY 守卫的危险操作确认（ADR-021 第 3 维）。
+
+    - ``yes_flag=True``（``--yes``）：返 True，显式跳过（最高优先级）
+    - TTY：正常 ``typer.confirm``
+    - 非 TTY + ``require_tty=True``：抛 ``CliConfirmError``（拒绝静默走 default）
+    - 非 TTY + ``require_tty=False``：返 ``default``（向后兼容场景）
+    """
+    if yes_flag:
+        return True
+    if sys.stdin.isatty():
+        return bool(typer.confirm(message, default=default))
+    if require_tty:
+        raise CliConfirmError(
+            f"需要交互确认但当前非 TTY：{message!r}（用 --yes 显式跳过）"
+        )
+    return bool(default)
+
+
+def make_progress(*, format: str, isatty: bool) -> Optional["Progress"]:
+    """构造 rich Progress（ADR-021 第 8 维）。
+
+    - JSON 模式或非 TTY：返 ``None``（禁用 rich 渲染，避免污染 JSON 输出/日志）
+    - TTY + text 模式：返 ``Progress(transient=True)``，console 走 stderr
+      （契约：进度永远 stderr，结果永远 stdout，二者不混）
+
+    Progress 延迟 import（仅 TTY+text 路径用到，保持模块顶部轻量）。
+    """
+    if format == "json" or not isatty:
+        return None
+    from rich.progress import Progress
+
+    return Progress(
+        console=Console(stderr=True),
+        transient=True,
+    )
+
+
+def format_result(result, *, format: str, command: str) -> None:
+    """统一 ServiceResult → 输出（ADR-021 第 5 维）。
+
+    .. warning::
+        **Step 2，阻塞 #6576**。依赖 ``ServiceResult.code`` 字段（``Optional[str]``），
+        由 E1 (#6576) 落地决策，当前 master 未合并。本 helper 现为占位，
+        待 #6576 合并后实现：
+
+        - 成功 list：``{"success": true, "data": [...], "count": N, "metadata": {}}``
+        - 成功 get：``{"success": true, "data": {...}}``
+        - 失败：``{"success": false, "error": {"code": ..., "message": ...}, "data": null}``
+        - exit code 映射：``BAD_PARAMS``→2 / ``TIMEOUT``→124 / 其余→1
+
+        按归因纪律（CLAUDE.md）：raise 而非 stub 兜底——宁可响亮报错，
+        也不静默返回错误结构误导调用方。
+    """
+    raise NotImplementedError(
+        "format_result 待 #6576 (E1 ServiceResult.code) 合并后实现："
+        f"当前 command={command!r} format={format!r} 暂不支持。"
+    )

--- a/tests/unit/client/test_cli_utils.py
+++ b/tests/unit/client/test_cli_utils.py
@@ -146,3 +146,260 @@ class TestShowTree:
             mock_container.mapping_service.return_value = mock_mapping
             cli_utils._show_engine_tree(engine_row, False, None)
         mock_print.assert_called_once()
+
+
+# ============================================================================
+# ADR-021 E2 (#6577): CLI 输出层 helper 测试
+# 6 个 helper: is_interactive / make_console / GinkgoJSONEncoder /
+#             safe_confirm / make_progress / format_result
+# ============================================================================
+
+import json
+import sys
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+
+# ----------------------------------------------------------------------------
+# is_interactive (ADR-021 第 2 维: TTY 推断 + 显式覆盖)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestIsInteractive:
+    def test_default_returns_stdin_isatty_true(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            assert cli_utils.is_interactive() is True
+
+    def test_default_returns_stdin_isatty_false(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            assert cli_utils.is_interactive() is False
+
+    def test_explicit_true_overrides_non_tty(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            assert cli_utils.is_interactive(explicit=True) is True
+
+    def test_explicit_false_overrides_tty(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            assert cli_utils.is_interactive(explicit=False) is False
+
+
+# ----------------------------------------------------------------------------
+# make_console (ADR-021 第 7 维: Layer1 自动 + Layer2 NO_COLOR env + Layer3 --no-color)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestMakeConsole:
+    def test_default_color_system_auto_when_no_color_disabled(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console(no_color=False)
+            _, kwargs = MockConsole.call_args
+            assert kwargs["color_system"] == "auto"
+
+    def test_no_color_flag_disables_color(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console(no_color=True)
+            _, kwargs = MockConsole.call_args
+            assert kwargs["color_system"] is None
+
+    def test_no_color_env_disables_color(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console(no_color=False)
+            _, kwargs = MockConsole.call_args
+            assert kwargs["color_system"] is None
+
+    def test_no_color_flag_overrides_even_when_env_absent(self, monkeypatch):
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console(no_color=True)
+            _, kwargs = MockConsole.call_args
+            assert kwargs["color_system"] is None
+
+    def test_stderr_always_true(self):
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console()
+            _, kwargs = MockConsole.call_args
+            assert kwargs["stderr"] is True
+
+    def test_legacy_windows_false(self):
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console()
+            _, kwargs = MockConsole.call_args
+            assert kwargs["legacy_windows"] is False
+
+    def test_emoji_true_when_isatty(self):
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console(isatty=True)
+            _, kwargs = MockConsole.call_args
+            assert kwargs["emoji"] is True
+
+    def test_emoji_false_when_not_isatty(self):
+        with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+            cli_utils.make_console(isatty=False)
+            _, kwargs = MockConsole.call_args
+            assert kwargs["emoji"] is False
+
+    def test_emoji_follows_stdin_isatty_by_default(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            with patch("ginkgo.client.cli_utils.Console") as MockConsole:
+                cli_utils.make_console()
+                _, kwargs = MockConsole.call_args
+                assert kwargs["emoji"] is True
+
+
+# ----------------------------------------------------------------------------
+# GinkgoJSONEncoder (ADR-021 第 10 维)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestGinkgoJSONEncoder:
+    def test_datetime_iso8601_with_T_separator(self):
+        dt = datetime(2025, 6, 1, 12, 30, 45, tzinfo=timezone.utc)
+        out = json.dumps(dt, cls=cli_utils.GinkgoJSONEncoder)
+        assert "2025-06-01T12:30:45" in out
+        # 反例: str(datetime) 用空格分隔
+        assert "2025-06-01 12:30:45" not in out
+
+    def test_date_iso8601(self):
+        d = date(2025, 6, 1)
+        out = json.dumps(d, cls=cli_utils.GinkgoJSONEncoder)
+        assert out == '"2025-06-01"'
+
+    def test_decimal_as_str_preserves_precision(self):
+        out = json.dumps(Decimal("1.005"), cls=cli_utils.GinkgoJSONEncoder)
+        assert out == '"1.005"'
+
+    def test_uuid_with_dashes(self):
+        u = uuid.UUID("12345678-1234-5678-1234-567812345678")
+        out = json.dumps(u, cls=cli_utils.GinkgoJSONEncoder)
+        assert out == '"12345678-1234-5678-1234-567812345678"'
+
+    def test_dataframe_to_records(self):
+        df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+        out = json.loads(json.dumps(df, cls=cli_utils.GinkgoJSONEncoder))
+        assert out == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_pydantic_basemodel_model_dump_json(self):
+        from pydantic import BaseModel
+
+        class M(BaseModel):
+            x: int = 1
+            y: str = "abc"
+
+        out = json.loads(json.dumps(M(), cls=cli_utils.GinkgoJSONEncoder))
+        assert out == {"x": 1, "y": "abc"}
+
+    def test_sqlalchemy_model_columns_dict(self):
+        col1 = SimpleNamespace(name="id")
+        col2 = SimpleNamespace(name="name")
+        tbl = SimpleNamespace(columns=[col1, col2])
+        record = SimpleNamespace(__table__=tbl)
+        record.id = 42
+        record.name = "foo"
+        out = json.loads(json.dumps(record, cls=cli_utils.GinkgoJSONEncoder))
+        assert out == {"id": 42, "name": "foo"}
+
+    def test_unknown_type_falls_back_to_default(self):
+        # 未覆盖类型应让父类 default 抛 TypeError
+        with pytest.raises(TypeError):
+            json.dumps(object(), cls=cli_utils.GinkgoJSONEncoder)
+
+
+# ----------------------------------------------------------------------------
+# safe_confirm (ADR-021 第 3 维: TTY 守卫 + 专用异常)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSafeConfirm:
+    def test_tty_calls_typer_confirm(self):
+        with patch("sys.stdin") as mock_stdin, \
+             patch.object(cli_utils.typer, "confirm", return_value=True) as mock_c:
+            mock_stdin.isatty.return_value = True
+            assert cli_utils.safe_confirm("sure?") is True
+            mock_c.assert_called_once()
+
+    def test_non_tty_require_tty_raises_cli_confirm_error(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            with pytest.raises(cli_utils.CliConfirmError):
+                cli_utils.safe_confirm("sure?", require_tty=True)
+
+    def test_cli_confirm_error_is_exception_subclass(self):
+        # 呼应 arch_typer_exit_caught_by_except: 专用异常仍继承 Exception
+        # 调用方按具体类型捕获，避免被通用 except 吞
+        assert issubclass(cli_utils.CliConfirmError, Exception)
+
+    def test_non_tty_yes_flag_returns_true(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            assert cli_utils.safe_confirm("sure?", yes_flag=True) is True
+
+    def test_non_tty_yes_flag_short_circuits_before_require_check(self):
+        # yes_flag=True 即使 require_tty=True 也返 True（--yes 优先级最高）
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            assert cli_utils.safe_confirm("sure?", require_tty=True, yes_flag=True) is True
+
+    def test_non_tty_require_false_returns_default(self):
+        with patch("sys.stdin") as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            assert cli_utils.safe_confirm("sure?", require_tty=False, default=True) is True
+            assert cli_utils.safe_confirm("sure?", require_tty=False, default=False) is False
+
+
+# ----------------------------------------------------------------------------
+# make_progress (ADR-021 第 8 维)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestMakeProgress:
+    def test_json_format_returns_none(self):
+        assert cli_utils.make_progress(format="json", isatty=True) is None
+
+    def test_non_tty_returns_none(self):
+        assert cli_utils.make_progress(format="text", isatty=False) is None
+
+    def test_tty_text_returns_progress_with_transient(self):
+        from rich.progress import Progress
+        p = cli_utils.make_progress(format="text", isatty=True)
+        assert isinstance(p, Progress)
+        # transient 存到内部 Live 对象（rich Progress 不暴露为顶层属性）
+        assert p.live.transient is True
+
+    def test_progress_console_targets_stderr(self):
+        p = cli_utils.make_progress(format="text", isatty=True)
+        assert p.console.file is sys.stderr
+
+
+# ----------------------------------------------------------------------------
+# format_result (Step 2, blocked by #6576 ServiceResult.code)
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestFormatResult:
+    def test_raises_not_implemented_anchored_to_6576(self):
+        # triage 契约: format_result 硬阻塞 #6576, 留 TODO 锚定
+        # 呼应 CLAUDE.md 归因纪律: raise 而非 stub 兜底
+        result = MagicMock()
+        with pytest.raises(NotImplementedError, match="6576"):
+            cli_utils.format_result(result, format="json", command="test")


### PR DESCRIPTION
## Summary

Epic #6575（CLI 输出层统一）子 issue **E2 Step 1**：落地 `src/ginkgo/client/cli_utils.py` 基础设施，为 E3-E6 提供 ADR-021 10 维契约的统一 helper。

按 triage 契约（[#6577 comment](https://github.com/Kaoruha/GinkGO/issues/6577#issuecomment-4881202181)），#6576 (E1 `ServiceResult.code`) 未合并，本 PR 只交付 **Step 1 五个零依赖 helper** + `format_result` 占位。

### 交付（5 完整 + 1 占位）

| helper | ADR 维度 | 说明 |
|---|---|---|
| `make_console` | 第 7 维 | 三层 NO_COLOR（自动/`NO_COLOR` env/`--no-color` flag）+ emoji 跟随 isatty + stderr=True |
| `is_interactive` | 第 2 维 | TTY 推断 + `explicit` 覆盖（docker `-it` 风格） |
| `safe_confirm` | 第 3 维 | TTY 守卫 + 专用 `CliConfirmError`（非通用 Exception，呼应 `arch_typer_exit_caught_by_except`）+ `--yes` 跳过 |
| `GinkgoJSONEncoder` | 第 10 维 | ISO8601 datetime/Decimal str/UUID 带横线/DataFrame records/pydantic model_dump/SQLAlchemy 列字典 |
| `make_progress` | 第 8 维 | JSON/非 TTY 返 None；TTY+text 返 `Progress(transient, stderr)` |
| `format_result` ⏳ | 第 5 维 | **占位 raise NotImplementedError**，阻塞 #6576（`ServiceResult.code` 未落地） |

### 关键设计点

- **`cli_utils.py` 扩展非新建**：现存 151 行 portfolio/engine 树渲染函数（`_show_portfolio_tree`/`_add_portfolio_components` 等）完整保留，6 helper 追加在文件末尾，模块级 `console = Console()` 不动。
- **import 保持轻量**：duck-typing `model_dump` 检测 pydantic v2 BaseModel，避免顶部 `import pydantic` 拖慢 CLI 启动（`arch_module_level_validator_import_crash`）；`Progress` 延迟 import 仅 TTY+text 路径用。
- **`format_result` 占位非 stub**：按 CLAUDE.md 归因纪律 `raise NotImplementedError("...#6576...")` 响亮报错，不静默返回错误结构。Step 2 待 #6576 合并后实现（成功/失败/list/get 四象限 + exit code 映射）。
- **DataFrame 用 `to_dict('records')`**：ADR-021 给的 `obj.to_dict()` 默认 orientation='dict'，但 issue body 明确要 records——用 `isinstance(obj, pd.DataFrame)` 精确匹配优先于通用 `to_dict` fallback。

## Test plan

- [x] `tests/unit/client/test_cli_utils.py` 追加 6 测试类 32 case（保留现有 4 测试类 7 case）
- [x] 全文件 39 passed（7 旧 + 32 新）
- [x] 三层 smoke：py_compile（src+api 全过）+ 启动路径点名（user_crud/containers/user_cli 29 passed）+ 变更相关（cli_utils 39 passed）

测试覆盖关键分支：
- `make_console` 三层 NO_COLOR 优先级（flag > env > auto）+ emoji 跟随 isatty + stderr/legacy_windows
- `GinkgoJSONEncoder` 7 类型（datetime ISO8601 T 分隔 / Decimal 精度 / UUID 带横线 / DataFrame records / pydantic model_dump / SQLAlchemy 列字典 / 未覆盖类型 fallback TypeError）
- `safe_confirm` 四分支（TTY confirm / 非 TTY require raise 专用异常 / `--yes` 跳过 / require_tty=False 返 default）+ `CliConfirmError` 继承 Exception
- `make_progress` 三路径（JSON 返 None / 非 TTY 返 None / TTY+text 返 Progress transient @ `p.live.transient` + console stderr）

## Step 2 追踪

`format_result` 完整实现（依赖 `ServiceResult.code`）由 #6576 (E1) 接力：
- 若 #6576 PR 含 `format_result` 实现，在该 PR body 补 `Closes #6577`
- 否则 #6576 合并后开 Step 2 follow-up issue

故本 PR 用 `Refs #6577` 不自动关闭。