### PR TITLE
fix: 通知系统字段漂移 + 死代码命令 (#6086)

### DIFF
--- a/src/ginkgo/client/notify_cli.py
+++ b/src/ginkgo/client/notify_cli.py
@@ -332,98 +332,6 @@ def send_template_notification(
         raise typer.Exit(1)
 
 
-@app.command("history")
-def get_notification_history(
-    user_uuid: Optional[str] = typer.Option(None, "--user", "-u", help="User UUID"),
-    status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (pending/sent/failed)"),
-    limit: int = typer.Option(50, "--limit", "-l", help="Max results"),
-    failed: bool = typer.Option(False, "--failed", "-f", help="Show only failed notifications"),
-):
-    """
-    :bookmark_tabs: Show notification history.
-
-    Examples:
-      ginkgo notify history --user <uuid>
-      ginkgo notify history --failed
-      ginkgo notify history -l 20
-    """
-    try:
-        from ginkgo.data.containers import container
-        from ginkgo.enums import NOTIFICATION_STATUS_TYPES
-
-        # Get service from container
-        service = container.notification_service()
-
-        # Get history
-        if failed:
-            result = service.get_failed_notifications(limit=limit)
-        elif user_uuid:
-            status_filter = None
-            if status:
-                status_map = {
-                    "pending": NOTIFICATION_STATUS_TYPES.PENDING.value,
-                    "sent": NOTIFICATION_STATUS_TYPES.SENT.value,
-                    "failed": NOTIFICATION_STATUS_TYPES.FAILED.value
-                }
-                status_filter = status_map.get(status.lower())
-
-            result = service.get_notification_history(
-                user_uuid=user_uuid,
-                limit=limit,
-                status=status_filter
-            )
-        else:
-            console.print("[yellow]:warning: Please specify --user or use --failed[/yellow]")
-            raise typer.Exit(1)
-
-        if result.is_success():
-            data = result.data
-            records = data.get("records", [])
-            count = data.get("count", 0)
-
-            if count == 0:
-                console.print(":memo: No notification records found.")
-                return
-
-            table = Table(title=f":bell: Notification History ({count} records)")
-            table.add_column("Message ID", style="cyan", max_width=20)
-            table.add_column("Status", style="yellow")
-            table.add_column("Channels", style="green")
-            table.add_column("Content", style="white", max_width=30)
-            table.add_column("Created", style="dim")
-
-            for rec in records[:limit]:
-                content = rec.get("content", "")[:30] + "..." if len(rec.get("content", "")) > 30 else rec.get("content", "")
-
-                status_val = rec.get("status", 0)
-                status_map = {
-                    0: "[dim]PENDING[/dim]",
-                    1: "[green]SENT[/green]",
-                    2: "[red]FAILED[/red]"
-                }
-                status_str = status_map.get(status_val, str(status_val))
-
-                channels = ", ".join(rec.get("channels", []))
-                created = str(rec.get("create_at", ""))[:16] if rec.get("create_at") else "N/A"
-
-                table.add_row(
-                    rec.get("message_id", "")[:18] + "...",
-                    status_str,
-                    channels,
-                    content,
-                    created
-                )
-
-            console.print(table)
-        else:
-            console.print(f"[red]:x: Failed to get history: {result.message}[/red]")
-            raise typer.Exit(1)
-
-    except Exception as e:
-        console.print(f"[red]:x: Error getting history: {e}[/red]")
-        raise typer.Exit(1)
-
-
 @app.command("search")
 def search_recipients(
     keyword: str = typer.Argument(..., help="Search keyword (user name or group name)"),
@@ -583,9 +491,8 @@ def notification_history(
         table = Table(show_header=True, header_style="bold magenta")
         table.add_column("Time", style="cyan", width=16)
         table.add_column("Message ID", style="white", width=28)
-        table.add_column("Channel", style="yellow", width=10)
+        table.add_column("Channels", style="yellow", width=14)
         table.add_column("Status", justify="center", width=8)
-        table.add_column("Title", style="green", width=20)
         table.add_column("Content", style="white", width=30)
 
         status_map = {
@@ -595,21 +502,13 @@ def notification_history(
         }
 
         for record in records:
-            # 格式化时间戳
-            timestamp = record.get("timestamp", "")
-            if timestamp:
-                try:
-                    from datetime import datetime
-                    if isinstance(timestamp, str):
-                        ts = datetime.fromisoformat(timestamp)
-                    else:
-                        ts = datetime.fromtimestamp(timestamp)
-                    timestamp_str = ts.strftime("%Y-%m-%d %H:%M")
-                except Exception as e:
-                    GLOG.ERROR(f"Failed to parse timestamp '{timestamp}': {e}")
-                    timestamp_str = str(timestamp)[:16]
-            else:
-                timestamp_str = "N/A"
+            # create_at：模型真实字段（MNotificationRecord.create_at），序列化为
+            # ISO str（含 T），截断 16 字符并把 T 换成空格得 "YYYY-MM-DD HH:MM"。
+            # 原代码读不存在的 ``timestamp`` → 恒 N/A（#6086 AC3 字段漂移）。
+            created_raw = record.get("create_at")
+            created_str = (
+                str(created_raw)[:16].replace("T", " ") if created_raw else "N/A"
+            )
 
             # 获取状态
             status_value = record.get("status", 0)
@@ -620,18 +519,16 @@ def notification_history(
             if len(content) > 27:
                 content = content[:27] + "..."
 
-            # 截断标题
-            title = record.get("title", "")
-            if len(title) > 18:
-                title = title[:18] + "..."
+            # channels：模型真实字段（复数列表）。原代码读 ``channel``（单数，
+            # 不存在）→ 恒空。
+            channels = ", ".join(str(c) for c in record.get("channels", []))
 
             table.add_row(
-                timestamp_str,
+                created_str,
                 str(record.get("message_id", ""))[:26],
-                str(record.get("channel", "")),
+                channels,
                 status_str,
-                title,
-                content
+                content,
             )
 
         console.print(table)

--- a/src/ginkgo/client/notify_cli.py
+++ b/src/ginkgo/client/notify_cli.py
@@ -355,11 +355,12 @@ def search_recipients(
         users = []
         if users_result.success:
             all_users = users_result.data.get("users", [])
-            # 模糊匹配用户名
+            # 模糊匹配用户名：display_name 优先，username 补充（list_users 返回
+            # username/display_name，无 name；原 u.get("name") 恒空→搜不到）
             keyword_lower = keyword.lower()
             users = [
                 u for u in all_users
-                if keyword_lower in u.get("name", "").lower() or
+                if keyword_lower in (u.get("display_name") or u.get("username") or "").lower() or
                    keyword_lower in u.get("uuid", "").lower()
             ][:limit]
 
@@ -393,7 +394,7 @@ def search_recipients(
                 active_style = "green" if u.get("is_active") else "red"
                 table.add_row(
                     u.get("uuid", ""),
-                    u.get("name", ""),
+                    u.get("display_name") or u.get("username") or "",
                     u.get("user_type", ""),
                     f"[{active_style}]{u.get('is_active')}[/{active_style}]"
                 )

--- a/src/ginkgo/notifier/core/notify.py
+++ b/src/ginkgo/notifier/core/notify.py
@@ -325,11 +325,9 @@ def notify_trading_signal(signal, order, async_mode: bool = True) -> bool:
     手动执行后回报（POST /api/v1/signals/{id}/report）。
 
     镜像 notify()：收件人从配置表（notification_recipient）解析，
-    支持同步直发与异步 Kafka→worker 两种模式。
-
-    Note:
-        通知发送实现由后续测试驱动（S1b 异步路径 / S2 渠道配置）。
-        当前为 seam 占位，确保 _process_signal 已接线。
+    支持同步直发与异步 Kafka→worker 两种模式。渠道用 webhook（send 链路
+    特判动态解析的唯一渠道），与 notify() 对齐——email 等需 register_channel
+    预注册，生产从不注册，故不可用。
 
     Args:
         signal: Signal 对象（含 code/direction/reason）
@@ -367,11 +365,14 @@ def notify_trading_signal(signal, order, async_mode: bool = True) -> bool:
 
         if async_mode:
             # 异步路径：Kafka→worker 订阅→渠道发送（镜像 notify()）
+            # webhook 是 send 链路特判动态解析的唯一渠道
+            # （notification_service._get_webhook_channel_for_user），
+            # email/discord 等需 register_channel 预注册，生产从不注册→Channel not found。
             success_count = 0
             for user_uuid in user_uuids:
                 result = service.send_async(
                     content=content,
-                    channels=["email"],
+                    channels=["webhook"],
                     user_uuid=user_uuid,
                     priority=2,
                     title=title,
@@ -384,14 +385,14 @@ def notify_trading_signal(signal, order, async_mode: bool = True) -> bool:
             )
             return success_count > 0
 
-        # 同步路径：逐个收件人直发
+        # 同步路径：逐个收件人直发（渠道同 async：用 webhook 动态解析）
         success_count = 0
         for user_uuid in user_uuids:
             result = service.send_to_user(
                 user_uuid=user_uuid,
                 content=content,
                 title=title,
-                channels=["email"],
+                channels=["webhook"],
                 priority=2,
             )
             if result.is_success():

--- a/tests/unit/client/test_notify_cli.py
+++ b/tests/unit/client/test_notify_cli.py
@@ -12,6 +12,7 @@ Mock strategy:
 import json
 import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
+from contextlib import contextmanager
 
 from ginkgo.client import notify_cli
 from ginkgo.data.services.base_service import ServiceResult
@@ -24,17 +25,21 @@ import ginkgo.service_hub as service_hub_module
 # ============================================================================
 
 
+@contextmanager
 def _patch_notifier_service(mock_service):
-    """Patch service_hub.notifier to return mock_service from notification_service()."""
-    # service_hub_module 实际是 ServiceHub 实例（由 ginkgo.__init__ 导出导致）
-    # 触发懒加载，让 __getattr__ 缓存到实例上
-    _ = service_hub_module.notifier
+    """注入 mock_service 为 service_hub.notifier.notification_service() 返回值。
+
+    ServiceHub.__getattr__ 走 ``_overrides``（测试覆盖优先）→ ``_module_cache`` →
+    ``_load_module``。``notifier`` 是动态属性（非类层 property），原实现用
+    ``patch.object(service_hub_module, "notifier", PropertyMock)`` 对 data
+    descriptor / 动态 __getattr__ 无效——mock 不生效，命令走 auto-MagicMock
+    链（恒 truthy），掩盖失败路径（send 异常/无用户 本应 exit≠0 却 exit 0）。
+    改走 ``_overrides`` 注入，mock 真正生效。
+    """
     mock_notifier = MagicMock()
     mock_notifier.notification_service.return_value = mock_service
-    return patch.object(
-        service_hub_module, "notifier",
-        new_callable=PropertyMock, return_value=mock_notifier,
-    )
+    with patch.dict(service_hub_module._overrides, {"notifier": mock_notifier}):
+        yield
 
 
 # ============================================================================
@@ -176,6 +181,76 @@ class TestChannels:
         assert result.exit_code == 0
         assert "console" in result.output
         assert "discord" in result.output
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestNotifyHistoryCommand:
+    """``history`` 命令的回归测试（#6086 AC3）。
+
+    两个 PR 各自实现了 ``history`` 命令，Typer 同名 ``@app.command`` 静默覆盖
+    （后者生效），导致 #5968 的字段名修复进了**死代码**分支，active 版用错
+    字段名（timestamp/channel 单数/title）重现 bug。本类固化两件事：
+    1. 全仓只注册一个 ``history`` 命令（结构层抓双注册）；
+    2. active ``history`` 渲染模型真实字段 ``create_at``/``channels``(复数)，
+       不读模型不存的 ``title``。
+    """
+
+    def test_only_one_history_command_registered(self):
+        """Typer 同名 ``@app.command`` 静默覆盖；必须只剩一个 ``history``。"""
+        history_cmds = [
+            c for c in notify_cli.app.registered_commands
+            if getattr(c, "name", None) == "history"
+        ]
+        assert len(history_cmds) == 1, (
+            f"history 命令应只注册一次，实际 {len(history_cmds)} 次"
+            "（Typer 同名静默覆盖会让字段修复进死代码分支）"
+        )
+
+    def test_history_renders_create_at_and_channels_not_title(self, cli_runner, monkeypatch):
+        """active history 读模型真实字段 create_at/channels(复数)，不读 title。
+
+        回归锚点：active 版曾读 ``timestamp``/``channel``(单数)/``title``，
+        而 MNotificationRecord 只存 ``create_at``/``channels``(复数)/无 title，
+        导致时间恒 N/A、渠道恒空、Title 列恒空。
+        """
+        # CliRunner 默认 80 列，Rich 会把 Time 列压缩成 "2026-07-0…"，
+        # 完整时间串不出现（假阴性）。patch console 宽度避免压缩。
+        monkeypatch.setattr(notify_cli.console, "width", 200)
+
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = {
+            "count": 1,
+            "records": [
+                {
+                    "message_id": "msg-001",
+                    "content": "hello world",
+                    "channels": ["email", "webhook"],
+                    "status": 1,
+                    "create_at": "2026-07-05T10:00:00",
+                }
+            ],
+        }
+
+        mock_service = MagicMock()
+        mock_service._resolve_user_uuid.return_value = "user-uuid-1"
+        mock_service.get_notification_history.return_value = mock_result
+
+        with _patch_notifier_service(mock_service):
+            result = cli_runner.invoke(
+                notify_cli.app, ["history", "--user", "alice"]
+            )
+
+        assert result.exit_code == 0, result.output
+        # create_at 渲染为可读时间（非 N/A）
+        assert "2026-07-05 10:00" in result.output, (
+            "必须渲染 create_at 字段，不能读不存在的 timestamp"
+        )
+        # channels(复数) 至少渲染一个渠道（非空）
+        assert "email" in result.output, "必须渲染 channels(复数) 列表元素"
+        # 模型不存 title → 不应有 Title 列头
+        assert "Title" not in result.output, "模型无 title 字段，不应渲染 Title 列"
 
 
 @pytest.mark.unit
@@ -339,10 +414,8 @@ class TestNotifyCLIExceptions:
         mock_notifier = MagicMock()
         mock_notifier.notification_service.side_effect = Exception("service down")
 
-        with patch.object(
-            service_hub_module, "notifier",
-            new_callable=PropertyMock, return_value=mock_notifier,
-        ):
+        # 走 _overrides 让 mock 生效（同 _patch_notifier_service 原理）。
+        with patch.dict(service_hub_module._overrides, {"notifier": mock_notifier}):
             result = cli_runner.invoke(notify_cli.app, ["send", "-u", "Alice", "-c", "Hello"])
 
         # send_notification catches exceptions and raises typer.Exit(1)

--- a/tests/unit/client/test_notify_cli.py
+++ b/tests/unit/client/test_notify_cli.py
@@ -255,6 +255,89 @@ class TestNotifyHistoryCommand:
 
 @pytest.mark.unit
 @pytest.mark.cli
+class TestNotifySearchCommand:
+    """``search`` 命令的用户字段漂移回归（#6086 AC4）。
+
+    user_service.list_users 返回 ``username``/``display_name``（无 ``name``），
+    但 search 命令读 ``u.get("name")`` → 过滤恒空（搜不到）+ Name 列恒空。
+    本类固化：搜索能命中 display_name/username，且 Name 列渲染 display_name。
+    """
+
+    def test_search_matches_user_by_display_name(self, cli_runner, monkeypatch):
+        """search 关键词应命中 display_name（非读不存在的 name 字段过滤）。"""
+        monkeypatch.setattr(notify_cli.console, "width", 200)
+
+        mock_user_service = MagicMock()
+        mock_user_service.list_users.return_value = MagicMock(
+            success=True,
+            data={
+                "users": [
+                    {
+                        "uuid": "u-1",
+                        "username": "alice_co",
+                        "display_name": "Alice Cohen",
+                        "is_active": True,
+                        "user_type": "USER",
+                    }
+                ]
+            },
+        )
+        mock_group_service = MagicMock()
+        mock_group_service.list_groups.return_value = MagicMock(
+            success=True, data={"groups": []}
+        )
+
+        mock_container = MagicMock()
+        mock_container.user_service.return_value = mock_user_service
+        mock_container.user_group_service.return_value = mock_group_service
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = cli_runner.invoke(notify_cli.app, ["search", "alice"])
+
+        assert result.exit_code == 0, result.output
+        assert "Alice Cohen" in result.output, (
+            "search 应按 display_name 命中并渲染（原 u.get('name') 恒空→搜不到+Name 列空）"
+        )
+
+    def test_search_falls_back_to_username_when_no_display_name(self, cli_runner, monkeypatch):
+        """display_name 缺失时回退 username，保证可搜可显示。"""
+        monkeypatch.setattr(notify_cli.console, "width", 200)
+
+        mock_user_service = MagicMock()
+        mock_user_service.list_users.return_value = MagicMock(
+            success=True,
+            data={
+                "users": [
+                    {
+                        "uuid": "u-2",
+                        "username": "bob_trader",
+                        "display_name": "",  # 无 display_name
+                        "is_active": True,
+                        "user_type": "USER",
+                    }
+                ]
+            },
+        )
+        mock_group_service = MagicMock()
+        mock_group_service.list_groups.return_value = MagicMock(
+            success=True, data={"groups": []}
+        )
+
+        mock_container = MagicMock()
+        mock_container.user_service.return_value = mock_user_service
+        mock_container.user_group_service.return_value = mock_group_service
+
+        with patch("ginkgo.data.containers.container", mock_container):
+            result = cli_runner.invoke(notify_cli.app, ["search", "bob"])
+
+        assert result.exit_code == 0, result.output
+        assert "bob_trader" in result.output, (
+            "display_name 空时应回退 username 渲染/过滤"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.cli
 class TestRecipientsList:
     """Tests for the 'recipients list' command."""
 

--- a/tests/unit/notifiers/test_notify_trading_signal.py
+++ b/tests/unit/notifiers/test_notify_trading_signal.py
@@ -98,7 +98,7 @@ class TestNotifyTradingSignalAsync:
 class TestSendFailureHandling:
     """回归（PR#6215 review Issue 1+2）：send 失败时不能报成功。
 
-    ServiceResult.is_success 是方法非属性；渠道必须用已注册的 email（非 mail）。
+    ServiceResult.is_success 是方法非属性；渠道必须用生产可解析的 webhook。
     两者叠加曾导致生产全程静默失败却返回 True。
     """
 
@@ -128,8 +128,18 @@ class TestSendFailureHandling:
 
         assert result is False, "send 失败时不能因 is_success 是方法而恒真报成功"
 
-    def test_uses_registered_email_channel_not_unregistered_mail(self):
-        """渠道必须用已注册的 email，而非不存在的 mail（否则 send 必 Channel not found）。"""
+    def test_uses_webhook_channel_dynamically_resolvable_not_email(self):
+        """渠道必须用 webhook（动态从 user contact 解析，无需预注册），
+        而非 email（生产运行时从未 register_channel → 必 Channel not found）。
+
+        回归锚点（#6086 AC2）：notify_trading_signal 早期硬编码 ``["email"]``，
+        但 EmailChannel 在 API/worker 启动时从不注册
+        （NotificationDeliveryService.__init__ self._channels={}，全仓仅
+        notify_cli.py:251 注册过 ConsoleChannel），导致交易信号通知全程
+        ``Channel not found: email`` 静默失败。webhook 是 send 链路特判动态
+        解析的唯一渠道（notification_service.py:220 ``_get_webhook_channel_for_user``），
+        必须与 notify() 对齐用 webhook。
+        """
         signal = Signal(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
         order = Order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=1000)
 
@@ -148,5 +158,5 @@ class TestSendFailureHandling:
             notify_trading_signal(signal, order, async_mode=True)
 
         channels = fake_service.send_async.call_args.kwargs["channels"]
-        assert "email" in channels, "必须用已注册的 email 渠道"
-        assert "mail" not in channels, "mail 未注册，会导致 Channel not found"
+        assert "webhook" in channels, "必须用 webhook（动态可解析），与 notify() 对齐"
+        assert "email" not in channels, "email 生产从未注册，会导致 Channel not found"


### PR DESCRIPTION
## Summary

META #6086 整合 9 子 issue（均 closed），但残留 3 处缺口，本 PR 完整闭环：

**Fix A — notify_trading_signal 渠道漂移**
- 硬编码 `channels=["email"]`，但 EmailChannel 生产从未 `register_channel`（`__init__` 中 `self._channels={}`，全仓仅 ConsoleChannel 注册过），导致交易信号通知全程 `Channel not found: email` 静默失败
- 改用 `webhook`：send 链路特判动态解析的唯一渠道（`_get_webhook_channel_for_user`），与 `notify()` 对齐

**Fix B — history 命令重复注册 + 字段漂移**
- 两个 PR 各实现 `@app.command("history")`，Typer 同名静默覆盖（后者生效），#5968 的字段名修复进了**死代码**分支
- 删死代码 `get_notification_history`；active `notification_history` 读模型真实字段：`timestamp→create_at`、`channel`(单数)→`channels`(复数 join)、删 Title 列（MNotificationRecord 不存 title）

**Fix C — search 用户字段漂移**
- `user_service.list_users` 返回 `username`/`display_name`（无 `name`），search 读 `u.get("name")` → 过滤恒空（搜不到）+ Name 列恒空
- 改 display_name 优先、username 回退；group 部分不动（MUserGroup 有 name，无漂移）

**附带：修测试 helper**
- `_patch_notifier_service` 用 `patch.object` 对 ServiceHub 动态 `__getattr__` 无效 → mock 不生效，3 个 send 失败路径测试（异常/无用户/群组）假绿
- 改走 `_overrides` 注入，假绿转真绿

## Test plan
- [x] `tests/unit/notifiers/test_notify_trading_signal.py`（Fix A，5 tests）
- [x] `tests/unit/client/test_notify_cli.py`（Fix B/C + helper，24 tests，含 3 个由假绿转真绿）
- [x] Layer 1 py_compile src+api 全通过
- [x] Layer 2 启动路径 smoke（user_crud_mock / containers / user_cli）36 passed
- [x] Layer 3 变更相关 29 passed

Closes #6086

🤖 Generated with [Claude Code](https://claude.com/claude-code)