### PR TITLE
refactor: Bar 数据读取不再向 feeder 泄漏 ModelList (#6624)

### DIFF
--- a/src/ginkgo/data/services/bar_service.py
+++ b/src/ginkgo/data/services/bar_service.py
@@ -774,13 +774,19 @@ class BarService(BaseService):
 
     def get_bars_df(self, code=None, start_date=None, end_date=None,
                     frequency: FREQUENCY_TYPES = FREQUENCY_TYPES.DAY,
+                    adjustment_type: ADJUSTMENT_TYPES = ADJUSTMENT_TYPES.NONE,
                     page: int = None, page_size: int = None,
                     order_by: str = "timestamp", desc_order: bool = False) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
 
         ADR-010：回测热路径及 DataFrame 消费方走此出口，不接触 ORM ModelList。
-        **不复权**——复权是多步状态变换，属 get() 的业务语义；DF 出口提供
-        原始数据，消费方按需自行处理。空结果返空 pd.DataFrame()。
+        **默认不复权**——DF 出口提供原始数据，消费方按需自行处理。空结果返空 pd.DataFrame()。
+
+        #6624 复权路径：feeder/sizer 等回测热路径消费方 historically 走 get(FORE) +
+        手动 .to_dataframe()（ADR-010 例外，依赖前复权语义防除权除息日跳空）。本出口
+        支持 ``adjustment_type`` 参数（默认 NONE 不破现有契约）；传 FORE/BACK 时走与
+        get() 完全一致的复权分支（_apply_price_adjustment_*），DF 出口内化复权，
+        消除 ModelList 向 feeder 泄漏的同时保行为 parity（避免回测静默错算）。
         """
         try:
             if not code and not start_date and not end_date:
@@ -794,10 +800,21 @@ class BarService(BaseService):
                 filters=filters, page=page, page_size=page_size,
                 order_by=order_by, desc_order=desc_order,
             )
-            df = model_list.to_dataframe() if model_list else pd.DataFrame()
+            # 空结果短路：复权对空集无定义，直接返空 DF
+            if not model_list:
+                df = pd.DataFrame()
+            elif adjustment_type == ADJUSTMENT_TYPES.NONE:
+                df = model_list.to_dataframe()
+            else:
+                # 复权路径：复用 get() 的复权入口，DF 在 Service 内转换（ModelList 不出边界）
+                if code is None:
+                    adjusted = self._apply_price_adjustment_multi_stock(model_list, adjustment_type)
+                else:
+                    adjusted = self._apply_price_adjustment_to_modellist(model_list, code, adjustment_type)
+                df = adjusted.to_dataframe() if adjusted else pd.DataFrame()
             return ServiceResult.success(
                 data=df,
-                message=f"Retrieved {len(df)} bar records (DataFrame, no adjustment)",
+                message=f"Retrieved {len(df)} bar records (DataFrame, adjustment={adjustment_type.value})",
             )
         except Exception as e:
             self._logger.ERROR(f"Failed to get bars (df): {e}")

--- a/src/ginkgo/trading/feeders/backtest_feeder.py
+++ b/src/ginkgo/trading/feeders/backtest_feeder.py
@@ -35,7 +35,7 @@ from ginkgo.entities.mixins import TimeMixin
 from ginkgo.trading.time.interfaces import ITimeProvider
 from ginkgo.trading.time.providers import TimeBoundaryValidator
 from ginkgo.libs import datetime_normalize, cache_with_expiration, GLOG
-from ginkgo.enums import SOURCE_TYPES, EVENT_TYPES
+from ginkgo.enums import SOURCE_TYPES, EVENT_TYPES, ADJUSTMENT_TYPES
 from ginkgo.data.mappers import BarMapper
 
 
@@ -273,10 +273,16 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
         try:
             for symbol in symbols:
                 if data_type == "bar":
-                    result = self.bar_service.get(symbol, start_date=start_time.date(),
-                                    end_date=end_time.date())
-                    if result.success and result.data:
-                        df = result.data.to_dataframe()
+                    # #6624: 走 DF 出口 get_bars_df，传 FORE 保回测热路径前复权语义
+                    # （与原 get() 默认一致，ADR-010 例外），不再接触 ORM ModelList
+                    result = self.bar_service.get_bars_df(symbol,
+                                    start_date=start_time.date(),
+                                    end_date=end_time.date(),
+                                    adjustment_type=ADJUSTMENT_TYPES.FORE)
+                    # DF 出口 data 是 DataFrame；pandas 真值对多元素歧义，用 is not None
+                    # （空 DF 由下方 df.empty 兜底，不靠 DataFrame 布尔化）
+                    if result.success and result.data is not None:
+                        df = result.data
                     else:
                         GLOG.ERROR(f"Failed to get bars for {symbol}: {result.error}")
                         continue

--- a/src/ginkgo/trading/feeders/base_feeder.py
+++ b/src/ginkgo/trading/feeders/base_feeder.py
@@ -79,22 +79,27 @@ class BaseFeeder(EngineBindableMixin, TimeMixin, NamedMixin, Base):
             return pd.DataFrame()
 
     def _load_daybar(self, code: str, dt, *args, **kwargs) -> pd.DataFrame:
-        """默认的数据加载实现（可被子类覆盖）。"""
+        """默认的数据加载实现（可被子类覆盖）。
+
+        #6624: 走 BarService DF 出口 get_bars_df，不再接触 ORM ModelList。
+        传 adjustment_type=FORE 保回测热路径前复权语义（与原 get() 默认一致，
+        ADR-010 例外：feeder 依赖前复权防除权除息日跳空）。
+        """
+        from ginkgo.enums import ADJUSTMENT_TYPES
+
         try:
-            # 调用BarService，获取ServiceResult包装的结果
-            result = self.bar_service.get(
+            result = self.bar_service.get_bars_df(
                 code=code,
                 start_date=dt.date(),
-                end_date=dt.date()
+                end_date=dt.date(),
+                adjustment_type=ADJUSTMENT_TYPES.FORE,
             )
 
-            # 检查ServiceResult并解包数据
-            if result.success and result.data:
-                # BarService现在返回ModelList，使用to_dataframe()转换
-                return result.data.to_dataframe()
-            else:
-                GLOG.ERROR(f"Failed to get bars data: {result.error}")
-                return pd.DataFrame()
+            # DF 出口 data 即 pandas.DataFrame，直接返回（不再 .to_dataframe()）
+            if result.success and result.data is not None:
+                return result.data
+            GLOG.ERROR(f"Failed to get bars data: {result.error}")
+            return pd.DataFrame()
 
         except Exception as e:
             GLOG.ERROR(f"Error in _load_daybar for {code} at {dt}: {e}")

--- a/tests/unit/data/services/test_bar_multiexit.py
+++ b/tests/unit/data/services/test_bar_multiexit.py
@@ -24,7 +24,7 @@ if _path not in sys.path:
 from ginkgo.data.crud.model_conversion import ModelList
 from ginkgo.data.services.bar_service import BarService
 from ginkgo.entities import Bar
-from ginkgo.enums import FREQUENCY_TYPES
+from ginkgo.enums import FREQUENCY_TYPES, ADJUSTMENT_TYPES
 
 
 def _make_empty_modellist() -> ModelList:
@@ -146,3 +146,111 @@ def test_get_bars_db_failure_returns_error():
     assert result.success is False
     assert "db down" in result.error
     assert "Database operation failed" in result.error
+
+
+# ===== 出口① get_bars_df 复权路径（#6624：DF 出口内化复权，消除 feeder ModelList 泄漏） =====
+#
+# ADR-010 例外：feeder/sizer 回测热路径依赖 get(FORE) 前复权（除权除息日 K 线不跳空、
+# ATR/仓位拆股后不错算）。盲迁不复权的 get_bars_df() 会静默错算（编译过、测试可能过、
+# 结果错——测试库无 adjustfactor，复权 no-op，掩盖回归）。故 DF 出口须能承载复权，
+# feeder 传 FORE 保行为一致。
+
+
+@pytest.mark.unit
+def test_get_bars_df_fore_applies_single_stock_adjustment():
+    """出口① 复权路径：get_bars_df(code, adjustment_type=FORE) 走单股复权分支。
+
+    断言 _apply_price_adjustment_to_modellist 被调用（与 get(FORE) 同一复权入口），
+    且返回 data 是 DataFrame（ModelList 不出 Service 边界）。
+    """
+    svc = _make_service(_make_bar_modellist())
+    svc._apply_price_adjustment_to_modellist = MagicMock(
+        side_effect=lambda ml, code, adj: ml
+    )
+    result = svc.get_bars_df(
+        code="000001", start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 2), adjustment_type=ADJUSTMENT_TYPES.FORE,
+    )
+    assert result.success is True
+    assert isinstance(result.data, pd.DataFrame)
+    assert not isinstance(result.data, ModelList)
+    svc._apply_price_adjustment_to_modellist.assert_called_once()
+
+
+@pytest.mark.unit
+def test_get_bars_df_fore_multi_stock_uses_multi_adjustment():
+    """出口① 复权路径：get_bars_df(code=None, adjustment_type=FORE) 走多股复权分支。"""
+    svc = _make_service(_make_bar_modellist())
+    svc._apply_price_adjustment_multi_stock = MagicMock(
+        side_effect=lambda ml, adj: ml
+    )
+    result = svc.get_bars_df(
+        start_date=datetime(2024, 1, 1), end_date=datetime(2024, 1, 2),
+        adjustment_type=ADJUSTMENT_TYPES.FORE,
+    )
+    assert result.success is True
+    assert isinstance(result.data, pd.DataFrame)
+    svc._apply_price_adjustment_multi_stock.assert_called_once()
+
+
+@pytest.mark.unit
+def test_get_bars_df_fore_parity_with_get_fore_to_dataframe():
+    """出口① 复权路径行为 parity：get_bars_df(FORE) == get(FORE) + 手动 .to_dataframe()。
+
+    #6624 核心约束（AC「行为与现有回测热路径保持一致」）：DF 出口内化复权后，
+    产出必须与旧热路径 (get() + .to_dataframe()) 完全一致，否则回测静默错算。
+    隔离复权计算本身（mock 为透传），专注两条调用链的结构等价性。
+    """
+    svc = _make_service(_make_bar_modellist())
+    svc._apply_price_adjustment_to_modellist = MagicMock(
+        side_effect=lambda ml, code, adj: ml
+    )
+
+    df_new = svc.get_bars_df(
+        code="000001", start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 2), adjustment_type=ADJUSTMENT_TYPES.FORE,
+    ).data
+
+    # 旧热路径：get(FORE) 返 ModelList 后手动 .to_dataframe()
+    df_old = svc.get(
+        code="000001", start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 2),
+    ).data.to_dataframe()
+
+    pd.testing.assert_frame_equal(df_new, df_old)
+
+
+@pytest.mark.unit
+def test_get_bars_df_default_skips_adjustment():
+    """出口① 默认不复权：adjustment_type 未传时走 NONE 分支，不触发复权（保现有契约）。
+
+    回归保护：扩展 adjustment_type 参数不得改变 get_bars_df() 既有「不复权」语义。
+    """
+    svc = _make_service(_make_bar_modellist())
+    svc._apply_price_adjustment_to_modellist = MagicMock()
+    svc._apply_price_adjustment_multi_stock = MagicMock()
+
+    result = svc.get_bars_df(
+        code="000001", start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 2),
+    )
+    assert result.success is True
+    assert isinstance(result.data, pd.DataFrame)
+    svc._apply_price_adjustment_to_modellist.assert_not_called()
+    svc._apply_price_adjustment_multi_stock.assert_not_called()
+
+
+@pytest.mark.unit
+def test_get_bars_df_fore_empty_returns_empty_dataframe():
+    """出口① 复权路径空结果：find 返空时返空 DataFrame（feeder 空结果场景）。"""
+    svc = _make_service(_make_empty_modellist())
+    svc._apply_price_adjustment_to_modellist = MagicMock()
+    result = svc.get_bars_df(
+        code="000001", start_date=datetime(2024, 1, 1),
+        end_date=datetime(2024, 1, 2), adjustment_type=ADJUSTMENT_TYPES.FORE,
+    )
+    assert result.success is True
+    assert isinstance(result.data, pd.DataFrame)
+    assert result.data.empty
+    # 空 ModelList 不进入复权分支（短路返空 DF）
+    svc._apply_price_adjustment_to_modellist.assert_not_called()

--- a/tests/unit/trading/engines/test_backtest_feeder.py
+++ b/tests/unit/trading/engines/test_backtest_feeder.py
@@ -937,3 +937,79 @@ class TestHistoricalDataAccess:
         assert isinstance(result, pd.DataFrame)
         assert result.empty
         assert len(result) == 0
+
+
+@pytest.mark.unit
+@pytest.mark.backtest
+class TestHistoricalDataDFExportContract:
+    """#6624: get_historical_data 走 DF 出口 get_bars_df(FORE)，不再接触 ORM ModelList。
+
+    ADR-010 例外：feeder 回测热路径依赖前复权（FORE）。get() 默认 FORE，DF 出口默认
+    NONE，故 feeder 须显式传 FORE 保行为 parity。本契约防回归把 get_bars_df 改回 get() +
+    .to_dataframe()（ModelList 重新泄漏过 Service 边界）。Mock-based，无 DB 依赖。
+    """
+
+    def test_get_historical_data_uses_df_export_with_fore_adjustment(self):
+        """get_historical_data 调 get_bars_df(adjustment_type=FORE)，不调 get()。"""
+        from unittest.mock import MagicMock
+        import pandas as pd
+        from ginkgo.data.services.base_service import ServiceResult
+        from ginkgo.enums import ADJUSTMENT_TYPES
+
+        feeder = BacktestFeeder()
+        # 注入 mock bar_service，隔绝 DB
+        mock_service = MagicMock()
+        expected_df = pd.DataFrame([{"code": "000001.SZ", "close": 10.0}])
+        mock_service.get_bars_df.return_value = ServiceResult(success=True, data=expected_df)
+        feeder.bar_service = mock_service
+
+        # 设置 time_provider（validate_time 装饰器需要 self.time_controller）
+        provider = LogicalTimeProvider(initial_time=datetime(2023, 6, 10))
+        feeder.set_time_provider(provider)
+
+        result = feeder.get_historical_data(
+            symbols=["000001.SZ"],
+            start_time=datetime(2023, 6, 1),
+            end_time=datetime(2023, 6, 2),
+            data_type="bar",
+        )
+
+        # 走 DF 出口，传 FORE 复权
+        mock_service.get_bars_df.assert_called_once()
+        _, kwargs = mock_service.get_bars_df.call_args
+        assert kwargs.get("adjustment_type") == ADJUSTMENT_TYPES.FORE
+        # 不再接触 ModelList 出口 get()
+        mock_service.get.assert_not_called()
+        # 直接返回 ServiceResult.data（DF），不再 .to_dataframe()
+        pd.testing.assert_frame_equal(result, expected_df)
+
+    def test_get_historical_data_empty_df_skips_append_without_ambiguous_truth(self):
+        """空 DF 不触发 'truth value of DataFrame is ambiguous'（pandas 真值陷阱回归保护）。
+
+        get_bars_df 返空 DF 时，get_historical_data 须靠 df.empty 判空而非 if result.data，
+        否则 bool(DataFrame) 多元素抛 ValueError。本测试覆盖该边界（#6624 迁移时踩过）。
+        """
+        from unittest.mock import MagicMock
+        import pandas as pd
+        from ginkgo.data.services.base_service import ServiceResult
+        from ginkgo.enums import ADJUSTMENT_TYPES
+
+        feeder = BacktestFeeder()
+        mock_service = MagicMock()
+        # 关键：返空 DataFrame（非 None）——触发真值歧义路径
+        mock_service.get_bars_df.return_value = ServiceResult(
+            success=True, data=pd.DataFrame())
+        feeder.bar_service = mock_service
+        provider = LogicalTimeProvider(initial_time=datetime(2023, 6, 10))
+        feeder.set_time_provider(provider)
+
+        # 不抛 'truth value of a DataFrame is ambiguous'
+        result = feeder.get_historical_data(
+            symbols=["000001.SZ"],
+            start_time=datetime(2023, 6, 1),
+            end_time=datetime(2023, 6, 2),
+            data_type="bar",
+        )
+
+        assert isinstance(result, pd.DataFrame)
+        assert result.empty

--- a/tests/unit/trading/feeders/test_base_feeder.py
+++ b/tests/unit/trading/feeders/test_base_feeder.py
@@ -26,6 +26,8 @@ def _mock_bar_service():
     """创建mock bar_service, 返回空DataFrame."""
     service = MagicMock()
     service.get.return_value = ServiceResult(success=False, error="no data", data=None)
+    # #6624: _load_daybar 改走 DF 出口 get_bars_df；mock 失败路径保空结果语义
+    service.get_bars_df.return_value = ServiceResult(success=False, error="no data", data=None)
     return service
 
 
@@ -184,7 +186,32 @@ class TestDaybarDataAccess:
         feeder = _make_feeder_with_time(time_val=datetime.datetime(2023, 6, 1))
         feeder.bar_service = service
         feeder.get_daybar("000001.SZ", "2023-01-01")
-        service.get.assert_called_once()
+        service.get_bars_df.assert_called_once()
+
+    def test_load_daybar_uses_df_export_with_fore_adjustment(self):
+        """#6624: _load_daybar 走 DF 出口 get_bars_df(FORE)，不再 .to_dataframe() ModelList。
+
+        ADR-010 例外：feeder 回测热路径依赖前复权（FORE）。DF 出口内化复权后，
+        feeder 传 FORE 保行为 parity，ModelList 不再泄漏到 feeder。
+        """
+        from ginkgo.enums import ADJUSTMENT_TYPES
+
+        service = _mock_bar_service()
+        expected_df = pd.DataFrame([{"code": "000001.SZ", "close": 10.0}])
+        service.get_bars_df.return_value = ServiceResult(success=True, data=expected_df)
+
+        feeder = _make_feeder_with_time(time_val=datetime.datetime(2023, 6, 1))
+        feeder.bar_service = service
+        result = feeder.get_daybar("000001.SZ", "2023-01-01")
+
+        # 走 DF 出口，传 FORE 复权
+        service.get_bars_df.assert_called_once()
+        _, kwargs = service.get_bars_df.call_args
+        assert kwargs.get("adjustment_type") == ADJUSTMENT_TYPES.FORE
+        # 不再接触 ModelList 出口 get()
+        service.get.assert_not_called()
+        # 直接返回 ServiceResult.data（DF），不再 .to_dataframe()
+        pd.testing.assert_frame_equal(result, expected_df)
 
 
 @pytest.mark.unit
@@ -257,7 +284,7 @@ class TestDataCaching:
         feeder.get_daybar("000001.SZ", "2023-01-01")
         feeder.get_daybar("000001.SZ", "2023-01-01")
         # Second call may use cache
-        assert service.get.call_count >= 1
+        assert service.get_bars_df.call_count >= 1
 
     def test_cache_expiration(self):
         """测试缓存过期"""
@@ -274,7 +301,7 @@ class TestDataCaching:
         feeder.bar_service = service
         feeder.get_daybar("000001.SZ", "2023-01-01")
         feeder.get_daybar("000002.SZ", "2023-01-02")
-        assert service.get.call_count == 2
+        assert service.get_bars_df.call_count == 2
 
 
 @pytest.mark.unit
@@ -334,7 +361,7 @@ class TestErrorHandling:
     def test_data_loading_exception_handling(self):
         """测试数据加载异常处理"""
         service = MagicMock()
-        service.get.side_effect = Exception("DB error")
+        service.get_bars_df.side_effect = Exception("DB error")
         feeder = _make_feeder_with_time(time_val=datetime.datetime(2023, 6, 1))
         feeder.bar_service = service
         result = feeder.get_daybar("000001.SZ", "2023-01-01")


### PR DESCRIPTION
## Summary

消除 feeder 调用点对 `BarService.get()` 返回 ModelList + 手动 `.to_dataframe()` 的依赖，迁移至类型契约稳定的 DF 出口 `get_bars_df()`。ADR-010：ModelList 不得越过 Service 边界。

### 核心约束（AC「行为与现有回测热路径一致」）

`get()` 默认 `adjustment_type=FORE`（前复权），而 `get_bars_df()` 原默认 NONE。**盲迁会导致回测静默错算**——编译过、测试库无 adjustfactor 时复权 no-op 掩盖回归，生产环境除权除息日 K 线跳空、ATR/仓位拆股后错算。

故先扩展 `get_bars_df` 支持 `adjustment_type` 参数（默认 NONE 保现有契约），feeder 显式传 FORE。复权计算复用与 `get()` 相同的 `_apply_price_adjustment_*` 管道，仅在 Service 边界内化 `.to_dataframe()` 转换。

## Changes

**1. `bar_service.get_bars_df` 扩展 adjustment_type 参数**（feat）
- 默认 NONE 保现有「不复权」契约（回归保护测试覆盖）
- FORE 单股/多股分支复用既有 `_apply_price_adjustment_to_modellist` / `_apply_price_adjustment_multi_stock`
- 空 ModelList 短路返空 DF

**2. feeder 迁移到 DF 出口**（refactor）
- `base_feeder._load_daybar`：`get()` + `.to_dataframe()` → `get_bars_df(FORE)`
- `backtest_feeder.get_historical_data`：同上迁移；用 `is not None` 而非 `if result.data` 判空，规避 pandas DataFrame 多元素真值歧义（迁移时踩过）

**注**：`backtest_feeder._fetch_day_bars_batch`（Entity 消费路径，经 `BarMapper.from_models`）保留 `get(code=None)`——属 ADR-010 Entity 出口消费，不在本 issue 范围（单独切片）。

## Test plan

- ✅ `test_bar_multiexit`：DF 出口契约 + FORE 复权 parity（5 个新测试，含与 `get(FORE)+.to_dataframe()` 的结构等价性验证）
- ✅ `test_base_feeder`：44 个测试全过，含 `_load_daybar` 走 DF 出口 + FORE 的契约测试
- ✅ `test_backtest_feeder`：6 个 `get_historical_data` 集成测试（真实 DB）全过 + 2 个新 mock 契约测试（含 pandas 真值陷阱回归保护）
- ✅ 三层 smoke：py_compile 全量 + 启动路径（user_crud/containers/user_cli）+ 变更相关测试（85 passed, 5 xfailed）
- 集成测试断言精确数据值（close == 101.0 等），测试数据无复权因子，FORE 复权 no-op，验证数据精确匹配

## 验收标准对照

- [x] AC1：feeder 不再依赖 `get()` 返回 ModelList 后手动 `.to_dataframe()` —— 两处泄漏点（`base_feeder._load_daybar`、`backtest_feeder.get_historical_data`）均已迁移到 `get_bars_df`
- [x] AC2：行为与现有回测热路径一致 —— parity 契约测试 + 6 个真实 DB 集成测试全过
- [x] AC3：测试覆盖读取成功与空结果 —— 集成测试 `test_get_historical_data_no_data_returns_empty` + mock 契约测试空 DF 路径

Closes #6624

🤖 Generated with [Claude Code](https://claude.com/claude-code)