### PR TITLE
fix(trading): use data container instance (#6028)

### DIFF
--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -30,11 +30,11 @@ def signal(
 
     All filters (-p/-e/-t) optional. Symmetric with ``record order/position``.
     """
-    from ginkgo.data.containers import Container
+    from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
-        signal_svc = Container.signal_service()
+        signal_svc = container.signal_service()
         result = signal_svc.get_signals_df(
             portfolio_id=portfolio,
             engine_id=engine,
@@ -88,11 +88,11 @@ def order(
     """
     :clipboard: List order records.
     """
-    from ginkgo.data.containers import Container
+    from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
-        order_svc = Container.order_service()
+        order_svc = container.order_service()
         result = order_svc.get_orders_df(
             portfolio_id=portfolio,
             engine_id=engine,
@@ -143,14 +143,14 @@ def position(
     """
     :bar_chart: List position records.
     """
-    from ginkgo.data.containers import Container
+    from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
         # #5341: 回测持仓经 create_position_record 写 MPositionRecord（流水表），
         # PositionService 查 MPosition（当前态表）永远空。改读 ResultService
         # （get_positions_df 查 PositionRecordCRUD，与写路径同表）。
-        result_svc = Container.result_service()
+        result_svc = container.result_service()
         result = result_svc.get_positions_df(
             portfolio_id=portfolio,
             engine_id=engine,
@@ -200,11 +200,11 @@ def analyzer(
     """
     :bar_chart: List analyzer records.
     """
-    from ginkgo.data.containers import Container
+    from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
 
     try:
-        analyzer_svc = Container.analyzer_service()
+        analyzer_svc = container.analyzer_service()
         result = analyzer_svc.get_records_df(
             portfolio_id=portfolio,
             engine_id=engine,

--- a/src/ginkgo/trading/comparison/backtest_comparator.py
+++ b/src/ginkgo/trading/comparison/backtest_comparator.py
@@ -127,10 +127,10 @@ class BacktestComparator:
             回测结果字典，如果不存在返回 None
         """
         try:
-            from ginkgo.data.containers import Container
+            from ginkgo.data.containers import container
 
             # 1. 查 backtest_task 获取关联信息
-            task_svc = Container.backtest_task_service()
+            task_svc = container.backtest_task_service()
             task_result = task_svc.get_by_task_id(backtest_id)
             if not task_result.success or not task_result.data:
                 GLOG.WARN(f"Backtest task not found: {backtest_id}")
@@ -138,7 +138,7 @@ class BacktestComparator:
             task = task_result.data
 
             # 2. 查 analyzer_record 获取指标
-            result_svc = Container.result_service()
+            result_svc = container.result_service()
             result = result_svc.get_analyzer_values(
                 task_id=backtest_id,
                 portfolio_id=task.portfolio_id,

--- a/tests/unit/client/test_record_cli.py
+++ b/tests/unit/client/test_record_cli.py
@@ -72,7 +72,7 @@ def mock_positions_df():
 class TestRecordOrderFilters:
     """record order 的 engine/task 过滤透传（#4743）"""
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_order_passes_engine_and_task(self, mock_container, cli_runner, mock_orders_df):
         """-e/-t 透传到 service.get_orders_df"""
         mock_service = MagicMock()
@@ -88,7 +88,7 @@ class TestRecordOrderFilters:
         assert kwargs.get("engine_id") == "e1"
         assert kwargs.get("task_id") == "t1"
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_order_without_filters_still_works(self, mock_container, cli_runner, mock_orders_df):
         """无过滤参数时正常返回全部（不传 None 进 service）"""
         mock_service = MagicMock()
@@ -110,7 +110,7 @@ class TestRecordPositionFilters:
     （查 PositionRecordCRUD）。
     """
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_position_passes_engine_and_task(self, mock_container, cli_runner, mock_positions_df):
         """-e/-t 透传到 result_service.get_positions_df"""
         mock_service = MagicMock()
@@ -126,7 +126,7 @@ class TestRecordPositionFilters:
         assert kwargs.get("engine_id") == "e1"
         assert kwargs.get("task_id") == "t1"
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_position_reads_result_service_not_position_service(
         self, mock_container, cli_runner, mock_positions_df
     ):
@@ -173,7 +173,7 @@ class TestRecordSignalFilters:
     都有→查 signals）。统一后 -p/-e/-t 全可选，与 order/position 一致。
     """
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_signal_passes_all_filters(self, mock_container, cli_runner):
         """-p/-e/-t 全透传到 service.get_signals_df"""
         mock_service = MagicMock()
@@ -189,7 +189,7 @@ class TestRecordSignalFilters:
         assert kwargs.get("engine_id") == "e1"
         assert kwargs.get("task_id") == "t1"
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_signal_portfolio_only_queries_directly(self, mock_container, cli_runner):
         """单 -p 直接查该 portfolio 全部 signal，不再强制先选 engine"""
         mock_service = MagicMock()
@@ -203,7 +203,7 @@ class TestRecordSignalFilters:
         _, kwargs = mock_service.get_signals_df.call_args
         assert kwargs.get("portfolio_id") == "p1"
 
-    @patch("ginkgo.data.containers.Container")
+    @patch("ginkgo.data.containers.container")
     def test_signal_no_filters_returns_all(self, mock_container, cli_runner):
         """无任何过滤参数时查全部 signal（不再强制选 engine）"""
         mock_service = MagicMock()

--- a/tests/unit/trading/comparison/comparison/test_backtest_comparator.py
+++ b/tests/unit/trading/comparison/comparison/test_backtest_comparator.py
@@ -15,6 +15,8 @@ TDD Green 阶段: 测试用例实现
 import pytest
 from decimal import Decimal
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 
 @pytest.mark.unit
@@ -103,6 +105,33 @@ class TestBacktestComparator:
 
         assert df is not None
         assert len(df) > 0
+
+    def test_load_backtest_result_uses_container_instance(self):
+        """#6028: DB service lookup must use injected `container`, not `Container` class."""
+        from ginkgo.trading.comparison.backtest_comparator import BacktestComparator
+
+        task_svc = MagicMock()
+        task_svc.get_by_task_id.return_value = SimpleNamespace(
+            success=True,
+            data=SimpleNamespace(portfolio_id="p1", engine_id="e1"),
+        )
+        result_svc = MagicMock()
+        result_svc.get_analyzer_values.return_value = SimpleNamespace(
+            success=True,
+            data=[SimpleNamespace(name="sharpe_ratio", value="1.25")],
+        )
+
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.backtest_task_service.return_value = task_svc
+            mock_container.result_service.return_value = result_svc
+
+            comparator = BacktestComparator()
+            metrics = comparator._load_backtest_result("bt_001")
+
+        assert metrics == {"sharpe_ratio": Decimal("1.25")}
+        mock_container.backtest_task_service.assert_called_once_with()
+        mock_container.result_service.assert_called_once_with()
+        result_svc.get_analyzer_values.assert_called_once_with(task_id="bt_001", portfolio_id="p1")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- Replace direct data Container class provider calls with the shared container instance in BacktestComparator.
- Apply the same runtime provider lookup fix to record CLI commands.
- Update CLI mocks and add a regression test for BacktestComparator service lookup.

## Verification
- rg -n "Container\.[A-Za-z_][A-Za-z0-9_]*\(" src/ginkgo tests --glob '!src/ginkgo/data/containers.py' (no matches)
- uv run pytest -c /dev/null tests/unit/trading/comparison/comparison/test_backtest_comparator.py tests/unit/client/test_record_cli.py -q

Closes #6028