### PR TITLE
fix(#4708): DualThrust/ATRSizer Decimal 算术 + ATRSizer self.now 修复

### DIFF
--- a/src/ginkgo/trading/sizers/atr_sizer.py
+++ b/src/ginkgo/trading/sizers/atr_sizer.py
@@ -54,6 +54,10 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
     def cal(self, portfolio_info, signal: Signal) -> Optional[Order]:
         code = signal.code
         o = None
+        # #4708: 对齐 RatioSizer/FixedSizer，经 get_time_provider() 取当前时间。
+        # #4706 误用 self.now（sizer 体系从未赋值），AttributeError 致全路径失效。
+        tp = self.get_time_provider()
+        now = tp.now() if tp is not None else None
         if signal.direction == DIRECTION_TYPES.SHORT:
             # 获取持仓信息
             if code not in portfolio_info["positions"]:
@@ -71,10 +75,10 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
                 transaction_volume=0,
                 remain=0,
                 fee=0,
-                timestamp=self.now,
+                timestamp=now,
             )
         if signal.direction == DIRECTION_TYPES.LONG:
-            if self.now is None:
+            if now is None:
                 GLOG.WARN("ATRSizer: now is None, passing the signal")
                 return None
             # #4706: LONG 取数走注入的 _data_feeder.get_historical_data()，对齐
@@ -84,8 +88,8 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
             if self._data_feeder is None:
                 GLOG.ERROR(f"ATRSizer:{self.name} has no data_feeder bound")
                 return None
-            start_date = self.now - datetime.timedelta(days=self.period + 7)
-            end_date = self.now
+            start_date = now - datetime.timedelta(days=self.period + 7)
+            end_date = now
             df = self._data_feeder.get_historical_data(
                 symbols=[code],
                 start_time=start_date,
@@ -106,7 +110,9 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
             close_prices = df['close'].tolist()
 
             # 使用新API计算ATR
-            atr = ATR.cal(self.period, high_prices[-(self.period+1):], low_prices[-(self.period+1):], close_prices[-(self.period+1):]) * self.risk_ratio
+            # #4708: Decimal 列下 ATR.cal 返回 Decimal，与 float 系数算术抛 TypeError；
+            # 显式 float() 归一（与 DualThrust._calculate_range 同范式）。
+            atr = float(ATR.cal(self.period, high_prices[-(self.period+1):], low_prices[-(self.period+1):], close_prices[-(self.period+1):])) * self.risk_ratio
 
             if atr == 0 or pd.isna(atr):
                 GLOG.WARN(f"ATRSizer: ATR is {atr} for {code}, signal dropped")
@@ -114,16 +120,16 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
             # #5490: floor ATR to a minimum fraction of close so a collapsed ATR
             # (halt / limit board / stale quotes) cannot inflate max_shares.
             close = df.iloc[-1]["close"]
-            min_atr = close * self.min_atr_percent
+            min_atr = float(close) * self.min_atr_percent
             if atr < min_atr:
                 GLOG.WARN(
                     f"ATRSizer: ATR {atr} below floor {min_atr:.4f} "
                     f"({self.min_atr_percent * 100:.2f}% of close {close}) for {code}; flooring"
                 )
                 atr = min_atr
-            max_money = portfolio_info["cash"] * self.risk
+            max_money = float(portfolio_info["cash"]) * self.risk
             max_shares = self.align_to_lot(int(max_money / atr))  # 向下对齐到 lot_size 整数倍（#6498，原硬编码 100）
-            price = close * 1.1
+            price = float(close) * 1.1
             o = self.create_order(
                 code=signal.code,
                 direction=signal.direction,
@@ -134,7 +140,7 @@ class ATRSizer(LotAlignableMixin, BaseSizer):
                 transaction_volume=0,
                 remain=0,
                 fee=0,
-                timestamp=self.now,
+                timestamp=now,
             )
             GLOG.INFO("Order Generated.")
             GLOG.INFO(o)

--- a/src/ginkgo/trading/strategies/dual_thrust.py
+++ b/src/ginkgo/trading/strategies/dual_thrust.py
@@ -40,7 +40,10 @@ class StrategyDualThrust(BaseStrategy):
         lc = df["close"].rolling(window=self._spans).min().iloc[-1]
         hc = df["close"].rolling(window=self._spans).max().iloc[-1]
         ll = df["low"].rolling(window=self._spans).min().iloc[-1]
-        return max(hh - lc, hc - ll)
+        # #4708: ClickHouse bar 列为 Decimal，max()/加减结果保留 Decimal；
+        # cal() 的 `open + k_buy * r`（float 系数）会触发 Decimal+float TypeError。
+        # 末尾 float() 归一，使本方法在 float / Decimal 列下都返回 float。
+        return float(max(hh - lc, hc - ll))
 
     def _generate_signal(
         self, portfolio_info, code: str, direction: DIRECTION_TYPES
@@ -75,12 +78,16 @@ class StrategyDualThrust(BaseStrategy):
             return []
 
         today_r = self._calculate_range(df)
-        today_buy_line = df.iloc[-1]["open"] + self._k_buy * today_r
-        today_sell_line = df.iloc[-1]["open"] - self._k_sell * today_r
+        # #4708: Decimal 列下 df.iloc[-1]["open"] 是 Decimal，与 float 系数算术抛
+        # TypeError；显式 float() 归一（与 _calculate_range 返回类型一致）。
+        today_open = float(df.iloc[-1]["open"])
+        today_buy_line = today_open + self._k_buy * today_r
+        today_sell_line = today_open - self._k_sell * today_r
 
         last_r = self._calculate_range(df.iloc[:-1])
-        last_buy_line = df.iloc[-2]["open"] + self._k_buy * last_r
-        last_sell_line = df.iloc[-2]["open"] - self._k_sell * last_r
+        last_open = float(df.iloc[-2]["open"])
+        last_buy_line = last_open + self._k_buy * last_r
+        last_sell_line = last_open - self._k_sell * last_r
 
         has_position = event.code in portfolio_info["positions"]
 

--- a/tests/unit/trading/sizers/test_atr_sizer.py
+++ b/tests/unit/trading/sizers/test_atr_sizer.py
@@ -6,6 +6,7 @@ Covers:
   FixedSizer/RatioSizer），缺数据时 WARN + return None 恢复可诊断性。
 - #5490: 近零 ATR 保护（floor）。
 - #6019: 不得以 INFO 输出完整 DataFrame。
+- #4708: self.now 误用（应 get_time_provider()）+ Decimal 列/cash 算术 TypeError。
 
 注：ATRSizer 经 portfolio_base.bind_data_feeder 注入 feeder（见 sizer_base），
 单测通过直接设置 sizer._data_feeder 模拟注入，走公共 cal() 接口验证行为。
@@ -24,7 +25,12 @@ from ginkgo.trading.sizers.atr_sizer import ATRSizer
 @pytest.fixture
 def sizer():
     s = ATRSizer(name="TestATRSizer", period=14, risk=0.01, risk_ratio=2)
-    s.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
+    # #4708: 对齐 RatioSizer/FixedSizer 范式，sizer 经 get_time_provider() 取当前时间。
+    # 旧 fixture 直接 `s.now = ...` 掩盖了 ATRSizer 误用 self.now（#4706 引入、不存在）
+    # 的 AttributeError —— 真实 engine 从不设置 sizer.now。
+    tp = MagicMock()
+    tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+    s._time_provider = tp
     return s
 
 
@@ -180,7 +186,9 @@ class TestATRSizerNearZeroFloor:
         Same tiny-ATR bar, min_atr_percent=0.01 → min_atr=0.1 → int(5000/0.1/100)*100=50,000.
         """
         s = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2, min_atr_percent=0.01)
-        s.now = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        tp = MagicMock()
+        tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        s._time_provider = tp
         df = _bar_df(15, high=10.001, low=10.0, close=10.0)
         _bind_feeder(s, df)
         signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
@@ -209,3 +217,62 @@ class TestATRSizerDoesNotLogDataFrame:
         assert not dataframe_logged, (
             f"#6019: ATRSizer 仍以 INFO 输出完整 DataFrame: {info_args}"
         )
+
+
+class TestATRSizerDecimalColumns:
+    """#4708: 真实回测下 bar 列为 Decimal、cash 也常为 Decimal。
+
+    #4706 引入的算术链 `ATR.cal()*risk_ratio` / `close*min_atr_percent` /
+    `cash*risk` / `close*1.1` 在 Decimal 输入下全部 TypeError（原测试用 float
+    bar + float cash 绕过）。本类补 Decimal 路径回归，与 DualThrust #4708 同源。
+    """
+
+    def test_decimal_bars_and_cash_no_typeerror(self):
+        """Decimal high/low/close + Decimal cash → cal() 不抛 TypeError 且产出合理 volume。
+
+        TR=1 → ATR=1 → atr=2；max_money=5000，max_shares=int(5000/2/100)*100=2500。
+        与 float 路径期望一致（ Decimal 不改变 sizing 语义）。
+        """
+        from decimal import Decimal
+        s = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2)
+        tp = MagicMock()
+        tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        s._time_provider = tp
+        df = pd.DataFrame({
+            "high": [Decimal("11")] * 15,
+            "low": [Decimal("10")] * 15,
+            "close": [Decimal("10")] * 15,
+        })
+        _bind_feeder(s, df)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = {"cash": Decimal("500000"), "positions": {}}
+
+        order = s.cal(info, signal)
+
+        assert order is not None
+        assert order.volume == 2500
+
+    def test_decimal_bars_near_zero_atr_floor(self):
+        """Decimal 列 + 近零 ATR → floor 保护生效，不抛 TypeError。
+
+        high=Decimal('10.001')/low=Decimal('10')/close=Decimal('10') → TR=0.001 →
+        atr=0.002 < floor(0.05) → floor 生效 → int(5000/0.05/100)*100=100000。
+        """
+        from decimal import Decimal
+        s = ATRSizer(name="T", period=14, risk=0.01, risk_ratio=2)
+        tp = MagicMock()
+        tp.now.return_value = datetime.datetime(2026, 1, 15, 10, 0, 0)
+        s._time_provider = tp
+        df = pd.DataFrame({
+            "high": [Decimal("10.001")] * 15,
+            "low": [Decimal("10")] * 15,
+            "close": [Decimal("10")] * 15,
+        })
+        _bind_feeder(s, df)
+        signal = _make_signal("000001.SZ", DIRECTION_TYPES.LONG)
+        info = {"cash": Decimal("500000"), "positions": {}}
+
+        order = s.cal(info, signal)
+
+        assert order is not None
+        assert order.volume == 100000

--- a/tests/unit/trading/strategies/test_dual_thrust.py
+++ b/tests/unit/trading/strategies/test_dual_thrust.py
@@ -4,8 +4,9 @@ Dual Thrust 策略单元测试
 覆盖范围:
 - TestDualThrustCal: 突破信号生成（LONG/SHORT/无信号）
 - #5496: Decimal * numpy.float64 类型混用导致 cal() 抛 TypeError 的回归防护
+- #4708: 真实回测下 ClickHouse bar 列为 Decimal，cal() 算术链 Decimal+float 抛 TypeError
 
-Related: #5496
+Related: #5496, #4708
 """
 
 import sys
@@ -160,3 +161,45 @@ class TestDualThrustHistoryWindow:
             f"A 股下交易日数将不足 {spans + 1}，"
             f"触发 df.shape[0] < spans+1 守卫恒零信号 (#4658)"
         )
+
+
+# #4708: 真实 ClickHouse bar 数据列为 Decimal（非 float）。#5496 仅覆盖 float 列路径，
+# 漏掉 Decimal 列：line 78 `df.iloc[-1]["open"] + k_buy * today_r` 触发
+# `Decimal + float` TypeError → cal() 抛 STRATEGY_FAILED → 回测 0 信号。
+# 下述 df 用 Decimal 列模拟真实回测数据形态。
+from decimal import Decimal as _Decimal
+
+DECIMAL_LONG_BREAKOUT_DF = pd.DataFrame({
+    "open":  [_Decimal("100"), _Decimal("100"), _Decimal("100"), _Decimal("100"), _Decimal("100")],
+    "high":  [_Decimal("100.1"), _Decimal("100.1"), _Decimal("100.1"), _Decimal("100.1"), _Decimal("101")],
+    "low":   [_Decimal("99.9"), _Decimal("99.9"), _Decimal("99.9"), _Decimal("99.9"), _Decimal("99")],
+    "close": [_Decimal("99.5"), _Decimal("99.5"), _Decimal("99.5"), _Decimal("99.5"), _Decimal("105")],
+})
+
+DECIMAL_SHORT_BREAKDOWN_DF = pd.DataFrame({
+    "open":  [_Decimal("100"), _Decimal("100"), _Decimal("100"), _Decimal("100"), _Decimal("100")],
+    "high":  [_Decimal("100.1"), _Decimal("100.1"), _Decimal("100.1"), _Decimal("100.1"), _Decimal("101")],
+    "low":   [_Decimal("99.9"), _Decimal("99.9"), _Decimal("99.9"), _Decimal("99.9"), _Decimal("99")],
+    "close": [_Decimal("100.5"), _Decimal("100.5"), _Decimal("100.5"), _Decimal("100.5"), _Decimal("95")],
+})
+
+
+class TestDualThrustDecimalColumns:
+    """#4708: Decimal 列（真实 ClickHouse 形态）下 cal() 不得抛 TypeError"""
+
+    def test_long_breakout_with_decimal_columns(self):
+        """Decimal open/high/low/close 列下，多头突破生成 LONG 不抛 TypeError"""
+        s = _make_strategy(DECIMAL_LONG_BREAKOUT_DF)
+        info = _make_portfolio_info(positions={})
+        result = s.cal(info, _make_price_event("000001.SZ"))
+        assert len(result) == 1
+        assert result[0].direction == DIRECTION_TYPES.LONG
+        assert result[0].code == "000001.SZ"
+
+    def test_short_breakdown_with_decimal_columns(self):
+        """Decimal 列 + 持仓下，空头跌破生成 SHORT 不抛 TypeError"""
+        s = _make_strategy(DECIMAL_SHORT_BREAKDOWN_DF)
+        info = _make_portfolio_info(positions={"000001.SZ": {}})
+        result = s.cal(info, _make_price_event("000001.SZ"))
+        assert len(result) == 1
+        assert result[0].direction == DIRECTION_TYPES.SHORT


### PR DESCRIPTION
## Summary

修复 #4708：真实回测下 ClickHouse bar 列为 **Decimal**（非 float），DualThrust 与 ATRSizer 在引擎中全路径失效。#5496 的测试用 float df，从未覆盖 Decimal 路径，故 bug 潜伏至今。

三个同源 bug：

1. **DualThrust.cal** — Decimal 列下 `df.iloc[-1]["open"]` 是 Decimal，与 float 系数 `k_buy`/`k_sell` 算术抛 `TypeError: unsupported operand type(s) for +: 'Decimal' and 'float'`；`_calculate_range` 的 `max(hh-lc, hc-ll)` 也保留 Decimal。
   - 修复：`_calculate_range` 末尾 `float()` 归一；`cal()` 中 `today_open`/`last_open` 显式 `float()`。

2. **ATRSizer self.now** — #4706 误用 `self.now`，但 sizer 体系从未赋值（与 RatioSizer/FixedSizer 不同），引擎中 `AttributeError: 'ATRSizer' object has no attribute 'now'`。
   - 修复：对齐 RatioSizer/FixedSizer 走 `get_time_provider().now()`；`None` 时 WARN 丢弃信号。

3. **ATRSizer Decimal 算术** — Decimal 列下 `ATR.cal()*risk_ratio`、`close*min_atr_percent`、`cash*risk`、`close*1.1` 全 TypeError。
   - 修复：`float(ATR.cal(...))`、`float(close)`、`float(cash)` 显式归一（与 DualThrust 同范式）。

## Test plan

三层冒烟（与 CI #6015 同标准）：
- [x] Layer 1 py_compile（src + api）✅
- [x] Layer 2 启动路径 smoke（user_crud/containers/user_cli）36 passed ✅
- [x] Layer 3 变更相关（dual_thrust + atr_sizer）20 passed ✅

新增回归：
- `TestDualThrustDecimalColumns`：Decimal 列下 LONG 突破 / SHORT 跌破不抛 TypeError。
- `TestATRSizerDecimalColumns`：Decimal bars + Decimal cash 正常 sizing（volume=2500）；Decimal 近零 ATR floor 生效（volume=100000）。
- ATRSizer fixture 由 `s.now = ...` 改为 `_time_provider`，揭露而非掩盖 bug B。

真实引擎端到端复测：DualThrust 0 异常（64 次 cal，茅台 k_buy=0.5 无突破 → 0 信号是策略判断非 bug）；ATRSizer 0 异常（AttributeError + TypeError 均解决）。

Closes #4708

🤖 Generated with [Claude Code](https://claude.com/claude-code)