### PR TITLE
fix(#6588): 批量复权入口预取全市场 adjustfactor 消除逐股 N+1

### DIFF
--- a/src/ginkgo/data/services/bar_adjustment.py
+++ b/src/ginkgo/data/services/bar_adjustment.py
@@ -492,11 +492,19 @@ def _prefetch_all_factors(adjustfactor_service, start_date, end_date) -> pd.Data
 
 
 def _factors_for_code(all_factors_df: pd.DataFrame, code: str) -> pd.DataFrame:
-    """从全市场 factors 中切出单 code 子集（calculate_adjusted_prices 按 timestamp merge，须单 code）。"""
+    """从全市场 factors 中切出单 code 子集。
+
+    calculate_adjusted_prices 按 timestamp merge（不区分 code），跨 code 因子
+    会笛卡尔放大 → 静默错乱。故本函数要求 all_factors_df 含 code 列以精确切分；
+    缺列时 fail-loud（防 ADR-010 DF 出口形状漂移），而非原样返回全市场。
+    """
     if all_factors_df is None or all_factors_df.empty:
         return pd.DataFrame()
     if "code" not in all_factors_df.columns:
-        return all_factors_df
+        raise ValueError(
+            "_factors_for_code: factors DataFrame 缺 'code' 列，无法按 code 切分"
+            "（calculate_adjusted_prices 按 timestamp merge 会跨 code 串台）"
+        )
     subset = all_factors_df[all_factors_df["code"] == code]
     return subset if not subset.empty else pd.DataFrame()
 

--- a/src/ginkgo/data/services/bar_adjustment.py
+++ b/src/ginkgo/data/services/bar_adjustment.py
@@ -292,6 +292,62 @@ def apply_matrix_adjustment(
 # ==================== 单股票复权（含格式转换） ====================
 
 
+def _bars_to_df(bars_data) -> pd.DataFrame:
+    """将 bars_data（DataFrame 或 ModelList）转为计算用 DataFrame。"""
+    if isinstance(bars_data, pd.DataFrame):
+        return bars_data.copy()
+    return pd.DataFrame(
+        [
+            {
+                "code": bar.code,
+                "timestamp": bar.timestamp,
+                "open": float(bar.open),
+                "high": float(bar.high),
+                "low": float(bar.low),
+                "close": float(bar.close),
+                "volume": bar.volume,
+                "amount": float(bar.amount),
+            }
+            for bar in bars_data
+        ]
+    )
+
+
+def _df_to_modellist(adjusted_df: pd.DataFrame) -> list:
+    """将复权后的 DataFrame 转回 MBar 列表。"""
+    from ginkgo.data.models import MBar
+
+    adjusted_bars = []
+    for _, row in adjusted_df.iterrows():
+        bar = MBar()
+        bar.code = row["code"]
+        bar.timestamp = row["timestamp"]
+        bar.open = to_decimal(row["open"])
+        bar.high = to_decimal(row["high"])
+        bar.low = to_decimal(row["low"])
+        bar.close = to_decimal(row["close"])
+        bar.volume = int(row["volume"])
+        bar.amount = to_decimal(row["amount"])
+        adjusted_bars.append(bar)
+    return adjusted_bars
+
+
+def _apply_adjustment_with_factors(
+    bars_df: pd.DataFrame,
+    adjustfactors_df: pd.DataFrame,
+    adjustment_type: ADJUSTMENT_TYPES,
+) -> pd.DataFrame | None:
+    """
+    应用预取的复权因子（不查 service）。复权计算核心。
+
+    adjustfactors_df 必须是**单 code 子集**——calculate_adjusted_prices 按 timestamp
+    merge，跨 code 因子会串台。无因子时返回 None（调用方回退原数据）。
+    """
+    if adjustfactors_df is None or adjustfactors_df.empty:
+        return None
+    return calculate_adjusted_prices(bars_df, adjustfactors_df, adjustment_type)
+
+
 def apply_price_adjustment(
     bars_data,
     code: str,
@@ -321,26 +377,7 @@ def apply_price_adjustment(
         return bars_data
 
     try:
-        # 转换为DataFrame进行计算
-        if isinstance(bars_data, pd.DataFrame):
-            bars_df = bars_data.copy()
-        else:
-            # 将模型列表转换为DataFrame
-            bars_df = pd.DataFrame(
-                [
-                    {
-                        "code": bar.code,
-                        "timestamp": bar.timestamp,
-                        "open": float(bar.open),
-                        "high": float(bar.high),
-                        "low": float(bar.low),
-                        "close": float(bar.close),
-                        "volume": bar.volume,
-                        "amount": float(bar.amount),
-                    }
-                    for bar in bars_data
-                ]
-            )
+        bars_df = _bars_to_df(bars_data)
 
         if bars_df.empty:
             return bars_data
@@ -360,33 +397,15 @@ def apply_price_adjustment(
         # ADR-010 出口①：data 已是 DataFrame
         adjustfactors_df = adjustfactors_result.data
 
-        if adjustfactors_df.empty:
+        adjusted_df = _apply_adjustment_with_factors(bars_df, adjustfactors_df, adjustment_type)
+        if adjusted_df is None:
             GLOG.DEBUG(f"No adjustment factors found for {code}, returning original data")
             return bars_data
-
-        # 应用复权因子
-        adjusted_df = calculate_adjusted_prices(bars_df, adjustfactors_df, adjustment_type)
 
         # 以原始格式返回
         if isinstance(bars_data, pd.DataFrame):
             return adjusted_df
-        else:
-            # 转换回模型列表
-            from ginkgo.data.models import MBar
-
-            adjusted_bars = []
-            for _, row in adjusted_df.iterrows():
-                bar = MBar()
-                bar.code = row["code"]
-                bar.timestamp = row["timestamp"]
-                bar.open = to_decimal(row["open"])
-                bar.high = to_decimal(row["high"])
-                bar.low = to_decimal(row["low"])
-                bar.close = to_decimal(row["close"])
-                bar.volume = int(row["volume"])
-                bar.amount = to_decimal(row["amount"])
-                adjusted_bars.append(bar)
-            return adjusted_bars
+        return _df_to_modellist(adjusted_df)
 
     except Exception as e:
         GLOG.ERROR(f"Failed to apply price adjustment for {code}: {e}")
@@ -457,14 +476,29 @@ def apply_price_adjustment_to_modellist(
 
 # ==================== 多股票批量复权 ====================
 
-# TODO: 多股票复权方法性能优化
-# 当前多股票批量复权实现存在性能问题，在大数据量处理时效率较低
-# 需要优化的方向：
-# 1. 批量复权因子获取，避免逐股票查询
-# 2. 向量化计算替代逐行处理
-# 3. 内存使用优化，减少数据复制
-# 4. 并行处理多股票复权
-# 未来版本需要重构以提升批量处理性能
+
+def _prefetch_all_factors(adjustfactor_service, start_date, end_date) -> pd.DataFrame:
+    """一次性预取全市场复权因子（code=None），返回 factors DataFrame（可能为空）。
+
+    消除逐股 N+1：调用方循环内按 code 从返回的 DataFrame 切分子集复用。
+    ADR-010 出口①：data 已是 DataFrame（get_adjustfactors_df），无需 to_dataframe()。
+    """
+    result = adjustfactor_service.get_adjustfactors_df(
+        code=None, start_date=start_date, end_date=end_date
+    )
+    if not result.success or result.data.empty:
+        return pd.DataFrame()
+    return result.data
+
+
+def _factors_for_code(all_factors_df: pd.DataFrame, code: str) -> pd.DataFrame:
+    """从全市场 factors 中切出单 code 子集（calculate_adjusted_prices 按 timestamp merge，须单 code）。"""
+    if all_factors_df is None or all_factors_df.empty:
+        return pd.DataFrame()
+    if "code" not in all_factors_df.columns:
+        return all_factors_df
+    subset = all_factors_df[all_factors_df["code"] == code]
+    return subset if not subset.empty else pd.DataFrame()
 
 
 def apply_price_adjustment_multi_stock(
@@ -476,7 +510,8 @@ def apply_price_adjustment_multi_stock(
     """
     对多股票K线数据批量应用价格复权
 
-    按股票代码分组，逐个应用复权因子
+    入口一次性预取全市场复权因子（adjustfactor_service.get(code=None)），
+    循环内按 code 切分复用，消除逐股 N+1 查询。
 
     Args:
         bars_data: 多股票K线数据（DataFrame或ModelList）
@@ -500,16 +535,21 @@ def apply_price_adjustment_multi_stock(
                 GLOG.ERROR("Cannot apply multi-stock adjustment: 'code' column missing")
                 return bars_data
 
-            # 按股票代码分组并逐个复权
-            adjusted_dfs = []
             unique_codes = bars_data["code"].unique()
-
             GLOG.INFO(f"Applying {adjustment_type.value} adjustment to {len(unique_codes)} stocks")
 
+            # 一次性预取全市场复权因子（消除逐股 N+1）
+            start_date = bars_data["timestamp"].min()
+            end_date = bars_data["timestamp"].max()
+            all_factors_df = _prefetch_all_factors(adjustfactor_service, start_date, end_date)
+
+            # 按 code 切分预取因子，循环内复用（不再查 service）
+            adjusted_dfs = []
             for code in unique_codes:
                 stock_data = bars_data[bars_data["code"] == code].copy()
-                adjusted_stock_data = apply_price_adjustment(stock_data, code, adjustment_type, adjustfactor_service)
-                adjusted_dfs.append(adjusted_stock_data)
+                factors_for_code = _factors_for_code(all_factors_df, code)
+                adjusted_df = _apply_adjustment_with_factors(stock_data, factors_for_code, adjustment_type)
+                adjusted_dfs.append(adjusted_df if adjusted_df is not None else stock_data)
 
             # 合并所有复权后的数据
             result_df = pd.concat(adjusted_dfs, ignore_index=True)
@@ -534,18 +574,26 @@ def apply_price_adjustment_multi_stock(
                     code_to_models[code] = []
                 code_to_models[code].append(bar)
 
-            # 对每只股票的数据应用复权
-            adjusted_models = []
             unique_codes = list(code_to_models.keys())
-
             GLOG.INFO(f"Applying {adjustment_type.value} adjustment to {len(unique_codes)} stocks")
 
+            # 一次性预取全市场复权因子（消除逐股 N+1）
+            all_bars_df = _bars_to_df(bars_data)
+            start_date = all_bars_df["timestamp"].min()
+            end_date = all_bars_df["timestamp"].max()
+            all_factors_df = _prefetch_all_factors(adjustfactor_service, start_date, end_date)
+
+            # 按 code 切分预取因子，循环内复用（不再查 service）
+            adjusted_models = []
             for code in unique_codes:
                 stock_models = code_to_models[code]
-                adjusted_stock_models = apply_price_adjustment(
-                    stock_models, code, adjustment_type, adjustfactor_service
-                )
-                adjusted_models.extend(adjusted_stock_models)
+                stock_df = _bars_to_df(stock_models)
+                factors_for_code = _factors_for_code(all_factors_df, code)
+                adjusted_df = _apply_adjustment_with_factors(stock_df, factors_for_code, adjustment_type)
+                if adjusted_df is None:
+                    adjusted_models.extend(stock_models)
+                else:
+                    adjusted_models.extend(_df_to_modellist(adjusted_df))
 
             # 保持原始顺序
             return adjusted_models

--- a/tests/unit/data/services/test_bar_adjustment_multi_stock.py
+++ b/tests/unit/data/services/test_bar_adjustment_multi_stock.py
@@ -1,0 +1,186 @@
+"""Tests for batch adjustfactor prefetch in apply_price_adjustment_multi_stock -- #6588
+
+Verifies the N+1 elimination: multi-stock entry prefetches the full-market
+adjustfactor in a single service call (code=None) instead of one call per code.
+
+Adapted to ADR-010 exit-① (get_adjustfactors_df): result.data is already a DataFrame.
+"""
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock
+
+try:
+    from ginkgo.data.services import bar_adjustment
+    from ginkgo.enums import ADJUSTMENT_TYPES
+    from ginkgo.libs import to_decimal as to_dec
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+pytestmark = pytest.mark.skipif(not HAS_MODULE, reason="bar_adjustment not importable")
+
+
+def _make_bars_df():
+    """3 股 × 1 日 bars"""
+    return pd.DataFrame([
+        {"code": "000001.SZ", "timestamp": pd.Timestamp("2025-01-01"),
+         "open": 10.0, "high": 11.0, "low": 9.0, "close": 10.0,
+         "volume": 1000, "amount": 10000.0},
+        {"code": "000002.SZ", "timestamp": pd.Timestamp("2025-01-01"),
+         "open": 20.0, "high": 21.0, "low": 19.0, "close": 20.0,
+         "volume": 2000, "amount": 40000.0},
+        {"code": "600000.SH", "timestamp": pd.Timestamp("2025-01-01"),
+         "open": 5.0, "high": 5.5, "low": 4.5, "close": 5.0,
+         "volume": 500, "amount": 2500.0},
+    ])
+
+
+def _make_factors_df(codes, factor=2.0):
+    """全市场 factors（含 code 列，用于按 code 切分）"""
+    return pd.DataFrame([
+        {"code": c, "timestamp": pd.Timestamp("2025-01-01"),
+         "foreadjustfactor": factor, "backadjustfactor": 1.0 / factor,
+         "adjustfactor": factor}
+        for c in codes
+    ])
+
+
+def _make_service(factors_df):
+    """mock adjustfactor_service：get_adjustfactors_df 返回 ServiceResult-like，data=factors_df (DataFrame)。
+
+    ADR-010 出口①：data 已是 DataFrame，不再走 to_dataframe()。
+    """
+    svc = MagicMock()
+    result = MagicMock()
+    result.success = True
+    result.data = factors_df
+    svc.get_adjustfactors_df.return_value = result
+    return svc
+
+
+class TestMultiStockBatchPrefetch:
+    def test_prefetch_calls_get_once_with_code_none(self):
+        """N>1 股输入：get_adjustfactors_df 恰好调用 1 次，且 code=None（全市场预取）"""
+        bars_df = _make_bars_df()
+        svc = _make_service(_make_factors_df(["000001.SZ", "000002.SZ", "600000.SH"]))
+
+        bar_adjustment.apply_price_adjustment_multi_stock(
+            bars_df, ADJUSTMENT_TYPES.FORE, svc)
+
+        assert svc.get_adjustfactors_df.call_count == 1
+        _, kwargs = svc.get_adjustfactors_df.call_args
+        assert kwargs.get("code", None) is None
+
+    def test_prefetch_applies_factors_per_code(self):
+        """预取路径仍正确复权：close * foreadjustfactor(2.0)"""
+        bars_df = _make_bars_df()
+        svc = _make_service(_make_factors_df(["000001.SZ", "000002.SZ", "600000.SH"]))
+
+        out = bar_adjustment.apply_price_adjustment_multi_stock(
+            bars_df, ADJUSTMENT_TYPES.FORE, svc)
+
+        assert isinstance(out, pd.DataFrame)
+        # 每股 close 翻倍
+        for code, orig_close in [("000001.SZ", 10.0), ("000002.SZ", 20.0), ("600000.SH", 5.0)]:
+            row = out[out["code"] == code].iloc[0]
+            assert row["close"] == pytest.approx(orig_close * 2.0)
+
+    def test_prefetch_result_equivalent_to_per_stock(self):
+        """预取路径结果与逐股路径等价（同样输入下输出一致）"""
+        bars_df = _make_bars_df()
+        codes = ["000001.SZ", "000002.SZ", "600000.SH"]
+        factors_all = _make_factors_df(codes)
+
+        # 批量路径：multi_stock 一次预取全市场
+        svc_batch = _make_service(factors_all)
+        out_batch = bar_adjustment.apply_price_adjustment_multi_stock(
+            bars_df.copy(), ADJUSTMENT_TYPES.FORE, svc_batch)
+
+        # 逐股路径：每股独立 apply_price_adjustment（代表既单股计算）
+        # apply_price_adjustment 现走 ADR-010 出口① get_adjustfactors_df
+        svc_per = MagicMock()
+        per_results = {}
+        for c in codes:
+            r = MagicMock()
+            r.success = True
+            r.data = factors_all[factors_all["code"] == c].reset_index(drop=True)
+            per_results[c] = r
+        svc_per.get_adjustfactors_df.side_effect = lambda **kw: per_results[kw["code"]]
+        per_dfs = []
+        for c in codes:
+            stock = bars_df[bars_df["code"] == c].copy()
+            per_dfs.append(bar_adjustment.apply_price_adjustment(
+                stock, c, ADJUSTMENT_TYPES.FORE, svc_per))
+        out_per = pd.concat(per_dfs, ignore_index=True)
+
+        # 比较核心数值（忽略行序）
+        pd.testing.assert_frame_equal(
+            out_batch.sort_values(["code", "timestamp"]).reset_index(drop=True),
+            out_per.sort_values(["code", "timestamp"]).reset_index(drop=True),
+            check_dtype=False,
+        )
+
+    def test_empty_dataframe_returns_empty(self):
+        """空 DataFrame 输入直接返回（不查 service）"""
+        svc = MagicMock()
+        out = bar_adjustment.apply_price_adjustment_multi_stock(
+            pd.DataFrame(), ADJUSTMENT_TYPES.FORE, svc)
+        assert out.empty
+        svc.get_adjustfactors_df.assert_not_called()
+
+    def test_empty_modellist_returns_empty(self):
+        """空 ModelList 输入直接返回（不查 service）"""
+        svc = MagicMock()
+        out = bar_adjustment.apply_price_adjustment_multi_stock(
+            [], ADJUSTMENT_TYPES.FORE, svc)
+        assert out == []
+        svc.get_adjustfactors_df.assert_not_called()
+
+    def test_no_factors_returns_original_per_code(self):
+        """预取 factors 为空时，每股指数据原样返回（仍只调 1 次 get_adjustfactors_df）"""
+        bars_df = _make_bars_df()
+        svc = MagicMock()
+        empty_result = MagicMock()
+        empty_result.success = False
+        empty_result.data = pd.DataFrame()
+        svc.get_adjustfactors_df.return_value = empty_result
+
+        out = bar_adjustment.apply_price_adjustment_multi_stock(
+            bars_df, ADJUSTMENT_TYPES.FORE, svc)
+
+        assert svc.get_adjustfactors_df.call_count == 1
+        # 无 factors → 原值未变
+        assert set(out["code"]) == {"000001.SZ", "000002.SZ", "600000.SH"}
+        assert out[out["code"] == "000001.SZ"]["close"].iloc[0] == 10.0
+
+    def test_modellist_input_prefetch_path(self):
+        """ModelList 输入也走预取路径（get_adjustfactors_df 恰好 1 次，code=None）"""
+        from ginkgo.data.models import MBar
+
+        bars = []
+        for code, close in [("000001.SZ", 10.0), ("000002.SZ", 20.0)]:
+            bar = MBar()
+            bar.code = code
+            bar.timestamp = pd.Timestamp("2025-01-01")
+            bar.open = to_dec(close)
+            bar.high = to_dec(close + 1)
+            bar.low = to_dec(close - 1)
+            bar.close = to_dec(close)
+            bar.volume = 1000
+            bar.amount = to_dec(close * 1000)
+            bars.append(bar)
+
+        factors_all = _make_factors_df(["000001.SZ", "000002.SZ"])
+        svc = _make_service(factors_all)
+
+        out = bar_adjustment.apply_price_adjustment_multi_stock(
+            bars, ADJUSTMENT_TYPES.FORE, svc)
+
+        assert svc.get_adjustfactors_df.call_count == 1
+        _, kwargs = svc.get_adjustfactors_df.call_args
+        assert kwargs.get("code", None) is None
+        assert len(out) == 2
+        # 复权应用：close * 2.0
+        out_by_code = {b.code: float(b.close) for b in out}
+        assert out_by_code["000001.SZ"] == pytest.approx(20.0)
+        assert out_by_code["000002.SZ"] == pytest.approx(40.0)

--- a/tests/unit/data/services/test_bar_adjustment_multi_stock.py
+++ b/tests/unit/data/services/test_bar_adjustment_multi_stock.py
@@ -184,3 +184,38 @@ class TestMultiStockBatchPrefetch:
         out_by_code = {b.code: float(b.close) for b in out}
         assert out_by_code["000001.SZ"] == pytest.approx(20.0)
         assert out_by_code["000002.SZ"] == pytest.approx(40.0)
+
+    def test_factors_for_code_raises_without_code_column(self):
+        """_factors_for_code 缺 code 列时 raise ValueError（直接单元守卫不变量）。
+
+        全市场预取若返回无 code 列的 DF，calculate_adjusted_prices 按 timestamp
+        merge 会跨 code 笛卡尔放大 → 静默错乱。_factors_for_code fail-loud。
+        """
+        factors_no_code = pd.DataFrame([
+            {"timestamp": pd.Timestamp("2025-01-01"),
+             "foreadjustfactor": 2.0, "backadjustfactor": 0.5, "adjustfactor": 2.0}
+        ])
+        with pytest.raises(ValueError, match="code"):
+            bar_adjustment._factors_for_code(factors_no_code, "000001.SZ")
+
+    def test_multi_stock_degrades_on_factors_shape_drift(self):
+        """端到端：factors 缺 code 列时 multi_stock 降级返回原数据（不笛卡尔错乱）。
+
+        _factors_for_code raise ValueError 被 multi_stock 既有 try/except 捕获，
+        GLOG.ERROR 记录形状漂移，返回未复权原数据（降级，非跨 code 串台错乱）。
+        """
+        bars_df = _make_bars_df()
+        # 无 code 列的 factors（模拟 ADR-010 出口形状漂移）
+        factors_no_code = pd.DataFrame([
+            {"timestamp": pd.Timestamp("2025-01-01"),
+             "foreadjustfactor": 2.0, "backadjustfactor": 0.5, "adjustfactor": 2.0}
+        ])
+        svc = _make_service(factors_no_code)
+
+        out = bar_adjustment.apply_price_adjustment_multi_stock(
+            bars_df, ADJUSTMENT_TYPES.FORE, svc)
+
+        # 降级：原值未变（未复权），未发生笛卡尔错乱
+        assert set(out["code"]) == {"000001.SZ", "000002.SZ", "600000.SH"}
+        assert out[out["code"] == "000001.SZ"]["close"].iloc[0] == 10.0
+        assert out[out["code"] == "000002.SZ"]["close"].iloc[0] == 20.0


### PR DESCRIPTION
## Summary

修复 PR #6587 引入的窄 universe 性能回归（~250×）：`apply_price_adjustment_multi_stock` 逐股循环调 `apply_price_adjustment`，后者每股自查 `adjustfactor_service.get(code=code)`，每日 ~5000 次查询（与 `interested` 大小无关）。

**方案 D**（triage 已排除含判断成分的阈值门控 / 改 `bar_service.get` 签名两方案）：根因在 `bar_adjustment.py` 一层，且 `adjustfactor_service.get(code=None)` 能力已存在——修法机械，无设计决策。

### 改动
- `apply_price_adjustment_multi_stock`（DataFrame / ModelList 两分支）入口一次 `adjustfactor_service.get(code=None)` 预取全市场 factors，循环内按 code 切分复用，**`get` 调用次数从 N 降为 1**。
- 抽出三个 helper：
  - `_apply_adjustment_with_factors` —— 不查 service 的复权计算核心（接受预取 factors）
  - `_bars_to_df` / `_df_to_modellist` —— bars↔df 转换
- `apply_price_adjustment` 单股对外签名**不变**（向后兼容 `bar_service._apply_price_adjustment` caller），内部复用 helper。
- 移除多股票复权段 TODO「批量复权因子获取，避免逐股票查询」。

### 关键不变量
`calculate_adjusted_prices` 内部 `pd.merge(on="timestamp")` 不区分 code——预取后必须按 code 切分喂入（`_factors_for_code` 守恒），否则跨 code 因子串台。

## Test plan

- [x] 新增 `tests/unit/data/services/test_bar_adjustment_multi_stock.py`（7 测试）：
  - N>1 股输入 `adjustfactor_service.get` **恰好调用 1 次**且 `code=None`
  - 按 code 复权结果正确（close × foreadjustfactor）
  - 批量预取路径 vs 逐股 `apply_price_adjustment` 路径输出等价
  - 空 DataFrame / 空 ModelList 早返回（不查 service）
  - 预取 factors 为空时每股原样回退
  - ModelList 输入也走预取路径
- [x] 既有 `bar_adjustment` 测试全绿无回归（`test_bar_adjustment_sort_order.py` + `test_bar_adjustment_smoke.py`，共 15 passed）
- [x] 冒烟三层：py_compile (src+api) ✅ ｜ 启动路径 smoke（user_crud/containers/user_cli 33 passed）✅ ｜ 变更相关测试 ✅

Closes #6588

🤖 Generated with [Claude Code](https://claude.com/claude-code)