### PR TITLE
fix(docker): backtest-worker 用 --id 替代 -id (修复卡 0%)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -562,7 +562,7 @@ services:
   # BacktestWorker - 回测任务执行节点
   backtest-worker:
     <<: *worker-common
-    command: ["python", "main.py", "serve", "worker-backtest", "-id", "${BACKTEST_WORKER_ID:-bw-1}"]
+    command: ["python", "main.py", "serve", "worker-backtest", "--id", "${BACKTEST_WORKER_ID:-bw-1}"]
     environment:
       <<: *worker-env
       BACKTEST_WORKER_ID: ${BACKTEST_WORKER_ID:-bw-1}


### PR DESCRIPTION
## Summary

`docker-compose.yml` 用 `-id` 启动 backtest-worker，typer/click 按短选项聚合解析为 `-i -d`，报 `No such option '-i'`。worker 自 commit 2b0a9c72e (2026-05-01) 起持续崩溃循环 (Restarting every 18s)，回测任务无 worker 领取 → 卡 0%（`#4757`）。

改为 `--id`，对齐 `serve_worker_backtest` 的 `typer.Option(None, "--id", "-i")` 声明。

## 根因证据链

| 证据 | 来源 |
|---|---|
| worker 崩溃日志 `No such option '-i'` | `docker logs ginkgo-backtest-worker-1` |
| 引入 commit | `2b0a9c72e` 2026-05-01 `feat(docker): add backtest-worker service` |
| 其他 worker 对照 | notify/data 不带参数，仅 backtest-worker 多 `-id` 故独崩 |
| 命令定义 | `src/ginkgo/client/serve_cli.py:627` 注册的是 `--id`/`-i` |

## Test plan（端到端实跑验证）

1. 改动前：`docker ps` → backtest-worker `Restarting (2) 18 seconds ago`
2. 改动后：`docker compose up -d --force-recreate backtest-worker` → `Up 8 seconds (healthy)`，日志显示 `Ready to receive tasks from Kafka`
3. 创建回测（momentum + fixed_selector SH600000，2025-01-01~2026-06-01，cash 200000）→ 任务被 worker 领取，21:20:11 启动即 21:20:11 完成（返回明确 `failed` 状态），**不再卡 0% 30 分钟**

> 备注：回测返回的 `No portfolios bound to engine` 是装配链路的独立问题（绑定树显示 Selectors/Strategies 均正确，疑似引擎装配 bug），不在本 PR 范畴。本 PR 解决的是 #4757 描述的"卡 0% 长时间无响应"——修复后回测不再无限挂起，符合 issue 验收标准"返回有意义的错误而非无限挂起"。

## 说明

- 变更仅 `docker-compose.yml` 单行配置，非 `.py` 代码，无对应单元测试（已通过 docker compose up 实跑端到端验证启动路径）

Closes #4757

🤖 Generated with [Claude Code](https://claude.com/claude-code)