### PR TITLE
refactor(#6586): 无数据 code 过滤下沉到 BacktestFeeder（预过滤+批量取bar+WARN去重）

### DIFF
--- a/src/ginkgo/trading/feeders/backtest_feeder.py
+++ b/src/ginkgo/trading/feeders/backtest_feeder.py
@@ -20,7 +20,7 @@ The `Datahandler` class will provide access to historical price and volume data 
 import time
 import pandas as pd
 from datetime import datetime, date, timedelta
-from typing import List, Dict, Any, Callable, Optional
+from typing import List, Dict, Any, Callable, Optional, Set
 from rich.progress import Progress
 
 from ginkgo.trading.feeders.base_feeder import BaseFeeder
@@ -63,6 +63,10 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
 
         # 兴趣集（通过EventInterestUpdate动态更新）
         self._interested_codes: List[str] = []
+
+        # 无数据 code WARN 去重（#6586）：同一 code 整个回测内 "No bar data" 至多 WARN 一次。
+        # 预过滤后仍可能出现的"当日无 bar"（停牌等）走此去重，避免逐日刷屏。
+        self._warned_no_data: Set[str] = set()
         
     # === IDataFeeder 基础接口实现 ===
 
@@ -133,7 +137,14 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
     # === IBacktestDataFeeder 扩展接口实现 ===
     
     def advance_time(self, target_time: datetime, *args, **kwargs) -> bool:
-        """推进到指定时间，主动推送价格事件到引擎"""
+        """推进到指定时间，主动推送价格事件到引擎。
+
+        #6586：无数据 code 过滤下沉到本层——
+          1. 用 bar_service.get_available_codes 与 _interested_codes 取交集（feedable），
+             剔除 DB 中完全无 bar 的 code，不为其查询/发事件/WARN；
+          2. 按日批量取当日全市场复权 bar（一次 get(code=None)，消除逐股 N+1）；
+          3. feedable code 当日无 bar 时 WARN，且整个回测内同一 code 至多 WARN 一次。
+        """
         try:
             # 调用父类TimeMixin的advance_time
             success = super().advance_time(target_time, *args, **kwargs)
@@ -145,15 +156,31 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
                 GLOG.WARN(f"BacktestFeeder: No interested symbols at {target_time.date()}")
                 return True
 
-            GLOG.INFO(f"BacktestFeeder: Advancing to {target_time.date()}, {len(self._interested_codes)} symbols: {self._interested_codes}")
+            # 1. 预过滤：interested ∩ available（剔除 DB 中完全无 bar 数据的 code）
+            feedable = self._compute_feedable_codes()
+            if len(feedable) == 0:
+                GLOG.WARN(f"BacktestFeeder: No feedable symbols at {target_time.date()}")
+                return True
 
-            # 为每个股票生成并推送价格更新事件
+            GLOG.INFO(
+                f"BacktestFeeder: Advancing to {target_time.date()}, "
+                f"feeding {len(feedable)}/{len(self._interested_codes)} symbols"
+            )
+
+            # 2. 批量取当日复权 bar（一次查询，消除逐股 N+1），按 code 索引
+            bars_by_code = self._fetch_day_bars_batch(target_time)
+
+            # 3. 对 feedable code 发事件；当日无 bar 的走 WARN 去重
             event_count = 0
-            for code in self._interested_codes:
-                price_events = self._generate_price_events(code, target_time)
-                for event in price_events:
-                    self.publish_price_update(event)
-                    event_count += 1
+            for code in feedable:
+                bar = bars_by_code.get(code)
+                if bar is None:
+                    self._warn_no_data_once(code, target_time)
+                    continue
+                event = EventPriceUpdate(payload=bar)
+                event.set_source(SOURCE_TYPES.BACKTESTFEEDER)
+                self.publish_price_update(event)
+                event_count += 1
 
             GLOG.INFO(f"BacktestFeeder: Published {event_count} price events for {target_time.date()}")
             return True
@@ -161,6 +188,63 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
         except Exception as e:
             GLOG.ERROR(f"BacktestFeeder: Error advancing time to {target_time}: {e}")
             return False
+
+    def _compute_feedable_codes(self) -> List[str]:
+        """interested ∩ available：剔除 DB 中完全无 bar 数据的 code（#6586）。
+
+        - available 取自 bar_service.get_available_codes（DB 中实际有 bar 的 code 集合）；
+        - _interested_codes 由事件链维护，**不改写它**（保护事件契约，见 ADR-019 与
+          arch_backtest_feeder_interested_event_driven），预过滤结果只作用于"实际取 bar 的循环"；
+        - get_available_codes 失败时降级为全 interested（不阻断回测，保留旧行为）。
+        """
+        result = self.bar_service.get_available_codes()
+        if not result.success or not result.data:
+            GLOG.WARN(
+                f"BacktestFeeder: get_available_codes unavailable, "
+                f"falling back to all {len(self._interested_codes)} interested codes"
+            )
+            return list(self._interested_codes)
+
+        available = set(result.data)
+        feedable = [c for c in self._interested_codes if c in available]
+        dropped = len(self._interested_codes) - len(feedable)
+        if dropped > 0:
+            GLOG.INFO(
+                f"BacktestFeeder: prefiltered {dropped} code(s) without bar data; "
+                f"feeding {len(feedable)}/{len(self._interested_codes)}"
+            )
+        return feedable
+
+    def _fetch_day_bars_batch(self, target_time: datetime) -> Dict[str, Any]:
+        """批量取当日全市场复权 bar，按 code 索引返回（#6586 消除 N+1）。
+
+        走 bar_service.get(code=None)（多股复权分支），一次查询取当日全部 code 的 bar
+        并按 code 索引；调用方只用 feedable 子集。相比逐股 bar_service.get，把每日 N 次
+        DB round-trip 压成 1 次（#5163 宽 universe 性能根因）。保留复权语义，与原
+        _generate_price_events 单股 get(code) 一致。
+        """
+        bars_by_code: Dict[str, Any] = {}
+        result = self.bar_service.get(
+            code=None,
+            start_date=target_time.date(),
+            end_date=target_time.date(),
+        )
+        if not result.success or not result.data:
+            return bars_by_code
+
+        bar_entities = BarMapper.from_models(result.data)
+        for bar in bar_entities:
+            code = getattr(bar, "code", None)
+            if code is not None:
+                bars_by_code.setdefault(code, bar)
+        return bars_by_code
+
+    def _warn_no_data_once(self, code: str, target_time: datetime) -> None:
+        """同一 code 的 "No bar data" WARN 整个回测内至多输出一次（#6586 刷屏根因）。"""
+        if code in self._warned_no_data:
+            return
+        self._warned_no_data.add(code)
+        GLOG.WARN(f"BacktestFeeder: No bar data for {code} at {target_time.date()}")
     
     @TimeMixin.validate_time(['start_time', 'end_time'])
     def get_historical_data(self,

--- a/tests/unit/trading/feeders/test_backtest_feeder_prefilter.py
+++ b/tests/unit/trading/feeders/test_backtest_feeder_prefilter.py
@@ -1,0 +1,129 @@
+# Upstream: BacktestFeeder, bar_service.get_available_codes, BarMapper
+# Downstream: -
+# Role: #6586 验证无数据 code 过滤下沉到 feeder（预过滤 + 批量取 bar + WARN 去重）
+"""
+BacktestFeeder 预过滤 / 批量 / WARN 去重测试（#6586）。
+
+把"剔除 DB 中无 bar 数据的 code"从 selector 下沉到 feeder：
+  - feeder 喂数据前用 bar_service.get_available_codes 与 _interested_codes 取交集
+  - 按日批量取当日复权 bar（一次查询，消除逐股 N+1）
+  - 同一 code 的 "No bar data" WARN 在整个回测内至多一次
+"""
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+import ginkgo.data.mappers as mappers_mod
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.entities import Bar
+from ginkgo.enums import FREQUENCY_TYPES, SOURCE_TYPES
+from ginkgo.trading.events import EventPriceUpdate
+from ginkgo.trading.feeders.backtest_feeder import BacktestFeeder
+from ginkgo.trading.time.providers import LogicalTimeProvider
+
+
+def _make_bar(code: str, day: int = 1) -> Bar:
+    """构造真实 Bar entity（避免 mock 导致 EventPriceUpdate 构造失败）。"""
+    return Bar(
+        code=code,
+        open=100.0 + day,
+        high=101.0 + day,
+        low=99.0 + day,
+        close=100.0 + day,
+        volume=10000,
+        amount=1000000.0,
+        frequency=FREQUENCY_TYPES.DAY,
+        timestamp=datetime(2023, 6, day, 9, 30),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.backtest
+class TestBacktestFeederPrefilter:
+    """#6586：无数据 code 过滤下沉到 feeder。"""
+
+    def test_advance_time_drops_codes_without_bar_data(self):
+        """interested 含全无数据 code（不在 get_available_codes）时，feeder 预过滤剔除它：
+        不为其发事件；当日 bar 走批量查询（bar_service.get 全市场一次），非逐股 N+1。"""
+        feeder = BacktestFeeder()
+        feeder.set_time_provider(LogicalTimeProvider(datetime(2023, 6, 1)))
+        feeder._interested_codes = ["A.SZ", "NODATA.SZ"]
+
+        mock_bs = Mock()
+        # 只有 A 在 DB 有 bar 数据，NODATA 被预过滤剔除
+        mock_bs.get_available_codes.return_value = ServiceResult(
+            success=True, data=["A.SZ"]
+        )
+        feeder.bar_service = mock_bs
+
+        captured: list = []
+        feeder.set_event_publisher(captured.append)
+
+        bar_a = _make_bar("A.SZ")
+        with patch.object(mappers_mod.BarMapper, "from_models", return_value=[bar_a]):
+            feeder.advance_time(datetime(2023, 6, 1, 9, 30))
+
+        # 只为 A 发事件，NODATA 被预过滤剔除不发事件
+        assert len(captured) == 1, "NODATA 应被预过滤剔除，只为 A 发事件"
+        assert isinstance(captured[0], EventPriceUpdate)
+        assert captured[0].source == SOURCE_TYPES.BACKTESTFEEDER
+        # 批量取 bar：bar_service.get 一次（code=None 全市场当日），非逐股 N 次
+        assert mock_bs.get.call_count == 1, "应批量取 bar 一次，非逐股 N+1"
+        _args, kwargs = mock_bs.get.call_args
+        assert kwargs.get("code") is None, "批量取 bar 应传 code=None（全市场当日复权）"
+
+    def test_warn_no_data_deduplicated_across_days(self):
+        """feedable code 当日无 bar（停牌等）时，跨多日 advance_time 该 code 的
+        No-bar WARN 整个回测内至多一次（#6586 刷屏根因）。"""
+        feeder = BacktestFeeder()
+        feeder.set_time_provider(LogicalTimeProvider(datetime(2023, 6, 1)))
+        feeder._interested_codes = ["A.SZ"]
+
+        mock_bs = Mock()
+        # A 在 DB 有数据（进 feedable），但当日批量查询返回空（停牌）
+        mock_bs.get_available_codes.return_value = ServiceResult(
+            success=True, data=["A.SZ"]
+        )
+        mock_bs.get.return_value = ServiceResult(success=True, data=[])
+        feeder.bar_service = mock_bs
+
+        captured: list = []
+        feeder.set_event_publisher(captured.append)
+
+        # 跨 3 个交易日推进，每日 A 都"无当日 bar"
+        for day in (1, 2, 3):
+            feeder.advance_time(datetime(2023, 6, day, 9, 30))
+
+        # 3 日均无当日 bar，但 WARN 去重：_warned_no_data 只记 A 一次
+        assert feeder._warned_no_data == {"A.SZ"}, (
+            "同一 code 整个回测内 WARN 至多一次，跨日不重复"
+        )
+        # 无 bar 不发事件
+        assert captured == []
+
+    def test_fallback_to_all_interested_when_available_codes_unavailable(self):
+        """get_available_codes 失败时，feeder 降级为全 interested 喂数据，不阻断回测。"""
+        feeder = BacktestFeeder()
+        feeder.set_time_provider(LogicalTimeProvider(datetime(2023, 6, 1)))
+        feeder._interested_codes = ["A.SZ", "B.SZ"]
+
+        mock_bs = Mock()
+        # available 查询失败 → 降级为全 interested（A、B 都喂）
+        mock_bs.get_available_codes.return_value = ServiceResult(success=False, error="db down")
+        bar_a = _make_bar("A.SZ")
+        bar_b = _make_bar("B.SZ")
+        feeder.bar_service = mock_bs
+
+        captured: list = []
+        feeder.set_event_publisher(captured.append)
+
+        with patch.object(
+            mappers_mod.BarMapper, "from_models", return_value=[bar_a, bar_b]
+        ):
+            feeder.advance_time(datetime(2023, 6, 1, 9, 30))
+
+        # 降级后 A、B 都被喂数据（不因 available 查询失败而阻断）
+        assert len(captured) == 2, "available 失败应降级为全 interested，不阻断回测"
+
+


### PR DESCRIPTION
## Summary

把"剔除 DB 中无 bar 数据的 code"从 selector 层下沉到 BacktestFeeder，并消除逐股取 bar 的 N+1、压制 No-bar WARN 刷屏（#6586）。

### 三处行为变更（`advance_time` 重构）

1. **预过滤**：`_compute_feedable_codes` 用 `bar_service.get_available_codes` 与 `_interested_codes` 取交集（feedable），不为 DB 中完全无 bar 的 code 查询/发事件/WARN。`get_available_codes` 失败时降级为全 interested，不阻断回测。
2. **批量取 bar**：`_fetch_day_bars_batch` 走 `get(code=None)`（多股复权分支）一次取当日全市场 bar 并按 code 索引，消除逐股 N+1（宽 universe 性能根因）。复权语义与原单股 `get(code)` 一致。
3. **WARN 去重**：`_warn_no_data_once` 用 set 去重，同一 code 整个回测内 No-bar WARN 至多一次（停牌等"当日无 bar"仍提示但不刷屏）。

### N+1 → 批量 结构性论证

| 维度 | 旧路径 | 新路径 |
|---|---|---|
| 每日 DB round-trip | N 次（N=len(interested)） | 1 次（全市场当日，filter feedable） |
| 无数据 code 处理 | selector 层感知 bar_service（越界） | feeder 层预过滤 + 单次 WARN |
| 复权 | 单股 `get(code, FORE)` | 多股 `_apply_price_adjustment_multi_stock` |

### 验收标准对照

- [x] **AC#1** selectors 不得 import/调用 `bar_service`：`grep -rn "bar_service" src/ginkgo/trading/selectors/` 无命中（selector 本就干净，本 PR 不改 selector）
- [x] **AC#2** feeder 喂食前调 `get_available_codes` 与 interested 取交集；批量取 bar（`get(code=None)`），无逐股 `bar_service.get` 循环
- [x] **AC#3** 同一 code 的 "No bar data" WARN 整个回测内至多一次：`_warned_no_data` set 去重
- [x] **AC#4** 既有 feeder/selector 测试通过 + 新增 ≥1 预过滤测试 + WARN 去重测试

## Test plan

- 新增 `tests/unit/trading/feeders/test_backtest_feeder_prefilter.py`（3 用例）：
  - `test_advance_time_drops_codes_without_bar_data`：预过滤剔除无数据 code + 批量取 bar（call_count==1, code=None）
  - `test_warn_no_data_deduplicated_across_days`：跨 3 日同一 code 无 bar，WARN 至多 1 次
  - `test_fallback_to_all_interested_when_available_codes_unavailable`：available 查询失败降级不阻断
- 回归：`tests/unit/trading/engines/test_backtest_feeder.py` 28 passed, 5 xfailed（无回归）
- 三层冒烟：L1 py_compile ✅ ｜ L2 启动路径（user_crud+containers+user_cli）33 passed ✅ ｜ L3 变更相关 ✅

Closes #6586
