### PR TITLE
refactor(#6448): 迁移 collect_portfolio_components 至 PortfolioService

### DIFF
--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -36,101 +36,6 @@ def _format_portfolio_mode(mode_value) -> str:
     return enum_val.name if enum_val else str(mode_value)
 
 
-def collect_portfolio_components(portfolio_id: str, container) -> dict:
-    """收集Portfolio的所有组件绑定和参数信息"""
-    from ginkgo.enums import FILE_TYPES
-
-    component_data = {
-        'strategies': [],
-        'risk_managers': [],
-        'analyzers': [],
-        'selectors': [],
-        'sizers': []
-    }
-
-    try:
-        # 1. 获取Portfolio的所有文件绑定关系
-        file_mapping_crud = container.cruds.portfolio_file_mapping()
-        all_file_mappings = file_mapping_crud.find(filters={"portfolio_id": portfolio_id})
-
-        # 2. 按类型分类文件映射
-        for mapping in all_file_mappings:
-            file_info = {
-                'name': mapping.name,
-                'file_id': mapping.file_id,
-                'type': mapping.type,
-                'mapping_uuid': mapping.uuid,
-                'parameters': []
-            }
-
-            if mapping.type == FILE_TYPES.STRATEGY.value:
-                component_data['strategies'].append(file_info)
-            elif mapping.type == FILE_TYPES.RISKMANAGER.value:
-                component_data['risk_managers'].append(file_info)
-            elif mapping.type == FILE_TYPES.ANALYZER.value:
-                component_data['analyzers'].append(file_info)
-            elif mapping.type == FILE_TYPES.SELECTOR.value:
-                component_data['selectors'].append(file_info)
-            elif mapping.type == FILE_TYPES.SIZER.value:
-                component_data['sizers'].append(file_info)
-
-        # 3. 获取所有参数
-        param_crud = container.cruds.param()
-        mapping_uuids = [mapping.uuid for mapping in all_file_mappings]
-
-        all_params = {}
-        for mapping_uuid in mapping_uuids:
-            params = param_crud.find(filters={"mapping_id": mapping_uuid})
-            if params:
-                sorted_params = sorted(params, key=lambda p: p.index)
-                all_params[mapping_uuid] = sorted_params
-
-        # 4. 将参数分配给对应的组件
-        for mapping in all_file_mappings:
-            mapping_uuid = mapping.uuid
-
-            if mapping_uuid in all_params:
-                params = all_params[mapping_uuid]
-
-                # 找到对应的组件
-                component_list = None
-                if mapping.type == FILE_TYPES.STRATEGY.value:
-                    component_list = component_data['strategies']
-                elif mapping.type == FILE_TYPES.RISKMANAGER.value:
-                    component_list = component_data['risk_managers']
-                elif mapping.type == FILE_TYPES.ANALYZER.value:
-                    component_list = component_data['analyzers']
-                elif mapping.type == FILE_TYPES.SELECTOR.value:
-                    component_list = component_data['selectors']
-                elif mapping.type == FILE_TYPES.SIZER.value:
-                    component_list = component_data['sizers']
-
-                # 将参数分配给对应的组件
-                if component_list:
-                    for component in component_list:
-                        if component['file_id'] == mapping.file_id:
-                            for param in params:
-                                import json
-                                try:
-                                    # 尝试解析JSON值
-                                    display_value = json.loads(param.value) if param.value and param.value.startswith('[') else param.value
-                                except Exception as e:
-                                    GLOG.ERROR(f"Failed to parse JSON param value: {e}")
-                                    display_value = param.value
-
-                                component['parameters'].append({
-                                    'index': param.index,
-                                    'value': display_value,
-                                    'raw_value': param.value
-                                })
-
-        return component_data
-
-    except Exception as e:
-        console.print(f"[red]:x: Error collecting component info: {e}[/red]")
-        return component_data
-
-
 def display_component_tree(console, component_data: dict):
     """以文件树结构显示组件信息（与engine cat风格一致）"""
 
@@ -359,7 +264,16 @@ def get(
             if details:
                 # 显示Portfolio的组件绑定和参数
                 console.print("\n📁 Component Bindings:")
-                component_data = collect_portfolio_components(portfolio.uuid, container)
+                # #6448: 通过 PortfolioService，不再调用 client 层旧函数
+                result = container.portfolio_service().collect_portfolio_components(portfolio.uuid)
+                if result.is_success():
+                    component_data = result.data
+                else:
+                    console.print(f"[yellow]:warning: Failed to collect components: {result.error}[/yellow]")
+                    component_data = {
+                        'strategies': [], 'risk_managers': [],
+                        'analyzers': [], 'selectors': [], 'sizers': [],
+                    }
 
                 # 检查是否有任何组件绑定
                 total_components = sum(len(component_data[key]) for key in component_data.keys())

--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -209,6 +209,7 @@ class Container(containers.DeclarativeContainer):
         crud_repo=portfolio_crud,
         portfolio_file_mapping_crud=portfolio_file_mapping_crud,
         deployment_crud=deployment_crud,
+        param_crud=param_crud,
     )
 
     # Param service with ParamCRUD dependency (must be before portfolio_mapping_service)

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -19,6 +19,8 @@ Enhanced with comprehensive error handling, retry mechanisms, and structured ret
 import time
 
 from typing import List, Union, Any, Optional, Dict
+import json
+
 import pandas as pd
 from datetime import datetime
 
@@ -29,7 +31,7 @@ from ginkgo.data.crud.model_conversion import ModelList
 
 
 class PortfolioService(BaseService):
-    def __init__(self, crud_repo, portfolio_file_mapping_crud, deployment_crud=None):
+    def __init__(self, crud_repo, portfolio_file_mapping_crud, deployment_crud=None, param_crud=None):
         """
         初始化PortfolioService，设置投资组合和文件映射仓储依赖
 
@@ -37,9 +39,13 @@ class PortfolioService(BaseService):
             crud_repo: 投资组合数据CRUD仓储实例
             portfolio_file_mapping_crud: 投资组合文件映射CRUD仓储实例
             deployment_crud: 部署CRUD仓储实例（可选，用于冻结判定）
+            param_crud: 参数CRUD仓储实例（用于 collect_portfolio_components 收集组件参数；
+                        #6448 顺带修复 delete 清理参数时 self._param_crud 缺失的静默 AttributeError）
         """
         super().__init__(
-            crud_repo=crud_repo, portfolio_file_mapping_crud=portfolio_file_mapping_crud
+            crud_repo=crud_repo,
+            portfolio_file_mapping_crud=portfolio_file_mapping_crud,
+            param_crud=param_crud,
         )
         self._deployment_crud = deployment_crud
 
@@ -822,6 +828,103 @@ class PortfolioService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"卸载组件失败 {mount_id}: {str(e)}")
             return ServiceResult.error(f"卸载组件失败: {str(e)}")
+
+    def collect_portfolio_components(self, portfolio_id: str) -> ServiceResult:
+        """
+        收集 Portfolio 的所有组件绑定和参数信息（按类型分组）。
+
+        数据装配逻辑：读 file_mapping 按 FILE_TYPES 分组，再读 param 按 file_id
+        分配回对应组件。返回的 dict 是 ComponentLoader.perform_component_binding
+        的输入契约，字段必须逐一对齐。
+
+        #6448: 从 client/portfolio_cli.py 并入 Service 层，解除 workers/notifier → client 反向依赖。
+
+        Args:
+            portfolio_id: 投资组合UUID
+
+        Returns:
+            ServiceResult: data 为按类型分组的组件 dict：
+                {
+                    'strategies': [...], 'risk_managers': [...],
+                    'analyzers': [...], 'selectors': [...], 'sizers': [...]
+                }
+                元素结构: {name, file_id, type, mapping_uuid,
+                          parameters:[{index, value, raw_value}]}
+        """
+        # #6103 模式: param_crud 未注入 = 装配接线 bug，禁止静默 WARN+返空
+        if self._param_crud is None:
+            return ServiceResult.error(
+                "param_crud not injected; cannot resolve component parameters. "
+                "Inject via PortfolioService(param_crud=...) / containers.py DI."
+            )
+
+        # FILE_TYPES.value(int) → 分组 key 单一映射（消除原函数双重 if/elif 链）
+        type_to_key = {
+            FILE_TYPES.STRATEGY.value: 'strategies',
+            FILE_TYPES.RISKMANAGER.value: 'risk_managers',
+            FILE_TYPES.ANALYZER.value: 'analyzers',
+            FILE_TYPES.SELECTOR.value: 'selectors',
+            FILE_TYPES.SIZER.value: 'sizers',
+        }
+        component_data = {key: [] for key in type_to_key.values()}
+
+        try:
+            # 1. 获取 Portfolio 的所有文件绑定关系
+            all_file_mappings = self._portfolio_file_mapping_crud.find(
+                filters={"portfolio_id": portfolio_id}
+            ) or []
+
+            # 2. 按类型分类文件映射
+            for mapping in all_file_mappings:
+                file_info = {
+                    'name': mapping.name,
+                    'file_id': mapping.file_id,
+                    'type': mapping.type,
+                    'mapping_uuid': mapping.uuid,
+                    'parameters': []
+                }
+                key = type_to_key.get(mapping.type)
+                if key is not None:
+                    component_data[key].append(file_info)
+
+            # 3. 按 mapping_uuid 读参数（按 index 排序）
+            all_params = {}
+            for mapping in all_file_mappings:
+                params = self._param_crud.find(filters={"mapping_id": mapping.uuid})
+                if params:
+                    all_params[mapping.uuid] = sorted(params, key=lambda p: p.index)
+
+            # 4. 将参数分配给对应组件（按 file_id 匹配）
+            for mapping in all_file_mappings:
+                params = all_params.get(mapping.uuid)
+                if not params:
+                    continue
+                key = type_to_key.get(mapping.type)
+                if key is None:
+                    continue
+                for component in component_data[key]:
+                    if component['file_id'] != mapping.file_id:
+                        continue
+                    for param in params:
+                        # value 以 '[' 开头尝试 JSON 解析（原契约：列表参数）
+                        display_value = param.value
+                        if param.value and param.value.startswith('['):
+                            try:
+                                display_value = json.loads(param.value)
+                            except (json.JSONDecodeError, TypeError) as e:
+                                GLOG.ERROR(f"Failed to parse JSON param value: {e}")
+                                display_value = param.value
+                        component['parameters'].append({
+                            'index': param.index,
+                            'value': display_value,
+                            'raw_value': param.value,
+                        })
+
+            return ServiceResult.success(component_data)
+
+        except Exception as e:
+            GLOG.ERROR(f"收集组件信息失败 portfolio={portfolio_id}: {e}")
+            return ServiceResult.error(f"收集组件信息失败: {e}")
 
     def get_components(self, portfolio_id: str = None, component_type: FILE_TYPES = None) -> ServiceResult:
         """

--- a/src/ginkgo/notifier/notifier_telegram.py
+++ b/src/ginkgo/notifier/notifier_telegram.py
@@ -189,25 +189,11 @@ def run_backtest(message):
             bot.send_message(message.chat.id, i)
         return
 
-    uuid = extract_arg(message.text)[0]
-    # TODO: Fix this reference - backtest_cli has been removed
-    # from ginkgo.client.backtest_cli import run as run_backtest
-    # For now, create a placeholder or use flat_cli
-    from ginkgo.client import flat_cli
-    def run_backtest(engine_id):
-        """Placeholder function for running backtest"""
-        # This should be implemented properly
-        pass
-
-    global is_running
-
-    if not is_running:
-        is_running = True
-        run_backtest(uuid)
-        is_running = False
-    else:
-        bot.reply_to(message, "Please wait for the previous backtest to finish.")
-        return
+    # #6448: notifier → client 反向依赖已解除；Telegram 触发回测已禁用，请用 CLI 跑
+    bot.reply_to(
+        message,
+        "Backtest via Telegram is disabled. Run via CLI: `ginkgo backtest run <uuid>`",
+    )
 
 
 @bot.message_handler(commands=["compare"])

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -96,7 +96,6 @@ class PaperTradingWorker:
         from ginkgo.trading.gateway.trade_gateway import TradeGateway
         from ginkgo.trading.brokers.sim_broker import SimBroker
         from ginkgo.trading.services._assembly.component_loader import ComponentLoader
-        from ginkgo.client.portfolio_cli import collect_portfolio_components
 
         GLOG.INFO(f"[PAPER-WORKER] {self.worker_id}: Assembling engine...")
 
@@ -141,11 +140,17 @@ class PaperTradingWorker:
         # 4. 加载每个 Portfolio
         for db_portfolio in db_portfolios:
             try:
-                # 收集组件绑定信息
-                components = collect_portfolio_components(
-                    portfolio_id=db_portfolio.uuid,
-                    container=container,
+                # 收集组件绑定信息（#6448: 通过 PortfolioService，不再 import client）
+                components_result = container.portfolio_service().collect_portfolio_components(
+                    db_portfolio.uuid,
                 )
+                if not components_result.is_success():
+                    GLOG.ERROR(
+                        f"[PAPER-WORKER] Failed to collect components for "
+                        f"{db_portfolio.uuid}: {components_result.error}"
+                    )
+                    continue
+                components = components_result.data
 
                 # 创建 Portfolio 实例
                 portfolio = PortfolioT1Backtest()
@@ -878,7 +883,6 @@ class PaperTradingWorker:
 
         from ginkgo.trading.portfolios.t1backtest import PortfolioT1Backtest
         from ginkgo.trading.services._assembly.component_loader import ComponentLoader
-        from ginkgo.client.portfolio_cli import collect_portfolio_components
         from ginkgo import services
 
         try:
@@ -902,11 +906,17 @@ class PaperTradingWorker:
                 )
                 return False
 
-            # 收集组件绑定信息
-            components = collect_portfolio_components(
-                portfolio_id=portfolio_id,
-                container=container,
+            # 收集组件绑定信息（#6448: 通过 PortfolioService，不再 import client）
+            components_result = container.portfolio_service().collect_portfolio_components(
+                portfolio_id,
             )
+            if not components_result.is_success():
+                GLOG.ERROR(
+                    f"[PAPER-WORKER] Failed to collect components for "
+                    f"{portfolio_id}: {components_result.error}"
+                )
+                return False
+            components = components_result.data
 
             # 创建 Portfolio 实例
             portfolio = PortfolioT1Backtest()

--- a/tests/unit/data/services/test_portfolio_service_collect.py
+++ b/tests/unit/data/services/test_portfolio_service_collect.py
@@ -1,0 +1,179 @@
+"""
+PortfolioService.collect_portfolio_components 单元测试
+
+验证：从 client/portfolio_cli.py 并入的数据装配逻辑（读 file_mapping 按类型分组 +
+读 param 按 file_id 分配 + JSON 解析），返回 ServiceResult。
+"""
+
+import sys
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.portfolio_service import PortfolioService
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.enums import FILE_TYPES
+
+
+@pytest.fixture
+def mock_deps():
+    return {
+        "crud_repo": MagicMock(),
+        "portfolio_file_mapping_crud": MagicMock(),
+        "param_crud": MagicMock(),
+    }
+
+
+@pytest.fixture
+def service(mock_deps):
+    with patch("ginkgo.libs.GLOG"):
+        svc = PortfolioService(
+            crud_repo=mock_deps["crud_repo"],
+            portfolio_file_mapping_crud=mock_deps["portfolio_file_mapping_crud"],
+            param_crud=mock_deps["param_crud"],
+        )
+        return svc
+
+
+def _make_mapping(uuid, file_id, name, mtype):
+    """构造 mock file_mapping 对象"""
+    m = MagicMock()
+    m.uuid = uuid
+    m.file_id = file_id
+    m.name = name
+    m.type = mtype
+    return m
+
+
+def _make_param(mapping_id, index, value):
+    """构造 mock param 对象"""
+    p = MagicMock()
+    p.mapping_id = mapping_id
+    p.index = index
+    p.value = value
+    return p
+
+
+# ============================================================
+# 切片 1（tracer bullet）：正常路径 — 分组 + 参数分配 + JSON 解析 + 字段契约
+# ============================================================
+
+def test_collect_portfolio_components_groups_by_type_with_params(service, mock_deps):
+    """给定 1 strategy + 1 selector 各自带参数，按类型分组并正确分配参数。
+
+    锁定契约：输出 dict 5 key 齐全；元素含 {name, file_id, type, mapping_uuid,
+    parameters:[{index, value, raw_value}]}；`[...]` value 解析为 list。
+    """
+    # Arrange: file_mapping 返回 1 strategy + 1 selector
+    strat_mapping = _make_mapping("mount-s1", "file-s1", "MyStrategy", FILE_TYPES.STRATEGY.value)
+    sel_mapping = _make_mapping("mount-sel1", "file-sel1", "FixedSelector", FILE_TYPES.SELECTOR.value)
+    mock_deps["portfolio_file_mapping_crud"].find.return_value = [strat_mapping, sel_mapping]
+
+    # param_crud.find 按 mapping_id 返回不同参数
+    strat_param = _make_param("mount-s1", index=0, value="MyStrategy")
+    sel_param = _make_param("mount-sel1", index=0, value='["SP500", "NASDAQ"]')
+
+    def param_find(filters):
+        mid = filters.get("mapping_id")
+        if mid == "mount-s1":
+            return [strat_param]
+        if mid == "mount-sel1":
+            return [sel_param]
+        return []
+    mock_deps["param_crud"].find.side_effect = param_find
+
+    # Act
+    result = service.collect_portfolio_components(portfolio_id="port-001")
+
+    # Assert: ServiceResult 成功
+    assert result.is_success()
+    data = result.data
+
+    # 5 key 齐全（即使空 list）
+    assert set(data.keys()) == {"strategies", "risk_managers", "analyzers", "selectors", "sizers"}
+    assert len(data["strategies"]) == 1
+    assert len(data["selectors"]) == 1
+    assert len(data["risk_managers"]) == 0
+    assert len(data["analyzers"]) == 0
+    assert len(data["sizers"]) == 0
+
+    # strategy 元素字段契约
+    strat = data["strategies"][0]
+    assert strat["file_id"] == "file-s1"
+    assert strat["name"] == "MyStrategy"
+    assert strat["mapping_uuid"] == "mount-s1"
+    assert strat["type"] == FILE_TYPES.STRATEGY.value
+    assert len(strat["parameters"]) == 1
+    assert strat["parameters"][0]["index"] == 0
+    assert strat["parameters"][0]["value"] == "MyStrategy"  # 非 JSON → 原值
+    assert strat["parameters"][0]["raw_value"] == "MyStrategy"
+
+    # selector 参数 JSON 解析
+    sel = data["selectors"][0]
+    assert sel["parameters"][0]["value"] == ["SP500", "NASDAQ"]  # JSON 解析为 list
+    assert sel["parameters"][0]["raw_value"] == '["SP500", "NASDAQ"]'  # 原始串保留
+
+
+# ============================================================
+# 切片 2：空 portfolio — 5 key 均为空 list
+# ============================================================
+
+def test_collect_returns_empty_lists_for_portfolio_with_no_bindings(service, mock_deps):
+    """portfolio 无组件绑定 → 5 key 均为空 list（结构完整）。"""
+    mock_deps["portfolio_file_mapping_crud"].find.return_value = []
+
+    result = service.collect_portfolio_components(portfolio_id="port-empty")
+
+    assert result.is_success()
+    data = result.data
+    assert set(data.keys()) == {"strategies", "risk_managers", "analyzers", "selectors", "sizers"}
+    for v in data.values():
+        assert v == []
+
+
+# ============================================================
+# 切片 3：异常路径 — param_crud 未注入 → ServiceResult 失败（不静默）
+# ============================================================
+
+def test_collect_returns_error_when_param_crud_not_injected(mock_deps):
+    """param_crud 未注入 → ServiceResult 失败（对齐 #6103 不静默 WARN+返空）。"""
+    with patch("ginkgo.libs.GLOG"):
+        svc = PortfolioService(
+            crud_repo=mock_deps["crud_repo"],
+            portfolio_file_mapping_crud=mock_deps["portfolio_file_mapping_crud"],
+            # 不传 param_crud
+        )
+
+    result = svc.collect_portfolio_components(portfolio_id="port-001")
+
+    assert not result.is_success()
+    assert "param_crud not injected" in result.error
+    # 短路：file_mapping_crud 不应被调用
+    mock_deps["portfolio_file_mapping_crud"].find.assert_not_called()
+
+
+# ============================================================
+# 切片 4：参数按 index 排序（多参数乱序输入）
+# ============================================================
+
+def test_collect_sorts_params_by_index(service, mock_deps):
+    """同一组件多个参数乱序返回 → 按 index 升序排列。"""
+    mapping = _make_mapping("mount-1", "file-1", "MyStrategy", FILE_TYPES.STRATEGY.value)
+    mock_deps["portfolio_file_mapping_crud"].find.return_value = [mapping]
+
+    # 故意乱序返回
+    p2 = _make_param("mount-1", index=2, value="third")
+    p0 = _make_param("mount-1", index=0, value="first")
+    p1 = _make_param("mount-1", index=1, value="second")
+    mock_deps["param_crud"].find.return_value = [p2, p0, p1]
+
+    result = service.collect_portfolio_components(portfolio_id="port-1")
+
+    assert result.is_success()
+    params = result.data["strategies"][0]["parameters"]
+    assert [p["index"] for p in params] == [0, 1, 2]
+    assert [p["value"] for p in params] == ["first", "second", "third"]

--- a/tests/unit/workers/test_paper_trading_worker.py
+++ b/tests/unit/workers/test_paper_trading_worker.py
@@ -78,9 +78,9 @@ class TestAssembleEngine:
         mock_engine.return_value = mock_engine_instance
 
         worker = PaperTradingWorker(worker_id="test-1")
-        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
-                   return_value=mock_components):
-            worker.assemble_engine(mock_container)
+        # #6448: collect 走 container.portfolio_service() 链，配 mock 返 ServiceResult
+        mock_container.portfolio_service.return_value.collect_portfolio_components.return_value = ServiceResult.success(mock_components)
+        worker.assemble_engine(mock_container)
 
         mock_engine.assert_called_once()
         call_kwargs = mock_engine.call_args
@@ -134,9 +134,9 @@ class TestAssembleEngine:
         mock_engine_cls.return_value = mock_engine_instance
 
         worker = PaperTradingWorker(worker_id="test-1")
-        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
-                   return_value=mock_components):
-            worker.assemble_engine(mock_container)
+        # #6448: collect 走 container.portfolio_service() 链，配 mock 返 ServiceResult
+        mock_container.portfolio_service.return_value.collect_portfolio_components.return_value = ServiceResult.success(mock_components)
+        worker.assemble_engine(mock_container)
 
         # 断言 pick 被调且传了非 None time（位置参数或 time= kwarg）
         mock_selector.pick.assert_called()
@@ -189,9 +189,9 @@ class TestAssembleEngine:
         mock_engine_cls.return_value = mock_engine_instance
 
         worker = PaperTradingWorker(worker_id="test-1")
-        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
-                   return_value=mock_components):
-            worker.assemble_engine(mock_container)
+        # #6448: collect 走 container.portfolio_service() 链，配 mock 返 ServiceResult
+        mock_container.portfolio_service.return_value.collect_portfolio_components.return_value = ServiceResult.success(mock_components)
+        worker.assemble_engine(mock_container)
 
         # Engine 应已创建
         assert worker._engine is not None
@@ -252,10 +252,12 @@ class TestAssembleEngine:
         mock_engine_cls.return_value = mock_engine_instance
 
         worker = PaperTradingWorker(worker_id="test-replay")
-        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
-                   return_value={"strategies": [], "risk_managers": [], "analyzers": [],
-                                 "selectors": [], "sizers": []}):
-            worker.assemble_engine(mock_container)
+        # #6448: collect 走 portfolio_service 链（已 mock 为 mock_pservice），配 ServiceResult
+        mock_pservice.collect_portfolio_components.return_value = ServiceResult.success(
+            {"strategies": [], "risk_managers": [], "analyzers": [],
+             "selectors": [], "sizers": []}
+        )
+        worker.assemble_engine(mock_container)
 
         # feeder 必须收到 LogicalTimeProvider，否则 REPLAY 快进喂 bar 全失败
         mock_feeder_instance.set_time_provider.assert_called()
@@ -544,11 +546,11 @@ class TestDeploy:
         mock_crud.find.return_value = [mock_db_portfolio]
         mock_container.cruds.portfolio.return_value = mock_crud
 
-        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
-                   return_value=mock_components):
-            with patch("ginkgo.services", create=True) as mock_services:
-                mock_services.data.container = mock_container
-                result = worker._handle_deploy({"portfolio_id": "p-new-001"})
+        # #6448: collect 走 container.portfolio_service() 链，配 mock 返 ServiceResult
+        mock_container.portfolio_service.return_value.collect_portfolio_components.return_value = ServiceResult.success(mock_components)
+        with patch("ginkgo.services", create=True) as mock_services:
+            mock_services.data.container = mock_container
+            result = worker._handle_deploy({"portfolio_id": "p-new-001"})
 
         assert result is True
         mock_engine.add_portfolio.assert_called_once_with(mock_portfolio_instance)
@@ -590,11 +592,11 @@ class TestDeploy:
         mock_crud.find.return_value = [mock_db_portfolio]
         mock_container.cruds.portfolio.return_value = mock_crud
 
-        with patch("ginkgo.client.portfolio_cli.collect_portfolio_components",
-                   return_value=mock_components):
-            with patch("ginkgo.services", create=True) as mock_services:
-                mock_services.data.container = mock_container
-                result = worker._handle_deploy({"portfolio_id": "p-new-001"})
+        # #6448: collect 走 container.portfolio_service() 链，配 mock 返 ServiceResult
+        mock_container.portfolio_service.return_value.collect_portfolio_components.return_value = ServiceResult.success(mock_components)
+        with patch("ginkgo.services", create=True) as mock_services:
+            mock_services.data.container = mock_container
+            result = worker._handle_deploy({"portfolio_id": "p-new-001"})
 
         assert result is True
         mock_engine.add_portfolio.assert_called_once_with(mock_portfolio_instance)


### PR DESCRIPTION
## Summary

解除 `workers/notifier → client` 反向依赖（#6448）。原 `client/portfolio_cli.py:collect_portfolio_components` 是数据装配逻辑（读 file_mapping 按类型分组 + 读 param 按 file_id 分配 + JSON 解析），逻辑上属数据服务层，却挂在 CLI 模块，导致 worker/notifier 反向 import client。

## 变更

**核心迁移**
- `PortfolioService.collect_portfolio_components` 新方法（从 client 并入），返回 `ServiceResult`
- `containers.py`：portfolio_service 注入 `param_crud`（顺带修复 #6103 类静默 AttributeError——原 `self._param_crud` 在 `portfolio_service.py:670` 被 try/except 吞，删组件参数时静默丢失）
- `paper_trading_worker.py`：INIT/deploy 两处对称改用 `container.portfolio_service().collect_portfolio_components()`（INIT 失败 `continue`，deploy 失败 `return False`）
- `portfolio_cli.py`：内部调用方（`portfolio get --details`）改走 service；删除旧函数
- `notifier_telegram.py`：`/run` handler 清理 `flat_cli` 死 import + pass 占位，改友好回复

**分层边界（本次明确）**

| 装配类型 | 归属 | 职责 |
|---|---|---|
| 数据装配 | `data/services/PortfolioService` | 读 file_mapping/param，按类型分组 |
| 对象装配 | `trading/services/_assembly/ComponentLoader` | 从源文件实例化组件 |

## Test plan

- [x] 新增 `test_portfolio_service_collect.py`（4 切片 TDD：分组/空/未注入报错/排序）
- [x] `test_paper_trading_worker.py` 52 passed（INIT 4 处 + deploy 2 处 patch 迁移；1 pre-existing hang deselect）
- [x] Layer 1 py_compile（5 变更文件）/ Layer 2 启动路径三层 smoke（user_crud_mock + containers + user_cli）

Pre-existing 失败（master stash 对照，与本次无关）：`test_portfolio_cli.py::TestPortfolioDelete` / `TestGenerateBaselinePagination`

Closes #6448