### PR TITLE
refactor(#6449): 引入 BacktestUseCase Protocol 收敛回测编排

### DIFF
--- a/docs/adrs/ADR-022-backtest-use-case-layer.md
+++ b/docs/adrs/ADR-022-backtest-use-case-layer.md
@@ -1,0 +1,96 @@
+# ADR-022: 回测应用用例层（BacktestUseCase Protocol）
+
+- **Status**: Accepted
+- **Date**: 2026-07-05
+- **Epic**: #6449 `mod:trading` 重构（引入应用用例层收敛回测编排）
+- **关联**: ADR-016（backtest id 边界）、ADR-018（backtest assignment 契约）、#6282（preflight 数据预检）、#6483（超时如实报告）
+
+## Context
+
+`BacktestOrchestrator`（`src/ginkgo/trading/services/backtest_orchestrator.py`）已经统一了**引擎执行编排**（流 A：load portfolio → assemble engine → start → wait → aggregate），消除 CLI 与 worker 在引擎层的重复。但**任务编排前置逻辑**（流 B：从 task 对象出发的"用例入口"）仍未收敛：
+
+| 职责 | 原 CLI `run_task` 行号 | 是否下沉前重复 |
+|---|---|---|
+| `config_snapshot` dict → `BacktestConfig`（11 行字段映射） | backtest_cli.py:185-198 | worker 路径另有等价解析 |
+| preflight 数据预检 + 阻断 | backtest_cli.py:204-211 | 仅 CLI 有，worker 依赖服务层守卫 |
+| 标 task `running` 状态机更新 | backtest_cli.py:214 | worker 路径另标 |
+| UI 输出（rich console） | backtest_cli.py:216-220 | 仅 CLI 应有 |
+| `raise typer.Exit(1)` 框架异常 | backtest_cli.py:211, 278 | 仅 CLI 应有 |
+
+问题：
+1. **业务逻辑混入 CLI 层**：config 解析、preflight、状态机更新本是用例层职责，散在 CLI 命令函数里，调用方（API/worker）无法复用同一入口。
+2. **框架耦合**：preflight 阻断用 `raise typer.Exit(1)`——typer 是 CLI 框架，业务层不应依赖框架异常。`typer.Exit` 继承 `RuntimeError`，被 `except Exception` 吞成 `exit_code=0` 的陷阱（[[arch_typer_exit_swallowed_by_except_exception]]）就源于此耦合。
+3. **职责漂移风险**：未来 API 或 worker 要复用"从 task 编排一次回测"这一用例，要么各自重写 config 解析（重复），要么强行调 CLI（不现实）。
+
+`BacktestOrchestrator` 实际上**已经是事实上的 UseCase**——它有 `run()` 入口、聚合 4 个 service、对外暴露 `OrchestratorResult`。本 ADR 把这一事实**显式化**：定义 `BacktestUseCase` Protocol，并把"从 task 出发"的用例入口 `run_from_task` 固化到 Orchestrator 内。
+
+## Decision
+
+### 1. 定义 `BacktestUseCase` Protocol（structural typing）
+
+`src/ginkgo/trading/services/backtest_orchestrator.py`：
+
+```python
+@runtime_checkable
+class BacktestUseCase(Protocol):
+    def run_from_task(
+        self,
+        task,
+        config_snapshot: Optional[Dict] = None,
+        progress_callback=None,
+        timeout: Optional[float] = None,
+    ) -> OrchestratorResult:
+        """从 task 对象编排一次回测。"""
+        ...
+```
+
+- **Protocol 而非抽象基类**：用 structural typing（鸭子类型），`BacktestOrchestrator` 无需显式继承即自动满足。未来若 API 层有别的实现，也不必继承同一基类。
+- **`@runtime_checkable`**：让 `isinstance(orchestrator, BacktestUseCase)` 可用，便于依赖注入容器校验。
+- **只声明 `run_from_task`**：`run()` 是引擎级原语（CLI/worker 也直接调，签名稳定），不强制在 Protocol 里。Protocol 只锁定"用例入口"这一契约。
+
+### 2. `BacktestOrchestrator.run_from_task` 一站式入口
+
+封装 4 步（按序）：
+
+1. **config 解析**：`config_snapshot`（dict 或 JSON 字符串）→ `BacktestConfig`。下沉 CLI:185-198 的 11 行字段映射。
+2. **preflight 数据预检**：调 `preflight_data_coverage` + `build_preflight_warning`。warning 存在时**标 task `failed` + 返回 `OrchestratorResult(success=False, error="preflight blocked: ...")`**——**不抛 typer.Exit**。下沉 CLI:204-211。
+3. **标 `running`**：`task_service.update_status(task.uuid, "running")`。下沉 CLI:214。
+4. **委派 `run()`**：把 task.uuid / config / task.portfolio_id 传给既有 `run()`，复用流 A 编排。
+
+### 3. 业务层不依赖框架异常（核心约束）
+
+- UseCase 层永远返回 `OrchestratorResult`（业务事实：成功/失败 + 原因），**从不 raise typer.Exit**。
+- CLI 是翻译层：收到 `success=False` 时自己 `raise typer.Exit(1)` + `console.print(result.error)`。
+- 这让 UseCase 可被 API（HTTP）、worker（异步）、CLI（typer）三种入口无差别调用——内层不知道外层是什么框架。
+
+### 4. CLI `run_task` 薄化
+
+重构后 CLI 仅保留：task 解析（含模糊匹配 UI）→ 构造 orchestrator → 委派 `run_from_task` → 翻译结果为 typer.Exit/console 输出。删除：config 解析（11 行）、preflight 调用、标 running。
+
+## Consequences
+
+**正面**：
+- 回测用例入口统一：CLI/API/worker 调 `run_from_task`，config 解析/preflight/状态机不再重复。
+- 业务层与框架解耦：UseCase 不知 typer 存在，避开 `typer.Exit` 被 `except Exception` 吞的陷阱。
+- Protocol 让"UseCase 契约"显式化、可校验、可替换实现。
+- preflight 从 CLI UX 阻断升级为业务用例契约——worker 路径未来也可受益（当前 worker 走 `run()` 直连，不经 `run_from_task`，不在本 ADR 范围）。
+
+**负面 / 权衡**：
+- `run_from_task` 在 bg（后台线程）模式下，"标 running"发生在子线程而非主线程——比原 CLI 主线程标 running 稍晚。这是 bg 模式本来的异步语义，可接受。
+- `BacktestConfig` 仍是函数级 import（`run_from_task` 内部 import），保持快启——不拖累 orchestrator 模块加载。
+- preflight 失败的 UI 文本从原 rich `:warning:` emoji 变成纯 error 字符串——视觉略损失，但与 ADR-021 的"非 TTY plain text"方向一致。
+
+**未收敛点（另开 issue，不在本 ADR 范围）**：
+- `BacktestTaskService.start_task`（流 B 的另一半：状态机检查 + 9 表清理 + Kafka 派发）220 行函数体揉合 4 职责，是真正未收敛的窄点。本 ADR 不动它（Kafka 派发是 worker 路径语义，与 UseCase 层正交）。
+
+## Alternatives considered
+
+- **A. 新建 `BacktestUseCase` 类，组合 Orchestrator**：增加一层间接，Orchestrator 已是事实 UseCase，多此一举。**否决**。
+- **B. 把 preflight 留在 CLI，不下沉**：worker 路径未来无法复用；且 preflight 是业务用例的一部分（数据不足不应启动回测），归 CLI 不合理。**否决**（用户选择"preflight 也下沉"）。
+- **C. `run_from_task` 直接调 `start_task` + 流 A**：把流 B 也并入。范围过大，且 `start_task` 含 Kafka 派发语义，与同步用例入口冲突。**否决**，另开 issue。
+
+## 实证锚点
+
+- `src/ginkgo/trading/services/backtest_orchestrator.py`：Protocol 定义 + `run_from_task` 实现
+- `src/ginkgo/client/backtest_cli.py`：CLI 薄化（删除 config 解析/preflight/标 running 11+8+1 行）
+- `tests/unit/trading/services/test_backtest_orchestrator.py`：4 个 slice 覆盖 Protocol 符合性 + config 解析 + 标 running + preflight 阻断不抛异常

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -136,6 +136,7 @@ def run_task(
     bg: bool = typer.Option(False, "--bg", help="Run in background thread"),
 ):
     """:rocket: Run a backtest task locally."""
+    import json as _json
     import threading
     from ginkgo import services
     from ginkgo.data.containers import container
@@ -199,6 +200,20 @@ def run_task(
                 current_date=current_date,
             )
 
+        # #6449 review fix: 补回 master 启动 banner（Period/Capital/Portfolio）。
+        # config 已下沉到 run_from_task，banner 仅需 UI 字段，从 task.config_snapshot
+        # 轻量取值；完整 BacktestConfig 解析仍由 UseCase 层负责，避免重复构造。
+        # 解析损坏时退化 '?'；run_from_task 会抛 JSONDecodeError 进下方 except 兜底。
+        try:
+            _snap = _json.loads(task.config_snapshot) if isinstance(task.config_snapshot, str) else (task.config_snapshot or {})
+        except Exception:
+            _snap = {}
+        console.print(f":rocket: Starting backtest: [bold]{task.name}[/bold]")
+        console.print(f"   Period: {_snap.get('start_date', '?')} ~ {_snap.get('end_date', '?')}")
+        console.print(f"   Capital: {_snap.get('initial_cash', '?')}")
+        console.print(f"   Portfolio: {(task.portfolio_id or '?')[:12]}")
+        console.print()
+
         if bg:
             def _run_in_thread():
                 # #6449 re-review 守卫：bg 线程内 run_from_task 在到达自带 try/except 的
@@ -219,7 +234,7 @@ def run_task(
                         task.uuid,
                         progress=100,
                         current_stage="FINALIZING",
-                        current_date=str(result.data.get("backtest_end_date", "")) if result.data else "",
+                        current_date=str(result.data.get("backtest_end_date", "")) if isinstance(result.data, dict) else "",
                     )
                     console.print(f":white_check_mark: Backtest completed: {task.uuid[:12]}")
                 else:
@@ -227,7 +242,6 @@ def run_task(
 
             thread = threading.Thread(target=_run_in_thread, daemon=True)
             thread.start()
-            console.print(f":rocket: Starting backtest (bg): [bold]{task.name}[/bold]")
             console.print(f":hourglass: Backtest running in background (thread)")
         else:
             result = orchestrator.run_from_task(
@@ -242,7 +256,7 @@ def run_task(
                 task.uuid,
                 progress=100,
                 current_stage="FINALIZING",
-                current_date=str(result.data.get("backtest_end_date", "")) if result.data else "",
+                current_date=str(result.data.get("backtest_end_date", "")) if isinstance(result.data, dict) else "",
             )
 
             # 灌入日志到 ClickHouse（静默降级）

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -248,6 +248,10 @@ def run_task(
 
             console.print(f":white_check_mark: Backtest completed: [bold green]{task.uuid[:12]}[/bold green]")
 
+    except typer.Exit:
+        # #6590/#6449 守卫：typer.Exit MRO 含 Exception，须在 except Exception 前透传，
+        # 否则 L229 的 raise typer.Exit(1) 被吞，error_message 被写成 str(e)=='1' 覆盖真因。
+        raise
     except Exception as e:
         service.update_status(task.uuid, "failed", error_message=str(e))
         console.print(f":x: Backtest failed: {e}")

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -136,20 +136,10 @@ def run_task(
     bg: bool = typer.Option(False, "--bg", help="Run in background thread"),
 ):
     """:rocket: Run a backtest task locally."""
-    import json as _json
     import threading
     from ginkgo import services
     from ginkgo.data.containers import container
-    from ginkgo.workers.backtest_worker.models import BacktestConfig
-    from ginkgo.workers.backtest_worker.task_helpers import (
-        build_engine_data,
-        load_portfolio_components,
-        build_portfolio_config,
-        preflight_data_coverage,
-        build_preflight_warning,
-    )
     from ginkgo.libs import GinkgoLogger
-    from ginkgo.trading.time.clock import now as clock_now
 
     service = container.backtest_task_service()
     result = service.get_by_id(task_id)
@@ -181,44 +171,10 @@ def run_task(
 
     task = result.data
 
-    # 解析 config_snapshot → BacktestConfig
-    config_snapshot = _json.loads(task.config_snapshot) if isinstance(task.config_snapshot, str) else task.config_snapshot
-    config = BacktestConfig(
-        start_date=config_snapshot.get("start_date", "2024-01-01"),
-        end_date=config_snapshot.get("end_date", "2024-12-31"),
-        initial_cash=config_snapshot.get("initial_cash", 100000),
-        commission_rate=config_snapshot.get("commission_rate", 0.0003),
-        slippage_rate=config_snapshot.get("slippage_rate", 0.0001),
-        benchmark_return=config_snapshot.get("benchmark_return", 0.0),
-        max_position_ratio=config_snapshot.get("max_position_ratio", 0.3),
-        stop_loss_ratio=config_snapshot.get("stop_loss_ratio", 0.05),
-        take_profit_ratio=config_snapshot.get("take_profit_ratio", 0.15),
-        frequency=config_snapshot.get("frequency", "DAY"),
-        analyzers=[],
-    )
-
-    portfolio_uuid = task.portfolio_id
-
-    # #6282: 回测前数据预检 — 在标 running 前查 selector codes 的 bar 覆盖，
-    # 数据缺失/稀疏时前置阻断，避免跑完整个回测才给模糊警告。
-    preflight_report = preflight_data_coverage(
-        portfolio_uuid, config.start_date, config.end_date
-    )
-    warning = build_preflight_warning(preflight_report, config.start_date, config.end_date)
-    if warning:
-        console.print(warning)
-        service.update_status(task.uuid, "failed")
-        raise typer.Exit(1)
-
-    # 更新状态为 running
-    service.update_status(task.uuid, "running")
-
-    console.print(f":rocket: Starting backtest: [bold]{task.name}[/bold]")
-    console.print(f"   Period: {config.start_date} ~ {config.end_date}")
-    console.print(f"   Capital: {config.initial_cash}")
-    console.print(f"   Portfolio: {portfolio_uuid[:12]}")
-    console.print()
-
+    # #6449: 委派 UseCase 层（BacktestOrchestrator.run_from_task）。
+    # config 解析 / preflight 数据预检 / 标 running 全部由 UseCase 层统一处理，
+    # CLI 仅做 task 解析 + UI 输出 + 框架异常翻译。业务层报"事实"
+    # （OrchestratorResult.success=False + 原因），CLI 翻译为 typer.Exit。
     try:
         from ginkgo.trading.services.backtest_orchestrator import BacktestOrchestrator
         from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAggregator
@@ -245,18 +201,15 @@ def run_task(
 
         if bg:
             def _run_in_thread():
-                result = orchestrator.run(
-                    task_id=task.uuid,
-                    config=config,
-                    portfolio_id=portfolio_uuid,
-                    progress_callback=_progress_callback,
+                result = orchestrator.run_from_task(
+                    task, progress_callback=_progress_callback,
                 )
                 if result.is_success():
                     service.update_progress(
                         task.uuid,
                         progress=100,
                         current_stage="FINALIZING",
-                        current_date=str(config.end_date),
+                        current_date=str(result.data.get("backtest_end_date", "")) if result.data else "",
                     )
                     console.print(f":white_check_mark: Backtest completed: {task.uuid[:12]}")
                 else:
@@ -264,13 +217,11 @@ def run_task(
 
             thread = threading.Thread(target=_run_in_thread, daemon=True)
             thread.start()
+            console.print(f":rocket: Starting backtest (bg): [bold]{task.name}[/bold]")
             console.print(f":hourglass: Backtest running in background (thread)")
         else:
-            result = orchestrator.run(
-                task_id=task.uuid,
-                config=config,
-                portfolio_id=portfolio_uuid,
-                progress_callback=_progress_callback,
+            result = orchestrator.run_from_task(
+                task, progress_callback=_progress_callback,
             )
 
             if not result.is_success():
@@ -281,7 +232,7 @@ def run_task(
                 task.uuid,
                 progress=100,
                 current_stage="FINALIZING",
-                current_date=str(config.end_date),
+                current_date=str(result.data.get("backtest_end_date", "")) if result.data else "",
             )
 
             # 灌入日志到 ClickHouse（静默降级）

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -201,9 +201,19 @@ def run_task(
 
         if bg:
             def _run_in_thread():
-                result = orchestrator.run_from_task(
-                    task, progress_callback=_progress_callback,
-                )
+                # #6449 re-review 守卫：bg 线程内 run_from_task 在到达自带 try/except 的
+                # self.run() 之前有未包裹抛异常路径（_json.loads / preflight_data_coverage
+                # DB 不可达 / BacktestConfig 构造）。master 把这些放主线程同步执行从不触发；
+                # 本 PR 下沉进 bg 线程，须镜像非 bg 路径（L255 except Exception）标 failed +
+                # 印原因，否则线程静默死亡、CLI exit 0、task 卡 pending（ADR-022 §3 不静默）。
+                try:
+                    result = orchestrator.run_from_task(
+                        task, progress_callback=_progress_callback,
+                    )
+                except Exception as e:
+                    service.update_status(task.uuid, "failed", error_message=str(e))
+                    console.print(f":x: Backtest failed: {e}")
+                    return
                 if result.is_success():
                     service.update_progress(
                         task.uuid,

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -35,6 +35,23 @@ def _display_progress(status_val, raw_progress):
     return raw_progress
 
 
+def _emit_backtest_failure(result):
+    """#6449 re-review #2: 回测失败时若 result.data['preflight_warning'] 有全文，印全文。
+
+    UseCase 层(BacktestOrchestrator)把 preflight warning 全文放 data['preflight_warning']，
+    error 留固定短语；翻译层(CLI)负责全文展示（master console.print(warning) 行为）。
+    多标的(≥4 symbol)时含 #6282 symbol 级 `ginkgo data sync` 指引，曾因 error[:200]
+    截断丢失。bg/非 bg 两失败分支共用此 helper 保对称（ADR-022 §3 不静默）。
+    """
+    console.print(f":x: Backtest failed: {result.error}")
+    preflight_warning = (
+        result.data.get("preflight_warning")
+        if isinstance(result.data, dict) else None
+    )
+    if preflight_warning:
+        console.print(preflight_warning)
+
+
 @app.command("create")
 def create_task(
     portfolio: str = typer.Option(..., "--portfolio", "-p", help="Portfolio UUID (required)"),
@@ -238,7 +255,7 @@ def run_task(
                     )
                     console.print(f":white_check_mark: Backtest completed: {task.uuid[:12]}")
                 else:
-                    console.print(f":x: Backtest failed: {result.error}")
+                    _emit_backtest_failure(result)
 
             thread = threading.Thread(target=_run_in_thread, daemon=True)
             thread.start()
@@ -249,7 +266,7 @@ def run_task(
             )
 
             if not result.is_success():
-                console.print(f":x: Backtest failed: {result.error}")
+                _emit_backtest_failure(result)
                 raise typer.Exit(1)
 
             service.update_progress(

--- a/src/ginkgo/trading/services/backtest_orchestrator.py
+++ b/src/ginkgo/trading/services/backtest_orchestrator.py
@@ -130,14 +130,22 @@ class BacktestOrchestrator:
         if self._task_service is not None:
             self._task_service.update_status(task.uuid, "running")
 
-        # 3. 委派 run()
-        return self.run(
+        # 4. 委派 run()
+        result = self.run(
             task_id=task.uuid,
             config=config,
             portfolio_id=task.portfolio_id,
             progress_callback=progress_callback,
             timeout=timeout,
         )
+
+        # #6449: 成功路径回填 backtest_end_date 给调用方（CLI FINALIZING 进度用）。
+        # aggregator 只把它写进 DB task 表、不进返回 dict；config 解析下沉到本层后
+        # 调用方拿不到 config.end_date，故由用例层在此回填，对齐 master 的
+        # str(config.end_date) 语义。
+        if result.is_success() and isinstance(result.data, dict):
+            result.data["backtest_end_date"] = str(config.end_date)
+        return result
 
     def run(self, task_id: str, config, portfolio_id: str,
             timeout: Optional[float] = None,

--- a/src/ginkgo/trading/services/backtest_orchestrator.py
+++ b/src/ginkgo/trading/services/backtest_orchestrator.py
@@ -5,12 +5,14 @@
 
 import os
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
 
 from ginkgo.data.services.base_service import ServiceResult
 from ginkgo.libs import GLOG
 from ginkgo.workers.backtest_worker.task_helpers import (
     load_portfolio_components,
+    preflight_data_coverage,
+    build_preflight_warning,
 )
 
 
@@ -24,6 +26,33 @@ class OrchestratorResult:
 
     def is_success(self) -> bool:
         return self.success
+
+
+@runtime_checkable
+class BacktestUseCase(Protocol):
+    """#6449: 回测应用用例层契约。
+
+    整洁架构的应用层入口——把"从 task 编排一次回测"这一业务用例固化成结构契约，
+    让 CLI / API / worker 通过统一入口调用，而非各自重复 config 解析、preflight、
+    状态机更新。BacktestOrchestrator 是该 Protocol 的参考实现。
+
+    Note: structural typing（鸭子类型）—— BacktestOrchestrator 无需显式继承，
+    只要实现了 run_from_task 即自动满足。@runtime_checkable 让 isinstance 可用。
+    """
+
+    def run_from_task(
+        self,
+        task,
+        config_snapshot: Optional[Dict] = None,
+        progress_callback=None,
+        timeout: Optional[float] = None,
+    ) -> OrchestratorResult:
+        """从 task 对象编排一次回测。
+
+        封装：config 解析 → preflight 数据预检 → 标 running → 委派 run()。
+        业务层报"事实"（success=False + 原因），由调用方（CLI）翻译为框架异常。
+        """
+        ...
 
 
 class BacktestOrchestrator:
@@ -40,6 +69,75 @@ class BacktestOrchestrator:
         self._portfolio_service = portfolio_service
         self._task_service = task_service
         self._result_aggregator = result_aggregator
+
+    def run_from_task(
+        self,
+        task,
+        config_snapshot: Optional[Dict] = None,
+        progress_callback=None,
+        timeout: Optional[float] = None,
+    ) -> OrchestratorResult:
+        """#6449: 从 task 对象编排回测（应用用例层入口）。
+
+        封装 config 解析 + preflight 数据预检 + 标 running + 委派 run()。
+        """
+        import json as _json
+        from ginkgo.workers.backtest_worker.models import BacktestConfig
+
+        # 1. 解析 config_snapshot → BacktestConfig
+        #    收敛点：CLI/worker 不再各自 11 行重复构造，由 UseCase 层统一解析。
+        if config_snapshot is None:
+            config_snapshot = task.config_snapshot
+        if isinstance(config_snapshot, str):
+            config_snapshot = _json.loads(config_snapshot)
+        config = BacktestConfig(
+            start_date=config_snapshot.get("start_date", "2024-01-01"),
+            end_date=config_snapshot.get("end_date", "2024-12-31"),
+            initial_cash=config_snapshot.get("initial_cash", 100000),
+            commission_rate=config_snapshot.get("commission_rate", 0.0003),
+            slippage_rate=config_snapshot.get("slippage_rate", 0.0001),
+            benchmark_return=config_snapshot.get("benchmark_return", 0.0),
+            max_position_ratio=config_snapshot.get("max_position_ratio", 0.3),
+            stop_loss_ratio=config_snapshot.get("stop_loss_ratio", 0.05),
+            take_profit_ratio=config_snapshot.get("take_profit_ratio", 0.15),
+            frequency=config_snapshot.get("frequency", "DAY"),
+            analyzers=[],
+        )
+
+        # 2. preflight 数据预检（#6282 数据覆盖前置阻断）
+        #    收敛点：CLI 不再各自跑 preflight + raise typer.Exit，
+        #    UseCase 层报业务事实（success=False + 原因），调用方翻译为框架异常。
+        preflight_report = preflight_data_coverage(
+            task.portfolio_id,
+            str(config.start_date),
+            str(config.end_date),
+        )
+        warning = build_preflight_warning(
+            preflight_report,
+            str(config.start_date),
+            str(config.end_date),
+        )
+        if warning:
+            if self._task_service is not None:
+                self._task_service.update_status(task.uuid, "failed")
+            return OrchestratorResult(
+                success=False,
+                error=f"preflight blocked: data coverage insufficient "
+                      f"({warning[:200]})",
+            )
+
+        # 3. 标 running（用例契约：状态机更新由 UseCase 层管，调用方不必手动标）
+        if self._task_service is not None:
+            self._task_service.update_status(task.uuid, "running")
+
+        # 3. 委派 run()
+        return self.run(
+            task_id=task.uuid,
+            config=config,
+            portfolio_id=task.portfolio_id,
+            progress_callback=progress_callback,
+            timeout=timeout,
+        )
 
     def run(self, task_id: str, config, portfolio_id: str,
             timeout: Optional[float] = None,

--- a/src/ginkgo/trading/services/backtest_orchestrator.py
+++ b/src/ginkgo/trading/services/backtest_orchestrator.py
@@ -120,10 +120,14 @@ class BacktestOrchestrator:
         if warning:
             if self._task_service is not None:
                 self._task_service.update_status(task.uuid, "failed")
+            # #6449 re-review #2: warning 全文走 data['preflight_warning']，error 留固定短语。
+            # master 行为是 CLI console.print(warning) 印全文；本 PR 收敛进 UseCase 层后曾用
+            # warning[:200] 截断塞进 error 字段——多标的(≥4 symbol)时 #6282 symbol 级
+            # ginkgo data sync 指引被截掉，用户看不到如何补数据。调用方(CLI/worker)负责全文展示。
             return OrchestratorResult(
                 success=False,
-                error=f"preflight blocked: data coverage insufficient "
-                      f"({warning[:200]})",
+                error="preflight blocked: data coverage insufficient",
+                data={"preflight_warning": warning},
             )
 
         # 3. 标 running（用例契约：状态机更新由 UseCase 层管，调用方不必手动标）

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -341,3 +341,106 @@ class TestBacktestRunTaskBgGuard:
         assert err and "boom" in str(err), (
             f"error_message 应含异常真因，实际: {err!r}"
         )
+
+
+class TestBacktestRunTaskBanner:
+    """#6449 review fix: 非 bg 模式补回 master 启动 banner（Period/Capital/Portfolio）。
+
+    config 下沉到 run_from_task 后，banner 字段从 task.config_snapshot 轻量取。
+    回归契约：用户 `ginkgo backtest run <id>` 应看到回测参数概览（master 既有 UX），
+    不能因下沉丢失。
+    """
+
+    @patch("ginkgo.services.logging.log_ingester.LogIngester")
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_non_bg_prints_starting_banner(
+        self, mock_orch_cls, mock_container, mock_log_cls):
+        from ginkgo.client.backtest_cli import app
+        from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+        # 屏蔽 ClickHouse 日志灌入（避免真实连接副作用）
+        mock_log_cls.return_value.ingest_task_logs.return_value = MagicMock(inserted=0)
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-banner-001"
+        task.name = "MyBacktest"
+        task.portfolio_id = "port-banner-123456"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30", "initial_cash": 999999}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.return_value = OrchestratorResult(success=True, data={})
+        mock_orch_cls.return_value = mock_orch
+
+        invoke_result = runner.invoke(app, ["run", "task-banner-001"])
+
+        assert invoke_result.exit_code == 0, (
+            f"期望 exit_code=0，实际 {invoke_result.exit_code}；"
+            f"exception={invoke_result.exception!r}"
+        )
+        plain = _strip_ansi(invoke_result.output)
+        assert "MyBacktest" in plain, f"输出应含 task.name，实际: {plain!r}"
+        assert "2024-01-01" in plain and "2024-06-30" in plain, (
+            f"输出应含 Period（start/end），实际: {plain!r}"
+        )
+        assert "999999" in plain, f"输出应含 Capital，实际: {plain!r}"
+        assert "port-banner-" in plain, f"输出应含 Portfolio 截断，实际: {plain!r}"
+
+
+class TestBacktestRunTaskListDataGuard:
+    """#6449 review fix: result.data 是 list（非 dict）时 FINALIZING 不得抛 AttributeError。
+
+    OrchestratorResult.data 可能是 list（backtest_orchestrator.py:98 有 isinstance(list)
+    分支）。master 用 str(config.end_date) 不依赖 data 类型；本 PR 改成 result.data.get(...)，
+    若 data 是 list，.get 抛 AttributeError。守卫：isinstance(result.data, dict) 退化 ""。
+    """
+
+    @patch("ginkgo.services.logging.log_ingester.LogIngester")
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_non_dict_data_does_not_raise(
+        self, mock_orch_cls, mock_container, mock_log_cls):
+        from ginkgo.client.backtest_cli import app
+        from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+        mock_log_cls.return_value.ingest_task_logs.return_value = MagicMock(inserted=0)
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-list-001"
+        task.portfolio_id = "port-list"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30"}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        # run_from_task 返回 list data（aggregator list 路径）+ success
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.return_value = OrchestratorResult(
+            success=True, data=["net_value_row_1", "net_value_row_2"],
+        )
+        mock_orch_cls.return_value = mock_orch
+
+        invoke_result = runner.invoke(app, ["run", "task-list-001"])
+
+        # 关键守卫：list data 不应抛 AttributeError（.get 在 list 上不存在）。
+        # 守卫缺失时（if result.data else）list truthy 进 .get 抛 AttributeError，
+        # CliRunner 捕获 → exception 非 None + exit_code=1。
+        assert invoke_result.exception is None, (
+            f"list data 路径不应抛异常；exception={invoke_result.exception!r}"
+        )
+        assert invoke_result.exit_code == 0, (
+            f"list data 路径应 exit 0；实际 {invoke_result.exit_code}"
+        )
+        # FINALIZING update_progress 应被调用（说明走到非 bg 成功路径末段未崩）
+        assert mock_service.update_progress.called, (
+            "list data 不应阻断 FINALIZING update_progress 调用"
+        )

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -211,3 +211,62 @@ class TestBacktestCompletedProgressFallback:
 
         plain = _strip_ansi(invoke_result.output)
         assert "100%" in plain
+
+
+class TestBacktestRunTaskExitGuard:
+    """#6449 review: run_task 失败路径的 typer.Exit 必须透传，不能被 except Exception 吞。
+
+    PR #6590 已为 8+ CLI 文件建立 `except typer.Exit: raise` 守卫；backtest_cli 是漏网者。
+    吞掉后果：typer.Exit(1) 被 except Exception 捕获，str(e)=='1'，error_message 被
+    覆盖成 '1' 丢失 preflight 真因（#6590 类陷阱）。
+    """
+
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_failure_path_does_not_swallow_typer_exit(
+        self, mock_orch_cls, mock_container):
+        """run_from_task 返失败时，不应把 error_message 写成 str(typer.Exit)=='1'。"""
+        from ginkgo.client.backtest_cli import app
+        from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-exit-001"
+        task.portfolio_id = "port-exit"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30"}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        # UseCase 层报业务事实（success=False + 真实原因），CLI 翻译为 typer.Exit
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.return_value = OrchestratorResult(
+            success=False, error="preflight blocked: data coverage insufficient",
+        )
+        mock_orch_cls.return_value = mock_orch
+
+        invoke_result = runner.invoke(app, ["run", "task-exit-001"])
+
+        # typer.Exit(1) 必须透传到 CliRunner（exit_code=1）
+        assert invoke_result.exit_code == 1, (
+            f"期望 exit_code=1，实际 {invoke_result.exit_code}；"
+            f"exception={invoke_result.exception!r}"
+        )
+        # 真实原因应在输出中（L228 先打印 result.error）
+        plain = _strip_ansi(invoke_result.output)
+        assert "preflight blocked" in plain, (
+            f"输出应含真实 preflight 原因，实际: {plain!r}"
+        )
+        # 关键守卫断言：typer.Exit 被 except Exception 吞后 str(e)=='1' 会覆盖真因。
+        # 守卫就位时 L252 不执行，update_status 不会被写成 error_message='1'。
+        error_messages = [
+            str(c.kwargs.get("error_message"))
+            for c in mock_service.update_status.call_args_list
+            if "error_message" in c.kwargs
+        ]
+        assert "1" not in error_messages, (
+            "typer.Exit 不应被 except Exception 吞（#6590/#6449 守卫）："
+            f"update_status error_messages={error_messages}"
+        )

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -270,3 +270,74 @@ class TestBacktestRunTaskExitGuard:
             "typer.Exit 不应被 except Exception 吞（#6590/#6449 守卫）："
             f"update_status error_messages={error_messages}"
         )
+
+
+class TestBacktestRunTaskBgGuard:
+    """#6449 re-review: --bg 模式 run_from_task 抛异常时 bg 线程不得静默死亡。
+
+    master 把 preflight/config 解析放主线程同步执行（try 外、bg 分支前），bg 线程只
+    调自带 try/except 的 orchestrator.run()，从不静默死亡。本 PR 把这些路径下沉进
+    run_from_task 并搬进 bg 线程，却没镜像非 bg 路径的 except Exception 守卫 → bg 线程
+    抛异常（JSONDecodeError / preflight DB 不可达 / BacktestConfig 构造）时静默死亡、
+    CLI exit 0、task 卡 pending，与 ADR-022 §3 "UseCase 层从不静默失败" 自相矛盾。
+    """
+
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_bg_thread_marks_failed_on_run_from_task_exception(
+        self, mock_orch_cls, mock_container):
+        """--bg 模式 run_from_task 抛异常时，必须标 task failed + 印原因，不得静默死亡。"""
+        import time
+        from ginkgo.client.backtest_cli import app
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-bg-001"
+        task.portfolio_id = "port-bg"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30"}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        # run_from_task 抛异常：模拟 _json.loads 损坏 / preflight DB 不可达 / BacktestConfig 构造异常。
+        # 这些路径在到达自带 try/except 的 self.run() 之前抛出，bg 线程无 handler 即静默死亡。
+        boom = RuntimeError("config_snapshot JSON corrupted: boom")
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.side_effect = boom
+        mock_orch_cls.return_value = mock_orch
+
+        invoke_result = runner.invoke(app, ["run", "task-bg-001", "--bg"])
+
+        # 主线程立即返回（exit 0，bg 线程后台跑）——这是 bg 模式契约，不是 bug
+        assert invoke_result.exit_code == 0, (
+            f"--bg 主线程应 exit 0，实际 {invoke_result.exit_code}；"
+            f"exception={invoke_result.exception!r}"
+        )
+
+        # 轮询等待 bg 线程跑完异常处理（daemon 线程异步，最多等 2s）
+        deadline = time.monotonic() + 2.0
+        failed_call = None
+        while time.monotonic() < deadline:
+            for c in mock_service.update_status.call_args_list:
+                # 镜像非 bg 路径：update_status(task.uuid, "failed", error_message=str(e))
+                if len(c.args) >= 2 and c.args[1] == "failed":
+                    failed_call = c
+                    break
+            if failed_call is not None:
+                break
+            time.sleep(0.02)
+
+        # 关键守卫断言：bg 线程内 run_from_task 抛异常 → 必须标 failed（而非静默死亡）。
+        # 守卫缺失时 bg 线程无 handler 死亡，update_status 永不被调 → failed_call is None。
+        assert failed_call is not None, (
+            "--bg 模式 run_from_task 抛异常时必须标 task failed + 印原因"
+            "（ADR-022 §3 不静默）；update_status 未收到 failed 调用 = bg 线程静默死亡。"
+            f" calls={mock_service.update_status.call_args_list}"
+        )
+        # error_message 应含真实异常信息（非空、非 '1'）
+        err = failed_call.kwargs.get("error_message")
+        assert err and "boom" in str(err), (
+            f"error_message 应含异常真因，实际: {err!r}"
+        )

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -444,3 +444,134 @@ class TestBacktestRunTaskListDataGuard:
         assert mock_service.update_progress.called, (
             "list data 不应阻断 FINALIZING update_progress 调用"
         )
+
+
+class TestBacktestRunTaskPreflightWarningDisplay:
+    """#6449 re-review #2: CLI 失败分支应印全文 preflight_warning（含 #6282 sync 指引）。
+
+    UseCase 层把 warning 全文放 data['preflight_warning']，CLI 翻译层负责展示。
+    不再只印被截断的 error 字段——master 行为是 console.print(warning) 印全文。
+    bg/非 bg 两分支对称（ADR-022 §3 不静默）。
+    """
+
+    @patch("ginkgo.services.logging.log_ingester.LogIngester")
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_nonbg_preflight_failure_prints_full_warning(
+        self, mock_orch_cls, mock_container, mock_log_cls):
+        """非 bg preflight 失败：输出含 #6282 sync 指引 + 尾部 symbol（全文未截断）。"""
+        from ginkgo.client.backtest_cli import app
+        from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+        mock_log_cls.return_value.ingest_task_logs.return_value = MagicMock(inserted=0)
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-pfdisp"
+        task.portfolio_id = "port-pfdisp"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30"}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        # UseCase 层报业务事实：固定短语 error + 全文 warning in data（>200 字符）
+        full_warning = (
+            ":warning: Data preflight failed: 4 symbol(s) have insufficient bars\n"
+            "   Window: 2024-01-01 ~ 2024-06-30\n"
+            "   - 000001.SZ: 5 bar(s)\n"
+            "   - 000002.SZ: 5 bar(s)\n"
+            "   - 000063.SZ: 5 bar(s)\n"
+            "   - 000333.SZ: 5 bar(s)\n"
+            ":bulb: Tip: sync day bars first — "
+            "`ginkgo data sync --code <CODE>` or widen the backtest window."
+        )
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.return_value = OrchestratorResult(
+            success=False,
+            error="preflight blocked: data coverage insufficient",
+            data={"preflight_warning": full_warning},
+        )
+        mock_orch_cls.return_value = mock_orch
+
+        invoke_result = runner.invoke(app, ["run", "task-pfdisp"])
+
+        assert invoke_result.exit_code == 1, (
+            f"非 bg preflight 失败应 exit 1，实际 {invoke_result.exit_code}；"
+            f"exception={invoke_result.exception!r}"
+        )
+        plain = _strip_ansi(invoke_result.output)
+        # 关键：#6282 symbol 级 sync 指引必须出现在输出（曾因 error[:200] 被截掉）
+        assert "ginkgo data sync" in plain, (
+            f"输出应含 #6282 全文 sync 指引，实际: {plain!r}"
+        )
+        # 尾部 symbol 也应出现（证明全文未截断，000333 在 200 字符之后）
+        assert "000333.SZ" in plain, (
+            f"输出应含尾部 symbol 000333.SZ，实际: {plain!r}"
+        )
+
+    @patch("ginkgo.services.logging.log_ingester.LogIngester")
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_bg_preflight_failure_uses_emit_helper(
+        self, mock_orch_cls, mock_container, mock_log_cls):
+        """--bg 模式 preflight 失败也走 _emit_backtest_failure（与非 bg 对称印全文 warning）。
+
+        bg 线程内 console.print 输出时机不可靠（daemon 线程，invoke 已返回），
+        故 spy 模块级 _emit_backtest_failure 验证 bg 失败分支调用了它且传入含
+        preflight_warning 的 result（与非 bg 分支共用 helper = 对称）。
+        """
+        import time as _time
+        from ginkgo.client import backtest_cli
+        from ginkgo.client.backtest_cli import app
+        from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+        mock_log_cls.return_value.ingest_task_logs.return_value = MagicMock(inserted=0)
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-bg-pf"
+        task.portfolio_id = "port-bg-pf"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30"}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        full_warning = (
+            ":warning: Data preflight failed: 4 symbol(s) have insufficient bars\n"
+            "   - 000333.SZ: 5 bar(s)\n"
+            ":bulb: Tip: `ginkgo data sync --code <CODE>` or widen the backtest window."
+        )
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.return_value = OrchestratorResult(
+            success=False,
+            error="preflight blocked: data coverage insufficient",
+            data={"preflight_warning": full_warning},
+        )
+        mock_orch_cls.return_value = mock_orch
+
+        # wraps 保留原实现（bg 线程仍真实打印），spy 仅记录调用
+        with patch.object(
+            backtest_cli, "_emit_backtest_failure",
+            wraps=backtest_cli._emit_backtest_failure,
+        ) as spy_emit:
+            invoke_result = runner.invoke(app, ["run", "task-bg-pf", "--bg"])
+            # 轮询等 bg daemon 线程跑到失败分支（最多 2s）
+            deadline = _time.monotonic() + 2.0
+            while _time.monotonic() < deadline and spy_emit.call_count == 0:
+                _time.sleep(0.02)
+
+        assert invoke_result.exit_code == 0, (
+            f"--bg 主线程应 exit 0（bg 线程后台跑），实际 {invoke_result.exit_code}"
+        )
+        assert spy_emit.call_count >= 1, (
+            "--bg 失败分支应调用 _emit_backtest_failure（与非 bg 对称印全文 warning），"
+            f"实际调用次数 {spy_emit.call_count} = bg 分支仍只印截断 error"
+        )
+        result_arg = spy_emit.call_args.args[0]
+        assert result_arg.data.get("preflight_warning") == full_warning, (
+            "传给 helper 的 result 应携带全文 preflight_warning"
+        )

--- a/tests/unit/trading/services/test_backtest_orchestrator.py
+++ b/tests/unit/trading/services/test_backtest_orchestrator.py
@@ -426,9 +426,10 @@ class TestRunFromTaskConfigParse:
     收敛点：CLI/worker 不再各自构造 BacktestConfig，由 UseCase 层统一解析。
     """
 
+    @patch("ginkgo.trading.services.backtest_orchestrator.preflight_data_coverage")
     @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
     def test_dict_snapshot_converted_to_backtest_config(
-        self, mock_load_components, orchestrator,
+        self, mock_load_components, mock_preflight, orchestrator,
         mock_assembly_service, mock_portfolio_service, mock_aggregator):
         """传 dict config_snapshot 时，应转 BacktestConfig 传给 run()。"""
         from ginkgo.workers.backtest_worker.models import BacktestConfig
@@ -446,6 +447,9 @@ class TestRunFromTaskConfigParse:
             is_success=lambda: True, data=[_make_portfolio_result()],
         )
         mock_load_components.return_value = _make_components()
+        # #6449 review: 隔离 preflight，避免查真实 MySQL（portfolio "port-x" 不存在
+        # → selector 空 → 偶然命中"动态 selector 放行"分支，无 DB 的 CI 会红）。
+        mock_preflight.return_value = {"ok": True, "sparse": [], "codes": []}
         mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
             success=True, data=_make_engine_mock(),
         )
@@ -484,9 +488,10 @@ class TestRunFromTaskMarksRunning:
     收敛点：状态机更新（running）成为用例契约，调用方不必手动管理。
     """
 
+    @patch("ginkgo.trading.services.backtest_orchestrator.preflight_data_coverage")
     @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
     def test_marks_running_before_run(
-        self, mock_load_components, orchestrator,
+        self, mock_load_components, mock_preflight, orchestrator,
         mock_assembly_service, mock_portfolio_service,
         mock_aggregator, mock_task_service):
         """run_from_task 应调 task_service.update_status(task.uuid, 'running')。"""
@@ -499,6 +504,8 @@ class TestRunFromTaskMarksRunning:
             is_success=lambda: True, data=[_make_portfolio_result()],
         )
         mock_load_components.return_value = _make_components()
+        # #6449 review: 隔离 preflight，避免查真实 MySQL（同 test_dict_snapshot_*）。
+        mock_preflight.return_value = {"ok": True, "sparse": [], "codes": []}
         mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
             success=True, data=_make_engine_mock(),
         )
@@ -516,6 +523,54 @@ class TestRunFromTaskMarksRunning:
         assert called_running, (
             "run_from_task 应标 running（#6449）："
             f"实际 update_status 调用 {status_calls}"
+        )
+
+
+# ===========================================================================
+# #6449: run_from_task — 成功路径回填 backtest_end_date（CLI FINALIZING 进度用）
+# ===========================================================================
+
+
+class TestRunFromTaskExposesEndDate:
+    """#6449: run_from_task 成功时应把 backtest_end_date 放入 result.data。
+
+    收敛点：aggregator 只把 backtest_end_date 写进 DB task 表、不进返回 dict；
+    config 解析下沉到 UseCase 层后 CLI 拿不到 config.end_date。用例层需在
+    result.data 回填该键，否则 CLI 成功路径的 FINALIZING current_date 恒空。
+    """
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.preflight_data_coverage")
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_success_exposes_backtest_end_date(
+        self, mock_load_components, mock_preflight, orchestrator,
+        mock_assembly_service, mock_portfolio_service, mock_aggregator):
+        """run_from_task 成功时 result.data 应含 backtest_end_date（对齐 config.end_date）。"""
+        mock_preflight.return_value = {"ok": True, "sparse": [], "codes": []}
+
+        task = MagicMock()
+        task.uuid = "task-end"
+        task.portfolio_id = "port-end"
+        task.config_snapshot = {
+            "start_date": "2024-01-01", "end_date": "2024-06-30",
+            "initial_cash": 500000, "frequency": "DAY",
+        }
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=_make_engine_mock(),
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        result = orchestrator.run_from_task(task)
+
+        assert result.is_success(), f"应成功，实际 error: {result.error}"
+        assert result.data.get("backtest_end_date") == "2024-06-30", (
+            "run_from_task 应在 result.data 回填 backtest_end_date（#6449）："
+            f"实际 {result.data.get('backtest_end_date')!r}"
         )
 
 

--- a/tests/unit/trading/services/test_backtest_orchestrator.py
+++ b/tests/unit/trading/services/test_backtest_orchestrator.py
@@ -621,6 +621,49 @@ class TestRunFromTaskPreflight:
             f"preflight 阻断应标 failed（#6449 保留原 CLI 语义）：实际 {status_calls}"
         )
 
+    @patch("ginkgo.trading.services.backtest_orchestrator.preflight_data_coverage")
+    def test_preflight_warning_full_text_not_truncated(
+        self, mock_preflight, orchestrator, mock_task_service):
+        """#6449 re-review #2: 多标的 preflight 失败时 warning 全文不得被 [:200] 截断。
+
+        master 行为：CLI 直接 console.print(warning) 印全文（含 #6282 symbol 级
+        ginkgo data sync 指引）。本 PR 收敛进 UseCase 层后曾用 warning[:200] 截断
+        塞进 error 字段——多标的(≥4 symbol)时 #6282 指引被截掉，用户看不到如何补数据。
+        修复契约：warning 全文走 data['preflight_warning']，error 留固定短语。
+        """
+        # 4 个标的 sparse → build_preflight_warning 产出 >200 字符（含 Tip 行）
+        sparse_codes = ["000001.SZ", "000002.SZ", "000063.SZ", "000333.SZ"]
+        mock_preflight.return_value = {
+            "codes": sparse_codes,
+            "coverage": {c: 5 for c in sparse_codes},
+            "sparse": sparse_codes,
+            "ok": False,
+        }
+
+        task = MagicMock()
+        task.uuid = "task-pf-full"
+        task.portfolio_id = "port-pf-full"
+        task.config_snapshot = {"start_date": "2024-01-01", "end_date": "2024-06-30"}
+
+        result = orchestrator.run_from_task(task)
+
+        # 1. error 是固定短语（不再含 warning[:200] 截断正文）
+        assert result.error == "preflight blocked: data coverage insufficient", (
+            f"error 应为固定短语（不再截断 warning），实际: {result.error!r}"
+        )
+        # 2. warning 全文走 data['preflight_warning']，含全部 symbol + #6282 sync 指引
+        assert isinstance(result.data, dict), "data 应为 dict 以承载 preflight_warning"
+        warning = result.data.get("preflight_warning")
+        assert warning is not None, "warning 全文应进 data['preflight_warning']"
+        assert len(warning) > 200, (
+            f"4 标的 warning 应 >200 字符（验证截断回归），实际长度 {len(warning)}"
+        )
+        for code in sparse_codes:
+            assert code in warning, f"warning 应含 symbol {code}，实际: {warning!r}"
+        assert "ginkgo data sync" in warning, (
+            f"warning 应含 #6282 symbol 级 sync 指引，实际: {warning!r}"
+        )
+
 
 class TestOrchestratorTimeoutConfig:
     """#6483: 超时阈值应可通过 GINKGO_BACKTEST_TIMEOUT 环境变量配置（覆盖默认 3600s）。"""

--- a/tests/unit/trading/services/test_backtest_orchestrator.py
+++ b/tests/unit/trading/services/test_backtest_orchestrator.py
@@ -392,6 +392,181 @@ class TestOrchestratorTimeoutReporting:
         )
 
 
+# ===========================================================================
+# #6449: BacktestUseCase Protocol — 应用用例层契约
+# ===========================================================================
+
+
+class TestUseCaseProtocol:
+    """#6449: BacktestOrchestrator 即隐式 UseCase。
+
+    ADR-022 引入 BacktestUseCase Protocol（structural typing），让 CLI/API/worker
+    通过统一的应用层入口编排回测，而非各自重复 config 解析/preflight/状态机。
+    验收：BacktestOrchestrator 实例满足 BacktestUseCase 结构契约。
+    """
+
+    def test_orchestrator_satisfies_usecase_protocol(self, orchestrator):
+        """BacktestOrchestrator 应当是 BacktestUseCase（duck typing 通过）。"""
+        from ginkgo.trading.services.backtest_orchestrator import BacktestUseCase
+
+        assert isinstance(orchestrator, BacktestUseCase), (
+            "BacktestOrchestrator 必须满足 BacktestUseCase Protocol（#6449）："
+            "缺少 run_from_task 方法"
+        )
+
+
+# ===========================================================================
+# #6449: run_from_task — config 解析下沉（dict snapshot → BacktestConfig）
+# ===========================================================================
+
+
+class TestRunFromTaskConfigParse:
+    """#6449: run_from_task 应把 task.config_snapshot（dict/JSON）解析为 BacktestConfig。
+
+    收敛点：CLI/worker 不再各自构造 BacktestConfig，由 UseCase 层统一解析。
+    """
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_dict_snapshot_converted_to_backtest_config(
+        self, mock_load_components, orchestrator,
+        mock_assembly_service, mock_portfolio_service, mock_aggregator):
+        """传 dict config_snapshot 时，应转 BacktestConfig 传给 run()。"""
+        from ginkgo.workers.backtest_worker.models import BacktestConfig
+
+        task = MagicMock()
+        task.uuid = "task-x"
+        task.portfolio_id = "port-x"
+        snapshot = {
+            "start_date": "2024-01-01", "end_date": "2024-06-30",
+            "initial_cash": 500000, "frequency": "DAY",
+        }
+        task.config_snapshot = snapshot
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=_make_engine_mock(),
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        # spy run() 捕获实际传入的 config
+        captured = {}
+        original_run = orchestrator.run
+
+        def spy_run(task_id, config, portfolio_id, **kw):
+            captured["config"] = config
+            return original_run(task_id, config, portfolio_id, **kw)
+
+        orchestrator.run = spy_run
+
+        orchestrator.run_from_task(task, config_snapshot=snapshot)
+
+        cfg = captured.get("config")
+        assert isinstance(cfg, BacktestConfig), (
+            "run_from_task 应把 dict snapshot 转 BacktestConfig（#6449）："
+            f"实际类型 {type(cfg).__name__}"
+        )
+        assert cfg.start_date == "2024-01-01"
+        assert cfg.initial_cash == 500000
+
+
+# ===========================================================================
+# #6449: run_from_task — 标 running 状态机下沉
+# ===========================================================================
+
+
+class TestRunFromTaskMarksRunning:
+    """#6449: run_from_task 应在委派 run() 前自动标 task 为 running。
+
+    收敛点：状态机更新（running）成为用例契约，调用方不必手动管理。
+    """
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.load_portfolio_components")
+    def test_marks_running_before_run(
+        self, mock_load_components, orchestrator,
+        mock_assembly_service, mock_portfolio_service,
+        mock_aggregator, mock_task_service):
+        """run_from_task 应调 task_service.update_status(task.uuid, 'running')。"""
+        task = MagicMock()
+        task.uuid = "task-r"
+        task.portfolio_id = "port-r"
+        task.config_snapshot = {}
+
+        mock_portfolio_service.get.return_value = MagicMock(
+            is_success=lambda: True, data=[_make_portfolio_result()],
+        )
+        mock_load_components.return_value = _make_components()
+        mock_assembly_service.assemble_backtest_engine.return_value = MagicMock(
+            success=True, data=_make_engine_mock(),
+        )
+        from ginkgo.data.services.base_service import ServiceResult
+        mock_aggregator.aggregate_and_save.return_value = ServiceResult.success()
+
+        orchestrator.run_from_task(task)
+
+        # task_service 是 orchestrator 的 _task_service
+        status_calls = mock_task_service.update_status.call_args_list
+        called_running = any(
+            c.args == ("task-r", "running") or c.kwargs == {"task_id": "task-r", "status": "running"}
+            for c in status_calls
+        )
+        assert called_running, (
+            "run_from_task 应标 running（#6449）："
+            f"实际 update_status 调用 {status_calls}"
+        )
+
+
+# ===========================================================================
+# #6449: run_from_task — preflight 数据预检下沉（不抛 typer.Exit）
+# ===========================================================================
+
+
+class TestRunFromTaskPreflight:
+    """#6449: preflight 数据预检由 UseCase 层做，业务层不抛框架异常。
+
+    收敛点：CLI 的 preflight 阻断语义（raise typer.Exit）下沉为业务事实
+    （success=False + 原因），CLI 翻译层负责转框架异常。
+    """
+
+    @patch("ginkgo.trading.services.backtest_orchestrator.preflight_data_coverage")
+    def test_preflight_fail_returns_failure_not_raises(
+        self, mock_preflight, orchestrator, mock_task_service):
+        """preflight 报数据缺失时，run_from_task 应返回失败结果，不抛异常。"""
+        # 构造一个会生成 warning 的 preflight 报告（数据稀疏）
+        # 字段名必须匹配 build_preflight_warning 的真实契约：sparse/coverage/ok
+        mock_preflight.return_value = {
+            "codes": ["000001.SZ", "000002.SZ"],
+            "coverage": {"000001.SZ": 2, "000002.SZ": 0},
+            "sparse": ["000001.SZ", "000002.SZ"],
+            "ok": False,
+        }
+
+        task = MagicMock()
+        task.uuid = "task-pf"
+        task.portfolio_id = "port-pf"
+        task.config_snapshot = {"start_date": "2024-01-01", "end_date": "2024-06-30"}
+
+        # 关键：调用不应抛任何异常（特别不能抛 typer.Exit）
+        result = orchestrator.run_from_task(task)
+
+        # 必须是失败结果（而非静默成功）
+        assert not result.is_success(), (
+            "preflight 失败应返回 success=False（#6449）"
+        )
+        assert "preflight" in result.error.lower(), (
+            f"error 应含 preflight 描述，实际: {result.error!r}"
+        )
+        # 应标 failed（保留原 CLI 语义）
+        status_calls = mock_task_service.update_status.call_args_list
+        called_failed = any(c.args == ("task-pf", "failed") for c in status_calls)
+        assert called_failed, (
+            f"preflight 阻断应标 failed（#6449 保留原 CLI 语义）：实际 {status_calls}"
+        )
+
+
 class TestOrchestratorTimeoutConfig:
     """#6483: 超时阈值应可通过 GINKGO_BACKTEST_TIMEOUT 环境变量配置（覆盖默认 3600s）。"""
 


### PR DESCRIPTION
## Summary

ADR-022 把 `BacktestOrchestrator` 显式化为应用用例层入口，收敛"从 task 对象编排一次回测"这一用例。

### 变更

- **定义 `BacktestUseCase` Protocol**（structural typing + `@runtime_checkable`）：锁定用例入口契约，`BacktestOrchestrator` 自动满足。
- **新增 `BacktestOrchestrator.run_from_task`** 一站式入口，封装 4 步：
  1. `config_snapshot` dict → `BacktestConfig`（下沉 CLI 11 行字段映射）
  2. preflight 数据预检 + 阻断（下沉 CLI 8 行）
  3. 标 task `running`（下沉 CLI 状态机更新）
  4. 委派既有 `run()` 复用流 A 编排
- **业务层不依赖框架异常**：preflight 阻断时返回 `OrchestratorResult(success=False, error="preflight blocked: ...")` + 标 failed，**不抛 `typer.Exit`**——避开 typer.Exit 被 `except Exception` 吞成 `exit_code=0` 的陷阱（[[arch_typer_exit_swallowed_by_except_exception]]）。CLI 翻译层负责把失败结果转 `typer.Exit(1)` + console 输出。
- **CLI `run_task` 薄化**：删除 config 解析 + preflight + 标 running 共 ~20 行，改委派 `run_from_task`。

### 范围边界（重要）

本 ADR 收敛的是**引擎执行编排前置逻辑**（config/preflight/状态机）。`BacktestTaskService.start_task`（状态机检查 + 9 表清理 + Kafka 派发，220 行函数体）是另一条正交流，**本 ADR 不动**，另开 issue 处理。

worker 路径仍直连 `run()`（不经 `run_from_task`），契约对称性保持。

## Test plan

TDD 4 vertical slice（每片一个测试 → 一段实现），全绿：
- `TestUseCaseProtocol::test_orchestrator_satisfies_usecase_protocol` — Protocol 符合性
- `TestRunFromTaskConfigParse::test_dict_snapshot_converted_to_backtest_config` — config 解析下沉
- `TestRunFromTaskMarksRunning::test_marks_running_before_run` — 标 running 状态机
- `TestRunFromTaskPreflight::test_preflight_fail_returns_failure_not_raises` — preflight 不抛异常

三层冒烟（推送前强制）：
- ✅ py_compile 全仓（src + api）
- ✅ 启动路径 smoke（user_crud + containers + user_cli，33/33）
- ✅ 相关测试（orchestrator 18 + CLI 6 + 派生 8 = 32/32）

总计 65/65 通过，零回归。

Closes #6449

🤖 Generated with [Claude Code](https://claude.com/claude-code)