### PR TITLE
fix(data): DI 容器 service 改引用具名 CRUD provider

### DIFF
--- a/src/ginkgo/data/containers.py
+++ b/src/ginkgo/data/containers.py
@@ -162,6 +162,18 @@ class Container(containers.DeclarativeContainer):
     api_key_crud = providers.Singleton(get_crud, "api_key")
     deployment_crud = providers.Singleton(get_crud, "deployment")
 
+    # Trading CRUDs（#5509：service 必须引用此处具名 provider，禁止 inline
+    # providers.Singleton(get_crud, name) —— 那会创建独立 provider → 独立实例
+    # → 独立 DB session，破坏同事务可见性）
+    position_crud = providers.Singleton(get_crud, "position")
+    signal_crud = providers.Singleton(get_crud, "signal")
+    order_crud = providers.Singleton(get_crud, "order")
+    signal_tracker_crud = providers.Singleton(get_crud, "signal_tracker")
+    position_record_crud = providers.Singleton(get_crud, "position_record")
+    order_record_crud = providers.Singleton(get_crud, "order_record")
+    transfer_crud = providers.Singleton(get_crud, "transfer")
+    transfer_record_crud = providers.Singleton(get_crud, "transfer_record")
+
     # NOTE: backtest_task_crud 已在上方主 CRUD 块(line 141)定义，勿重复（#5554）
 
     # Services (Dependencies are injected here)
@@ -191,8 +203,13 @@ class Container(containers.DeclarativeContainer):
     )
 
     # TickService with TickCRUD instance
+    # #5509 AC3: crud_repo 用 providers.Singleton(TickCRUD) 懒实例化；
+    # TickCRUD 需 code 参数的场景走 container.create_tick_crud(code)。
     tick_service = providers.Singleton(
-        TickService, data_source=ginkgo_tdx_source, stockinfo_service=stockinfo_service, crud_repo=TickCRUD()
+        TickService,
+        data_source=ginkgo_tdx_source,
+        stockinfo_service=stockinfo_service,
+        crud_repo=providers.Singleton(TickCRUD),
     )
 
     file_service = providers.Singleton(FileService, crud_repo=file_crud)
@@ -237,24 +254,24 @@ class Container(containers.DeclarativeContainer):
 
     position_service = providers.Singleton(
         PositionService,
-        crud_repo=providers.Singleton(get_crud, "position"),
+        crud_repo=position_crud,
     )
 
     kafka_service = providers.Singleton(KafkaService, kafka_crud=kafka_crud)
 
     # Signal tracking service with SignalTrackerCRUD dependency
     signal_tracking_service = providers.Singleton(
-        SignalTrackingService, tracker_crud=providers.Singleton(get_crud, "signal_tracker")
+        SignalTrackingService, tracker_crud=signal_tracker_crud
     )
 
     # Signal service with SignalCRUD dependency
     signal_service = providers.Singleton(
-        SignalService, crud_repo=providers.Singleton(get_crud, "signal")
+        SignalService, crud_repo=signal_crud
     )
 
     # Order service with OrderCRUD dependency
     order_service = providers.Singleton(
-        OrderService, crud_repo=providers.Singleton(get_crud, "order")
+        OrderService, crud_repo=order_crud
     )
 
     # Factor service with FactorCRUD dependency
@@ -273,15 +290,15 @@ class Container(containers.DeclarativeContainer):
         analyzer_service=analyzer_service,
         engine_service=engine_service,
         portfolio_service=portfolio_service,
-        signal_crud=providers.Singleton(get_crud, "signal"),
-        order_crud=providers.Singleton(get_crud, "order"),
-        position_crud=providers.Singleton(get_crud, "position"),
-        position_record_crud=providers.Singleton(get_crud, "position_record"),
+        signal_crud=signal_crud,
+        order_crud=order_crud,
+        position_crud=position_crud,
+        position_record_crud=position_record_crud,
         analyzer_record_crud=analyzer_record_crud,
-        order_record_crud=providers.Singleton(get_crud, "order_record"),
-        transfer_record_crud=providers.Singleton(get_crud, "transfer_record"),
-        transfer_crud=providers.Singleton(get_crud, "transfer"),
-        signal_tracker_crud=providers.Singleton(get_crud, "signal_tracker"),
+        order_record_crud=order_record_crud,
+        transfer_record_crud=transfer_record_crud,
+        transfer_crud=transfer_crud,
+        signal_tracker_crud=signal_tracker_crud,
     )
 
     # User management services
@@ -318,7 +335,7 @@ class Container(containers.DeclarativeContainer):
     # Live account service for live trading
     live_account_service = providers.Singleton(
         LiveAccountService,
-        live_account_crud=providers.Singleton(get_crud, "live_account")
+        live_account_crud=live_account_crud,
     )
 
     # API Key service for API key management
@@ -332,7 +349,7 @@ class Container(containers.DeclarativeContainer):
     # DEPRECATED: validation_result_crud 参数已废弃。验证结果存储方案需重新设计。
     validation_service = providers.Singleton(
         ValidationService,
-        analyzer_record_crud=providers.Singleton(get_crud, "analyzer_record"),
+        analyzer_record_crud=analyzer_record_crud,
         validation_result_crud=validation_result_crud,
     )
 

--- a/tests/unit/data/test_container_crud_sharing.py
+++ b/tests/unit/data/test_container_crud_sharing.py
@@ -1,0 +1,89 @@
+"""#5509 DI 容器 CRUD 接线契约测试
+
+核心契约：service provider 的 CRUD 依赖必须【引用】顶层具名 provider，
+不能 inline `providers.Singleton(get_crud, name)` 重新创建独立 provider。
+
+inline 写法在每个 service 上新建独立 provider 对象——当前 `get_crud` 的全局
+`_crud_instances` 缓存恰好掩盖了实例层面的后果（所有 provider 解析出同一 CRUD
+实例），但接线层面仍是错的：一旦缓存策略变化（如按 session 区分），inline
+立即产生独立 CRUD 实例 → 独立 DB session → "同事务写 A 读 B 不可见"。
+
+因此本测试在【provider 身份】层面断言接线正确性：service provider 的
+`kwargs[<crud_arg>]` 必须 `is` 顶层具名 CRUD provider 对象。
+"""
+import pytest
+
+from dependency_injector import providers as di
+
+
+def _fresh_container():
+    """新建 Container 实例，避免 module-level singleton 缓存污染。"""
+    from ginkgo.data.containers import Container
+
+    return Container()
+
+
+class TestContainerCRUDWiring:
+    """service provider 必须引用具名 CRUD provider（#5509 AC2）。"""
+
+    @pytest.mark.parametrize(
+        "service_attr,crud_attr,arg_name",
+        [
+            ("position_service", "position_crud", "crud_repo"),
+            ("signal_service", "signal_crud", "crud_repo"),
+            ("order_service", "order_crud", "crud_repo"),
+            ("signal_tracking_service", "signal_tracker_crud", "tracker_crud"),
+            ("live_account_service", "live_account_crud", "live_account_crud"),
+            ("validation_service", "analyzer_record_crud", "analyzer_record_crud"),
+        ],
+    )
+    def test_service_references_named_crud_provider(
+        self, service_attr, crud_attr, arg_name
+    ):
+        """service 的 CRUD 依赖 provider 必须 identity 等于具名 CRUD provider。"""
+        c = _fresh_container()
+        service_provider = getattr(c, service_attr)
+        named_provider = getattr(c, crud_attr)
+        assert service_provider.kwargs.get(arg_name) is named_provider, (
+            f"{service_attr}.{arg_name} 未引用具名 {crud_attr} provider（疑似 inline Singleton）"
+        )
+
+    def test_backtest_task_service_references_all_named_crud_providers(self):
+        """backtest_task_service 内部 8 个 CRUD 依赖全部引用具名 provider（#5509 AC2）。"""
+        c = _fresh_container()
+        bt_provider = c.backtest_task_service
+        pairs = [
+            ("signal_crud", "signal_crud"),
+            ("order_crud", "order_crud"),
+            ("position_crud", "position_crud"),
+            ("position_record_crud", "position_record_crud"),
+            ("order_record_crud", "order_record_crud"),
+            ("transfer_record_crud", "transfer_record_crud"),
+            ("transfer_crud", "transfer_crud"),
+            ("signal_tracker_crud", "signal_tracker_crud"),
+        ]
+        for arg_name, crud_attr in pairs:
+            assert bt_provider.kwargs.get(arg_name) is getattr(c, crud_attr), (
+                f"backtest_task_service.{arg_name} 未引用具名 {crud_attr} provider"
+            )
+
+    def test_tick_crud_is_lazy_provider_not_eager_instance(self):
+        """TickCRUD 应作为 provider 懒注入，非容器定义期 eager 实例（#5509 AC3）。"""
+        c = _fresh_container()
+        crud_arg = c.tick_service.kwargs.get("crud_repo")
+        assert isinstance(crud_arg, di.Provider), (
+            f"crud_repo 应为 provider（懒注入），实为 {type(crud_arg).__name__}（eager 实例）"
+        )
+
+    def test_crud_instances_shared_end_to_end(self):
+        """端到端契约：所有路径解析的同名 CRUD 是同一实例（get_crud 缓存下成立）。
+
+        此测试防御 get_crud 缓存被移除后的回归——届时 inline 接线会立刻让本测试红。
+        """
+        c = _fresh_container()
+        assert c.position_service()._crud_repo is c.position_crud()
+        assert c.signal_service()._crud_repo is c.signal_crud()
+        assert c.order_service()._crud_repo is c.order_crud()
+        bt = c.backtest_task_service()
+        assert bt._signal_crud is c.signal_crud()
+        assert bt._position_crud is c.position_crud()


### PR DESCRIPTION
## Summary

修复 #5509（认领孤儿续接：上一次 6/9 认领后搁置，5904 分支未建；本次会话补完）。

### AC 核对（实测 containers.py 当前状态）

| AC | issue 说法 | 实测 | 本 PR |
|---|---|---|---|
| 1 | 去重 backtest_task_crud | ✅ 已被 #5554 顺带修复 | 跳过 |
| 2 | service 引用 aggregate | ❌ 11 处 inline Singleton 真实存在 | ✅ 修 |
| 3 | TickCRUD 走 DI 非 eager | ⚠️ 描述不准（TickCRUD 需 code 故排除 aggregate）；真意=别容器定义期实例化 | ✅ 改懒 |
| 4 | lambda 换 DI 接线 | ⚠️ 已失效（notification_recipient 已规范 Singleton，#5624） | 跳过 |

### 改动

- **新增 8 个 trading CRUD 顶层具名 provider**：`position_crud` / `signal_crud` / `order_crud` / `signal_tracker_crud` / `position_record_crud` / `order_record_crud` / `transfer_crud` / `transfer_record_crud`
- **11 处 inline `providers.Singleton(get_crud, name)` 改引用具名 provider**：`position_service` / `signal_service` / `order_service` / `signal_tracking_service` 各 1 处，`backtest_task_service` 内部 8 处
- **TickCRUD**：`crud_repo=TickCRUD()`（容器定义期 eager 实例化）→ `crud_repo=providers.Singleton(TickCRUD)`（懒注入）
- **顺手修（同根因）**：`live_account_service` / `validation_service` 顶层已有具名 provider 却仍 inline

### ⚠️ 重要诚实声明：AC2 被 `get_crud` 全局缓存掩盖

`src/ginkgo/data/utils.py` 的 `get_crud` 有 module-level `_crud_instances` 缓存——所有 inline Singleton 最终解析出**同一 CRUD 实例**。所以 issue 描述的"独立 session 数据不可见"在当前实现下**不可复现**。

本 PR 的 AC2 修复是**架构契约**（service provider 引用具名 provider，不 inline 新建），价值在：
1. 防御性——一旦缓存策略变化（如按 session 区分），inline 立刻断链
2. 接线正确性可读性
3. 减少冗余 provider 对象

AC3（TickCRUD eager）是与缓存无关的真实问题：容器 import 即触发 `TickCRUD()` 构造。

## Test plan

新增 `tests/unit/data/test_container_crud_sharing.py`（9 tests）：
- **provider identity 契约**（有区分度）：`service.kwargs[crud_arg] is named_provider` —— inline 红具名绿
- **TickCRUD 懒注入**：`tick_service.kwargs[crud_repo]` 是 Provider 而非实例
- **端到端实例同一性**：防御 get_crud 缓存移除后的回归

三层冒烟全绿：
- Layer 1 py_compile (src+api) ✅
- Layer 2 启动路径 smoke (user_crud_mock + containers + user_cli) 36 passed ✅
- Layer 3 变更相关 (container_crud_sharing + service_container_paths) 15 passed ✅

Closes #5509