### PR TITLE
refactor(#6625): 复权流程改走 DF 出口契约

### DIFF
--- a/src/ginkgo/data/services/bar_adjustment.py
+++ b/src/ginkgo/data/services/bar_adjustment.py
@@ -138,16 +138,15 @@ def get_precomputed_adjustment_factors(
         start_date = min(dates)
         end_date = max(dates)
 
-        # 获取原始adjustfactor数据
-        result = adjustfactor_service.get(
+        # 获取原始adjustfactor数据（ADR-010 出口①：data 已是 DataFrame）
+        result = adjustfactor_service.get_adjustfactors_df(
             code=code, start_date=start_date, end_date=end_date
         )
 
-        if not result.success or len(result.data) == 0:
+        if not result.success or result.data.empty:
             return pd.DataFrame(columns=['timestamp', factor_column])
 
-        # 使用ServiceResult.data中的ModelList转换为DataFrame
-        df_factors = result.data.to_dataframe()
+        df_factors = result.data
 
         if df_factors.empty:
             return pd.DataFrame(columns=['timestamp', factor_column])
@@ -350,16 +349,16 @@ def apply_price_adjustment(
         start_date = bars_df["timestamp"].min()
         end_date = bars_df["timestamp"].max()
 
-        adjustfactors_result = adjustfactor_service.get(
+        adjustfactors_result = adjustfactor_service.get_adjustfactors_df(
             code=code, start_date=start_date, end_date=end_date
         )
 
-        if not adjustfactors_result.success or not adjustfactors_result.data:
+        if not adjustfactors_result.success or adjustfactors_result.data.empty:
             GLOG.DEBUG(f"No adjustment factors found for {code}, returning original data")
             return bars_data
 
-        # 将ModelList转换为DataFrame
-        adjustfactors_df = adjustfactors_result.data.to_dataframe()
+        # ADR-010 出口①：data 已是 DataFrame
+        adjustfactors_df = adjustfactors_result.data
 
         if adjustfactors_df.empty:
             GLOG.DEBUG(f"No adjustment factors found for {code}, returning original data")

--- a/tests/unit/services/test_bar_adjustment_df_contract.py
+++ b/tests/unit/services/test_bar_adjustment_df_contract.py
@@ -1,0 +1,145 @@
+"""TDD for bar_adjustment DF 出口契约切换 -- #6625
+
+ADR-010 出口①：复权因子读取改走 ``AdjustfactorService.get_adjustfactors_df``，
+``ServiceResult.data`` 即 ``pandas.DataFrame``，不再 ``result.data.to_dataframe()``。
+
+本文件锁定的行为（与 #5501 排序回归解耦，专注契约语义）：
+- path1 ``get_precomputed_adjustment_factors``：成功（预计算列）/ 空 / 异常
+- path2 ``apply_price_adjustment``：成功（K 线复权）/ 空 / 异常
+
+排序方向正确性由 ``test_bar_adjustment_sort_order.py`` 覆盖（#5501）。
+"""
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from ginkgo.data.services import bar_adjustment
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.enums import ADJUSTMENT_TYPES
+
+
+def _df_service(df: pd.DataFrame, success: bool = True) -> MagicMock:
+    """构造 mock：get_adjustfactors_df 返 ServiceResult(data=df)。"""
+    mock_svc = MagicMock()
+    mock_svc.get_adjustfactors_df.return_value = ServiceResult(
+        success=success, message="mock", data=df,
+    )
+    return mock_svc
+
+
+class TestGetPrecomputedFactorsDFContract:
+    """path1: get_precomputed_adjustment_factors 消费 DF 出口。"""
+
+    def test_success_with_precomputed_factor_column_returned_directly(self):
+        """DF 已含 foreadjustfactor 列 → 直接返回 [timestamp, factor] 子集。
+
+        命中 ``if factor_column in df_factors.columns`` 早出分支（非临时因子计算）。
+        """
+        df = pd.DataFrame({
+            "timestamp": ["2025-01-01", "2025-01-02"],
+            "foreadjustfactor": [1.0, 1.1],
+            "backadjustfactor": [1.0, 0.9],
+            "adjustfactor": [1.0, 1.1],
+        })
+        svc = _df_service(df)
+
+        result = bar_adjustment.get_precomputed_adjustment_factors(
+            code="000001.SZ",
+            dates=["2025-01-01", "2025-01-02"],
+            adjustment_type=ADJUSTMENT_TYPES.FORE,
+            adjustfactor_service=svc,
+        )
+
+        assert list(result.columns) == ["timestamp", "foreadjustfactor"]
+        assert len(result) == 2
+        # 必须走 DF 出口，不能再调 .get() + to_dataframe()
+        svc.get_adjustfactors_df.assert_called_once()
+        svc.get.assert_not_called()
+
+    def test_empty_result_returns_empty_df_with_expected_columns(self):
+        """service 返空 DataFrame → 返回 [timestamp, factor_column] 空壳。"""
+        svc = _df_service(pd.DataFrame())
+
+        result = bar_adjustment.get_precomputed_adjustment_factors(
+            code="000001.SZ",
+            dates=["2025-01-01"],
+            adjustment_type=ADJUSTMENT_TYPES.FORE,
+            adjustfactor_service=svc,
+        )
+
+        assert result.empty
+        assert list(result.columns) == ["timestamp", "foreadjustfactor"]
+
+    def test_failure_returns_empty_df(self):
+        """service success=False → 返回空 DF（不抛异常）。"""
+        svc = _df_service(pd.DataFrame(), success=False)
+
+        result = bar_adjustment.get_precomputed_adjustment_factors(
+            code="000001.SZ",
+            dates=["2025-01-01"],
+            adjustment_type=ADJUSTMENT_TYPES.BACK,
+            adjustfactor_service=svc,
+        )
+
+        assert result.empty
+        assert list(result.columns) == ["timestamp", "backadjustfactor"]
+
+
+class TestApplyPriceAdjustmentDFContract:
+    """path2: apply_price_adjustment 消费 DF 出口。"""
+
+    @staticmethod
+    def _bars_df() -> pd.DataFrame:
+        return pd.DataFrame({
+            "code": ["000001.SZ", "000001.SZ"],
+            "timestamp": ["2025-01-01", "2025-01-02"],
+            "open": [10.0, 11.0],
+            "high": [11.0, 12.0],
+            "low": [9.0, 10.0],
+            "close": [10.5, 11.5],
+            "volume": [1000, 1100],
+            "amount": [10500.0, 12650.0],
+        })
+
+    def test_success_applies_fore_factor_to_prices(self):
+        """FORE 因子=2.0 → 所有价格 ×2（向量化 merge 复权）。"""
+        factors = pd.DataFrame({
+            "timestamp": ["2025-01-01", "2025-01-02"],
+            "foreadjustfactor": [2.0, 2.0],
+        })
+        svc = _df_service(factors)
+        bars = self._bars_df()
+
+        result = bar_adjustment.apply_price_adjustment(
+            bars_data=bars, code="000001.SZ",
+            adjustment_type=ADJUSTMENT_TYPES.FORE, adjustfactor_service=svc,
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert result["close"].tolist() == [21.0, 23.0]
+        svc.get_adjustfactors_df.assert_called_once()
+        svc.get.assert_not_called()
+
+    def test_empty_factors_returns_original_bars(self):
+        """service 返空 DF → 原始 bars 不变（仅格式透传）。"""
+        svc = _df_service(pd.DataFrame())
+        bars = self._bars_df()
+
+        result = bar_adjustment.apply_price_adjustment(
+            bars_data=bars, code="000001.SZ",
+            adjustment_type=ADJUSTMENT_TYPES.FORE, adjustfactor_service=svc,
+        )
+
+        assert result.equals(bars)
+
+    def test_failure_returns_original_bars(self):
+        """service success=False → 原始 bars 不变。"""
+        svc = _df_service(pd.DataFrame(), success=False)
+        bars = self._bars_df()
+
+        result = bar_adjustment.apply_price_adjustment(
+            bars_data=bars, code="000001.SZ",
+            adjustment_type=ADJUSTMENT_TYPES.BACK, adjustfactor_service=svc,
+        )
+
+        assert result.equals(bars)

--- a/tests/unit/services/test_bar_adjustment_sort_order.py
+++ b/tests/unit/services/test_bar_adjustment_sort_order.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock
 import pandas as pd
 
 from ginkgo.data.services import bar_adjustment
+from ginkgo.data.services.base_service import ServiceResult
 from ginkgo.enums import ADJUSTMENT_TYPES
 
 
@@ -28,18 +29,15 @@ def _make_descending_factors() -> pd.DataFrame:
 
 
 def _make_mock_service(df: pd.DataFrame) -> MagicMock:
-    """构造 adjustfactor_service mock，data 支持 len() + to_dataframe()。
+    """构造 adjustfactor_service mock：get_adjustfactors_df 走 DF 出口契约。
 
-    MagicMock 默认 __len__ 返回 0 会触发 L146 空分支，须显式配非 0。
+    ADR-010 出口①：``data`` 已是 ``pandas.DataFrame``，不再绕 ``.to_dataframe()``。
+    用真实 ``ServiceResult`` 避免 MagicMock 链耦合 ModelList 实现细节。
     """
     mock_svc = MagicMock()
-    mock_result = MagicMock()
-    mock_result.success = True
-    mock_data = MagicMock()
-    mock_data.__len__ = MagicMock(return_value=len(df))
-    mock_data.to_dataframe.return_value = df
-    mock_result.data = mock_data
-    mock_svc.get.return_value = mock_result
+    mock_svc.get_adjustfactors_df.return_value = ServiceResult(
+        success=True, message="mock (df contract)", data=df,
+    )
     return mock_svc
 
 


### PR DESCRIPTION
## Summary

切片 #6625（parent epic #6623）：`bar_adjustment` 两处复权因子读取从 `get()` + `result.data.to_dataframe()` 切到 `get_adjustfactors_df()`（ADR-010 出口①，`ServiceResult.data` 已是 `pandas.DataFrame`）。

**为什么**：原路径依赖上游 `ServiceResult.data` 携带 `ModelList` 再 `.to_dataframe()`，形状耦合、且 `apply_price_adjustment` 的 `not adjustfactors_result.data` 守卫在 DataFrame 语义下会抛 `ValueError: truth value of a DataFrame is ambiguous`。出口①已由 #6106 落地（`AdjustfactorService.get_adjustfactors_df`，`adjustfactor_service.py:320`，返 `ServiceResult(data=pd.DataFrame)`），本切片把消费端切过去。

**改动**（仅 `bar_adjustment.py` 两处调用点，业务语义不变）：
- `get_precomputed_adjustment_factors` (path 1)：`get()` → `get_adjustfactors_df()`；守卫 `len(result.data) == 0` → `result.data.empty`；删 `.to_dataframe()`。`:167` 显式 `sort_values('timestamp')` 保留（#5501 排序回归防护——helper 内 `crud find` 仍不保证排序）。
- `apply_price_adjustment` (path 2)：同切换；守卫 `not adjustfactors_result.data` → `.empty`（顺带消除 DataFrame truthity 歧义的潜在 bug）。

## Test plan

三层 smoke 全绿（对齐 `.github/workflows/ci.yml`）：
- **Layer 1**：`py_compile` src+api 全过
- **Layer 2**：启动路径点名（`test_user_crud_mock` / `test_containers` / `test_user_cli`）33 passed
- **Layer 3**（变更相关）：
  ```
  pytest tests/unit/services/test_bar_adjustment_sort_order.py \
         tests/unit/services/test_bar_adjustment_df_contract.py \
         tests/unit/services/smoke/test_bar_adjustment_smoke.py -q
  # → 14 passed
  ```

新增覆盖（`test_bar_adjustment_df_contract.py`，与 #5501 排序测试解耦）：
- path 1 成功（预计算列直返）/ 空 / 异常
- path 2 成功（FORE 因子 ×2 价格）/ 空 / 异常

机器可验 AC：`grep -n "result\.data\.to_dataframe\|\.data\.to_dataframe()" src/ginkgo/data/services/bar_adjustment.py` → 0 命中 ✅

不在范围（brief 已界定）：`factor_service.py` / `bar_service.py:797` / `adjustfactor_service` 内部 `.to_dataframe()`（出口内部实现）。

Closes #6625

🤖 Generated with [Claude Code](https://claude.com/claude-code)