### PR TITLE
test(#6633): align backtest feeder publish contract with batch feed path

### DIFF
--- a/tests/unit/trading/feeders/test_backtest_feeder_publish.py
+++ b/tests/unit/trading/feeders/test_backtest_feeder_publish.py
@@ -3,13 +3,38 @@ BacktestFeeder 端到端：advance_time 的 emit 经 FeederPublishMixin.publish_
 
 验证 BacktestFeeder 装 EngineBindableMixin+FeederPublishMixin 后 MRO 链通：
 advance_time 内 emit 走 publish_price_update → publish_event → engine.put，
-成功投递计 stats['events_published']。mock _generate_price_events 避开 DB。
+成功投递计 stats['events_published']。
+
+#6587 重构后 advance_time 取数从单股 _generate_price_events 改为批量
+_compute_feedable_codes（∩ available）+ _fetch_day_bars_batch（code=None 全市场）。
+本契约测试 mock 经 public collaborator bar_service（DI seam）让新路径产出当日 bar，
+验证 emit 经 publish seam 投递并计数——不 mock feeder 内部方法（实现细节，重构即坏）。
 """
 from datetime import datetime
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+import ginkgo.data.mappers as mappers_mod
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.entities import Bar
+from ginkgo.enums import FREQUENCY_TYPES, SOURCE_TYPES
+from ginkgo.trading.events import EventPriceUpdate
 from ginkgo.trading.feeders.backtest_feeder import BacktestFeeder
 from ginkgo.trading.time.providers import LogicalTimeProvider
+
+
+def _make_bar(code: str) -> Bar:
+    """构造真实 Bar entity（避免 mock 导致 EventPriceUpdate 构造失败）。"""
+    return Bar(
+        code=code,
+        open=100.0,
+        high=101.0,
+        low=99.0,
+        close=100.0,
+        volume=10000,
+        amount=1000000.0,
+        frequency=FREQUENCY_TYPES.DAY,
+        timestamp=datetime(2023, 6, 1, 9, 30),
+    )
 
 
 class TestBacktestFeederEmitsViaPublishPriceUpdate:
@@ -17,18 +42,37 @@ class TestBacktestFeederEmitsViaPublishPriceUpdate:
         """advance_time emit 经 publish_price_update 投递到 engine.put 并计 events_published。
 
         BacktestFeeder 已继承 EngineBindableMixin；装 FeederPublishMixin 后，
-        set_event_publisher 注入 _engine_put，advance_time 内 publish_price_update
-        → publish_event → _engine_put(event)。端到端验证 MRO 链通 + 统计计数。
+        set_event_publisher 注入 _engine_put，advance_time 内构造 EventPriceUpdate
+        → publish_price_update → publish_event → _engine_put(event)。
+        端到端验证 MRO 链通 + 投递 + 计数。
+
+        mock 经 public collaborator bar_service（DI）让 #6587 重构后的批量取数路径
+        产出当日 bar；不 mock feeder 内部方法（实现细节，重构即坏）。
         """
         feeder = BacktestFeeder()
         feeder.set_time_provider(LogicalTimeProvider(datetime(2023, 6, 1)))
         captured: list = []
         feeder.set_event_publisher(captured.append)
         feeder._interested_codes = ["X.SZ"]
-        event = Mock(name="price_event")
-        feeder._generate_price_events = lambda code, t: [event]  # 避开 DB
 
-        feeder.advance_time(datetime(2023, 6, 1, 9, 30, 0))
+        # mock bar_service（DI seam）让新取数路径产出当日 X.SZ bar：
+        #   get_available_codes 返 ["X.SZ"]（_compute_feedable_codes 交集非空）
+        #   get(code=None, ...) 返 ModelList（_fetch_day_bars_batch 批量取当日 bar）
+        bar_x = _make_bar("X.SZ")
+        mock_bs = Mock()
+        mock_bs.get_available_codes.return_value = ServiceResult(
+            success=True, data=["X.SZ"]
+        )
+        feeder.bar_service = mock_bs
 
-        assert captured == [event], "emit 应经 publish_price_update 投递到 engine.put"
+        with patch.object(
+            mappers_mod.BarMapper, "from_models", return_value=[bar_x]
+        ):
+            feeder.advance_time(datetime(2023, 6, 1, 9, 30, 0))
+
+        # emit 经 publish_price_update 投递到 engine.put
+        assert len(captured) == 1, "emit 应经 publish_price_update 投递到 engine.put"
+        assert isinstance(captured[0], EventPriceUpdate)
+        assert captured[0].payload is bar_x, "投递的应是当日 bar 包成的 EventPriceUpdate"
+        assert captured[0].source == SOURCE_TYPES.BACKTESTFEEDER
         assert feeder.stats["events_published"] == 1


### PR DESCRIPTION
## Summary

恢复 ADR-019 publish 契约测试 `test_backtest_feeder_publish.py` 在 master 通过。

**根因**：PR #6587 重构 `BacktestFeeder.advance_time` 取数链路（单股 `_generate_price_events` → 批量 `_compute_feedable_codes` ∩ available + `_fetch_day_bars_batch` 走 `bar_service.get(code=None)` 全市场），但 ADR-019 publish 契约测试仍 mock 旧方法 `_generate_price_events = lambda code, t: [event]` 绕开 DB。该 mock 对新路径无效 → `bar_service.get_available_codes` 未 mock 返空（fallback 走真实 ClickHouse find）→ feedable 空 → 早 return → 0 事件 → `assert captured == [price_event]` FAIL。

CI 盲区：`.github/workflows/ci.yml` 只跑 `test_user_crud_mock` / `test_containers` / `test_user_cli` + py_compile，不覆盖 `tests/unit/trading/feeders/`，故 master CI 绿而测试实红。

**修复**（仅测试文件，生产代码零变更）：mock 经 public collaborator `bar_service`（DI seam）让 #6587 重构后的批量取数路径产出当日 bar：
- `get_available_codes` 返 `["X.SZ"]`（`_compute_feedable_codes` 交集非空）
- `patch BarMapper.from_models` 返真实 `Bar(code="X.SZ")`（`_fetch_day_bars_batch` 批量取当日 bar）
- 删除失效的 `feeder._generate_price_events = lambda...` 行
- 断言 emit 经 `publish_price_update` 投递 `EventPriceUpdate`（payload=bar, source=BACKTESTFEEDER）并计 `events_published == 1`

mock 点在 public collaborator（`bar_service` 依赖注入）而非 feeder 私有方法，符合"测行为不测实现"——契约测试聚焦 ADR-019 seam 投递+计数，不再因取数实现变动而坏。与同批 #6587 重构测试 `test_backtest_feeder_prefilter.py` 的 mock 模式一致。

## Test plan

- [x] `pytest tests/unit/trading/feeders/test_backtest_feeder_publish.py -v` → PASSED
- [x] 同目录其余 publish 契约测试保持绿：`test_feeder_publish_mixin.py` / `test_live_feeder_publish.py` / `test_okx_data_feeder_publish.py`（12 passed）
- [x] 同目录全量无回归（59 passed，含 `test_backtest_feeder_prefilter.py`）
- [x] Layer 1 py_compile（src+api 全仓）通过
- [x] Layer 2 启动路径 smoke（CI 点名三测试）33 passed

## Out of scope

- `_generate_price_events` 孤儿方法清理（生产 0 调用方，仅 `tests/unit/trading/engines/test_backtest_feeder.py` 3 个直测依赖）
- Bug 2（窄 universe 性能回归）—— 留在 #6588
- `.github/workflows/ci.yml` 扩大测试覆盖（CI-blind 是独立 infra 缺陷）

Closes #6633

🤖 Generated with [Claude Code](https://claude.com/claude-code)