### PR TITLE
fix(api): add deploy templates endpoint (#5738)

### DIFF
--- a/api/api/deployment.py
+++ b/api/api/deployment.py
@@ -1,12 +1,31 @@
 """部署 API 路由"""
 from fastapi import APIRouter, HTTPException, Query
-from typing import Optional
+from typing import Any, Dict, List, Optional
 from pydantic import BaseModel, Field
 from core.response import ok
 from core.exceptions import BusinessError
 from core.logging import logger
 
 router = APIRouter()
+
+DEPLOYMENT_TEMPLATES: List[Dict[str, Any]] = [
+    {
+        "id": "paper",
+        "name": "Paper Trading",
+        "mode": "paper",
+        "description": "部署到模拟盘组合，用于无实盘风险验证策略。",
+        "required_fields": ["portfolio_id"],
+        "optional_fields": ["name"],
+    },
+    {
+        "id": "live",
+        "name": "Live Trading",
+        "mode": "live",
+        "description": "部署到实盘组合，需要绑定实盘账户。",
+        "required_fields": ["portfolio_id", "account_id"],
+        "optional_fields": ["name"],
+    },
+]
 
 
 class DeployRequest(BaseModel):
@@ -52,6 +71,12 @@ async def deploy(req: DeployRequest):
     result = saga.steps[0].result
     deploy_data = result.data if hasattr(result, 'data') else result
     return ok(data=deploy_data, message="部署成功")
+
+
+@router.get("/templates")
+async def list_deployment_templates():
+    """列出可用部署模板；必须位于 /{portfolio_id} 之前避免被动态路由吞掉。"""
+    return ok(data=DEPLOYMENT_TEMPLATES, message="查询成功")
 
 
 @router.get("/{portfolio_id}")

--- a/tests/api/test_deploy_templates_5738.py
+++ b/tests/api/test_deploy_templates_5738.py
@@ -1,0 +1,19 @@
+"""#5738: deploy templates endpoint must not be swallowed by /{portfolio_id}."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_deploy_templates_returns_200_with_list():
+    from api import deployment
+
+    app = FastAPI()
+    app.include_router(deployment.router, prefix="/api/v1/deploy")
+    client = TestClient(app)
+
+    response = client.get("/api/v1/deploy/templates")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"]
+    assert {item["mode"] for item in body["data"]} == {"paper", "live"}


### PR DESCRIPTION
## Summary
- Add GET /api/v1/deploy/templates before the dynamic /{portfolio_id} route.
- Return static paper/live deployment templates without touching DB/runtime services.
- Add an API regression test for the real /api/v1/deploy/templates path.

## Verification
- uv run pytest -c /dev/null tests/api/test_deploy_templates_5738.py tests/api/test_deployment_api.py -q

Closes #5738