### PR TITLE
fix: 删除 data_preparer 废弃的 live/backtest 引擎装配分支 (#6221)

### DIFF
--- a/src/ginkgo/trading/services/_assembly/data_preparer.py
+++ b/src/ginkgo/trading/services/_assembly/data_preparer.py
@@ -56,8 +56,7 @@ class DataPreparer:
         self._engine_type_mapping = {
             "historic": "TimeControlledEventEngine",
             "backtest": "TimeControlledEventEngine",  # 别名
-            "live": "LiveEngine",
-            "realtime": "LiveEngine",  # 别名
+            # ADR-003: live/realtime 装配已废弃，实盘走 livecore/execution_node，不再由此映射
             "time_controlled": "TimeControlledEventEngine",
             "time_based": "TimeControlledEventEngine",  # 别名
         }
@@ -361,29 +360,26 @@ class DataPreparer:
             # 延迟导入避免循环依赖
             engine_class_name = self._engine_type_mapping[engine_type]
 
-            if engine_class_name == "LiveEngine":
-                from ginkgo.trading.engines.live_engine import LiveEngine
-
-                engine_class = LiveEngine
-            elif engine_class_name == "TimeControlledEventEngine":
+            # ADR-003: 引擎二态化后唯一支持 TimeControlledEventEngine；
+            # 旧 LiveEngine 已废弃（实盘走 livecore/execution_node，不经 YAML 装配），
+            # 旧 BacktestEngine 路径已删除（ginkgo.trading.engines.backtest_engine 从未存在）。
+            if engine_class_name == "TimeControlledEventEngine":
                 from ginkgo.trading.engines.time_controlled_engine import TimeControlledEventEngine
 
                 engine_class = TimeControlledEventEngine
-            else:  # BacktestEngine
-                from ginkgo.trading.engines.backtest_engine import BacktestEngine
+            else:
+                raise EngineConfigurationError(
+                    f"Unsupported engine class: {engine_class_name}. "
+                    "Only TimeControlledEventEngine is supported (ADR-003)."
+                )
 
-                engine_class = BacktestEngine
-
-            if engine_type in ["live", "realtime"]:
-                # LiveEngine需要task_id参数
-                engine = engine_class(task_id=task_id)
-            elif engine_type in ["time_controlled", "time_based"]:
-                # TimeControlledEventEngine需要特殊处理
+            if engine_type in ["time_controlled", "time_based"]:
+                # TimeControlledEventEngine 显式别名
                 name = config.get("name", "TimeControlledEngine")
                 engine = engine_class(name=name)
                 engine.set_task_id(task_id)
             else:
-                # BacktestEngine等其他引擎
+                # historic/backtest 统一走 TimeControlledEventEngine
                 name = config.get("name", f"{engine_type.title()}Engine")
                 engine = engine_class(name=name)
                 engine.set_task_id(task_id)
@@ -648,13 +644,8 @@ class DataPreparer:
                 ],
                 "settings": {"log_level": "INFO", "debug": False},
             },
-            "live": {
-                "engine": {"type": "live", "name": "LiveEngine", "task_id": "live_sample_001"},
-                "data_feeder": {"type": "live", "settings": {"symbols": ["000001.SZ"], "subscription_timeout": 30.0}},
-                "routing": {"enabled": True},
-                "portfolios": [{"type": "base", "name": "LivePortfolio", "strategies": [], "risk_managers": []}],
-                "settings": {"log_level": "INFO", "debug": True},
-            },
+            # ADR-003: "live" sample 已移除——实盘装配走 livecore/execution_node，
+            # 不再经 YAML 装配；get_sample_config("live") 自动 fallback 到 historic。
         }
 
         return sample_configs.get(engine_type, sample_configs["historic"])

--- a/tests/unit/services/smoke/test_data_preparer_smoke.py
+++ b/tests/unit/services/smoke/test_data_preparer_smoke.py
@@ -93,6 +93,14 @@ class TestDataPreparerSmoke:
             assert isinstance(result, dict)
             assert "engine" in result
 
+    def test_get_sample_config_live_fallback_historic(self):
+        """ADR-003: live sample 已移除，get_sample_config('live') fallback 到 historic"""
+        with patch("ginkgo.trading.services._assembly.data_preparer.GLOG"):
+            preparer = DataPreparer()
+            live_config = preparer.get_sample_config("live")
+            historic_config = preparer.get_sample_config("historic")
+            assert live_config == historic_config
+
     def test_save_sample_config_callable(self, tmp_path):
         """save_sample_config() 可调用"""
         with patch("ginkgo.trading.services._assembly.data_preparer.GLOG"):

--- a/tests/unit/trading/services/test_engine_assembly_service.py
+++ b/tests/unit/trading/services/test_engine_assembly_service.py
@@ -70,8 +70,9 @@ class TestEngineAssemblyServiceConstruction:
         mapping = service._data_preparer._engine_type_mapping
         assert "historic" in mapping
         assert "backtest" in mapping
-        assert "live" in mapping
-        assert "realtime" in mapping
+        # ADR-003: live/realtime 已从 mapping 移除（实盘走 livecore/execution_node）
+        assert "live" not in mapping
+        assert "realtime" not in mapping
         assert mapping["historic"] == mapping["backtest"]
 
 
@@ -143,8 +144,9 @@ class TestConfigurationValidation:
         assert "data_feeder" in config
         assert "portfolios" in config
         assert config["engine"]["type"] == "historic"
+        # ADR-003: live sample 已移除，get_sample_config("live") fallback 到 historic
         config_live = service.get_sample_config("live")
-        assert config_live["engine"]["type"] == "live"
+        assert config_live["engine"]["type"] == "historic"
 
 
 @pytest.mark.unit
@@ -536,8 +538,10 @@ class TestLiveModeAssembly:
 
     def test_live_engine_type_resolution(self):
         service = EngineAssemblyService()
-        assert service._data_preparer._engine_type_mapping["live"] == "LiveEngine"
-        assert service._data_preparer._engine_type_mapping["realtime"] == "LiveEngine"
+        # ADR-003: live/realtime 装配已废弃，data_preparer 不再支持
+        # （实盘走 livecore/execution_node 的 assemble_live_portfolio，不经过 YAML 装配）
+        assert "live" not in service._data_preparer._engine_type_mapping
+        assert "realtime" not in service._data_preparer._engine_type_mapping
 
     def test_live_feeder_binding(self):
         assert callable(getattr(InfrastructureFactory, 'create_feeder_for_mode', None))
@@ -562,3 +566,34 @@ class TestLiveModeAssembly:
         task_id = str(uuid.uuid4())
         assert len(task_id) == 36  # UUID format
         assert task_id.count("-") == 4
+
+
+@pytest.mark.unit
+class TestDeadEngineStubsRemoved:
+    """ADR-003: data_preparer 中已废弃的 live_engine / 不存在的 backtest_engine
+    import 必须彻底移除（与 #6118 threading.py 处置对称，refactor guard）。"""
+
+    def test_data_preparer_no_dead_engine_imports(self):
+        import inspect
+        from ginkgo.trading.services._assembly import data_preparer
+
+        src = inspect.getsource(data_preparer)
+        # 仅检查非注释代码行（注释里可能保留历史说明）
+        code_lines = [
+            ln for ln in src.splitlines()
+            if ln.strip() and not ln.strip().startswith("#")
+        ]
+        code = "\n".join(code_lines)
+        assert "from ginkgo.trading.engines.live_engine" not in code, (
+            "dead live_engine import still present"
+        )
+        assert "from ginkgo.trading.engines.backtest_engine" not in code, (
+            "dead backtest_engine import still present"
+        )
+        assert "LiveEngine(" not in code, "LiveEngine still instantiated"
+
+    def test_create_engine_from_config_live_rejected(self):
+        """ADR-003: live 装配在 data_preparer 不支持，公共入口必须拒绝"""
+        service = EngineAssemblyService()
+        result = service.create_engine_from_config({"engine": {"type": "live"}})
+        assert not result.is_success()


### PR DESCRIPTION
## Summary

ADR-003 引擎二态化（BACKTEST / LIVE）落地后，`data_preparer._create_base_engine_from_config` 的分发逻辑没跟上 `_engine_type_mapping` 的收紧，残留三处 dead code：

1. **LiveEngine 分支**：引用 `ginkgo.trading.engines.live_engine.LiveEngine`，但 `LiveEngine` 已在 057f844a 标记 deprecated 并迁至 `livecore/`，实盘装配走 `assemble_live_portfolio`（livecore/execution_node），不经 YAML 装配路径。
2. **BacktestEngine 分支**（`else`）：引用 `ginkgo.trading.engines.backtest_engine.BacktestEngine`——**该路径从未存在**，正是 #6221 报错点。mapping 收紧后此 else 永不可达，但 import 在被触发时崩。
3. **live/realtime 构造分支**：mapping 删 live/realtime key 后，此 if 永不成立。

### 变更
- `data_preparer.py`：
  - `_engine_type_mapping` 移除 `live`/`realtime` key（与 #6118 `threading.py` LiveEngine 处置对称）
  - `_create_base_engine_from_config` 删除 LiveEngine/BacktestEngine 分支，`else` 改为 `raise EngineConfigurationError`（响亮报错优于 import 不存在模块）
  - 删除 live/realtime 构造分支
  - `get_sample_config` 移除 live sample，自动 fallback 到 historic
- 测试（TDD：先 RED 后 GREEN）：
  - `test_data_preparer_no_dead_engine_imports`（inspect 源码契约，仿 `test_threading_live_control_retired`，防回归）
  - `test_create_engine_from_config_live_rejected`（公共入口契约：type=live 必须被拒）
  - `test_get_sample_config_live_fallback_historic`（fallback 契约）
  - 同步修正旧断言：`test_live_engine_type_resolution` / `test_engine_type_mapping_initialization` / `test_sample_config_generation`

### 设计依据
- ADR-003：引擎二态化，LIVE/PAPER 差异下沉 Broker/Gateway
- 与 #6118（`threading.py` 移除 LiveEngine stub）对称处置

## Test plan

- [x] `pytest tests/unit/trading/services/test_engine_assembly_service.py`（66 项含 4 新测试，全 GREEN）
- [x] `pytest tests/unit/services/smoke/test_data_preparer_smoke.py`（8 项全 GREEN）
- [x] Layer 1 py_compile（src + api 全量）通过
- [x] Layer 2 启动路径 smoke（user_crud_mock + containers + user_cli）通过
- [x] inspect 契约确认无 `from ginkgo.trading.engines.live_engine` / `backtest_engine` / `LiveEngine(` 残留

Closes #6221