### PR TITLE
feat: 回测组件完整性可见性 (创建预检 + 装配错误透传) (#6640)

### DIFF
--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -239,7 +239,12 @@ class BacktestTaskService(BaseService):
                     format_missing_components_message,
                 )
                 comp_result = portfolio_service.get_components(portfolio_id=portfolio_id)
-                if comp_result.is_success() and comp_result.data:
+                # 注意用 `is not None` 而非 truthiness：空 portfolio（0 绑定）的合法
+                # 返回是空 list []（falsy），但语义=「该 portfolio 无绑定」=缺全部必需组件，
+                # 是预检最该拦截的场景。truthiness 会把 [] 当「查询失败」放行，让 fast-feedback
+                # 对最常见的配置不全场景失效（用户须跑到 run 阶段才见错误）。None 才是
+                # 「无 payload / 查询异常」信号，交装配层兜底。
+                if comp_result.is_success() and comp_result.data is not None:
                     bound_types = {
                         c.get("component_type")
                         for c in comp_result.data

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -226,6 +226,31 @@ class BacktestTaskService(BaseService):
             ServiceResult: 创建结果
         """
         try:
+            # #6640: 创建预检——校验 portfolio 必需组件（清单单点定义于装配层 requirements）
+            # 缺必需组件时拒绝创建并返回具体组件名 + 绑定命令，避免用户跑到 run
+            # 阶段才看到笼统的 'No portfolios bound to engine'。校验在 service 层
+            # （API/CLI 共享）；portfolio_service 未注入或查询失败时保守放行，
+            # 由装配层 component_loader 兜底（错误经 #6640 透传机制回传具体缺失组件）。
+            portfolio_service = getattr(self, "_portfolio_service", None)
+            if portfolio_id and portfolio_service is not None:
+                # 延迟 import 规避 data → trading 的模块加载期循环
+                from ginkgo.trading.services._assembly.requirements import (
+                    find_missing_required_components,
+                    format_missing_components_message,
+                )
+                comp_result = portfolio_service.get_components(portfolio_id=portfolio_id)
+                if comp_result.is_success() and comp_result.data:
+                    bound_types = {
+                        c.get("component_type")
+                        for c in comp_result.data
+                        if c.get("component_type")
+                    }
+                    missing = find_missing_required_components(bound_types)
+                    if missing:
+                        return ServiceResult.error(
+                            format_missing_components_message(portfolio_id, missing)
+                        )
+
             # 创建任务 (task_id 自动等于 uuid)
             task_data = {
                 "name": name,

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -935,7 +935,13 @@ class PortfolioService(BaseService):
             component_type: 组件类型过滤
 
         Returns:
-            ServiceResult: 组件列表
+            ServiceResult: 组件列表，每个组件为 dict，含字段：
+                - mount_id / portfolio_id / component_id / component_name / created_at
+                - component_type: 组件类型，**数字字符串**（FILE_TYPES value 的 str 形式，
+                  如 "6"/"4"/"5"）。生产路径 mapping.type 经 FILE_TYPES.validate_input
+                  转 int 存储，本方法用 `mapping.type.name if hasattr(...) else str(...)`
+                  兜底，int 无 .name → 返回 str(int)。消费方判类型须兼容数字串
+                  （见 _assembly/requirements.find_missing_required_components）。
         """
         try:
             filters = {"is_del": False}

--- a/src/ginkgo/trading/services/_assembly/requirements.py
+++ b/src/ginkgo/trading/services/_assembly/requirements.py
@@ -1,0 +1,121 @@
+"""#6640: Portfolio 装配回测引擎所需的必需组件清单（单点维护）。
+
+创建回测预检（backtest_task_service.create）与装配层（component_loader /
+engine_assembly_service）共用此清单，替代散落在多处 `# Add ... (required)` 检查。
+
+Upstream: ginkgo.enums (FILE_TYPES)
+Downstream: backtest_task_service (创建预检), component_loader (装配检查),
+            engine_assembly_service (错误透传)
+Role: 必需组件清单 + 缺失检测/格式化辅助（纯逻辑，无 data 层依赖，避免循环 import）
+"""
+from typing import Dict, Iterable, List, Tuple
+
+from ginkgo.enums import FILE_TYPES
+
+# 必需组件清单：(FILE_TYPES, 可读标签, bind-component 的 --type 值)
+# 顺序与装配阶段一致（strategy → selector → sizer），错误信息按此顺序呈现。
+# 当前覆盖 component_loader.perform_component_binding 的全部 required 检查点；
+# 未来新增必需组件只需在此追加元组（issue #6640「单点维护」目标）。
+REQUIRED_PORTFOLIO_COMPONENT_TYPES: Tuple[Tuple[FILE_TYPES, str, str], ...] = (
+    (FILE_TYPES.STRATEGY, "Strategy", "strategy"),
+    (FILE_TYPES.SELECTOR, "Selector", "selector"),
+    (FILE_TYPES.SIZER, "Sizer", "sizer"),
+)
+
+
+def find_missing_required_components(
+    bound_component_types: Iterable,
+) -> List[Tuple[str, str]]:
+    """对比已绑定组件类型与必需清单，返回缺失项。
+
+    Args:
+        bound_component_types: 已绑定组件的类型集合（可迭代）。元素可为：
+            - FILE_TYPES 枚举成员
+            - 成员名字符串（如 "STRATEGY"，PortfolioService.get_components 返回此格式）
+            - 成员 value（int）
+
+    Returns:
+        缺失的必需组件 [(label, bind_type), ...]，按 REQUIRED_PORTFOLIO_COMPONENT_TYPES 顺序。
+        已全部满足时返回空 list。
+    """
+    bound_normalized = set()
+    for t in bound_component_types:
+        if isinstance(t, FILE_TYPES):
+            bound_normalized.add(t)
+        elif isinstance(t, str):
+            # 成员名（如 "STRATEGY"）；忽略未知字符串（非必需类型的合法组件可传入）
+            try:
+                bound_normalized.add(FILE_TYPES[t])
+            except KeyError:
+                continue
+        elif isinstance(t, int):
+            try:
+                bound_normalized.add(FILE_TYPES(t))
+            except ValueError:
+                continue
+
+    return [
+        (label, bind_type)
+        for ftype, label, bind_type in REQUIRED_PORTFOLIO_COMPONENT_TYPES
+        if ftype not in bound_normalized
+    ]
+
+
+def format_missing_components_message(
+    portfolio_id: str, missing: List[Tuple[str, str]]
+) -> str:
+    """生成统一的缺失组件错误信息（含绑定命令提示）。
+
+    Args:
+        portfolio_id: portfolio UUID
+        missing: find_missing_required_components 的返回值
+
+    Returns:
+        形如:
+            Portfolio <pid> missing required component: Sizer is required.
+              Bind via: ginkgo portfolio bind-component <pid> <sizer_file_id> --type sizer
+
+        missing 为空时返回空串（调用方应先判空）。
+    """
+    if not missing:
+        return ""
+    labels = " and ".join(label for label, _ in missing)
+    hints = "\n".join(
+        f"  Bind via: ginkgo portfolio bind-component {portfolio_id} <{bt}_file_id> --type {bt}"
+        for _, bt in missing
+    )
+    return (
+        f"Portfolio {portfolio_id} missing required component: "
+        f"{labels} is required.\n{hints}"
+    )
+
+
+# 分桶名 → FILE_TYPES 映射（与 component_loader/task_helpers 的分桶一致）
+_BUCKET_TO_FILE_TYPE = {
+    "strategies": FILE_TYPES.STRATEGY,
+    "selectors": FILE_TYPES.SELECTOR,
+    "sizers": FILE_TYPES.SIZER,
+}
+
+
+def find_missing_required_from_bucketed(
+    components: Dict[str, List],
+) -> List[Tuple[str, str]]:
+    """从分桶后的 components dict 检查缺失的必需组件（装配层用）。
+
+    Args:
+        components: 分桶 dict，键为桶名（"strategies"/"selectors"/"sizers"），
+            值为组件列表。空 list / 缺键 均视为该组件未绑定。
+
+    Returns:
+        缺失的必需组件 [(label, bind_type), ...]，按 REQUIRED_PORTFOLIO_COMPONENT_TYPES 顺序。
+    """
+    if not components:
+        bound_types: set = set()
+    else:
+        bound_types = {
+            ftype
+            for bucket, ftype in _BUCKET_TO_FILE_TYPE.items()
+            if components.get(bucket)  # 非空 list 才算已绑定
+        }
+    return find_missing_required_components(bound_types)

--- a/src/ginkgo/trading/services/_assembly/requirements.py
+++ b/src/ginkgo/trading/services/_assembly/requirements.py
@@ -43,10 +43,16 @@ def find_missing_required_components(
         if isinstance(t, FILE_TYPES):
             bound_normalized.add(t)
         elif isinstance(t, str):
-            # 成员名（如 "STRATEGY"）；忽略未知字符串（非必需类型的合法组件可传入）
+            # 兼容两种字符串形态（与 engine_assembly_service._resolve_component_type 同语义）：
+            #   - 数字串（"6"）：生产 get_components 的真实返回格式。mapping.type 经
+            #     FILE_TYPES.validate_input 转 int 存储，get_components 用
+            #     `mapping.type.name if hasattr(...) else str(mapping.type)`，int 无 .name
+            #     → 返回 str(int)，即数字串。#6643 P0：原分支仅 FILE_TYPES[t] 会抛 KeyError
+            #     被静默吞，致全部已绑组件归一化为空集、预检误判全缺。
+            #   - 成员名（"STRATEGY"）：忽略未知字符串（非必需类型的合法组件可传入）。
             try:
-                bound_normalized.add(FILE_TYPES[t])
-            except KeyError:
+                bound_normalized.add(FILE_TYPES(int(t)) if t.isdigit() else FILE_TYPES[t])
+            except (KeyError, ValueError):
                 continue
         elif isinstance(t, int):
             try:

--- a/src/ginkgo/trading/services/engine_assembly_service.py
+++ b/src/ginkgo/trading/services/engine_assembly_service.py
@@ -39,6 +39,10 @@ from ginkgo.trading.services._assembly.component_loader import ComponentLoader
 from ginkgo.trading.services._assembly.infrastructure_factory import InfrastructureFactory
 from ginkgo.trading.services._assembly.task_engine_builder import TaskEngineBuilder
 from ginkgo.trading.services._assembly.data_preparer import DataPreparer, EngineConfigurationError
+from ginkgo.trading.services._assembly.requirements import (
+    find_missing_required_from_bucketed,
+    format_missing_components_message,
+)
 
 
 # #6098: component_type int → perform_component_binding 的桶名
@@ -145,6 +149,8 @@ class EngineAssemblyService(BaseService):
         # 装配上下文 - 用于ID注入
         self._current_engine_id = None
         self._current_task_id = None
+        # #6640: 最近一次装配失败的具体原因（缺组件时含组件名+绑定命令）；每次装配重置
+        self._assembly_failure_reason = None
 
         # 配置管理器已统一使用GCONF
         self.config_manager = config_manager
@@ -400,6 +406,11 @@ class EngineAssemblyService(BaseService):
             )
 
             if engine is None:
+                # #6640: 优先透传装配层捕获的具体失败原因（如缺 Sizer 的组件名+绑定命令）；
+                # 无具体原因时 fallback 到原笼统信息（如实例化失败、未知装配异常）。
+                reason = self._assembly_failure_reason
+                if reason:
+                    return ServiceResult(success=False, error=reason)
                 return ServiceResult(success=False, error=f"No portfolios bound to engine {engine_id}")
 
             # 清理历史记录（仅当从数据服务获取时）
@@ -470,6 +481,8 @@ class EngineAssemblyService(BaseService):
         # 设置装配上下文
         self._current_engine_id = engine_id
         self._current_task_id = engine_data.get("task_id", engine_id)
+        # #6640: 每次装配重置失败原因，避免上次装配残留污染本次 error
+        self._assembly_failure_reason = None
 
         try:
             self._logger.INFO(
@@ -525,6 +538,18 @@ class EngineAssemblyService(BaseService):
 
                 if not success:
                     self._logger.ERROR(f"Failed to bind portfolio {portfolio_id} to engine")
+                    # #6640: 透传具体缺失组件——用清单检查分桶 components，记录到
+                    # assembly_failure_reason 供 assemble_backtest_engine 构造用户可读 error，
+                    # 替代笼统的 'No portfolios bound to engine'。仅保留首个失败原因，
+                    # 避免多 portfolio 场景下错误信息混乱。
+                    if self._assembly_failure_reason is None:
+                        missing = find_missing_required_from_bucketed(
+                            portfolio_components.get(portfolio_id, {})
+                        )
+                        if missing:
+                            self._assembly_failure_reason = (
+                                format_missing_components_message(portfolio_id, missing)
+                            )
                     continue
                 else:
                     self._logger.INFO(f"✅ Successfully bound portfolio {portfolio_id} to engine")

--- a/tests/unit/data/services/test_backtest_task_create_precheck.py
+++ b/tests/unit/data/services/test_backtest_task_create_precheck.py
@@ -109,3 +109,28 @@ class TestCreatePrecheck:
         assert "Sizer" in result.error
         assert "--type strategy" in result.error
         assert "--type sizer" in result.error
+
+    @pytest.mark.unit
+    def test_empty_portfolio_rejected_not_silently_passed(self):
+        """#6643 review P0 回归：空 portfolio（0 绑定）是「缺全部必需组件」最常见场景，
+        必须在 create 时拦截。get_components 生产返回 ServiceResult.success([])（空 list，
+        falsy），若预检用 truthiness 判定会把 [] 当查询失败放行 → fast-feedback 失效，
+        用户须跑到 run 阶段才见错误。用 `is not None` 区分「空 list（查询成功，无绑定）」
+        与「None（查询异常）」。
+        """
+        crud = MagicMock()
+        portfolio_svc = MagicMock()
+        # 模拟生产 get_components 对无绑定 portfolio 的真实返回：success + 空 list
+        portfolio_svc.get_components.return_value = ServiceResult.success([])
+        svc = BacktestTaskService(crud, portfolio_service=portfolio_svc)
+
+        result = svc.create(name="empty", portfolio_id=_PORTFOLIO_ID)
+
+        assert not result.is_success(), "空 portfolio 应拒绝创建（缺全部必需组件）"
+        # 错误信息含全部必需组件 + 各自绑定命令
+        assert "Strategy" in result.error
+        assert "Sizer" in result.error
+        assert "--type strategy" in result.error
+        assert "--type sizer" in result.error
+        # 拒绝创建：crud.create 未被调用
+        crud.create.assert_not_called()

--- a/tests/unit/data/services/test_backtest_task_create_precheck.py
+++ b/tests/unit/data/services/test_backtest_task_create_precheck.py
@@ -1,0 +1,102 @@
+"""#6640: backtest create 时校验 portfolio 必需组件（清单：strategy/selector/sizer，
+与装配层 component_loader 实际要求的必需组件一致）。缺必需组件时拒绝创建并返回
+具体组件名 + 绑定命令，而非让用户跑到 run 阶段才看到笼统的 'No portfolios bound to engine'。
+
+预检在 service 层（API/CLI 共享），调 portfolio_service.get_components 查绑定组件。
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+_PORTFOLIO_ID = "aa11223344556677889900aabbccddee"
+
+
+def _portfolio_service_with(*component_types):
+    """构造 mock portfolio_service，get_components 返回含指定类型组件的 ServiceResult。
+
+    component_type 字段模拟 PortfolioService.get_components 的返回格式
+    （mapping.type.name，即 FILE_TYPES 成员名，如 "STRATEGY"/"SELECTOR"/"SIZER"）。
+    """
+    svc = MagicMock()
+    components = [
+        {"component_type": t, "component_name": f"{t.lower()}_1"}
+        for t in component_types
+    ]
+    svc.get_components.return_value = ServiceResult.success(components)
+    return svc
+
+
+class TestCreatePrecheck:
+    """#6640: create() 预检 portfolio 必需组件（清单单点定义于装配层 requirements 模块）。"""
+
+    @pytest.mark.unit
+    def test_missing_sizer_rejected_with_bind_hint(self):
+        """有 strategy+selector 缺 sizer → 拒绝创建 + 错误含 Sizer 与 bind-component 命令。"""
+        crud = MagicMock()
+        portfolio_svc = _portfolio_service_with("STRATEGY", "SELECTOR")
+        svc = BacktestTaskService(crud, portfolio_service=portfolio_svc)
+
+        result = svc.create(name="repro", portfolio_id=_PORTFOLIO_ID)
+
+        assert not result.is_success(), "缺 Sizer 应拒绝创建"
+        assert "Sizer" in result.error
+        assert "bind-component" in result.error
+        assert "--type sizer" in result.error
+        # 拒绝创建：crud.create 未被调用
+        crud.create.assert_not_called()
+
+    @pytest.mark.unit
+    def test_all_required_present_creates_normally(self):
+        """回归保护：strategy+selector+sizer 齐全 → 正常创建，crud.create 被调用。"""
+        crud = MagicMock()
+        crud.create.return_value = MagicMock(uuid=_PORTFOLIO_ID)
+        portfolio_svc = _portfolio_service_with("STRATEGY", "SELECTOR", "SIZER")
+        svc = BacktestTaskService(crud, portfolio_service=portfolio_svc)
+
+        result = svc.create(name="ok", portfolio_id=_PORTFOLIO_ID)
+
+        assert result.is_success(), "必需组件齐全应正常创建"
+        crud.create.assert_called_once()
+
+    @pytest.mark.unit
+    def test_no_portfolio_service_does_not_block_create(self):
+        """向后兼容：portfolio_service 未注入（旧调用方）→ 不阻断创建。"""
+        crud = MagicMock()
+        crud.create.return_value = MagicMock(uuid=_PORTFOLIO_ID)
+        svc = BacktestTaskService(crud)  # 不注入 portfolio_service
+
+        result = svc.create(name="legacy", portfolio_id=_PORTFOLIO_ID)
+
+        assert result.is_success(), "portfolio_service 未注入时应放行（保守）"
+        crud.create.assert_called_once()
+
+    @pytest.mark.unit
+    def test_get_components_failure_does_not_block_create(self):
+        """保守放行：portfolio_service.get_components 失败 → 不阻断（装配层兜底）。"""
+        crud = MagicMock()
+        crud.create.return_value = MagicMock(uuid=_PORTFOLIO_ID)
+        portfolio_svc = MagicMock()
+        portfolio_svc.get_components.return_value = ServiceResult.error("db error")
+        svc = BacktestTaskService(crud, portfolio_service=portfolio_svc)
+
+        result = svc.create(name="dbfail", portfolio_id=_PORTFOLIO_ID)
+
+        assert result.is_success(), "get_components 失败应放行，交装配层兜底"
+        crud.create.assert_called_once()
+
+    @pytest.mark.unit
+    def test_missing_multiple_components_lists_all(self):
+        """缺 strategy+sizer（仅绑 selector）→ 错误信息含两者 + 各自绑定命令。"""
+        crud = MagicMock()
+        portfolio_svc = _portfolio_service_with("SELECTOR")
+        svc = BacktestTaskService(crud, portfolio_service=portfolio_svc)
+
+        result = svc.create(name="multi", portfolio_id=_PORTFOLIO_ID)
+
+        assert not result.is_success()
+        assert "Strategy" in result.error
+        assert "Sizer" in result.error
+        assert "--type strategy" in result.error
+        assert "--type sizer" in result.error

--- a/tests/unit/data/services/test_backtest_task_create_precheck.py
+++ b/tests/unit/data/services/test_backtest_task_create_precheck.py
@@ -12,16 +12,25 @@ from ginkgo.data.services.base_service import ServiceResult
 
 _PORTFOLIO_ID = "aa11223344556677889900aabbccddee"
 
+# 成员名 → 生产数字串映射（FILE_TYPES value，与 get_components 实际返回格式一致）。
+# 生产路径：MPortfolioFileMapping.type 经 FILE_TYPES.validate_input 转 int 存储，
+# get_components 用 `mapping.type.name if hasattr(mapping.type, "name") else str(mapping.type)`，
+# int 无 .name → 返回 str(int)，即数字串 "6"/"4"/"5"。
+# #6643 P0 回归保护：mock 必须用生产数字串格式，原 mock 用成员名 "STRATEGY" 掩盖了
+# requirements.py str 分支对数字串的归一化 bug（全绿却生产炸）。
+_MEMBER_TO_PROD = {"STRATEGY": "6", "SELECTOR": "4", "SIZER": "5"}
+
 
 def _portfolio_service_with(*component_types):
     """构造 mock portfolio_service，get_components 返回含指定类型组件的 ServiceResult。
 
-    component_type 字段模拟 PortfolioService.get_components 的返回格式
-    （mapping.type.name，即 FILE_TYPES 成员名，如 "STRATEGY"/"SELECTOR"/"SIZER"）。
+    component_type 字段模拟 PortfolioService.get_components 的【生产返回格式】：
+    数字字符串（FILE_TYPES value 的 str 形式，"6"/"4"/"5"），非成员名 "STRATEGY"。
+    调用方仍传可读成员名（"STRATEGY" 等），由本 helper 映射到生产格式。
     """
     svc = MagicMock()
     components = [
-        {"component_type": t, "component_name": f"{t.lower()}_1"}
+        {"component_type": _MEMBER_TO_PROD[t], "component_name": f"{t.lower()}_1"}
         for t in component_types
     ]
     svc.get_components.return_value = ServiceResult.success(components)

--- a/tests/unit/trading/services/test_component_requirements.py
+++ b/tests/unit/trading/services/test_component_requirements.py
@@ -1,0 +1,123 @@
+"""#6640: 必需组件清单 + 缺失检测辅助函数的直接单测。
+
+覆盖创建预检/装配透传间接路径未触达的边界（int 类型输入、未知字符串忽略、
+空 components、清单顺序）。
+"""
+import pytest
+
+from ginkgo.enums import FILE_TYPES
+from ginkgo.trading.services._assembly.requirements import (
+    REQUIRED_PORTFOLIO_COMPONENT_TYPES,
+    find_missing_required_components,
+    find_missing_required_from_bucketed,
+    format_missing_components_message,
+)
+
+
+class TestFindMissingRequiredComponents:
+    """find_missing_required_components: 从类型集合判缺失。"""
+
+    @pytest.mark.unit
+    def test_all_present_returns_empty(self):
+        """strategy+selector+sizer 齐全 → 无缺失。"""
+        result = find_missing_required_components(
+            {FILE_TYPES.STRATEGY, FILE_TYPES.SELECTOR, FILE_TYPES.SIZER}
+        )
+        assert result == []
+
+    @pytest.mark.unit
+    def test_string_member_names_accepted(self):
+        """字符串成员名（PortfolioService.get_components 返回格式）→ 正确识别。"""
+        result = find_missing_required_components(["STRATEGY", "SELECTOR"])
+        # 仅缺 SIZER
+        assert len(result) == 1
+        assert result[0][0] == "Sizer"
+
+    @pytest.mark.unit
+    def test_int_values_accepted(self):
+        """int value（FILE_TYPES.SIZER.value=5）→ 正确识别。"""
+        result = find_missing_required_components([6, 4])  # strategy + selector
+        assert ("Sizer", "sizer") in result
+
+    @pytest.mark.unit
+    def test_unknown_strings_ignored(self):
+        """未知字符串（非必需类型的合法组件，如 analyzer）→ 忽略，不报错。"""
+        result = find_missing_required_components(
+            ["STRATEGY", "SELECTOR", "SIZER", "ANALYZER", "UNKNOWN_TYPE"]
+        )
+        assert result == []
+
+    @pytest.mark.unit
+    def test_order_follows_required_list(self):
+        """缺失项顺序与 REQUIRED_PORTFOLIO_COMPONENT_TYPES 一致（strategy→selector→sizer）。"""
+        result = find_missing_required_components([])  # 全缺
+        labels = [label for label, _ in result]
+        assert labels == ["Strategy", "Selector", "Sizer"]
+
+
+class TestFindMissingFromBucketed:
+    """find_missing_required_from_bucketed: 从分桶 dict 判缺失（装配层用）。"""
+
+    @pytest.mark.unit
+    def test_empty_dict_all_missing(self):
+        assert len(find_missing_required_from_bucketed({})) == 3
+
+    @pytest.mark.unit
+    def test_none_components_all_missing(self):
+        assert len(find_missing_required_from_bucketed(None)) == 3
+
+    @pytest.mark.unit
+    def test_empty_list_treated_as_missing(self):
+        """空 list 视为未绑定（与 component_loader 的 len()==0 检查一致）。"""
+        result = find_missing_required_from_bucketed(
+            {"strategies": [{"file_id": "x"}], "selectors": [], "sizers": []}
+        )
+        labels = [l for l, _ in result]
+        assert "Selector" in labels
+        assert "Sizer" in labels
+        assert "Strategy" not in labels
+
+    @pytest.mark.unit
+    def test_all_buckets_filled_no_missing(self):
+        result = find_missing_required_from_bucketed(
+            {"strategies": [1], "selectors": [1], "sizers": [1]}
+        )
+        assert result == []
+
+
+class TestFormatMissingComponentsMessage:
+    """format_missing_components_message: 错误信息格式。"""
+
+    @pytest.mark.unit
+    def test_empty_missing_returns_empty_string(self):
+        assert format_missing_components_message("pid", []) == ""
+
+    @pytest.mark.unit
+    def test_single_component_message(self):
+        msg = format_missing_components_message("abc123", [("Sizer", "sizer")])
+        assert "abc123" in msg
+        assert "Sizer" in msg
+        assert "bind-component" in msg
+        assert "--type sizer" in msg
+
+    @pytest.mark.unit
+    def test_multiple_components_joined(self):
+        msg = format_missing_components_message(
+            "pid", [("Strategy", "strategy"), ("Sizer", "sizer")]
+        )
+        assert "Strategy" in msg
+        assert "Sizer" in msg
+        assert "--type strategy" in msg
+        assert "--type sizer" in msg
+
+
+class TestRequiredListDefinition:
+    """清单本身的不变量：单点维护的权威来源。"""
+
+    @pytest.mark.unit
+    def test_required_list_covers_core_three(self):
+        """清单覆盖装配层 component_loader 实际要求的三个必需组件。"""
+        types = {ft for ft, _, _ in REQUIRED_PORTFOLIO_COMPONENT_TYPES}
+        assert FILE_TYPES.STRATEGY in types
+        assert FILE_TYPES.SELECTOR in types
+        assert FILE_TYPES.SIZER in types

--- a/tests/unit/trading/services/test_component_requirements.py
+++ b/tests/unit/trading/services/test_component_requirements.py
@@ -27,11 +27,25 @@ class TestFindMissingRequiredComponents:
 
     @pytest.mark.unit
     def test_string_member_names_accepted(self):
-        """字符串成员名（PortfolioService.get_components 返回格式）→ 正确识别。"""
+        """字符串成员名（"STRATEGY"）→ 正确识别。"""
         result = find_missing_required_components(["STRATEGY", "SELECTOR"])
         # 仅缺 SIZER
         assert len(result) == 1
         assert result[0][0] == "Sizer"
+
+    @pytest.mark.unit
+    def test_numeric_string_values_accepted(self):
+        """数字字符串（生产 get_components 实际返回格式）→ 正确识别。
+
+        生产路径：MPortfolioFileMapping.type 经 FILE_TYPES.validate_input 转 int 存储，
+        get_components 用 `mapping.type.name if hasattr(mapping.type, "name") else str(mapping.type)`，
+        int 无 .name → 返回 str(int)，即 FILE_TYPES value 的数字串 "6"/"4"/"5"。
+        此为 #6643 P0 回归点：原 str 分支 FILE_TYPES["6"] 抛 KeyError 被静默吞，
+        致所有已绑组件归一化为空集、预检误判全部必需组件缺失。
+        """
+        result = find_missing_required_components(["6", "4"])  # strategy + selector 数字串
+        assert ("Sizer", "sizer") in result
+        assert len(result) == 1
 
     @pytest.mark.unit
     def test_int_values_accepted(self):

--- a/tests/unit/trading/services/test_engine_assembly_error_propagation.py
+++ b/tests/unit/trading/services/test_engine_assembly_error_propagation.py
@@ -1,0 +1,161 @@
+"""#6640: 装配失败错误透传——缺必需组件时 assemble_backtest_engine 返回的 error
+含具体缺失组件名（非笼统 'No portfolios bound to engine'），便于 backtest cat /
+API 回测详情向用户暴露真因（'No sizer found' 此前仅在 worker 日志，用户看不到）。
+
+清单驱动：requirements.find_missing_required_components 检查分桶 portfolio_components，
+缺失组件透传到 ServiceResult.error。
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.trading.services.engine_assembly_service import EngineAssemblyService
+from ginkgo.trading.services._assembly.infrastructure_factory import InfrastructureFactory
+
+_PORTFOLIO_ID = "pp11223344556677889900aabbccdd01"
+_ENGINE_ID = "en11223344556677889900aabbccdd02"
+
+
+def _make_portfolio_mapping(pid):
+    m = MagicMock()
+    m.portfolio_id = pid
+    return m
+
+
+class _StubInfraFactory:
+    """InfrastructureFactory 静态方法的 no-op 替身，跳过真实 engine 构造。"""
+
+    @staticmethod
+    def create_base_engine(engine_data, engine_id, logger, progress_callback=None):
+        engine = MagicMock()
+        engine.status = "READY"
+        engine.state = 0
+        return engine
+
+    @staticmethod
+    def setup_engine_infrastructure(engine, logger, engine_data, skip_feeder=False):
+        return True
+
+    @staticmethod
+    def setup_data_feeder_for_engine(engine, logger, engine_data):
+        return True
+
+
+def _patch_infra_factory():
+    """patch InfrastructureFactory 的三个静态方法为 stub。"""
+    return [
+        patch.object(InfrastructureFactory, "create_base_engine", _StubInfraFactory.create_base_engine),
+        patch.object(InfrastructureFactory, "setup_engine_infrastructure", _StubInfraFactory.setup_engine_infrastructure),
+        patch.object(InfrastructureFactory, "setup_data_feeder_for_engine", _StubInfraFactory.setup_data_feeder_for_engine),
+    ]
+
+
+class TestAssemblyErrorPropagation:
+    """#6640: 缺必需组件时装配错误含具体组件名（清单驱动透传）。"""
+
+    @pytest.mark.unit
+    def test_missing_sizer_error_names_component(self):
+        """portfolio_components 缺 sizer + binding 失败 → error 含 'Sizer'。"""
+        service = EngineAssemblyService()
+        # 直接 mock binding 入口，聚焦错误透传逻辑（不依赖 portfolio 实例创建细节）
+        service._bind_portfolio_to_engine_with_ids = MagicMock(return_value=False)
+
+        engine_data = {"name": "test_engine", "task_id": _ENGINE_ID}
+        portfolio_mappings = [_make_portfolio_mapping(_PORTFOLIO_ID)]
+        portfolio_configs = {_PORTFOLIO_ID: {"uuid": _PORTFOLIO_ID, "cash": 100000}}
+        portfolio_components = {
+            _PORTFOLIO_ID: {
+                "strategies": [{"file_id": "f1", "type": 6, "uuid": "m1"}],
+                "selectors": [{"file_id": "f2", "type": 4, "uuid": "m2"}],
+                "sizers": [],  # 缺 sizer
+            }
+        }
+
+        patches = _patch_infra_factory()
+        for p in patches:
+            p.start()
+        try:
+            result = service.assemble_backtest_engine(
+                engine_id=_ENGINE_ID,
+                engine_data=engine_data,
+                portfolio_mappings=portfolio_mappings,
+                portfolio_configs=portfolio_configs,
+                portfolio_components=portfolio_components,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert not result.is_success(), "缺 sizer 装配应失败"
+        assert "Sizer" in result.error, "error 应含具体缺失组件名 Sizer"
+        # 不再是笼统信息（用户可见路径已透传真因）
+        assert "No portfolios bound to engine" not in result.error
+
+    @pytest.mark.unit
+    def test_missing_strategy_and_selector_listed(self):
+        """缺 strategy+selector（仅绑 sizer）→ error 含 Strategy 与 Selector。"""
+        service = EngineAssemblyService()
+        service._bind_portfolio_to_engine_with_ids = MagicMock(return_value=False)
+
+        engine_data = {"name": "test_engine", "task_id": _ENGINE_ID}
+        portfolio_mappings = [_make_portfolio_mapping(_PORTFOLIO_ID)]
+        portfolio_configs = {_PORTFOLIO_ID: {"uuid": _PORTFOLIO_ID, "cash": 100000}}
+        portfolio_components = {
+            _PORTFOLIO_ID: {
+                "strategies": [],
+                "selectors": [],
+                "sizers": [{"file_id": "f3", "type": 5, "uuid": "m3"}],
+            }
+        }
+
+        patches = _patch_infra_factory()
+        for p in patches:
+            p.start()
+        try:
+            result = service.assemble_backtest_engine(
+                engine_id=_ENGINE_ID,
+                engine_data=engine_data,
+                portfolio_mappings=portfolio_mappings,
+                portfolio_configs=portfolio_configs,
+                portfolio_components=portfolio_components,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert not result.is_success()
+        assert "Strategy" in result.error
+        assert "Selector" in result.error
+
+    @pytest.mark.unit
+    def test_all_present_binding_success_does_not_raise(self):
+        """回归保护：组件齐全 + binding 成功 → 不触发缺失组件错误路径。"""
+        service = EngineAssemblyService()
+        service._bind_portfolio_to_engine_with_ids = MagicMock(return_value=True)
+
+        engine_data = {"name": "test_engine", "task_id": _ENGINE_ID}
+        portfolio_mappings = [_make_portfolio_mapping(_PORTFOLIO_ID)]
+        portfolio_configs = {_PORTFOLIO_ID: {"uuid": _PORTFOLIO_ID, "cash": 100000}}
+        portfolio_components = {
+            _PORTFOLIO_ID: {
+                "strategies": [{"file_id": "f1", "type": 6, "uuid": "m1"}],
+                "selectors": [{"file_id": "f2", "type": 4, "uuid": "m2"}],
+                "sizers": [{"file_id": "f3", "type": 5, "uuid": "m3"}],
+            }
+        }
+
+        patches = _patch_infra_factory()
+        for p in patches:
+            p.start()
+        try:
+            result = service.assemble_backtest_engine(
+                engine_id=_ENGINE_ID,
+                engine_data=engine_data,
+                portfolio_mappings=portfolio_mappings,
+                portfolio_configs=portfolio_configs,
+                portfolio_components=portfolio_components,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert result.is_success(), "组件齐全应装配成功"


### PR DESCRIPTION
## Summary

实现 #6640：回测组件完整性可见性——**创建预检 + 装配失败错误透传**。

### 问题

创建回测后才发现组件缺失时，错误信息对用户不透明：
- `backtest create` 不校验 portfolio 是否绑齐必需组件，缺组件也能创建成功
- 缺组件导致装配失败时，`backtest cat` / API 仅显示笼统的 `No portfolios bound to engine`，真因（如 `No sizer found`）埋在 worker 日志，用户看不到
- 必需组件清单散落在 `component_loader` 的多处 `# Add ... (required)` 检查中，无单点维护

### 方案

**1. 必需组件清单单点定义**（`src/ginkgo/trading/services/_assembly/requirements.py`，新增）

```python
REQUIRED_PORTFOLIO_COMPONENT_TYPES = (
    (FILE_TYPES.STRATEGY, "Strategy", "strategy"),
    (FILE_TYPES.SELECTOR, "Selector", "selector"),
    (FILE_TYPES.SIZER, "Sizer", "sizer"),
)
```

提供 `find_missing_required_components`（接受枚举/成员名/int）、`find_missing_required_from_bucketed`（装配层分桶 dict）、`format_missing_components_message`（统一错误信息 + bind 命令提示）。未来新增必需组件只需在此追加元组。

**2. 创建预检**（`backtest_task_service.create`）

创建回测前调 `portfolio_service.get_components` 查绑定组件，缺失必需项时拒绝创建并返回具体组件名 + 绑定命令：

```
Portfolio <pid> missing required component: Sizer is required.
  Bind via: ginkgo portfolio bind-component <pid> <sizer_file_id> --type sizer
```

预检在 service 层，API/CLI 共享。保守放行：portfolio_service 未注入（旧调用方）或 get_components 失败时放行，交装配层兜底。

**3. 装配错误透传**（`engine_assembly_service`）

`_perform_backtest_engine_assembly` 在 binding 失败分支检测缺失组件，记入 `self._assembly_failure_reason`；`assemble_backtest_engine` 在 engine 为 None 时把该原因塞入 `ServiceResult.error`，使 `backtest cat` / API 可暴露真因，取代 `No portfolios bound to engine`。

### 诚实权衡

`component_loader.perform_component_binding` 内部的散落必需检查**保留**作为兜底（不重构）：
- 该函数有 5 个调用方 + mock 测试（含 paper_trading_worker 实盘路径），改签名风险高
- 内部检查有顺序依赖 + sizer 单键兼容性历史包袱
- 用户可见路径（创建预检 + 装配透传）已**完全清单驱动**——散落检查仅在 worker 内部日志作为最后防线，不影响用户可见错误

## Test plan

三层冒烟全绿：

- **Layer 1 py_compile**：`find src api -name "*.py" | xargs py_compile` ✅
- **Layer 2 启动路径**：`test_user_crud_mock.py + test_containers.py + test_user_cli.py`（36 passed）✅
- **Layer 3 变更相关**：
  - `test_component_requirements.py`（13，新增，清单辅助直接单测）
  - `test_backtest_task_create_precheck.py`（5，新增，创建预检 TDD）
  - `test_engine_assembly_error_propagation.py`（3，新增，错误透传 TDD）
  - `test_backtest_task_service_metrics.py`（10，回归）✅
  - `test_engine_assembly_service.py`（64 + 1 skipped，回归）✅

手动验证路径：
1. 创建一个只绑 strategy + selector（缺 sizer）的 portfolio
2. `ginkgo backtest create --portfolio <pid> ...` → 应被拒绝，error 含 `Sizer` 与 `--type sizer`
3. 补绑 sizer 后 `backtest create` → 成功

Closes #6640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
