### PR TITLE
docs: 记录测试 OOM 铁律(单进程禁跑全量,必须 -n auto)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 - 函数级 import（CLI 为快启把重度 import 延到命令体内）让路径漂移只在命令实跑时暴露——模块 import 不崩，最容易误判"未实现"
 - `return` stub 让失败静默（命令"安静失败"而非"响亮报错"），反而盖住真因，后续无人回头查；宁可原样 `raise` 也别加 stub 兜底
 
+### 测试（OOM 铁律）
+- **禁止单进程跑全量 `tests/`**：`Base.metadata` + autouse fixture 不释放，单进程累积到 80GB anon-rss 必 global OOM（96GB 仍爆）
+- **跑全量必须 `-n auto`**：xdist 进程隔离，worker 各自释放，总 RSS ~5.75GB
+
 ## Key Commands
 ```bash
 ginkgo version / status                       # 版本/状态

--- a/README.md
+++ b/README.md
@@ -380,6 +380,17 @@ ginkgo deploy deploy <portfolio_id> --mode live --account <account_uuid>
 3. Commit and push to branch
 4. Open Pull Request
 
+### Running Tests
+
+```bash
+# Full suite MUST use -n auto (process isolation via pytest-xdist)
+# Single-process accumulates 80GB+ RSS → OOM (Base.metadata + autouse fixtures never released, confirmed even on 96GB hosts)
+pytest tests/ -n auto --ignore=tests/integration
+
+# Single file/module — no -n auto needed
+pytest tests/unit/data/test_xxx.py -v
+```
+
 ## License
 
 MIT License - see the LICENSE file for details.


### PR DESCRIPTION
## 改动
- `CLAUDE.md` 开发约束新增「测试（OOM 铁律）」小节（中文，给 AI 助手）
- `README.md` Contributing 新增「Running Tests」子节（英文，给贡献者）

## 背景
单进程跑全量 `tests/` 会累积到 80GB anon-rss（`Base.metadata` + autouse fixture 不释放），96GB 主机仍 global OOM。必须 `-n auto`（xdist 进程隔离），总 RSS ~5.75GB。

让贡献者和 AI 助手都看到这条铁律，避免重复踩坑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)