### PR TITLE
refactor(version): 提取版本解析共享核心 _version_core.py

### DIFF
--- a/src/ginkgo/config/_version_core.py
+++ b/src/ginkgo/config/_version_core.py
@@ -1,0 +1,73 @@
+"""
+版本解析共享核心 —— 单一真相源的算法实现。
+
+供两处导入路径互不可达的调用方共享：
+  - ``ginkgo.config.package``：打包元数据层，被 CLI 快速路径 ``main.py`` 通过
+    ``sys.path.insert + import package`` 提升为顶层裸模块导入，**绕过**
+    ``ginkgo/__init__.py`` 的 ServiceHub 重型加载。故 ``package.py`` 不能写
+    任何 ``from ginkgo...`` 导入，只能 import 本文件（同目录 sibling）。
+  - ``ginkgo.libs.utils.version``：运行时/API 路径（SystemService /
+    ``GET /system/status``），无上述约束，走 ``from ginkgo.config._version_core`` 导入。
+
+本文件因此**只依赖 stdlib**（``importlib.metadata`` / ``tomllib`` / ``os``），
+永不 import 任何 ``ginkgo.*``，否则会捅破 CLI 快速路径。
+
+fallback 链（永不抛异常，#5406 AC#3）：
+  1. ``importlib.metadata``：已安装 dist 时最准（``pip install .`` 后）。
+  2. 解析 ``pyproject.toml``：开发环境 / Docker 仅 COPY src 场景。向上逐层查找
+     至文件系统根，不依赖固定层数 —— 兼容 src-layout（4 次 dirname 到不了 repo
+     root，原 off-by-one 已修）及生产镜像 ``/app/src/ginkgo/...`` 布局。
+  3. 兜底常量。
+"""
+
+import os
+import importlib.metadata
+from typing import Optional
+
+try:  # py>=3.11 stdlib
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+_PACKAGE_NAME = "ginkgo"
+_FALLBACK_VERSION = "0.0.0+unknown"
+
+
+def _version_from_metadata() -> Optional[str]:
+    """从已安装的 dist-info 读取版本（Docker 未装 dist 时返 None）。"""
+    try:
+        return importlib.metadata.version(_PACKAGE_NAME)
+    except Exception:
+        return None
+
+
+def _version_from_pyproject() -> Optional[str]:
+    """从 pyproject.toml [project].version 读取（开发环境 / Docker 仅 COPY src）。
+
+    向上逐层查找至文件系统根，不依赖固定层数。
+    """
+    if tomllib is None:
+        return None
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        parent = here
+        while True:
+            candidate = os.path.join(parent, "pyproject.toml")
+            if os.path.isfile(candidate):
+                with open(candidate, "rb") as f:
+                    data = tomllib.load(f)
+                version = data.get("project", {}).get("version")
+                if version:
+                    return version
+            nxt = os.path.dirname(parent)
+            if nxt == parent:  # 已到文件系统根
+                break
+            parent = nxt
+    except Exception:
+        return None
+    return None
+
+
+def resolve_version() -> str:
+    """返回当前版本，fallback 链永不抛异常。"""
+    return _version_from_metadata() or _version_from_pyproject() or _FALLBACK_VERSION

--- a/src/ginkgo/config/_version_core.py
+++ b/src/ginkgo/config/_version_core.py
@@ -9,8 +9,11 @@
   - ``ginkgo.libs.utils.version``：运行时/API 路径（SystemService /
     ``GET /system/status``），无上述约束，走 ``from ginkgo.config._version_core`` 导入。
 
-本文件因此**只依赖 stdlib**（``importlib.metadata`` / ``tomllib`` / ``os``），
-永不 import 任何 ``ginkgo.*``，否则会捅破 CLI 快速路径。
+本文件因此**只依赖 stdlib**（``importlib.metadata`` / ``tomllib`` / ``os`` /
+``logging`` / ``typing``），永不 import 任何 ``ginkgo.*``，否则会捅破 CLI 快速路径。
+诊断日志用标准库 ``logging.getLogger(__name__)`` 而非 GLOG —— 与 ``package.py``
+在 #6518/#6486 的选型同款（本层 stdlib-only 不能 import ginkgo），且搬迁自原
+``package.py::_resolve_version`` 的留痕一并携带，避免 refactor 静默丢语义。
 
 fallback 链（永不抛异常，#5406 AC#3）：
   1. ``importlib.metadata``：已安装 dist 时最准（``pip install .`` 后）。
@@ -21,6 +24,7 @@ fallback 链（永不抛异常，#5406 AC#3）：
 """
 
 import os
+import logging
 import importlib.metadata
 from typing import Optional
 
@@ -38,6 +42,9 @@ def _version_from_metadata() -> Optional[str]:
     try:
         return importlib.metadata.version(_PACKAGE_NAME)
     except Exception:
+        logging.getLogger(__name__).debug(
+            "importlib.metadata version lookup failed", exc_info=True
+        )
         return None
 
 
@@ -64,6 +71,9 @@ def _version_from_pyproject() -> Optional[str]:
                 break
             parent = nxt
     except Exception:
+        logging.getLogger(__name__).debug(
+            "pyproject.toml version lookup failed", exc_info=True
+        )
         return None
     return None
 

--- a/src/ginkgo/config/package.py
+++ b/src/ginkgo/config/package.py
@@ -1,56 +1,19 @@
-# Upstream: 安装脚本和打包工具(setup.py/pip install读取版本信息)
+# Upstream: 安装脚本和打包工具(setup.py/pip install 读取版本信息)
 # Downstream: 无(纯元数据定义模块)
 # Role: 配置管理包，提供配置文件读取、环境变量解析、配置验证、分层配置(环境变量→配置文件→默认值)等功能，定义GCONF全局配置实例
 
 
 
-
-
-
-import os
+# 版本解析逻辑共享自 _version_core（见该文件头注释关于双模导入的约束）。
+# 本文件必须能被 CLI 快速路径（main.py: sys.path.insert + import package）作为
+# 顶层裸模块导入 —— 故不能写任何 `from ginkgo...`，只能 import 同目录 sibling。
+try:
+    from _version_core import resolve_version  # CLI 快速路径：顶层裸模块
+except ImportError:
+    from ._version_core import resolve_version  # 常规/setup_install：包内相对导入
 
 PACKAGENAME = "ginkgo"
-
-
-def _resolve_version() -> str:
-    """动态解析版本，fallback 链永不抛异常（#5406 AC#3）。
-
-    与 libs/utils/version.get_version() 读同一真相源（importlib.metadata →
-    pyproject.toml → 兜底），保证 CLI `ginkgo version` 与 API /system/status
-    返回一致版本。
-
-    独立解析、不 import ginkgo：package.py 是打包元数据层，setup.py 读取时
-    ginkgo 尚未安装；CLI 快速路径（main.py）也不应触发 ServiceHub 重型加载。
-    """
-    # 1. importlib.metadata：已安装 dist 时最准（pip install . 后）
-    try:
-        import importlib.metadata
-        return importlib.metadata.version(PACKAGENAME)
-    except Exception:
-        pass
-    # 2. 解析 pyproject.toml：开发环境 / 构建中（向上逐层查找至 repo root）
-    try:
-        import tomllib
-        here = os.path.dirname(os.path.abspath(__file__))
-        parent = here
-        while True:
-            candidate = os.path.join(parent, "pyproject.toml")
-            if os.path.isfile(candidate):
-                with open(candidate, "rb") as f:
-                    version = tomllib.load(f).get("project", {}).get("version")
-                    if version:
-                        return version
-            nxt = os.path.dirname(parent)
-            if nxt == parent:  # 已到文件系统根
-                break
-            parent = nxt
-    except Exception:
-        pass
-    # 3. 兜底常量（极端情况，永不抛异常）
-    return "0.0.0+unknown"
-
-
-VERSION = _resolve_version()
+VERSION = resolve_version()
 AUTHOR = "suny"
 EMAIL = "sun159753@gmail.com"
 DESC = "Python Backtesting library for trading research"

--- a/src/ginkgo/libs/utils/version.py
+++ b/src/ginkgo/libs/utils/version.py
@@ -1,64 +1,19 @@
 """
-版本读取工具 —— 单一真相源。
+版本读取工具 —— 运行时/API 真相源的公共入口。
 
-提供 get_version() fallback 链，供 SystemService 与 CLI 共用：
-1. importlib.metadata（已装 dist 时最准）
-2. 解析 pyproject.toml（开发环境 / Docker 仅 COPY src 场景）
-3. 兜底常量（极端情况，永不抛异常）
+算法实现共享自 ``ginkgo.config._version_core.resolve_version``（该模块为单一
+真相源；本文件只是面向运行时调用方——``SystemService`` / ``GET /system/status``
+——的薄壳，保留 ``get_version()`` 公共 API）。
+
+为何不复用 ``config.package.VERSION``：``package.py`` 被 CLI 快速路径
+（``main.py``）以顶层裸模块方式导入以绕过 ServiceHub，运行时路径不应依赖该
+快速路径的 sys.path 副作用。两端通过共享 ``_version_core`` 算法收敛，
+``tests/unit/config/test_package_version.py`` 守护其一致性（#5406 AC#3）。
 """
 
-import os
-import importlib.metadata
-from typing import Optional
-
-try:  # py>=3.11 stdlib
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover
-    tomllib = None
-
-_FALLBACK_VERSION = "0.0.0+unknown"
-_PACKAGE_NAME = "ginkgo"
-
-
-def _version_from_metadata() -> Optional[str]:
-    """从已安装的 dist-info 读取版本（Docker 未装 dist 时返 None）。"""
-    try:
-        return importlib.metadata.version(_PACKAGE_NAME)
-    except Exception:
-        return None
-
-
-def _version_from_pyproject() -> Optional[str]:
-    """从 pyproject.toml [project].version 读取（开发环境 / Docker 仅 COPY src 场景）。
-
-    向上逐层查找 pyproject.toml 直到文件系统根，不依赖固定层数 —— 兼容
-    src-layout（src/ginkgo/libs/utils/ → ... → repo root，4 次 dirname）及
-    生产镜像 /app/src/ginkgo/libs/utils/ → /app 布局（pyproject 需 COPY 进镜像，
-    见 Dockerfile.api-server）。原实现固定遍历 4 层，src-layout 下 repo root
-    在第 5 层，永远返 None（off-by-one）。
-    """
-    if tomllib is None:
-        return None
-    try:
-        here = os.path.dirname(os.path.abspath(__file__))
-        parent = here
-        while True:
-            candidate = os.path.join(parent, "pyproject.toml")
-            if os.path.isfile(candidate):
-                with open(candidate, "rb") as f:
-                    data = tomllib.load(f)
-                version = data.get("project", {}).get("version")
-                if version:
-                    return version
-            nxt = os.path.dirname(parent)
-            if nxt == parent:  # 已到文件系统根
-                break
-            parent = nxt
-    except Exception:
-        return None
-    return None
+from ginkgo.config._version_core import resolve_version
 
 
 def get_version() -> str:
-    """返回当前版本，fallback 链永不抛异常。"""
-    return _version_from_metadata() or _version_from_pyproject() or _FALLBACK_VERSION
+    """返回当前版本，fallback 链永不抛异常（委托给共享核心）。"""
+    return resolve_version()

--- a/tests/unit/config/test_package_version.py
+++ b/tests/unit/config/test_package_version.py
@@ -132,3 +132,57 @@ class TestPackageVersionSource:
             sys.path[:] = saved_path
             sys.modules.pop("package", None)
             sys.modules.pop("_version_core", None)
+
+    def test_version_core_logs_when_metadata_lookup_fails(self, caplog):
+        """metadata 查询失败时必须 emit debug log（#6518/#6486 可观测性不变量）。
+
+        回归锚点：``_version_core`` 的 except 块用 ``return None`` 形态（非 ``pass``），
+        绕过 ``test_except_pass_logging`` 守门扫描器（该扫描器只抓 ``except...: pass``
+        形态）。故 logging 行为须由本测试直接断言，否则未来有人删掉 logging 行
+        无人发现 —— 这正是 refactor 搬迁时漏带语义不变量的事故温床（CLAUDE.md
+        「归因纪律（防 #4652 类事故）」）。
+        """
+        import logging
+        from unittest.mock import patch
+
+        import ginkgo.config._version_core as core
+
+        # GinkgoLogger (logger.py:434) 把上层 logger propagate=False，caplog 经
+        # root 收不到；直接把 caplog.handler 挂到目标 logger 绕开传播链。
+        target = logging.getLogger(core.__name__)
+        target.addHandler(caplog.handler)
+        caplog.set_level(logging.DEBUG, logger=core.__name__)
+        try:
+            with patch("importlib.metadata.version", side_effect=Exception("boom")):
+                result = core._version_from_metadata()
+        finally:
+            target.removeHandler(caplog.handler)
+        assert result is None, "metadata 失败应返 None 触发 fallback"
+        debug_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("importlib.metadata" in m for m in debug_msgs), (
+            f"metadata 失败应留 debug 日志，实际 caplog: {debug_msgs}"
+        )
+
+    def test_version_core_logs_when_pyproject_parse_fails(self, caplog):
+        """pyproject 解析失败时必须 emit debug log（同上，pyproject 路径对称）。"""
+        import logging
+        from unittest.mock import MagicMock, patch
+
+        import ginkgo.config._version_core as core
+
+        # tomllib.load 抛错 → except 块触发；walk 仍找到 repo root 的真 pyproject
+        fake_tomllib = MagicMock()
+        fake_tomllib.load.side_effect = Exception("parse boom")
+        target = logging.getLogger(core.__name__)
+        target.addHandler(caplog.handler)
+        caplog.set_level(logging.DEBUG, logger=core.__name__)
+        try:
+            with patch.object(core, "tomllib", fake_tomllib):
+                result = core._version_from_pyproject()
+        finally:
+            target.removeHandler(caplog.handler)
+        assert result is None, "pyproject 解析失败应返 None 触发 fallback"
+        debug_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("pyproject.toml" in m for m in debug_msgs), (
+            f"pyproject 解析失败应留 debug 日志，实际 caplog: {debug_msgs}"
+        )

--- a/tests/unit/config/test_package_version.py
+++ b/tests/unit/config/test_package_version.py
@@ -1,14 +1,21 @@
 """
-CLI 版本真相源契约测试（#5406 AC#3）。
+CLI/API 版本真相源契约测试（#5406 AC#3）。
 
-验证 config/package.py 的 VERSION 与 API 侧 get_version() 同源，确保
-`ginkgo version` CLI 与 GET /system/status 返回一致版本。
+验证 ``ginkgo version`` CLI 与 ``GET /system/status`` 返回一致版本。
 
-package.py 是打包元数据层（被 setup.py / pip install 读取），不能 import
-ginkgo 包（打包时尚未安装；CLI 快速路径也不应触发 ServiceHub 重型加载），
-故独立解析同一真相源（importlib.metadata → pyproject.toml → 兜底），
-结果与 libs/utils/version.get_version() 收敛。
+架构约束（订正：原论据 setup.py 循环已失效，真约束如下）：
+  - ``config/package.py`` 被 CLI 快速路径（``main.py``）通过 ``sys.path.insert +
+    import package`` 提升为**顶层裸模块**导入，**绕过** ``ginkgo/__init__.py``
+    的 ServiceHub 重型加载。故 ``package.py`` 不能写任何 ``from ginkgo...``，
+    只能 import 同目录 sibling ``_version_core``。
+  - ``libs/utils/version.py`` 走运行时路径（``SystemService``），无此约束。
+  - 两端共享 ``config/_version_core.py::resolve_version`` 算法收敛。
+  - ``setup.py`` 现为空壳，setuptools 直接读 ``pyproject.toml``，**不**读
+    ``package.py``；故打包循环不再是约束。
 """
+
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -23,8 +30,8 @@ class TestPackageVersionSource:
     def test_package_version_equals_api_version(self):
         """CLI package.VERSION == API get_version()。
 
-        AC#3 核心：`ginkgo version` 与 /system/status 返回同一版本。
-        package.py 硬编码 0.8.1 而 get_version()=0.8.2 时此断言失败。
+        重构后两端委托同一 resolve_version()，此断言近乎同义反复，
+        但保留作 smoke：守护导入链（双模 shim / 委托）未断。
         """
         assert PACKAGE_VERSION == get_version(), (
             f"CLI {PACKAGE_VERSION!r} ≠ API {get_version()!r}，#5406 AC#3 违反"
@@ -34,3 +41,94 @@ class TestPackageVersionSource:
         """VERSION 非空、非占位符。"""
         assert PACKAGE_VERSION
         assert PACKAGE_VERSION != "unknown"
+        assert PACKAGE_VERSION != "0.0.0+unknown"
+
+    def test_package_version_matches_pyproject(self):
+        """两端都应解析到 pyproject.toml 的真实版本（当前 0.8.x），非兜底常量。
+
+        强制 exercise 真实解析路径，而非偶然命中兜底。
+        """
+        repo_root = Path(__file__).resolve().parents[3]
+        pyproject = repo_root / "pyproject.toml"
+        try:
+            import tomllib
+            with open(pyproject, "rb") as f:
+                expected = tomllib.load(f).get("project", {}).get("version")
+        except Exception:
+            pytest.skip("无法解析 pyproject.toml")
+        assert expected, "pyproject.toml 缺 [project].version"
+        assert PACKAGE_VERSION == expected
+        assert get_version() == expected
+
+    def test_package_importable_via_src_prefix(self):
+        """setup_install.py 契约：`from src.ginkgo.config.package import VERSION` 可用。
+
+        setup_install.py:10 在 install 阶段（pip uninstall 前后）从源码读 VERSION
+        命名构建产物（ginkgo-{VERSION}.tar.gz）。此时 ginkgo 可能尚未装/已卸载，
+        importlib.metadata 失败，resolver 必须回退读源码 pyproject.toml。
+
+        此导入路径要求 package.py 的 shim 第二分支用**相对导入**（`from
+        ._version_core`）而非绝对（`from ginkgo.config._version_core`）——后者
+        依赖 `ginkgo` 顶层可导入，违背 install 时"读源码不依赖已装包"原则。
+        相对导入锚定 package.py 自身位置，src.ginkgo.config.* / ginkgo.config.*
+        两种前缀都能定位到同目录源码文件。
+        """
+        import importlib
+        # repo root 已在 sys.path（pytest rootdir），src 为 namespace package
+        mod = importlib.import_module("src.ginkgo.config.package")
+        assert mod.VERSION == PACKAGE_VERSION, (
+            f"src.ginkgo.config.package.VERSION={mod.VERSION!r} ≠ "
+            f"常规 PACKAGE_VERSION={PACKAGE_VERSION!r}，相对导入 shim 失效"
+        )
+        assert mod.VERSION != "0.0.0+unknown", "install 时 resolver 退化到兜底常量"
+
+    def test_install_time_reads_source_when_metadata_fails(self):
+        """install 时 ginkgo 未装（metadata 失败）→ resolver 必须读源码 pyproject。
+
+        回归锚点：setup_install.py 在 pip uninstall ginkgo 后仍能拿到正确版本
+        命名 sdist。若 resolver 仅依赖 importlib.metadata，install 时会得到
+        兜底常量 `0.0.0+unknown` → pip install ginkgo-0.0.0+unknown.tar.gz 失败。
+        """
+        import ginkgo.config._version_core as core
+        # 模拟 ginkgo 未装：metadata 路径返 None
+        original = core._version_from_metadata
+        core._version_from_metadata = lambda: None
+        try:
+            result = core.resolve_version()
+        finally:
+            core._version_from_metadata = original
+        assert result == PACKAGE_VERSION, (
+            f"metadata 失败时 resolve_version()={result!r}，应回退读源码得 "
+            f"{PACKAGE_VERSION!r}（install 时命名 sdist 依赖此路径）"
+        )
+
+    def test_package_importable_as_top_level_module(self):
+        """CLI 快速路径契约：package.py 能作为顶层裸模块 `import package` 导入。
+
+        复刻 main.py:197-209 的 sys.path 技巧 —— 这要求 package.py 不能写任何
+        `from ginkgo...` 导入（否则 ginkgo 未在快速路径 sys.path 上 → ImportError，
+        或触发 ServiceHub 拖慢启动）。双模 shim 的第一分支（`from _version_core
+        import resolve_version`）必须在此模式命中。
+        """
+        repo_root = Path(__file__).resolve().parents[3]
+        config_dir = str(repo_root / "src" / "ginkgo" / "config")
+        saved_path = list(sys.path)
+        # 清掉可能已作为 ginkgo.config.* 缓存的副本，强制走顶层裸模块路径
+        for mod in list(sys.modules):
+            if mod in ("package", "_version_core") or mod.startswith("ginkgo.config._version_core"):
+                # 注意：不删 ginkgo.config.package（其它测试可能依赖）
+                if mod in ("package", "_version_core"):
+                    del sys.modules[mod]
+
+        sys.path.insert(0, config_dir)
+        try:
+            import package  # 顶层裸模块，与 main.py 快速路径一致
+            assert package.VERSION == PACKAGE_VERSION, (
+                f"快速路径 package.VERSION={package.VERSION!r} ≠ "
+                f"常规 PACKAGE_VERSION={PACKAGE_VERSION!r}，双模 shim 失效"
+            )
+            assert package.PACKAGENAME == "ginkgo"
+        finally:
+            sys.path[:] = saved_path
+            sys.modules.pop("package", None)
+            sys.modules.pop("_version_core", None)

--- a/tests/unit/core/services/test_system_service_version.py
+++ b/tests/unit/core/services/test_system_service_version.py
@@ -2,7 +2,12 @@
 版本读取契约测试。
 
 验证 get_version() 的 fallback 链与 SystemService.VERSION 的单一真相源行为。
-通过公共接口 + mock 注入固定 fallback 各分支，不耦合内部解析实现。
+通过公共接口 + mock 注入固定 fallback 各分支。
+
+注：算法实现共享自 ``ginkgo.config._version_core``（``version.py`` 仅薄壳委托），
+故 fallback 链 mock 注入点为 ``ginkgo.config._version_core._version_from_*``。
+patch 必须作用在 ``resolve_version`` 实际查符号的命名空间（``_version_core``），
+否则 patch 命中调用方命名空间、被测函数看不到 → 假阳性。
 """
 
 import pytest
@@ -32,9 +37,9 @@ class TestVersionFallbackChain:
 
     def test_falls_back_to_pyproject_when_importlib_fails(self):
         """importlib.metadata 不可用时，fallback 读 pyproject.toml 返回有效版本。"""
-        with patch("ginkgo.libs.utils.version._version_from_metadata", return_value=None):
+        with patch("ginkgo.config._version_core._version_from_metadata", return_value=None):
             with patch(
-                "ginkgo.libs.utils.version._version_from_pyproject",
+                "ginkgo.config._version_core._version_from_pyproject",
                 return_value="0.8.2",
             ):
                 assert get_version() == "0.8.2"
@@ -42,20 +47,20 @@ class TestVersionFallbackChain:
     def test_prefers_metadata_when_available(self):
         """importlib.metadata 可用时，优先返回 dist 版本（不被 pyproject 覆盖）。"""
         with patch(
-            "ginkgo.libs.utils.version._version_from_metadata",
+            "ginkgo.config._version_core._version_from_metadata",
             return_value="1.2.3",
         ):
             with patch(
-                "ginkgo.libs.utils.version._version_from_pyproject",
+                "ginkgo.config._version_core._version_from_pyproject",
                 return_value="0.8.2",
             ):
                 assert get_version() == "1.2.3"
 
     def test_returns_fallback_when_all_sources_fail(self):
         """所有来源都读不到时，返回兜底常量，永不抛异常。"""
-        with patch("ginkgo.libs.utils.version._version_from_metadata", return_value=None):
+        with patch("ginkgo.config._version_core._version_from_metadata", return_value=None):
             with patch(
-                "ginkgo.libs.utils.version._version_from_pyproject",
+                "ginkgo.config._version_core._version_from_pyproject",
                 return_value=None,
             ):
                 result = get_version()
@@ -67,9 +72,10 @@ class TestVersionFallbackChain:
 class TestVersionPyprojectDiscovery:
     """_version_from_pyproject 真实路径查找（回归 off-by-one）。
 
-    src-layout 下 version.py 位于 src/ginkgo/libs/utils/，pyproject.toml 在
-    repo root（第 5 层）。原实现固定遍历 4 层够不到 root，永远返 None；
-    改 while 循环向上查找后应命中。本测试不 mock，走真实文件系统查找。
+    _version_core.py 位于 src/ginkgo/config/，pyproject.toml 在 repo root
+    （向上 3 层 dirname）。原 off-by-one 实现固定遍历 4 层在旧位置（libs/utils/，
+    5 层）永远返 None；改 while 循环向上查找后应命中。本测试不 mock，走真实
+    文件系统查找 —— 守护任意未来"固定层数"回退。
     """
 
     def test_finds_real_pyproject_at_repo_root(self):
@@ -77,7 +83,7 @@ class TestVersionPyprojectDiscovery:
 
         回归锚点：off-by-one 时此断言失败（返 None）。
         """
-        from ginkgo.libs.utils.version import _version_from_pyproject
+        from ginkgo.config._version_core import _version_from_pyproject
 
         result = _version_from_pyproject()
         assert result is not None, "未找到 repo root pyproject.toml（向上查找层数不足？off-by-one）"
@@ -85,13 +91,13 @@ class TestVersionPyprojectDiscovery:
 
     def test_real_version_matches_pyproject(self, monkeypatch):
         """隔离 metadata 后，get_version() 应回退到真实 pyproject 版本（非 fallback 常量）。"""
-        import ginkgo.libs.utils.version as v
+        import ginkgo.config._version_core as core
 
         # 强制 metadata 不可用（模拟生产镜像未装 dist），逼 fallback 走 pyproject 真实路径
-        monkeypatch.setattr(v, "_version_from_metadata", lambda: None)
+        monkeypatch.setattr(core, "_version_from_metadata", lambda: None)
         result = get_version()
         assert result  # 非空
-        assert result != v._FALLBACK_VERSION, (
-            f"get_version() 退化到 fallback 常量 {v._FALLBACK_VERSION!r}，"
+        assert result != core._FALLBACK_VERSION, (
+            f"get_version() 退化到 fallback 常量 {core._FALLBACK_VERSION!r}，"
             "说明 _version_from_pyproject 未命中真实 pyproject（off-by-one?）"
         )


### PR DESCRIPTION
## Summary

消除 `config/package.py` 与 `libs/utils/version.py` 之间 ~15 行逐字节相同的版本解析 fallback 链（曾出 off-by-one 回归），提取为 stdlib-only 共享核心 `config/_version_core.py::resolve_version()`，两端委托调用。

PR 6560 提到 version 获取存在两套实现；本 PR 把重复的**算法**收敛到单一真相源，同时保留两条不可互通的**导入路径**（架构约束使然，见下）。

## 架构约束：为何不能简单"互相 import"

`package.py` 被两条路径导入，二者 sys.path 互不可达，故共享核心只能放在它的 sibling 位置 `config/_version_core.py`：

| 导入路径 | 调用方 | sys.path | shim 分支 |
|---|---|---|---|
| 顶层裸模块 `import package` | `main.py:197-209` CLI 快速路径（绕过 ServiceHub） | 仅挂 `src/ginkgo/config/` | 第一分支 `from _version_core` |
| `src.ginkgo.config.package` | `setup_install.py:10` install 时读源码命名 sdist | repo root | 第二分支 `from ._version_core`（相对导入） |
| `ginkgo.config.package` | 常规（test / mcp_server / 其它） | package-dir | 第二分支（相对导入） |

**install 时读源码**这条尤其关键：`setup_install.py:10` 在 `pip uninstall ginkgo` 前后从源码读 VERSION 命名构建产物 `ginkgo-{VERSION}.tar.gz`。此时 `importlib.metadata.version("ginkgo")` 失败，resolver 必须回退读源码 `pyproject.toml`。shim 第二分支用**相对导入**而非绝对导入，避免依赖 `ginkgo` 顶层可导入，守住"读源码不依赖已装包"原则。

## Test plan

- [x] Layer 1 py_compile（5 文件）
- [x] Layer 3 版本相关：13 passed（`test_package_version.py` 6 + `test_system_service_version.py` 7）
- [x] 启动冒烟：`import ginkgo` + `main` + `SystemService` + 三导入路径全通，版本三处一致 `0.8.2`
- [x] install 时场景实测：模拟 `importlib.metadata.version` 失败（卸载后），`resolve_version()` 正确回退读源码 pyproject → `0.8.2`

新增回归测试：
- `test_package_importable_via_src_prefix` —— setup_install.py 契约
- `test_install_time_reads_source_when_metadata_fails` —— install 时读源码（fallback 链承重）
- `test_package_importable_as_top_level_module` —— CLI 快速路径契约

`test_system_service_version.py` 的 fallback 链 patch 注入点同步迁至 `ginkgo.config._version_core._version_from_*`（helper 搬家后 patch 必须跟着搬，否则命中空属性致假阳性）。

## 变更树

```
src/ginkgo/config/_version_core.py      [新增] 算法共享核心 stdlib-only
src/ginkgo/config/package.py            [瘦身] 双模 shim
src/ginkgo/libs/utils/version.py        [瘦身] 薄壳委托 resolve_version()
tests/unit/config/test_package_version.py          +3 回归测试
tests/unit/core/services/test_system_service_version.py  patch 路径迁移
```

生产代码净减 ~73 行，新增 ~70 行回归测试。

🤖 Generated with [Claude Code](https://claude.com/claude-code)