### PR TITLE
refactor: 实现 ServiceResult.code 字段 + 补完 format_result (#6591)

### DIFF
--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -292,22 +292,72 @@ def make_progress(*, format: str, isatty: bool) -> Optional["Progress"]:
 
 
 def format_result(result, *, format: str, command: str) -> None:
-    """统一 ServiceResult → 输出（ADR-021 第 5 维）。
+    """统一 ServiceResult → stdout JSON 输出 + exit code 映射（ADR-021 第 5/6/9 维）。
 
-    .. warning::
-        **Step 2，阻塞 #6576**。依赖 ``ServiceResult.code`` 字段（``Optional[str]``），
-        由 E1 (#6576) 落地决策，当前 master 未合并。本 helper 现为占位，
-        待 #6576 合并后实现：
+    三种输出结构：
 
-        - 成功 list：``{"success": true, "data": [...], "count": N, "metadata": {}}``
-        - 成功 get：``{"success": true, "data": {...}}``
-        - 失败：``{"success": false, "error": {"code": ..., "message": ...}, "data": null}``
-        - exit code 映射：``BAD_PARAMS``→2 / ``TIMEOUT``→124 / 其余→1
+    - 成功 list（``data`` 是 ``list``）：``{"success": true, "data": [...], "count": N, "metadata": {}}``
+    - 成功 get（``data`` 非 list）：``{"success": true, "data": {...}}``
+    - 失败：``{"success": false, "error": {"code": <result.code>, "message": <result.error>}, "data": null}``
 
-        按归因纪律（CLAUDE.md）：raise 而非 stub 兜底——宁可响亮报错，
-        也不静默返回错误结构误导调用方。
+    list vs get 区分：由 ``result.data`` 类型推断（``isinstance(data, list)`` → list 结构，
+    含 ``count``/``metadata``）；其余（dict / 标量 / None）走 get 结构。对应 ADR-021 第 9 维
+    「list/get 二分」。
+
+    exit code 映射（ADR-021 第 6 维，失败路径 ``raise typer.Exit(code)``）：
+
+    - 成功 → ``return``（exit 0，不显式 Exit；呼应 ADR「0 = 正常 return，不 Exit」）
+    - ``code == "BAD_PARAMS"`` → exit 2（参数错误）
+    - ``code == "TIMEOUT"`` → exit 124（超时，GNU timeout 惯例）
+    - 其余失败（含 ``code is None``）→ exit 1（业务失败）
+
+    向后兼容：用 ``getattr(result, "code", None)`` 读取 code，无 ``code`` 属性的旧
+    ``ServiceResult`` 实例（全仓 436 处）按 ``code=None`` 处理，成功路径不受影响。
+
+    ``format="text"`` 当前复用 JSON 输出（过渡）：rich 人读渲染（红框/table）留给
+    E4/E5 接入时连同 ``make_console`` 一起落地；本 helper 保证 text 路径不崩、
+    exit code 仍正确分流。
+
+    Args:
+        result: ``ServiceResult`` 实例（或 duck-typed 对象，需 ``success``/``error``/``data``）
+        format: ``"json"`` 或 ``"text"``（来自 ``--format`` flag）
+        command: 调用方命令名（如 ``"list"`` / ``"get"``），当前仅用于诊断/日志
     """
-    raise NotImplementedError(
-        "format_result 待 #6576 (E1 ServiceResult.code) 合并后实现："
-        f"当前 command={command!r} format={format!r} 暂不支持。"
-    )
+    success = bool(getattr(result, "success", False))
+    # getattr 兜底：旧 ServiceResult 实例（无 code 字段）按 None 处理
+    code = getattr(result, "code", None)
+
+    if success:
+        data = getattr(result, "data", None)
+        if isinstance(data, list):
+            # list 结构（ADR-021 第 9 维 list 类）：含 count + metadata
+            payload = {
+                "success": True,
+                "data": data,
+                "count": len(data),
+                "metadata": getattr(result, "metadata", None) or {},
+            }
+        else:
+            # get 结构（ADR-021 第 9 维 get 类）
+            payload = {"success": True, "data": data}
+        print(json.dumps(payload, cls=GinkgoJSONEncoder))
+        # ADR-021 第 6 维：成功 = 正常 return（不显式 Exit），typer 自然 exit 0
+        return
+
+    # 失败路径（ADR-021 第 5 维 fail 结构）
+    error_message = getattr(result, "error", None) or ""
+    payload = {
+        "success": False,
+        "error": {"code": code, "message": error_message},
+        "data": None,
+    }
+    print(json.dumps(payload, cls=GinkgoJSONEncoder))
+
+    # exit code 映射（ADR-021 第 6 维）
+    if code == "BAD_PARAMS":
+        exit_code = 2
+    elif code == "TIMEOUT":
+        exit_code = 124
+    else:
+        exit_code = 1
+    raise typer.Exit(code=exit_code)

--- a/src/ginkgo/data/services/base_service.py
+++ b/src/ginkgo/data/services/base_service.py
@@ -19,7 +19,7 @@ T = TypeVar("T")
 class ServiceResult(Generic[T]):
     """Standardized service operation result structure."""
 
-    def __init__(self, success: bool = False, error: str = "", data: Optional[T] = None, message: str = ""):
+    def __init__(self, success: bool = False, error: str = "", data: Optional[T] = None, message: str = "", code: Optional[str] = None):
         """
         Initialize service result with success status, error info, data and message
 
@@ -28,6 +28,9 @@ class ServiceResult(Generic[T]):
             error: Error message when operation fails
             data: Result data payload
             message: Optional status message
+            code: Optional structured error code (ADR-021 第 5 维, e.g.
+                  BAD_PARAMS/TIMEOUT/NOT_FOUND/INTERNAL); defaults to None for
+                  backward compatibility (436 legacy call sites unchanged).
         """
         self.success = success
         self.error = error
@@ -35,6 +38,7 @@ class ServiceResult(Generic[T]):
         self.warnings = []
         self.data = data  # 允许None值，不自动转换为{}
         self.metadata = {}
+        self.code = code  # ADR-021 第 5 维：结构化错误码，默认 None 向后兼容
 
     def add_warning(self, message: str):
         """
@@ -84,25 +88,31 @@ class ServiceResult(Generic[T]):
             result.update(self.data)
         if self.metadata:
             result["metadata"] = self.metadata
+        # ADR-021 第 5 维 (#6591): code 仅在非 None 时序列化，避免 436 处旧调用
+        # 的 to_dict 输出突然多字段（向后兼容）
+        if self.code is not None:
+            result["code"] = self.code
 
         return result
 
     @classmethod
-    def success(cls, data: Any = None, message: str = "") -> 'ServiceResult':
+    def success(cls, data: Any = None, message: str = "", code: Optional[str] = None) -> 'ServiceResult':
         """
         Create successful service result
 
         Args:
             data: Return data
             message: Success message
+            code: Optional structured error code (rarely needed on success path;
+                  defaults to None per ADR-021 第 5 维)
 
         Returns:
             ServiceResult: Successful result object
         """
-        return cls(success=True, error="", data=data, message=message)
+        return cls(success=True, error="", data=data, message=message, code=code)
 
     @classmethod
-    def error(cls, error: str = "", data: Any = None, message: str = "") -> 'ServiceResult':
+    def error(cls, error: str = "", data: Any = None, message: str = "", code: Optional[str] = None) -> 'ServiceResult':
         """
         Create failed service result
 
@@ -110,27 +120,31 @@ class ServiceResult(Generic[T]):
             error: Error message
             data: Optional error-related data
             message: Optional message (uses error if not provided)
+            code: Optional structured error code (ADR-021 第 5 维, e.g.
+                  BAD_PARAMS/TIMEOUT/NOT_FOUND/INTERNAL); stamped at failure source
 
         Returns:
             ServiceResult: Failed result object
         """
         if not message:
             message = error
-        return cls(success=False, error=error, message=message, data=data)
+        return cls(success=False, error=error, message=message, data=data, code=code)
 
     @classmethod
-    def failure(cls, message: str = "", data: Any = None) -> 'ServiceResult':
+    def failure(cls, message: str = "", data: Any = None, code: Optional[str] = None) -> 'ServiceResult':
         """
         Create failed service result (alias method)
 
         Args:
             message: Failure message
             data: Optional failure-related data
+            code: Optional structured error code (ADR-021 第 5 维); stamped at
+                  failure source so format_result can map exit code
 
         Returns:
             ServiceResult: Failed result object
         """
-        return cls(success=False, error=message, message=message, data=data)
+        return cls(success=False, error=message, message=message, data=data, code=code)
 
     def is_success(self) -> bool:
         """

--- a/tests/unit/client/test_cli_utils.py
+++ b/tests/unit/client/test_cli_utils.py
@@ -160,6 +160,8 @@ from datetime import date, datetime, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 
+import typer
+
 
 # ----------------------------------------------------------------------------
 # is_interactive (ADR-021 第 2 维: TTY 推断 + 显式覆盖)
@@ -390,16 +392,122 @@ class TestMakeProgress:
 
 
 # ----------------------------------------------------------------------------
-# format_result (Step 2, blocked by #6576 ServiceResult.code)
+# format_result (ADR-021 第 5/6/9 维, #6591 实现)
 # ----------------------------------------------------------------------------
+
+from ginkgo.data.services.base_service import ServiceResult
 
 
 @pytest.mark.unit
 @pytest.mark.cli
 class TestFormatResult:
-    def test_raises_not_implemented_anchored_to_6576(self):
-        # triage 契约: format_result 硬阻塞 #6576, 留 TODO 锚定
-        # 呼应 CLAUDE.md 归因纪律: raise 而非 stub 兜底
-        result = MagicMock()
-        with pytest.raises(NotImplementedError, match="6576"):
-            cli_utils.format_result(result, format="json", command="test")
+    """format_result 行为测试（ADR-021 第 5/6/9 维，#6591）。
+
+    三种输出结构（list/get/fail）+ exit code 映射（0/1/2/124）。
+    占位测试 test_raises_not_implemented_anchored_to_6576 已随 #6591 实现删除。
+    """
+
+    def test_success_list_json_structure(self, capsys):
+        """成功 list：data 是 list → {success:true, data:[...], count:N, metadata:{}}"""
+        result = ServiceResult.success(data=[{"id": 1}, {"id": 2}])
+        cli_utils.format_result(result, format="json", command="list")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+        assert out["data"] == [{"id": 1}, {"id": 2}]
+        assert out["count"] == 2
+        assert out["metadata"] == {}
+
+    def test_success_get_json_structure(self, capsys):
+        """成功 get：data 非 list → {success:true, data:{...}}（无 count/metadata）"""
+        result = ServiceResult.success(data={"uuid": "abc", "name": "foo"})
+        cli_utils.format_result(result, format="json", command="get")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+        assert out["data"] == {"uuid": "abc", "name": "foo"}
+        # get 结构不含 count / metadata
+        assert "count" not in out
+        assert "metadata" not in out
+
+    def test_success_empty_list_has_count_zero(self, capsys):
+        """空 list（ADR-021 第 9 维）：count=0，仍是成功 exit 0"""
+        result = ServiceResult.success(data=[])
+        cli_utils.format_result(result, format="json", command="list")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+        assert out["data"] == []
+        assert out["count"] == 0
+
+    def test_success_does_not_raise_exit(self, capsys):
+        """成功路径不 raise typer.Exit（ADR-021 第 6 维：0 = 正常 return）"""
+        result = ServiceResult.success(data={"x": 1})
+        # 不抛异常即成功路径 return
+        cli_utils.format_result(result, format="json", command="get")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+
+    def test_fail_json_structure_with_code(self, capsys):
+        """失败：{success:false, error:{code, message}, data:null}"""
+        result = ServiceResult.failure(message="参数错误", code="BAD_PARAMS")
+        with pytest.raises(typer.Exit) as exc_info:
+            cli_utils.format_result(result, format="json", command="create")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is False
+        assert out["error"] == {"code": "BAD_PARAMS", "message": "参数错误"}
+        assert out["data"] is None
+        assert exc_info.value.exit_code == 2
+
+    def test_exit_code_bad_params_is_2(self, capsys):
+        """exit code 映射：BAD_PARAMS → 2"""
+        result = ServiceResult.failure(message="bad", code="BAD_PARAMS")
+        with pytest.raises(typer.Exit) as exc_info:
+            cli_utils.format_result(result, format="json", command="x")
+        assert exc_info.value.exit_code == 2
+
+    def test_exit_code_timeout_is_124(self, capsys):
+        """exit code 映射：TIMEOUT → 124（GNU timeout 惯例）"""
+        result = ServiceResult.failure(message="超时", code="TIMEOUT")
+        with pytest.raises(typer.Exit) as exc_info:
+            cli_utils.format_result(result, format="json", command="x")
+        assert exc_info.value.exit_code == 124
+
+    def test_exit_code_other_non_none_code_is_1(self, capsys):
+        """exit code 映射：其他非 None code（如 NOT_FOUND）→ 1"""
+        result = ServiceResult.failure(message="未找到", code="NOT_FOUND")
+        with pytest.raises(typer.Exit) as exc_info:
+            cli_utils.format_result(result, format="json", command="get")
+        assert exc_info.value.exit_code == 1
+
+    def test_exit_code_none_code_failure_is_1(self, capsys):
+        """exit code 映射：code=None 的失败 → 1（默认业务失败）"""
+        result = ServiceResult.failure(message="未知错误")
+        with pytest.raises(typer.Exit) as exc_info:
+            cli_utils.format_result(result, format="json", command="x")
+        assert exc_info.value.exit_code == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["error"]["code"] is None
+
+    def test_backward_compat_legacy_result_without_code_attr(self, capsys):
+        """向后兼容：无 code 属性的旧 ServiceResult（duck-typed）调用不崩"""
+        # 旧实例：仅 success/error/data，无 code 属性（模拟 436 处历史调用）
+        legacy = SimpleNamespace(success=True, data={"k": "v"}, error="")
+        cli_utils.format_result(legacy, format="json", command="get")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+        assert out["data"] == {"k": "v"}
+
+    def test_backward_compat_legacy_failure_without_code_attr(self, capsys):
+        """向后兼容：无 code 属性的旧失败实例 → exit 1，error.code=null"""
+        legacy = SimpleNamespace(success=False, data=None, error="旧错误")
+        with pytest.raises(typer.Exit) as exc_info:
+            cli_utils.format_result(legacy, format="json", command="x")
+        assert exc_info.value.exit_code == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["error"] == {"code": None, "message": "旧错误"}
+
+    def test_text_format_does_not_raise_not_implemented(self, capsys):
+        """format='text' 当前复用 JSON 输出（rich 渲染留 E4/E5），不抛 NotImplementedError"""
+        result = ServiceResult.success(data=[{"id": 1}])
+        cli_utils.format_result(result, format="text", command="list")
+        out = json.loads(capsys.readouterr().out)
+        assert out["success"] is True
+        assert out["count"] == 1

--- a/tests/unit/data/services/test_base_service.py
+++ b/tests/unit/data/services/test_base_service.py
@@ -375,3 +375,54 @@ class TestBaseServiceStringRepresentation:
         assert "ConcreteService" in r
         assert "at 0x" in r
         assert hex(id(service)) in r
+
+
+# ============================================================================
+# ADR-021 第 5 维 (#6591): ServiceResult.code 字段
+# ============================================================================
+
+
+@pytest.mark.unit
+class TestServiceResultCodeField:
+    """ServiceResult.code 字段测试（ADR-021 第 5 维，#6591）。
+
+    code 承载结构化业务错误码（BAD_PARAMS/TIMEOUT/NOT_FOUND/INTERNAL 等），
+    默认 None 保证全仓 436 处旧调用零改动（向后兼容）。
+    """
+
+    def test_code_field_defaults_none(self):
+        """默认构造 code=None，向后兼容旧调用"""
+        result = ServiceResult(success=True, data={"k": "v"})
+        assert result.code is None
+
+    def test_code_field_constructed_with_value(self):
+        """code 可通过构造函数传入"""
+        result = ServiceResult(success=False, error="参数错误", code="BAD_PARAMS")
+        assert result.code == "BAD_PARAMS"
+
+    def test_failure_factory_propagates_code(self):
+        """failure() 工厂支持 code 参数（失败路径源头打 code）"""
+        result = ServiceResult.failure(message="未找到", code="NOT_FOUND")
+        assert result.success is False
+        assert result.code == "NOT_FOUND"
+
+    def test_error_factory_propagates_code(self):
+        """error() 工厂支持 code 参数"""
+        result = ServiceResult.error(error="超时", code="TIMEOUT")
+        assert result.success is False
+        assert result.code == "TIMEOUT"
+
+    def test_success_factory_code_defaults_none(self):
+        """success() 工厂 code 默认 None（成功路径不打 code）"""
+        result = ServiceResult.success(data={"k": "v"})
+        assert result.code is None
+
+    def test_to_dict_omits_code_when_none(self):
+        """to_dict() 在 code=None 时不含 code 字段（向后兼容旧序列化输出）"""
+        d = ServiceResult.success(data={"x": 1}).to_dict()
+        assert "code" not in d
+
+    def test_to_dict_includes_code_when_set(self):
+        """to_dict() 在 code 非 None 时包含 code 字段"""
+        d = ServiceResult.failure(message="参数错误", code="BAD_PARAMS").to_dict()
+        assert d.get("code") == "BAD_PARAMS"


### PR DESCRIPTION
## Summary

填补 CLI 输出层 Epic 的规划断层: E1 #6576 (PR #6582) 仅合并 ADR-021 决策文档 (docs-only, 0 行代码), E2 #6577 (PR #6583) 落了 `format_result` 占位 (`raise NotImplementedError`, docstring 自陈"阻塞 #6576")。`ServiceResult.code` 字段从未实现 → E4 #6579 / E5 #6580"接入 format_result"调用即崩。本 PR 实现字段 + 补完 helper, 解除 E4/E5 阻塞。

### 变更

**1. `ServiceResult` (`src/ginkgo/data/services/base_service.py`)**
- `__init__` 加 `code: Optional[str] = None` 参数 (向后兼容, 全仓 436 处旧调用零改动)
- `success()` / `error()` / `failure()` 工厂方法支持 `code` 参数
- `to_dict()` 在 `code` 非 None 时序列化 (默认 None 不输出, 保持旧 to_dict 输出形态)
- ⚠️ 安全阀澄清: `ServiceResult(Generic[T])` 是泛型**值对象** (非 ABC、无子类、无 metaclass), **不是** CLAUDE.md 禁令所指的 `BaseService(ABC)` (同文件 line 168 才是 Base 类)。加字段不违反 Base 类禁令。

**2. `format_result` (`src/ginkgo/client/cli_utils.py`)** — 按 ADR-021 第 5/6/9 维契约
- 成功 list (`data` 是 list): `{"success": true, "data": [...], "count": N, "metadata": {}}`
- 成功 get (`data` 非 list): `{"success": true, "data": {...}}`
- 失败: `{"success": false, "error": {"code": <result.code>, "message": <result.error>}, "data": null}`
- exit code 映射 (失败 `raise typer.Exit(code)`): `BAD_PARAMS`→2 / `TIMEOUT`→124 / 其他(含 code=None)→1 / 成功→return(exit 0)
- list vs get 区分: `isinstance(result.data, list)` 推断 (ADR-021 第 9 维 list/get 二分)
- `getattr(result, "code", None)` 向后兼容无 code 属性的旧实例
- 移除 docstring"阻塞 #6576"warning + `raise NotImplementedError`
- `format="text"` 暂复用 JSON 输出 (rich 人读渲染留给 E4/E5 接入时连同 `make_console` 一起落地; 本 helper 保证 text 路径不崩、exit code 仍正确分流)

**3. 测试**
- `test_base_service.py`: 新增 `TestServiceResultCodeField` (7 tests: 字段构造/默认/3 工厂/to_dict 含与不含)
- `test_cli_utils.py`: 删占位 `test_raises_not_implemented_anchored_to_6576`, 替为 12 个 `format_result` 行为测试 (成功 list/get/空 list + 失败结构 + 4 种 exit code 分支 + 2 向后兼容旧实例 + text 不崩)

## Acceptance criteria 核对

- [x] `ServiceResult` 类有 `code: Optional[str]` 字段, 默认 None, `__init__` 含参数
- [x] `success()/error()/failure()` 工厂支持传 code
- [x] `format_result` 实现成功 list/get/失败三种 JSON 输出结构, 不再 raise NotImplementedError
- [x] exit code 映射: BAD_PARAMS→2 / TIMEOUT→124 / 其他非 None code→1 / 成功→0
- [x] `code=None` 成功路径输出不含 error 字段 (失败路径 error.code=null)
- [x] 向后兼容: 无 code 的旧 ServiceResult 实例调 format_result 不崩
- [x] 删除 `test_raises_not_implemented_anchored_to_6576` 占位测试, 替为实现行为测试
- [x] `pytest tests/unit/client/test_cli_utils.py` + `test_base_service.py` 全绿 (50 + 38 passed)
- [x] E4 #6579 任务 1 调 `format_result` 不再抛 NotImplementedError

## Out of scope

- E4 #6579 的 data_cli 接入 (仍归 E4)
- E5 #6580 的 list 推广 (仍归 E5)
- 全仓 436 处旧 `ServiceResult` 调用迁移 (ADR-021 第 5.5 条明确"初版不动旧调用")
- format="text" rich 渲染 (留 E4/E5 接入时连同 make_console 落地)

## Test plan

```bash
# Layer 1 py_compile
/home/kaoru/.ginkgo/.venv/bin/python -m py_compile src/**/*.py api/**/*.py

# Layer 2 启动路径 smoke
/home/kaoru/.ginkgo/.venv/bin/python -m pytest \
  tests/unit/data/crud/test_user_crud_mock.py \
  tests/unit/features/test_containers.py \
  tests/unit/client/test_user_cli.py -q -o "addopts="

# Layer 3 变更相关
/home/kaoru/.ginkgo/.venv/bin/python -m pytest \
  tests/unit/data/services/test_base_service.py \
  tests/unit/client/test_cli_utils.py -q -o "addopts="
```
全部通过 (33 + 38 + 50 passed)。

Spec: ADR-021 第 5/6/9 维 (PR #6582 merged) ｜ Parent: #6575 ｜ Blocks: #6579 (E4), #6580 (E5)

Closes #6591
