### PR TITLE
fix(data): unify ORM transaction entrypoints

### DIFF
--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -931,7 +931,6 @@ def _init_admin_user():
             "update_at": now
         })
 
-        session.commit()
 
         return {
             "username": "admin",

--- a/src/ginkgo/data/crud/base_crud.py
+++ b/src/ginkgo/data/crud/base_crud.py
@@ -6,12 +6,14 @@
 
 
 from typing import TypeVar, Generic, List, Optional, Any, Union, Dict, Callable, Type
+from contextlib import contextmanager
 from abc import ABC, abstractmethod
 import pandas as pd
 from sqlalchemy import and_, delete, text, update
 from sqlalchemy.orm import Session
 
 from ginkgo.data.drivers import get_db_connection, add, add_all
+from ginkgo.data.transaction import get_transaction_session, transaction_scope
 from ginkgo.data.models import MClickBase, MMysqlBase, MMongoBase
 from ginkgo.libs import GLOG, time_logger, retry, cache_with_expiration
 from ginkgo.data.access_control import restrict_crud_access
@@ -269,6 +271,22 @@ class _CoreCRUD(Generic[T], ABC):
         """Get a new database session for external transaction management."""
         return self._get_connection().get_session()
 
+    def _transaction_key(self) -> str:
+        """Return the transaction scope key for this CRUD's backing storage."""
+        return self._get_connection().driver_name
+
+    @contextmanager
+    def _session_scope(self, session: Optional[Session] = None):
+        """Reuse an explicit / active transaction session, or open one new scope."""
+        active_session = session or get_transaction_session(self._transaction_key())
+        if active_session is not None:
+            yield active_session
+            return
+
+        conn = self._get_connection()
+        with transaction_scope(self._transaction_key(), conn.get_session) as managed_session:
+            yield managed_session
+
     # ============================================================================
     # Template Methods - With unified decorators, should not be overridden
     # ============================================================================
@@ -492,58 +510,59 @@ class _CoreCRUD(Generic[T], ABC):
                     f"got {type(item).__name__}"
                 )
 
-        # Step 1: Query existing items
-        backup_items = []
-        try:
-            existing_items = self.find(filters=filters, session=session)
-            backup_items = list(existing_items)
-
-            if len(backup_items) == 0:
-                GLOG.INFO(
-                    f"No existing {self.model_class.__name__} items found matching filters. "
-                    f"No replacement performed."
-                )
-                # Return empty result without performing any insertion
-                return ModelList([], self)
-
-            GLOG.DEBUG(f"Found {len(backup_items)} existing {self.model_class.__name__} items to replace")
-
-        except Exception as e:
-            GLOG.ERROR(f"Failed to query existing {self.model_class.__name__} items: {e}")
-            raise
-
-        # Step 2: Delete existing items
-        try:
-            removed_count = self.remove(filters=filters, session=session)
-            GLOG.DEBUG(f"Deleted {removed_count} existing {self.model_class.__name__} items")
-        except Exception as e:
-            GLOG.ERROR(f"Failed to delete {self.model_class.__name__} items: {e}")
-            raise
-
-        # Step 3: Insert new items
-        try:
-            inserted_items = self.add_batch(new_items, session=session)
-            GLOG.INFO(
-                f"Successfully replaced {len(backup_items)} with {len(new_items)} "
-                f"{self.model_class.__name__} items"
-            )
-            return inserted_items
-        except Exception as e:
-            GLOG.ERROR(f"Failed to insert new {self.model_class.__name__} items, attempting restoration: {e}")
-
-            # Step 4: Restore from backup if insertion fails
+        with self._session_scope(session) as transaction_session:
+            # Step 1: Query existing items
+            backup_items = []
             try:
-                if backup_items:
-                    self.add_batch(backup_items, session=session)
-                    GLOG.INFO(f"Successfully restored {len(backup_items)} backed up {self.model_class.__name__} items")
-            except Exception as restore_error:
-                GLOG.CRITICAL(
-                    f"CRITICAL: Failed to restore {self.model_class.__name__} backup! "
-                    f"Original error: {e}, Restore error: {restore_error}"
-                )
-                raise Exception(f"Replace operation failed and restoration failed: {restore_error}")
+                existing_items = self.find(filters=filters, session=transaction_session)
+                backup_items = list(existing_items)
 
-            raise Exception(f"Replace operation failed: {e}")
+                if len(backup_items) == 0:
+                    GLOG.INFO(
+                        f"No existing {self.model_class.__name__} items found matching filters. "
+                        f"No replacement performed."
+                    )
+                    # Return empty result without performing any insertion
+                    return ModelList([], self)
+
+                GLOG.DEBUG(f"Found {len(backup_items)} existing {self.model_class.__name__} items to replace")
+
+            except Exception as e:
+                GLOG.ERROR(f"Failed to query existing {self.model_class.__name__} items: {e}")
+                raise
+
+            # Step 2: Delete existing items
+            try:
+                removed_count = self.remove(filters=filters, session=transaction_session)
+                GLOG.DEBUG(f"Deleted {removed_count} existing {self.model_class.__name__} items")
+            except Exception as e:
+                GLOG.ERROR(f"Failed to delete {self.model_class.__name__} items: {e}")
+                raise
+
+            # Step 3: Insert new items
+            try:
+                inserted_items = self.add_batch(new_items, session=transaction_session)
+                GLOG.INFO(
+                    f"Successfully replaced {len(backup_items)} with {len(new_items)} "
+                    f"{self.model_class.__name__} items"
+                )
+                return inserted_items
+            except Exception as e:
+                GLOG.ERROR(f"Failed to insert new {self.model_class.__name__} items, attempting restoration: {e}")
+
+                # Step 4: Restore from backup if insertion fails
+                try:
+                    if backup_items:
+                        self.add_batch(backup_items, session=transaction_session)
+                        GLOG.INFO(f"Successfully restored {len(backup_items)} backed up {self.model_class.__name__} items")
+                except Exception as restore_error:
+                    GLOG.CRITICAL(
+                        f"CRITICAL: Failed to restore {self.model_class.__name__} backup! "
+                        f"Original error: {e}, Restore error: {restore_error}"
+                    )
+                    raise Exception(f"Replace operation failed and restoration failed: {restore_error}")
+
+                raise Exception(f"Replace operation failed: {e}")
 
     def count(self, filters: Optional[Dict[str, Any]] = None, session: Optional[Session] = None) -> int:
         """
@@ -613,12 +632,8 @@ class _CoreCRUD(Generic[T], ABC):
         # 🎯 Validate enum fields before adding to database
         validated_item = self._validate_item_enum_fields(item)
 
-        if session:
-            result = add(validated_item, session=session)
-        else:
-            conn = self._get_connection()
-            with conn.get_session() as s:
-                result = add(validated_item, session=s)
+        with self._session_scope(session) as s:
+            result = add(validated_item, session=s)
         GLOG.DEBUG(f"Added {self.model_class.__name__} item successfully")
         return result
 
@@ -628,12 +643,8 @@ class _CoreCRUD(Generic[T], ABC):
         """
         converted_items = self._convert_input_batch(items)
 
-        if session:
-            result = add_all(converted_items, session=session)
-        else:
-            conn = self._get_connection()
-            with conn.get_session() as s:
-                result = add_all(converted_items, session=s)
+        with self._session_scope(session) as s:
+            result = add_all(converted_items, session=s)
 
         GLOG.DEBUG(f"Added {len(converted_items)} {self.model_class.__name__} items in batch")
         return result
@@ -651,13 +662,7 @@ class _CoreCRUD(Generic[T], ABC):
         """
         Hook method: Override to customize find logic.
         """
-        if session is None:
-            conn = self._get_connection()
-            session_context = conn.get_session()
-        else:
-            session_context = session
-
-        with session_context as s:
+        with self._session_scope(session) as s:
             # Handle DISTINCT query for specific field
             if distinct_field and hasattr(self.model_class, distinct_field):
                 from sqlalchemy import distinct
@@ -736,13 +741,7 @@ class _CoreCRUD(Generic[T], ABC):
         """
         Hook method: Override to customize remove logic.
         """
-        if session is None:
-            conn = self._get_connection()
-            session_context = conn.get_session()
-        else:
-            session_context = session
-
-        with session_context as s:
+        with self._session_scope(session) as s:
             if self._is_clickhouse:
                 # ClickHouse requires native SQL for DELETE operations
                 from ginkgo.enums import EnumBase  # Import for enum conversion
@@ -802,7 +801,6 @@ class _CoreCRUD(Generic[T], ABC):
                 else:
                     GLOG.DEBUG(f"No filter conditions provided for MySQL delete operation")
                     return 0
-            s.commit()
 
     def _do_modify(self, filters: Dict[str, Any], updates: Dict[str, Any], session: Optional[Session] = None) -> int:
         """
@@ -811,13 +809,7 @@ class _CoreCRUD(Generic[T], ABC):
         Returns:
             int: Number of records updated
         """
-        if session is None:
-            conn = self._get_connection()
-            session_context = conn.get_session()
-        else:
-            session_context = session
-
-        with session_context as s:
+        with self._session_scope(session) as s:
             # Build filter conditions
             filter_conditions = []
             for field, value in filters.items():
@@ -844,13 +836,7 @@ class _CoreCRUD(Generic[T], ABC):
         """
         Hook method: Override to customize count logic.
         """
-        if session is None:
-            conn = self._get_connection()
-            session_context = conn.get_session()
-        else:
-            session_context = session
-
-        with session_context as s:
+        with self._session_scope(session) as s:
             query = s.query(self.model_class)
 
             if filters:
@@ -866,13 +852,7 @@ class _CoreCRUD(Generic[T], ABC):
         """
         Hook method: Override to customize exists logic.
         """
-        if session is None:
-            conn = self._get_connection()
-            session_context = conn.get_session()
-        else:
-            session_context = session
-
-        with session_context as s:
+        with self._session_scope(session) as s:
             query = s.query(self.model_class)
 
             if filters:

--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Union, Any, Dict
 import pandas as pd
 from datetime import datetime
 from sqlalchemy import update, or_, and_
+from sqlalchemy.orm import Session
 import re
 
 from ginkgo.data.crud.base_crud import BaseCRUD
@@ -112,7 +113,13 @@ class UserCRUD(BaseCRUD[MUser]):
 
     # ==================== 级联软删除实现 ====================
 
-    def delete(self, filters: Optional[Dict[str, Any]] = None, *args, **kwargs) -> int:
+    def delete(
+        self,
+        filters: Optional[Dict[str, Any]] = None,
+        session: Optional[Session] = None,
+        *args,
+        **kwargs,
+    ) -> int:
         """
         软删除用户，并级联软删除相关记录
 
@@ -133,46 +140,39 @@ class UserCRUD(BaseCRUD[MUser]):
         if filters is None:
             raise ValueError("filters参数必须提供")
 
-        # #3955 查询要删除的用户
-        users = self.find(filters=filters)
-        user_uuids = [u.uuid for u in users]
+        with self._session_scope(session) as transaction_session:
+            # #3955 查询要删除的用户
+            users = self.find(filters=filters, session=transaction_session)
+            user_uuids = [u.uuid for u in users]
 
-        if not user_uuids:
-            GLOG.WARN(f"未找到匹配的用户: filters={filters}")
-            return 0
+            if not user_uuids:
+                GLOG.WARN(f"未找到匹配的用户: filters={filters}")
+                return 0
 
-        GLOG.INFO(f"开始软删除用户及其相关记录: {len(user_uuids)} 个用户")
+            GLOG.INFO(f"开始软删除用户及其相关记录: {len(user_uuids)} 个用户")
 
-        # 2. 先级联软删除用户组映射（避免外键约束）
-        self._cascade_delete_group_mappings(user_uuids)
+            # 2. 先级联软删除用户组映射（避免外键约束）
+            self._cascade_delete_group_mappings(user_uuids, session=transaction_session)
 
-        # 3. 级联软删除联系方式
-        self._cascade_delete_contacts(user_uuids)
+            # 3. 级联软删除联系方式
+            self._cascade_delete_contacts(user_uuids, session=transaction_session)
 
-        # 4. 级联软删除凭据
-        self._cascade_delete_credentials(user_uuids)
+            # 4. 级联软删除凭据
+            self._cascade_delete_credentials(user_uuids, session=transaction_session)
 
-        # 5. 最后软删除用户本身（直接执行 UPDATE）
-        import datetime
-        from sqlalchemy import update
-
-        conn = self._get_connection()
-        with conn.get_session() as session:
-            # 构建过滤条件
+            # 5. 最后软删除用户本身（直接执行 UPDATE）
             filter_conditions = []
             for field, value in filters.items():
                 if hasattr(MUser, field):
                     filter_conditions.append(getattr(MUser, field) == value)
 
-            # 执行软删除
             if filter_conditions:
                 stmt = (
                     update(MUser.__table__)
                     .where(and_(*filter_conditions))
-                    .values(is_del=True, update_at=datetime.datetime.now())
+                    .values(is_del=True, update_at=datetime.now())
                 )
-                result = session.execute(stmt)
-                session.commit()
+                result = transaction_session.execute(stmt)
                 count = result.rowcount
             else:
                 count = 0
@@ -180,7 +180,7 @@ class UserCRUD(BaseCRUD[MUser]):
         GLOG.INFO(f"已软删除用户: {count} 个")
         return count
 
-    def _cascade_delete_contacts(self, user_uuids: List[str]) -> int:
+    def _cascade_delete_contacts(self, user_uuids: List[str], session: Optional[Session] = None) -> int:
         """
         级联软删除用户联系方式
 
@@ -191,10 +191,7 @@ class UserCRUD(BaseCRUD[MUser]):
             删除的联系方式数量
         """
         try:
-            # 使用 CRUD 自己的连接
-            conn = self._get_connection()
-
-            with conn.get_session() as session:
+            with self._session_scope(session) as transaction_session:
                 # 批量更新联系方式
                 from sqlalchemy import update
                 stmt = (
@@ -204,8 +201,7 @@ class UserCRUD(BaseCRUD[MUser]):
                     .values(is_del=True, update_at=datetime.now())
                 )
 
-                result = session.execute(stmt)
-                session.commit()
+                result = transaction_session.execute(stmt)
 
                 contact_count = result.rowcount
                 GLOG.INFO(f"已级联软删除联系方式: {contact_count} 条")
@@ -215,7 +211,7 @@ class UserCRUD(BaseCRUD[MUser]):
             GLOG.ERROR(f"级联删除联系方式失败: {e}")
             return 0
 
-    def _cascade_delete_credentials(self, user_uuids: List[str]) -> int:
+    def _cascade_delete_credentials(self, user_uuids: List[str], session: Optional[Session] = None) -> int:
         """
         级联软删除用户凭据 — #3896
 
@@ -226,9 +222,7 @@ class UserCRUD(BaseCRUD[MUser]):
             删除的凭据数量
         """
         try:
-            conn = self._get_connection()
-
-            with conn.get_session() as session:
+            with self._session_scope(session) as transaction_session:
                 stmt = (
                     update(MUserCredential.__table__)
                     .where(MUserCredential.user_id.in_(user_uuids))
@@ -236,8 +230,7 @@ class UserCRUD(BaseCRUD[MUser]):
                     .values(is_del=True, update_at=datetime.now())
                 )
 
-                result = session.execute(stmt)
-                session.commit()
+                result = transaction_session.execute(stmt)
 
                 cred_count = result.rowcount
                 GLOG.INFO(f"已级联软删除凭据: {cred_count} 条")
@@ -247,7 +240,7 @@ class UserCRUD(BaseCRUD[MUser]):
             GLOG.ERROR(f"级联删除凭据失败: {e}")
             return 0
 
-    def _cascade_delete_group_mappings(self, user_uuids: List[str]) -> int:
+    def _cascade_delete_group_mappings(self, user_uuids: List[str], session: Optional[Session] = None) -> int:
         """
         级联删除用户组映射（硬删除）
 
@@ -258,10 +251,7 @@ class UserCRUD(BaseCRUD[MUser]):
             删除的映射数量
         """
         try:
-            # 使用 CRUD 自己的连接
-            conn = self._get_connection()
-
-            with conn.get_session() as session:
+            with self._session_scope(session) as transaction_session:
                 # 硬删除用户组映射
                 from sqlalchemy import delete
                 stmt = (
@@ -269,8 +259,7 @@ class UserCRUD(BaseCRUD[MUser]):
                     .where(MUserGroupMapping.user_uuid.in_(user_uuids))
                 )
 
-                result = session.execute(stmt)
-                session.commit()
+                result = transaction_session.execute(stmt)
 
                 mapping_count = result.rowcount
                 GLOG.INFO(f"已级联删除用户组映射: {mapping_count} 条")

--- a/src/ginkgo/data/crud/user_crud.py
+++ b/src/ginkgo/data/crud/user_crud.py
@@ -209,7 +209,7 @@ class UserCRUD(BaseCRUD[MUser]):
 
         except Exception as e:
             GLOG.ERROR(f"级联删除联系方式失败: {e}")
-            return 0
+            raise
 
     def _cascade_delete_credentials(self, user_uuids: List[str], session: Optional[Session] = None) -> int:
         """
@@ -238,7 +238,7 @@ class UserCRUD(BaseCRUD[MUser]):
 
         except Exception as e:
             GLOG.ERROR(f"级联删除凭据失败: {e}")
-            return 0
+            raise
 
     def _cascade_delete_group_mappings(self, user_uuids: List[str], session: Optional[Session] = None) -> int:
         """
@@ -267,7 +267,7 @@ class UserCRUD(BaseCRUD[MUser]):
 
         except Exception as e:
             GLOG.ERROR(f"级联删除用户组映射失败: {e}")
-            return 0
+            raise
 
     # ==================== 业务辅助方法 ====================
 

--- a/src/ginkgo/data/drivers/__init__.py
+++ b/src/ginkgo/data/drivers/__init__.py
@@ -398,6 +398,14 @@ def add(value, *args, **kwargs) -> any:
         return
 
     GLOG.DEBUG("Try add data to session.")
+    session = kwargs.get("session")
+    if session is not None:
+        session.add(value)
+        session.flush()  # 获取数据库生成的ID等信息
+        session.refresh(value)  # 确保所有属性都被加载
+        session.expunge(value)  # 将对象从session中分离，但保留属性
+        return value
+
     conn = get_db_connection(value)
 
     # 使用上下文管理器改进会话管理
@@ -424,9 +432,12 @@ def add_all(values: List[Any], *args, **kwargs) -> None:
     Returns:
         None
     """
+    from contextlib import nullcontext
+
     GLOG.DEBUG(f"Try add {len(values)} multi data to session.")
 
     from ginkgo.data.models import MClickBase, MMysqlBase
+    session = kwargs.get("session")
     click_list = []
     click_count = 0
     mysql_list = []
@@ -439,12 +450,19 @@ def add_all(values: List[Any], *args, **kwargs) -> None:
         else:
             GLOG.DEBUG(f"Just support clickhouse and mysql now. Ignore other type: {type(i)}")
 
+    if session is not None and len(click_list) > 0 and len(mysql_list) > 0:
+        raise ValueError("External session mode does not support mixed ClickHouse/MySQL batches")
+
     if len(click_list) > 0:
         try:
-            click_conn = get_click_connection()
+            if session is None:
+                click_conn = get_click_connection()
+                session_context = click_conn.get_session()
+            else:
+                session_context = nullcontext(session)
 
             # 使用上下文管理器改进会话管理
-            with click_conn.get_session() as session:
+            with session_context as session_obj:
                 # 使用bulk_insert_mappings提高ClickHouse插入性能
                 if click_list:
                     # 按模型类型分组进行批量插入
@@ -467,7 +485,7 @@ def add_all(values: List[Any], *args, **kwargs) -> None:
                                 mappings.append(mapping)
 
                             # 执行批量插入
-                            session.bulk_insert_mappings(model_type, mappings)
+                            session_obj.bulk_insert_mappings(model_type, mappings)
                             GLOG.DEBUG(f"ClickHouse bulk inserted {len(mappings)} {model_type.__name__} records")
 
                         except Exception as bulk_error:
@@ -475,7 +493,7 @@ def add_all(values: List[Any], *args, **kwargs) -> None:
                                 f"ClickHouse bulk insert failed for {model_type.__name__}, falling back to add_all: {bulk_error}"
                             )
                             # 回退到add_all方法
-                            session.add_all(items)
+                            session_obj.add_all(items)
 
                 click_count = len(click_list)
                 GLOG.DEBUG(f"Clickhouse committed {len(click_list)} records total.")
@@ -486,19 +504,23 @@ def add_all(values: List[Any], *args, **kwargs) -> None:
 
     if len(mysql_list) > 0:
         try:
-            mysql_conn = get_mysql_connection()
+            if session is None:
+                mysql_conn = get_mysql_connection()
+                session_context = mysql_conn.get_session()
+            else:
+                session_context = nullcontext(session)
 
             # 使用上下文管理器改进会话管理，支持对象解绑
-            with mysql_conn.get_session() as session:
-                session.add_all(mysql_list)
+            with session_context as session_obj:
+                session_obj.add_all(mysql_list)
                 mysql_count = len(mysql_list)
                 # 上下文管理器会在退出时自动commit
                 GLOG.DEBUG(f"MySQL will commit {len(mysql_list)} records.")
 
                 # 在session关闭前进行批量解绑，创建干净的脱管对象
                 # 常见做法：flush确保状态完整，expunge_all批量脱管
-                session.flush()          # 确保最新状态写入数据库
-                session.expunge_all()    # 批量脱管所有ORM实例
+                session_obj.flush()          # 确保最新状态写入数据库
+                session_obj.expunge_all()    # 批量脱管所有ORM实例
 
         except Exception as e:
             GLOG.ERROR(f"MySQL batch operation failed: {e}")

--- a/src/ginkgo/data/seeding.py
+++ b/src/ginkgo/data/seeding.py
@@ -268,7 +268,6 @@ class DataSeeder:
                 stmt = text("DELETE FROM engine WHERE name = :name")
                 result = session.execute(stmt, {"name": engine_name})
                 deleted_count = result.rowcount
-                session.commit()
 
                 if deleted_count > 0:
                     GLOG.WARN(f"直接SQL删除 {deleted_count} 个现有引擎: {engine_name}")
@@ -376,7 +375,6 @@ class DataSeeder:
                             "type": file_type.value
                         })
                         deleted_count = result.rowcount
-                        session.commit()
 
                         if deleted_count > 0:
                             GLOG.WARN(f"直接SQL删除 {deleted_count} 个现有文件: {preset_name} (包括所有前缀版本)")
@@ -447,7 +445,6 @@ class DataSeeder:
                 stmt = text("DELETE FROM portfolio WHERE name = :name")
                 result = session.execute(stmt, {"name": portfolio_name})
                 deleted_count = result.rowcount
-                session.commit()
 
                 if deleted_count > 0:
                     GLOG.WARN(f"删除 {deleted_count} 个现有投资组合: {portfolio_name}")

--- a/src/ginkgo/data/services/mapping_service.py
+++ b/src/ginkgo/data/services/mapping_service.py
@@ -126,7 +126,6 @@ class MappingService(BaseService):
                     cleaned_count += count
                     cleaning_details.append(f"清理孤立Engine-Handler映射(Handler): {count} 个")
 
-                session.commit()
 
             if cleaned_count > 0:
                 GLOG.INFO(f"清理了 {cleaned_count} 个孤立映射关系")
@@ -182,7 +181,6 @@ class MappingService(BaseService):
                 result = session.execute(stmt, {"pattern": name_pattern})
                 engine_handler_deleted = result.rowcount
 
-                session.commit()
 
                 total_deleted = portfolio_file_deleted + engine_portfolio_deleted + engine_handler_deleted
 
@@ -235,7 +233,6 @@ class MappingService(BaseService):
                     cleaned_count += count
                     cleaning_details.append(f"清理孤立Handler映射: {count} 个")
 
-                session.commit()
 
             if cleaned_count > 0:
                 GLOG.INFO(f"清理了 {cleaned_count} 个孤立Engine-Handler映射关系")
@@ -276,7 +273,6 @@ class MappingService(BaseService):
                 result = session.execute(stmt, {"pattern": name_pattern})
                 deleted_count = result.rowcount
 
-                session.commit()
 
             GLOG.INFO(f"根据名称模式 '{name_pattern}' 清理了 {deleted_count} 个Engine-Handler映射关系")
 

--- a/src/ginkgo/data/transaction.py
+++ b/src/ginkgo/data/transaction.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import contextvars
+from contextlib import contextmanager
+from typing import Callable, ContextManager, Dict, Iterator, Optional
+
+from sqlalchemy.orm import Session
+
+
+_session_registry_ctx: contextvars.ContextVar[Dict[str, Session]] = contextvars.ContextVar(
+    "data_transaction_sessions",
+    default={},
+)
+
+
+def get_transaction_session(key: str) -> Optional[Session]:
+    """Return the active transaction session for the given key, if any."""
+    return _session_registry_ctx.get().get(key)
+
+
+@contextmanager
+def transaction_scope(key: str, session_factory: Callable[[], ContextManager[Session]]) -> Iterator[Session]:
+    """
+    Provide a single transaction entry point per storage key.
+
+    Nested calls with the same key reuse the active session; the outermost
+    scope remains responsible for automatic commit / rollback via the driver's
+    context-managed session factory.
+    """
+    current = get_transaction_session(key)
+    if current is not None:
+        yield current
+        return
+
+    with session_factory() as session:
+        registry = dict(_session_registry_ctx.get())
+        registry[key] = session
+        token = _session_registry_ctx.set(registry)
+        try:
+            yield session
+        finally:
+            _session_registry_ctx.reset(token)

--- a/tests/unit/client/test_core_cli.py
+++ b/tests/unit/client/test_core_cli.py
@@ -518,3 +518,35 @@ class TestListComponentsEngines:
 
         mock_display.assert_not_called()
 
+
+
+class TestInitAdminUserTransactions:
+    @pytest.mark.unit
+    def test_init_admin_user_does_not_commit_inside_managed_session(self):
+        from ginkgo.client.core_cli import _init_admin_user
+
+        session = MagicMock()
+        select_result = MagicMock()
+        select_result.fetchone.return_value = None
+        session.execute.side_effect = [select_result, MagicMock(), MagicMock()]
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_session_manager():
+            yield session
+
+        user_crud = MagicMock()
+        user_crud.get_session.side_effect = fake_session_manager
+        mock_container = MagicMock()
+        mock_container.user_crud.return_value = user_crud
+        mock_container.user_credential_crud.return_value = MagicMock()
+
+        with patch("ginkgo.data.containers.container", mock_container), \
+             patch("bcrypt.gensalt", return_value=b"salt"), \
+             patch("bcrypt.hashpw", return_value=b"hashed"):
+            result = _init_admin_user()
+
+        assert result["status"] == "created"
+        assert session.execute.call_count == 3
+        session.commit.assert_not_called()

--- a/tests/unit/data/crud/test_base_crud_transactions.py
+++ b/tests/unit/data/crud/test_base_crud_transactions.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.data.crud import BarCRUD
+
+
+@pytest.mark.unit
+class TestBaseCRUDTransactionBehavior:
+    def test_remove_with_provided_session_does_not_commit_or_close(self):
+        crud = BarCRUD()
+        session = MagicMock()
+        session.execute.return_value.rowcount = 1
+
+        crud.remove(filters={"code": "000001.SZ"}, session=session)
+
+        session.execute.assert_called_once()
+        session.commit.assert_not_called()
+        session.close.assert_not_called()
+
+
+    def test_replace_reuses_single_transaction_session_for_all_steps(self):
+        crud = BarCRUD()
+        transaction_session = object()
+        existing = [MagicMock()]
+        inserted = [MagicMock()]
+        seen_sessions = []
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_scope(session=None):
+            assert session is None
+            yield transaction_session
+
+        def fake_find(*args, **kwargs):
+            seen_sessions.append(("find", kwargs.get("session")))
+            return existing
+
+        def fake_remove(*args, **kwargs):
+            seen_sessions.append(("remove", kwargs.get("session")))
+            return len(existing)
+
+        def fake_add_batch(*args, **kwargs):
+            seen_sessions.append(("add_batch", kwargs.get("session")))
+            return inserted
+
+        crud._session_scope = fake_scope
+        crud.find = fake_find
+        crud.remove = fake_remove
+        crud.add_batch = fake_add_batch
+
+        result = crud.replace(filters={"code": "000001.SZ"}, new_items=[MagicMock(spec=crud.model_class)])
+
+        assert result is inserted
+        assert seen_sessions == [
+            ("find", transaction_session),
+            ("remove", transaction_session),
+            ("add_batch", transaction_session),
+        ]

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -233,3 +233,69 @@ class TestUserCRUDConstruction:
         assert crud_instance.model_class is MUser
         assert crud_instance._is_mysql is True
         assert crud_instance._is_clickhouse is False
+
+
+class TestUserCRUDTransactions:
+    """事务边界回归测试"""
+
+    @pytest.mark.unit
+    def test_delete_reuses_single_transaction_session_for_all_cascade_steps(self, crud_instance):
+        transaction_session = MagicMock()
+        transaction_session.execute.return_value.rowcount = 1
+        seen_sessions = []
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_scope(session=None):
+            assert session is None
+            yield transaction_session
+
+        mock_user = MagicMock()
+        mock_user.uuid = "user-1"
+
+        def fake_find(*args, **kwargs):
+            seen_sessions.append(("find", kwargs.get("session")))
+            return [mock_user]
+
+        def fake_group(*args, **kwargs):
+            seen_sessions.append(("group", kwargs.get("session")))
+            return 1
+
+        def fake_contacts(*args, **kwargs):
+            seen_sessions.append(("contacts", kwargs.get("session")))
+            return 1
+
+        def fake_credentials(*args, **kwargs):
+            seen_sessions.append(("credentials", kwargs.get("session")))
+            return 1
+
+        crud_instance._session_scope = fake_scope
+        crud_instance.find = fake_find
+        crud_instance._cascade_delete_group_mappings = fake_group
+        crud_instance._cascade_delete_contacts = fake_contacts
+        crud_instance._cascade_delete_credentials = fake_credentials
+
+        result = crud_instance.delete(filters={"uuid": "user-1"})
+
+        assert result == 1
+        assert seen_sessions == [
+            ("find", transaction_session),
+            ("group", transaction_session),
+            ("contacts", transaction_session),
+            ("credentials", transaction_session),
+        ]
+        transaction_session.commit.assert_not_called()
+        transaction_session.close.assert_not_called()
+
+    @pytest.mark.unit
+    def test_cascade_delete_credentials_with_external_session_does_not_commit(self, crud_instance):
+        session = MagicMock()
+        session.execute.return_value.rowcount = 2
+
+        result = crud_instance._cascade_delete_credentials(["user-1"], session=session)
+
+        assert result == 2
+        session.execute.assert_called_once()
+        session.commit.assert_not_called()
+        session.close.assert_not_called()

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -219,7 +219,9 @@ class TestUserCRUDCascadeCredentials:
 
         crud_instance.delete(filters={"uuid": "test-uuid-123"})
 
-        crud_instance._cascade_delete_credentials.assert_called_once_with(["test-uuid-123"])
+        crud_instance._cascade_delete_credentials.assert_called_once_with(
+            ["test-uuid-123"], session=mock_session
+        )
 
 
 class TestUserCRUDConstruction:

--- a/tests/unit/data/crud/test_user_crud_mock.py
+++ b/tests/unit/data/crud/test_user_crud_mock.py
@@ -301,3 +301,37 @@ class TestUserCRUDTransactions:
         session.execute.assert_called_once()
         session.commit.assert_not_called()
         session.close.assert_not_called()
+
+    @pytest.mark.unit
+    def test_delete_propagates_cascade_db_error_instead_of_swallowing(self, crud_instance):
+        """#6593: 级联 execute() 抛真实 DB 异常时,delete() 必须冒泡真因,而非 except:return 0 静默吞掉。
+
+        回归锚点:共享 session 下,若级联 except 吞异常,session 进入 PendingRollbackState,
+        后续级联与末尾 UPDATE 会在 poisoned session 上继续跑,真因被 PendingRollbackError 掩盖。
+        改 raise 后,第一处级联失败即冒泡真实异常,后续 cascade/UPDATE 的 execute 不应再执行。
+        """
+        from contextlib import contextmanager
+
+        from sqlalchemy.exc import OperationalError
+
+        transaction_session = MagicMock()
+        # 第 1 次 execute(级联 group_mappings)抛真实 DB 异常;后续 execute 即使成功也不应被触达
+        ok_result = MagicMock()
+        ok_result.rowcount = 1
+        db_error = OperationalError("DELETE FROM ...", {}, Exception("connection lost"))
+        transaction_session.execute.side_effect = [db_error, ok_result, ok_result, ok_result]
+
+        @contextmanager
+        def fake_scope(session=None):
+            yield transaction_session
+
+        mock_user = MagicMock()
+        mock_user.uuid = "user-1"
+        crud_instance._session_scope = fake_scope
+        crud_instance.find = MagicMock(return_value=[mock_user])
+
+        with pytest.raises(OperationalError):
+            crud_instance.delete(filters={"uuid": "user-1"})
+
+        # 修复后:第一处级联失败即冒泡,后续 cascade 与末尾 UPDATE 的 execute 不应执行
+        assert transaction_session.execute.call_count == 1

--- a/tests/unit/data/drivers/test_transaction_helpers.py
+++ b/tests/unit/data/drivers/test_transaction_helpers.py
@@ -1,0 +1,52 @@
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.drivers import add, add_all
+from ginkgo.data.models import MBar
+
+
+def _make_bar(code: str, day: int) -> MBar:
+    return MBar(
+        code=code,
+        timestamp=datetime(2023, 12, day, 9, 30),
+        open=Decimal("100.0"),
+        close=Decimal("101.0"),
+        high=Decimal("102.0"),
+        low=Decimal("99.0"),
+        volume=1000000,
+        amount=Decimal("101000000.0"),
+        frequency=1,
+    )
+
+
+@pytest.mark.unit
+class TestTransactionAwareDriverHelpers:
+    def test_add_reuses_provided_session(self):
+        session = MagicMock()
+        bar = _make_bar("ADD.SZ", 1)
+
+        with patch("ginkgo.data.drivers.get_db_connection", side_effect=AssertionError("should not open a new session")):
+            result = add(bar, session=session)
+
+        assert result is bar
+        session.add.assert_called_once_with(bar)
+        session.flush.assert_called_once()
+        session.refresh.assert_called_once_with(bar)
+        session.expunge.assert_called_once_with(bar)
+
+    def test_add_all_reuses_provided_session_for_clickhouse_batch(self):
+        session = MagicMock()
+        bars = [_make_bar("BATCH.SZ", 1), _make_bar("BATCH.SZ", 2)]
+
+        with patch(
+            "ginkgo.data.drivers.get_click_connection",
+            side_effect=AssertionError("should not open a new ClickHouse session"),
+        ):
+            click_count, mysql_count = add_all(bars, session=session)
+
+        assert click_count == 2
+        assert mysql_count == 0
+        session.bulk_insert_mappings.assert_called_once()

--- a/tests/unit/data/services/test_mapping_service_transactions.py
+++ b/tests/unit/data/services/test_mapping_service_transactions.py
@@ -1,0 +1,62 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.mapping_service import MappingService
+
+
+def _session_manager(session):
+    @contextmanager
+    def _manager():
+        yield session
+
+    return _manager()
+
+
+def _make_service(session):
+    with patch("ginkgo.libs.GLOG"):
+        engine_portfolio = MagicMock()
+        engine_portfolio.get_session.side_effect = lambda: _session_manager(session)
+        handler = MagicMock()
+        handler.get_session.side_effect = lambda: _session_manager(session)
+        return MappingService(engine_portfolio, MagicMock(), handler, MagicMock())
+
+
+@pytest.mark.unit
+def test_cleanup_by_names_does_not_commit_inside_managed_session():
+    session = MagicMock()
+    session.execute.side_effect = [MagicMock(rowcount=1), MagicMock(rowcount=2), MagicMock(rowcount=3)]
+    service = _make_service(session)
+
+    result = service.cleanup_by_names()
+
+    assert result.success
+    assert session.execute.call_count == 3
+    session.commit.assert_not_called()
+
+
+@pytest.mark.unit
+def test_cleanup_orphaned_handler_mappings_does_not_commit_inside_managed_session():
+    session = MagicMock()
+    session.execute.side_effect = [MagicMock(rowcount=1), MagicMock(rowcount=2)]
+    service = _make_service(session)
+
+    result = service.cleanup_orphaned_handler_mappings()
+
+    assert result.success
+    assert session.execute.call_count == 2
+    session.commit.assert_not_called()
+
+
+@pytest.mark.unit
+def test_cleanup_handler_mappings_by_names_does_not_commit_inside_managed_session():
+    session = MagicMock()
+    session.execute.return_value = MagicMock(rowcount=4)
+    service = _make_service(session)
+
+    result = service.cleanup_handler_mappings_by_names()
+
+    assert result.success
+    session.execute.assert_called_once()
+    session.commit.assert_not_called()

--- a/tests/unit/data/test_seeding_transactions.py
+++ b/tests/unit/data/test_seeding_transactions.py
@@ -1,0 +1,70 @@
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+from ginkgo.data.seeding import DataSeeder
+
+
+def _session_manager(session):
+    @contextmanager
+    def _manager():
+        yield session
+
+    return _manager()
+
+
+@pytest.mark.unit
+def test_create_example_engine_does_not_commit_inside_managed_session():
+    seeder = DataSeeder()
+    session = MagicMock()
+    session.execute.return_value = MagicMock(rowcount=1)
+    engine_crud = MagicMock()
+    engine_crud.get_session.side_effect = lambda: _session_manager(session)
+    engine_service = MagicMock()
+    engine_service.add.return_value = SimpleNamespace(success=False, error="boom")
+
+    with patch("ginkgo.data.crud.engine_crud.EngineCRUD", return_value=engine_crud), \
+         patch("ginkgo.data.seeding.container.engine_service", return_value=engine_service):
+        seeder._create_example_engine()
+
+    session.commit.assert_not_called()
+
+
+@pytest.mark.unit
+def test_create_example_files_does_not_commit_inside_managed_session():
+    seeder = DataSeeder()
+    session = MagicMock()
+    session.execute.return_value = MagicMock(rowcount=1)
+    file_crud = MagicMock()
+    file_crud.get_session.side_effect = lambda: _session_manager(session)
+    file_service = MagicMock()
+    file_service.add.return_value = SimpleNamespace(success=True, data={"file_info": {"uuid": "f-1"}})
+
+    with patch("ginkgo.data.crud.file_crud.FileCRUD", return_value=file_crud), \
+         patch("ginkgo.data.seeding.container.file_service", return_value=file_service), \
+         patch("ginkgo.data.seeding.GCONF.WORKING_PATH", "/tmp/work"), \
+         patch("ginkgo.data.seeding.os.path.isdir", return_value=True), \
+         patch("ginkgo.data.seeding.os.listdir", return_value=["alpha.py"]), \
+         patch("builtins.open", mock_open(read_data=b"print('x')")):
+        count = seeder._create_example_files()
+
+    assert count == 5
+    session.commit.assert_not_called()
+
+
+@pytest.mark.unit
+def test_create_single_portfolio_does_not_commit_inside_managed_session():
+    seeder = DataSeeder()
+    session = MagicMock()
+    session.execute.return_value = MagicMock(rowcount=1)
+    portfolio_crud = MagicMock()
+    portfolio_crud.get_session.side_effect = lambda: _session_manager(session)
+    portfolio_service = MagicMock()
+    portfolio_service.add.return_value = SimpleNamespace(success=False, error="boom")
+
+    with patch("ginkgo.data.crud.portfolio_crud.PortfolioCRUD", return_value=portfolio_crud):
+        seeder._create_single_portfolio(portfolio_service, "present_portfolio", is_live=False)
+
+    session.commit.assert_not_called()

--- a/tests/unit/data/test_seeding_transactions.py
+++ b/tests/unit/data/test_seeding_transactions.py
@@ -1,6 +1,6 @@
 from contextlib import contextmanager
 from types import SimpleNamespace
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
 
 import pytest
 
@@ -44,7 +44,7 @@ def test_create_example_files_does_not_commit_inside_managed_session():
 
     with patch("ginkgo.data.crud.file_crud.FileCRUD", return_value=file_crud), \
          patch("ginkgo.data.seeding.container.file_service", return_value=file_service), \
-         patch("ginkgo.data.seeding.GCONF.WORKING_PATH", "/tmp/work"), \
+         patch("ginkgo.libs.core.config.GinkgoConfig.WORKING_PATH", new_callable=PropertyMock, return_value="/tmp/work"), \
          patch("ginkgo.data.seeding.os.path.isdir", return_value=True), \
          patch("ginkgo.data.seeding.os.listdir", return_value=["alpha.py"]), \
          patch("builtins.open", mock_open(read_data=b"print('x')")):

--- a/tests/unit/data/test_transaction.py
+++ b/tests/unit/data/test_transaction.py
@@ -1,0 +1,36 @@
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.data.transaction import get_transaction_session, transaction_scope
+
+
+@pytest.mark.unit
+class TestTransactionScope:
+    def test_nested_scope_reuses_active_session(self):
+        session = MagicMock()
+        factory_calls = 0
+
+        @contextmanager
+        def factory():
+            nonlocal factory_calls
+            factory_calls += 1
+            yield session
+            session.commit()
+
+        @contextmanager
+        def fail_factory():
+            raise AssertionError("nested transaction should reuse active session")
+            yield
+
+        with transaction_scope("mysql", factory) as outer:
+            assert outer is session
+            assert get_transaction_session("mysql") is session
+
+            with transaction_scope("mysql", fail_factory) as inner:
+                assert inner is session
+
+        assert factory_calls == 1
+        session.commit.assert_called_once()
+        assert get_transaction_session("mysql") is None


### PR DESCRIPTION
## Summary
- introduce a shared transaction scope so nested CRUD operations reuse one ORM session per storage backend
- move BaseCRUD.replace() and UserCRUD.delete() onto a single transaction entrypoint and remove internal ORM commits from cleanup/helper paths
- add regression coverage for transaction reuse across CRUD, mapping cleanup, seeding, and admin-user initialization

## Testing
- python3 -m py_compile src/ginkgo/data/transaction.py src/ginkgo/data/drivers/__init__.py src/ginkgo/data/crud/base_crud.py src/ginkgo/data/crud/user_crud.py src/ginkgo/data/services/mapping_service.py src/ginkgo/data/seeding.py src/ginkgo/client/core_cli.py tests/unit/data/test_transaction.py tests/unit/data/drivers/test_transaction_helpers.py tests/unit/data/crud/test_base_crud_transactions.py tests/unit/data/crud/test_user_crud_mock.py tests/unit/data/services/test_mapping_service_transactions.py tests/unit/data/test_seeding_transactions.py tests/unit/client/test_core_cli.py
- Focused pytest execution is currently blocked in this environment because required local test dependencies/plugins are missing: pytest-cov, pytest-timeout, numpy

Closes #6589
