### PR TITLE
refactor(cli): add data get format and limit output (#6579)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -3,10 +3,6 @@
 # Role: 数据管理CLI，提供init初始化、update更新、sync同步、list列表等命令，支持股票信息、K线、Tick等多维度数据管理
 
 
-
-
-
-
 """
 Ginkgo Data CLI - 数据管理命令
 """
@@ -32,6 +28,7 @@ def _normalize_stock_code(code: str) -> str:
     不依赖 mootdx 首位推断（前缀已带市场标记）。
     """
     import re
+
     if not code:
         return code
     m = re.fullmatch(r"(SH|SZ)(\d{6})", code)
@@ -65,27 +62,66 @@ class SyncStats:
     def summary(self, type_name: str) -> str:
         """统一汇总行：``{Type} sync completed. Success: N, Skipped: S, Errors: M``。"""
         return (
-            f"{type_name} sync completed. "
-            f"Success: {self.success}, Skipped: {self.skipped}, Errors: {self.errors}"
+            f"{type_name} sync completed. " f"Success: {self.success}, Skipped: {self.skipped}, Errors: {self.errors}"
         )
+
+
+def _emit_json_records(records: list, *, total: int, limit: Optional[int], order: Optional[str] = None) -> None:
+    from ginkgo.client.cli_utils import format_result
+    from ginkgo.data.services.base_service import ServiceResult
+
+    result = ServiceResult.success(data=records)
+    result.set_metadata("total", total)
+    result.set_metadata("limit", limit)
+    result.set_metadata("offset", 0)
+    if order:
+        result.set_metadata("order", order)
+    format_result(result, format="json", command="get")
 
 
 @app.command()
 def get(
-    data_type: str = typer.Argument(..., help="Data type to get (stockinfo/day/tick/adjustfactor/sources) \\[planned: calendar]"),
+    data_type: str = typer.Argument(
+        ..., help="Data type to get (stockinfo/day/tick/adjustfactor/sources) \\[planned: calendar]"
+    ),
     code: Optional[str] = typer.Option(None, "--code", "-c", help="Stock code (required for bars/ticks)"),
     start: Optional[str] = typer.Option(None, "--start", "-s", help="Start date (YYYYMMDD)"),
     end: Optional[str] = typer.Option(None, "--end", "-e", help="End date (YYYYMMDD)"),
-    page_size: Optional[int] = typer.Option(None, "--page-size", "-p", help="Page size for interactive mode (default: all)"),
-    filter: Optional[str] = typer.Option(None, "--filter", "-f", help="Filter by fuzzy matching (code, industry, name)"),
+    page_size: Optional[int] = typer.Option(
+        None, "--page-size", "-p", help="Page size for interactive mode (default: all)"
+    ),
+    filter: Optional[str] = typer.Option(
+        None, "--filter", "-f", help="Filter by fuzzy matching (code, industry, name)"
+    ),
     market: Optional[str] = typer.Option(None, "--market", help="Filter by market"),
     exchange: Optional[str] = typer.Option(None, "--exchange", help="Filter by exchange"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
+    format: Optional[str] = typer.Option(None, "--format", help="Output format: auto/text/json. ADR-021"),
+    limit: Optional[int] = typer.Option(
+        None, "--limit", "-l", help="Max records. day/tick=tail(latest), stockinfo/adjustfactor=head. ADR-021"
+    ),
+    no_color: bool = typer.Option(
+        False, "--no-color", help="Disable ANSI colors (TTY 场景 pipe 输出友好). ADR-021 任务1"
+    ),
 ):
     """
     :inbox_tray: Get data from database.
     """
     try:
+        # ADR-021 E4: auto keeps legacy text output; explicit json is machine-readable.
+        if format is None or format == "auto":
+            format = "text"
+        elif format not in ("text", "json"):
+            console.print(f":x: Invalid --format {format!r}: must be 'auto', 'text' or 'json'")
+            raise typer.Exit(2)  # BAD_PARAMS 语义（ADR-021 第 6 维 exit 2）
+        if limit is not None and limit < 1:
+            console.print(":x: --limit must be greater than 0")
+            raise typer.Exit(2)
+
+        # ADR-021 任务1：--no-color 禁用 ANSI（TTY pipe 输出/CI 日志友好；json 模式本就无 ANSI，幂等）
+        if no_color:
+            console.no_color = True
+
         if data_type == "stockinfo":
             from ginkgo.data.containers import container
             from ginkgo.libs.utils.display import display_dataframe_interactive
@@ -100,7 +136,8 @@ def get(
                 # Raw output mode
                 if raw:
                     import json
-                    raw_data = df.to_dict('records')
+
+                    raw_data = df.to_dict("records")
                     console.print(json.dumps(raw_data, indent=2, ensure_ascii=False, default=str))
                     return
 
@@ -113,16 +150,16 @@ def get(
                     mask = pd.Series([False] * len(df))
 
                     # 按代码过滤
-                    if 'code' in df.columns:
-                        mask |= df['code'].astype(str).str.lower().str.contains(filter_lower, na=False)
+                    if "code" in df.columns:
+                        mask |= df["code"].astype(str).str.lower().str.contains(filter_lower, na=False)
 
                     # 按名称过滤
-                    if 'code_name' in df.columns:
-                        mask |= df['code_name'].astype(str).str.lower().str.contains(filter_lower, na=False)
+                    if "code_name" in df.columns:
+                        mask |= df["code_name"].astype(str).str.lower().str.contains(filter_lower, na=False)
 
                     # 按行业过滤
-                    if 'industry' in df.columns:
-                        mask |= df['industry'].astype(str).str.lower().str.contains(filter_lower, na=False)
+                    if "industry" in df.columns:
+                        mask |= df["industry"].astype(str).str.lower().str.contains(filter_lower, na=False)
 
                     df = df[mask]
 
@@ -138,7 +175,7 @@ def get(
                     "code_name": {"display_name": "名称", "style": "green", "width": 12},
                     "industry": {"display_name": "行业", "style": "yellow", "width": 10},
                     "market": {"display_name": "市场", "style": "blue", "width": 8, "justify": "center"},
-                    "list_date": {"display_name": "上市日期", "style": "dim", "width": 15, "justify": "center"}
+                    "list_date": {"display_name": "上市日期", "style": "dim", "width": 15, "justify": "center"},
                 }
 
                 # 数据处理函数
@@ -146,28 +183,28 @@ def get(
                     df = df_original.copy()
 
                     # 格式化代码
-                    if 'code' in df.columns:
-                        df['code'] = df['code'].astype(str)
+                    if "code" in df.columns:
+                        df["code"] = df["code"].astype(str)
 
                     # 格式化名称
-                    if 'code_name' in df.columns:
-                        df['code_name'] = df['code_name'].astype(str)
+                    if "code_name" in df.columns:
+                        df["code_name"] = df["code_name"].astype(str)
 
                     # 格式化行业
-                    if 'industry' in df.columns:
-                        df['industry'] = df['industry'].astype(str)
+                    if "industry" in df.columns:
+                        df["industry"] = df["industry"].astype(str)
 
                     # 格式化市场
-                    if 'market' in df.columns:
-                        df['market'] = df['market'].astype(str)
+                    if "market" in df.columns:
+                        df["market"] = df["market"].astype(str)
                         # 提取市场名称（取最后一部分）
-                        df['market'] = df['market'].apply(lambda x: str(x).split('.')[-1] if '.' in str(x) else str(x))
+                        df["market"] = df["market"].apply(lambda x: str(x).split(".")[-1] if "." in str(x) else str(x))
 
                     # 格式化上市日期
-                    if 'list_date' in df.columns:
-                        df['list_date'] = df['list_date'].astype(str).str[:10]
+                    if "list_date" in df.columns:
+                        df["list_date"] = df["list_date"].astype(str).str[:10]
                         # 确保日期格式为YYYY-MM-DD，去除时间部分
-                        df['list_date'] = df['list_date'].apply(lambda x: x[:10] if len(x) > 10 else x)
+                        df["list_date"] = df["list_date"].apply(lambda x: x[:10] if len(x) > 10 else x)
 
                     return df
 
@@ -175,10 +212,22 @@ def get(
                 formatted_df = format_data_for_display(df)
 
                 # 按code排序
-                formatted_df = formatted_df.sort_values('code')
+                formatted_df = formatted_df.sort_values("code")
+                total_records = len(formatted_df)
+
+                if format == "json":
+                    json_df = formatted_df.head(limit) if limit is not None else formatted_df
+                    _emit_json_records(
+                        json_df.to_dict("records"),
+                        total=total_records,
+                        limit=limit,
+                        order="head",
+                    )
+                    return
 
                 # 交互式翻页仅在 TTY 下启用；非 TTY（CI/脚本/管道）退化为 limit 输出（#5280）
                 import sys
+
                 if page_size and page_size > 0 and sys.stdin.isatty():
                     console.print(f":information: Interactive mode enabled (page size: {page_size})")
                     console.print(":information: Single-key navigation: n=next, p=prev, q=quit")
@@ -196,8 +245,11 @@ def get(
                         current_data = formatted_df.iloc[start_idx:end_idx]
 
                         # 创建Rich表格
-                        table = Table(show_header=True, header_style="bold magenta",
-                                     title=f":page_facing_up: Stock Information - Page {current_page + 1}/{total_pages} ({start_idx + 1}-{end_idx}/{len(formatted_df)})")
+                        table = Table(
+                            show_header=True,
+                            header_style="bold magenta",
+                            title=f":page_facing_up: Stock Information - Page {current_page + 1}/{total_pages} ({start_idx + 1}-{end_idx}/{len(formatted_df)})",
+                        )
 
                         # 添加列
                         for col_name, config in columns_config.items():
@@ -207,7 +259,7 @@ def get(
                                     config["display_name"],
                                     style=config["style"],
                                     width=config.get("width", None),
-                                    justify=justify
+                                    justify=justify,
                                 )
 
                         # 添加行数据
@@ -215,7 +267,7 @@ def get(
                             row_data = []
                             for col_name in columns_config.keys():
                                 if col_name in current_data.columns:
-                                    value = str(row.get(col_name, 'N/A'))
+                                    value = str(row.get(col_name, "N/A"))
                                     # 截断过长的文本
                                     max_length = columns_config[col_name].get("width", 20) - 3
                                     if len(value) > max_length:
@@ -225,30 +277,36 @@ def get(
 
                         # 显示表格
                         console.print(table)
-                        console.print(f"\n[dim]Page {current_page + 1}/{total_pages} | Records {start_idx + 1}-{end_idx} of {len(formatted_df)}[/dim]")
+                        console.print(
+                            f"\n[dim]Page {current_page + 1}/{total_pages} | Records {start_idx + 1}-{end_idx} of {len(formatted_df)}[/dim]"
+                        )
                         console.print("[yellow]Options:[/] n=next, p=prev, q=quit, <Enter>=next")
 
                         # 简化输入处理
                         try:
-                            action = Prompt.ask(
-                                "[bold cyan]Action[/bold cyan] (n/p/q/Enter)",
-                                choices=["n", "p", "q", ""],
-                                default="",
-                                show_default=False
-                            ).strip().lower()
+                            action = (
+                                Prompt.ask(
+                                    "[bold cyan]Action[/bold cyan] (n/p/q/Enter)",
+                                    choices=["n", "p", "q", ""],
+                                    default="",
+                                    show_default=False,
+                                )
+                                .strip()
+                                .lower()
+                            )
 
-                            if action == 'n' or action == '':
+                            if action == "n" or action == "":
                                 # 下一页
                                 if current_page < total_pages - 1:
                                     current_page += 1
                                 else:
                                     console.print("\n[bold blue]Last page reached[/bold blue]")
                                     break
-                            elif action == 'p':
+                            elif action == "p":
                                 # 上一页
                                 if current_page > 0:
                                     current_page -= 1
-                            elif action == 'q':
+                            elif action == "q":
                                 # 退出
                                 console.print("\n[yellow]User quit[/yellow]")
                                 break
@@ -257,18 +315,23 @@ def get(
                         except Exception:
                             break
                 else:
-                    # 非交互模式：按 page_size 限制输出（无 page_size 默认 50），#5280
-                    limit = page_size or 50
-                    display_df = formatted_df.sort_values('code').head(limit)
+                    # 非交互模式：--limit 截断（head，按 code 排序）；无 --limit 默认 50
+                    # ADR-021 任务3：--page-size 收窄为 TTY 交互翻页（上面 if 分支），非交互用 --limit
+                    si_limit = limit if limit is not None else 50
+                    display_df = formatted_df.sort_values("code").head(si_limit)
 
                     if display_df.empty:
                         console.print(":memo: No stock records found.")
                         return
 
-                    console.print(f":information_source: Showing first {len(display_df)} of {len(formatted_df)} records (sorted by code)")
+                    console.print(
+                        f":information_source: Showing first {len(display_df)} of {len(formatted_df)} records (sorted by code)"
+                    )
 
                     # 创建Rich表格
-                    table = Table(show_header=True, header_style="bold magenta", title=f":page_facing_up: Stock Information")
+                    table = Table(
+                        show_header=True, header_style="bold magenta", title=f":page_facing_up: Stock Information"
+                    )
 
                     # 添加列
                     for col_name, config in columns_config.items():
@@ -278,7 +341,7 @@ def get(
                                 config["display_name"],
                                 style=config["style"],
                                 width=config.get("width", None),
-                                justify=justify
+                                justify=justify,
                             )
 
                     # 添加行数据
@@ -286,7 +349,7 @@ def get(
                         row_data = []
                         for col_name in columns_config.keys():
                             if col_name in display_df.columns:
-                                value = str(row.get(col_name, 'N/A'))
+                                value = str(row.get(col_name, "N/A"))
                                 # 截断过长的文本
                                 max_length = columns_config[col_name].get("width", 20) - 3
                                 if len(value) > max_length:
@@ -308,12 +371,14 @@ def get(
             code = _normalize_stock_code(code)
 
             from datetime import datetime, timedelta
+
             if not end:
                 end = datetime.now().strftime("%Y%m%d")
             if not start:
                 start = (datetime.now() - timedelta(days=30)).strftime("%Y%m%d")
 
             from ginkgo.data.containers import container
+
             bar_service = container.bar_service()
             result = bar_service.get_bars_df(code=code, start_date=start, end_date=end)
 
@@ -322,10 +387,21 @@ def get(
                 raise typer.Exit(1)
 
             import pandas as pd
+
             df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
             if df.empty:
                 console.print(f":information: No bar data found for {code} ({start}-{end})")
+                return
+
+            if format == "json":
+                json_df = df.sort_values("timestamp").tail(limit) if limit is not None else df
+                _emit_json_records(
+                    json_df.to_dict("records"),
+                    total=len(df),
+                    limit=limit,
+                    order="tail",
+                )
                 return
 
             display_cols = ["code", "timestamp", "open", "high", "low", "close", "volume", "amount"]
@@ -333,6 +409,11 @@ def get(
             df_display = df[show_cols].copy()
             if "timestamp" in df_display.columns:
                 df_display["timestamp"] = df_display["timestamp"].astype(str).str[:10]
+
+            # ADR-021 第 2 维：day = 时序行情，--limit 取最新 N 条（tail，按 timestamp 排序后取尾）
+            # 修 bug：原实现全量 iterrows 打印表格，--page-size 只打印提示不实际截断
+            if limit and limit > 0:
+                df_display = df_display.sort_values("timestamp").tail(limit)
 
             table = Table(title=f"Bar Data: {code} ({start}-{end})", show_lines=False)
             for col in show_cols:
@@ -348,6 +429,7 @@ def get(
                 raise typer.Exit(1)
 
             from datetime import datetime, timedelta
+
             if not end:
                 end = datetime.now().strftime("%Y%m%d")
             if not start:
@@ -355,6 +437,7 @@ def get(
                 start = start_date.strftime("%Y%m%d")
 
             from ginkgo.data.containers import container
+
             tick_service = container.tick_service()
             result = tick_service.get_ticks_df(code=code, start_date=start, end_date=end)
 
@@ -363,16 +446,29 @@ def get(
                 raise typer.Exit(1)
 
             import pandas as pd
+
             df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
             if df.empty:
                 console.print(f":information: No tick data found for {code} ({start}-{end})")
                 return
 
-            limit = page_size or 50
-            if len(df) > limit:
-                console.print(f":information: Showing {limit} of {len(df)} records")
-                df = df.tail(limit)
+            if format == "json":
+                json_df = df.tail(limit) if limit is not None else df
+                _emit_json_records(
+                    json_df.to_dict("records"),
+                    total=len(df),
+                    limit=limit,
+                    order="tail",
+                )
+                return
+
+            # ADR-021 第 2/3 维：tick = 分笔时序，--limit 取最新 N（tail）
+            # 任务3：--page-size 收窄为交互翻页语义（tick 无 TTY 翻页，弃用 page-size 作 limit）
+            text_limit = limit if limit is not None else 50
+            if len(df) > text_limit:
+                console.print(f":information: Showing {text_limit} of {len(df)} records")
+                df = df.tail(text_limit)
 
             table = Table(title=f"Tick Data: {code} ({start}-{end})", show_lines=False)
             display_cols = ["code", "timestamp", "price", "volume", "amount", "direction"]
@@ -390,6 +486,7 @@ def get(
 
             # 默认时间范围（对齐 day 分支：end 缺省补 now，start 缺省补 now-365d）
             from datetime import datetime, timedelta
+
             if not end:
                 end = datetime.now().strftime("%Y%m%d")
             if not start:
@@ -401,26 +498,37 @@ def get(
             end_dt = datetime.strptime(end, "%Y%m%d")
 
             from ginkgo.data.containers import container
+
             adjustfactor_service = container.adjustfactor_service()
-            result = adjustfactor_service.get_adjustfactors_df(
-                code=code, start_date=start_dt, end_date=end_dt
-            )
+            result = adjustfactor_service.get_adjustfactors_df(code=code, start_date=start_dt, end_date=end_dt)
 
             if not result.success:
                 console.print(f":x: Failed to get adjustfactor data: {result.message}")
                 raise typer.Exit(1)
 
             import pandas as pd
+
             df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
             if df.empty:
                 console.print(f":information: No adjustfactor data found for {code} ({start}-{end})")
                 return
 
+            if format == "json":
+                json_df = df.sort_values("timestamp").head(limit) if limit is not None else df
+                _emit_json_records(
+                    json_df.to_dict("records"),
+                    total=len(df),
+                    limit=limit,
+                    order="head",
+                )
+                return
+
             # Raw JSON 输出（对齐 stockinfo 分支）
             if raw:
                 import json
-                console.print(json.dumps(df.to_dict('records'), indent=2, ensure_ascii=False, default=str))
+
+                console.print(json.dumps(df.to_dict("records"), indent=2, ensure_ascii=False, default=str))
                 return
 
             # 列名对齐 MAdjustfactor（foreadjustfactor/backadjustfactor/adjustfactor），
@@ -432,10 +540,12 @@ def get(
             if "timestamp" in df_display.columns:
                 df_display["timestamp"] = df_display["timestamp"].astype(str).str[:10]
 
-            limit = page_size or 50
-            if len(df_display) > limit:
-                console.print(f":information: Showing {limit} of {len(df_display)} records")
-                df_display = df_display.tail(limit)
+            # ADR-021 第 2 维 + 任务4 核实：adjustfactor = 低频事件型（全量列表语义），
+            # --limit 取最早 N 条除权事件（head，按 timestamp 正序）；page-size 收窄弃用
+            af_limit = limit if limit is not None else 50
+            if len(df_display) > af_limit:
+                console.print(f":information: Showing first {af_limit} of {len(df_display)} records")
+                df_display = df_display.head(af_limit)
 
             table = Table(title=f"Adjustfactor Data: {code} ({start}-{end})", show_lines=False)
             for col in show_cols:
@@ -456,6 +566,18 @@ def get(
                 ("tdx", GinkgoTDX, None),  # TDX 无 token 依赖
             ]
 
+            if format == "json":
+                records = [
+                    {
+                        "name": name,
+                        "type": cls.__name__,
+                        "configured": "yes" if token is None or token else "no",
+                    }
+                    for name, cls, token in configured_sources
+                ]
+                _emit_json_records(records, total=len(records), limit=None)
+                return
+
             table = Table(title=":plug: Configured Data Sources", show_lines=False)
             table.add_column("name", style="cyan")
             table.add_column("type", style="green")
@@ -474,10 +596,7 @@ def get(
             # 仿 sources 分支：print 后 fall-through 正常结束 try，不走 else。
             # ⚠️ 勿用 raise typer.Exit —— click.Exit 是 Exception 子类（非 SystemExit），
             # 会被外层 except Exception 捕获并转成 Exit(1) + "Error getting data" 污染输出。
-            console.print(
-                ":information: calendar is planned but not yet implemented. "
-                "See `ginkgo data get --help`."
-            )
+            console.print(":information: calendar is planned but not yet implemented. " "See `ginkgo data get --help`.")
         elif data_type == "status":
             # #5992: data get status 友好 stub，提示用 top-level 'data status' 命令，
             # 而非落 else 分支报 'Unknown data type: status'。
@@ -513,6 +632,7 @@ def _is_valid_stock_code(code: str) -> bool:
     service 层后以 "no data" + exit 0 的形式误报成功（见 [[arch_ashare_code_market_prefix_gap]]）。
     """
     import re
+
     if not code:
         return False
     suffix = r"\d{6}\.(SH|SZ)"
@@ -550,6 +670,7 @@ def sync(
         # 如果是daemon模式，发送Kafka消息并退出
         if daemon:
             from ginkgo.data.containers import container
+
             kafka_service = container.kafka_service()
 
             console.print(f":information: Sending {data_type} sync task to background queue...")
@@ -593,6 +714,7 @@ def sync(
 
         if data_type == "stockinfo":
             from ginkgo.data.containers import container
+
             stockinfo_service = container.stockinfo_service()
             console.print(":repeat: Syncing stock information...")
             result = stockinfo_service.sync()
@@ -618,7 +740,11 @@ def sync(
                 # 获取所有股票代码
                 stock_result = stockinfo_service.list(page_size=5000)
                 if stock_result.is_success() and stock_result.data:
-                    stocks = stock_result.data.get('data', stock_result.data) if isinstance(stock_result.data, dict) else stock_result.data
+                    stocks = (
+                        stock_result.data.get("data", stock_result.data)
+                        if isinstance(stock_result.data, dict)
+                        else stock_result.data
+                    )
                     codes = [s.code for s in stocks]
                     console.print(f":repeat: Syncing day data for all {len(codes)} stocks...")
                 else:
@@ -636,9 +762,7 @@ def sync(
                             # 全量同步：从1990年开始
                             console.print(f":information: Full sync for {current_code} (from 1990-01-01)")
                             result = bar_service.sync_range(
-                                code=current_code,
-                                start_date=datetime(1990, 1, 1),
-                                end_date=datetime.now()
+                                code=current_code, start_date=datetime(1990, 1, 1), end_date=datetime.now()
                             )
                         else:
                             # 增量同步：智能同步
@@ -649,19 +773,25 @@ def sync(
                             # 检查实际同步的记录数，避免误导性成功消息
                             records_added = 0
                             try:
-                                raw = getattr(result.data, 'records_added', 0)
+                                raw = getattr(result.data, "records_added", 0)
                                 records_added = int(raw) if isinstance(raw, (int, float)) else 0
                             except (AttributeError, TypeError, ValueError):
                                 records_added = 0
                             if records_added > 0:
                                 stats.record_success()
-                                console.print(f":white_check_mark: {current_code} sync completed ({records_added} records)")
+                                console.print(
+                                    f":white_check_mark: {current_code} sync completed ({records_added} records)"
+                                )
                             else:
                                 stats.record_skipped()
                                 console.print(f":warning: {current_code} — no data available from source")
                         else:
                             stats.record_error()
-                            error_msg = result.message if hasattr(result, 'message') else str(result.error) if hasattr(result, 'error') else 'Unknown error'
+                            error_msg = (
+                                result.message
+                                if hasattr(result, "message")
+                                else str(result.error) if hasattr(result, "error") else "Unknown error"
+                            )
                             console.print(f":x: {current_code} sync failed: {error_msg}")
 
                     except Exception as e:
@@ -691,7 +821,11 @@ def sync(
                 # 获取所有股票代码
                 stock_result = stockinfo_service.list(page_size=5000)
                 if stock_result.is_success() and stock_result.data:
-                    stocks = stock_result.data.get('data', stock_result.data) if isinstance(stock_result.data, dict) else stock_result.data
+                    stocks = (
+                        stock_result.data.get("data", stock_result.data)
+                        if isinstance(stock_result.data, dict)
+                        else stock_result.data
+                    )
                     codes = [s.code for s in stocks]
                     console.print(f":repeat: Syncing tick data for all {len(codes)} stocks...")
                 else:
@@ -725,7 +859,11 @@ def sync(
                             console.print(f":white_check_mark: {current_code} sync completed")
                         else:
                             stats.record_error()
-                            error_msg = result.message if hasattr(result, 'message') else str(result.error) if hasattr(result, 'error') else 'Unknown error'
+                            error_msg = (
+                                result.message
+                                if hasattr(result, "message")
+                                else str(result.error) if hasattr(result, "error") else "Unknown error"
+                            )
                             console.print(f":x: {current_code} sync failed: {error_msg}")
 
                     except Exception as e:
@@ -742,6 +880,7 @@ def sync(
 
         elif data_type == "adjustfactor":
             from ginkgo.data.containers import container
+
             # CLI → Service 直调（分层规则）。旧 import 的两个自由函数从未在 src/ 实现，
             # 每次执行必 ImportError。sync 带 fast_mode 参数，full/force 语义无损透传。
             adjustfactor_service = container.adjustfactor_service()
@@ -784,25 +923,26 @@ def sync(
 
                         # Check sync result - ServiceResult has success property, other results may not
                         sync_success = False
-                        if hasattr(result, 'success'):
+                        if hasattr(result, "success"):
                             sync_success = result.success
                         elif result is None:  # Some functions return None on success
                             sync_success = True
-
 
                         if sync_success:
                             # 仿 day 分支：从 result.data.records_added 提取实际入库条数，
                             # 避免无数据时仍打印 ":white_check_mark: sync completed" 误导用户（#6053）。
                             records_added = 0
                             try:
-                                _data = getattr(result, 'data', None)
-                                raw = getattr(_data, 'records_added', 0)
+                                _data = getattr(result, "data", None)
+                                raw = getattr(_data, "records_added", 0)
                                 records_added = int(raw) if isinstance(raw, (int, float)) else 0
                             except (AttributeError, TypeError, ValueError):
                                 records_added = 0
                             if records_added > 0:
                                 stats.record_success()
-                                console.print(f":white_check_mark: {current_code} sync completed ({records_added} records)")
+                                console.print(
+                                    f":white_check_mark: {current_code} sync completed ({records_added} records)"
+                                )
                             else:
                                 # service.sync 成功但源端无数据：计 skipped（#6053/#6054 统一三态）
                                 stats.record_skipped()
@@ -811,18 +951,20 @@ def sync(
                             # 同步完成后立即计算该股票的复权因子
                             console.print(f":information: Calculating adjustment factors for {current_code}...")
                             calc_result = adjustfactor_service.calculate(current_code)
-                            if calc_result and hasattr(calc_result, 'success') and calc_result.success:
-                                console.print(f":white_check_mark: {current_code} adjustment factor calculation completed")
+                            if calc_result and hasattr(calc_result, "success") and calc_result.success:
+                                console.print(
+                                    f":white_check_mark: {current_code} adjustment factor calculation completed"
+                                )
                             else:
                                 console.print(f":warning: {current_code} adjustment factor calculation failed")
-                                if hasattr(calc_result, 'error') and calc_result.error:
+                                if hasattr(calc_result, "error") and calc_result.error:
                                     console.print(f"   Error: {calc_result.error}")
                         else:
                             stats.record_error()
                             console.print(f":x: {current_code} sync failed")
-                            if hasattr(result, 'error') and result.error:
+                            if hasattr(result, "error") and result.error:
                                 console.print(f"   Error: {result.error}")
-                            elif hasattr(result, 'message') and result.message:
+                            elif hasattr(result, "message") and result.message:
                                 console.print(f"   Message: {result.message}")
 
                     except Exception as e:
@@ -842,6 +984,7 @@ def sync(
             # paper worker _run_live_paper_cycle 通过 trade_day_crud 查 is_open 判断开市，
             # 表空则整轮 skip 致 0 signal。trade_day 无 code 参数，全量同步。
             from ginkgo.data.containers import container
+
             trade_day_service = container.trade_day_service()
             console.print(":repeat: Syncing trade calendar...")
             result = trade_day_service.sync()
@@ -869,7 +1012,9 @@ def migrate(
     revision: Optional[str] = typer.Option(None, "--revision", "-r", help="Specific revision to upgrade/downgrade"),
     action: str = typer.Option("upgrade", "--action", help="Action: upgrade/downgrade/heads/history/current"),
     path: Optional[str] = typer.Option(
-        None, "--path", "-p",
+        None,
+        "--path",
+        "-p",
         help="Override migrations directory (absolute or relative to cwd). Default: <source-tree>/migrations/<database>",
     ),
 ):

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -107,17 +107,19 @@ def get(
     """
     :inbox_tray: Get data from database.
     """
-    try:
-        # ADR-021 E4: auto keeps legacy text output; explicit json is machine-readable.
-        if format is None or format == "auto":
-            format = "text"
-        elif format not in ("text", "json"):
-            console.print(f":x: Invalid --format {format!r}: must be 'auto', 'text' or 'json'")
-            raise typer.Exit(2)  # BAD_PARAMS 语义（ADR-021 第 6 维 exit 2）
-        if limit is not None and limit < 1:
-            console.print(":x: --limit must be greater than 0")
-            raise typer.Exit(2)
+    # ADR-021 第 6 维 + #6579 review finding 1：参数校验须在 try 块外，否则
+    # typer.Exit(2) 被末尾 except Exception 吞成 Exit(1)（MRO: Exit→RuntimeError→Exception）。
+    # 对齐 sync 函数写法（见本文件 sync 的 --code 校验，同样置于 try 外）。
+    if format is None or format == "auto":
+        format = "text"
+    elif format not in ("text", "json"):
+        console.print(f":x: Invalid --format {format!r}: must be 'auto', 'text' or 'json'")
+        raise typer.Exit(2)  # BAD_PARAMS 语义（ADR-021 第 6 维 exit 2）
+    if limit is not None and limit < 1:
+        console.print(":x: --limit must be greater than 0")
+        raise typer.Exit(2)
 
+    try:
         # ADR-021 任务1：--no-color 禁用 ANSI（TTY pipe 输出/CI 日志友好；json 模式本就无 ANSI，幂等）
         if no_color:
             console.no_color = True
@@ -454,11 +456,15 @@ def get(
                 return
 
             if format == "json":
-                json_df = df.tail(limit) if limit is not None else df
+                # #6579 review finding 2：tick 默认 7 天窗单股可达 10-50 万行，
+                # json 无 --limit 时全量 dump 爆 stdout。取 1000 作默认上限（与文本路径 50
+                # 解耦——机读场景需更多样本，1000 兼顾样本量与 stdout 友好）。
+                json_limit = limit if limit is not None else 1000
+                json_df = df.tail(json_limit) if len(df) > json_limit else df
                 _emit_json_records(
                     json_df.to_dict("records"),
                     total=len(df),
-                    limit=limit,
+                    limit=json_limit,
                     order="tail",
                 )
                 return
@@ -537,7 +543,10 @@ def get(
             display_cols = ["code", "timestamp", "foreadjustfactor", "backadjustfactor", "adjustfactor"]
             show_cols = [c for c in display_cols if c in df.columns]
             df_display = df[show_cols].copy()
+            # #6579 review finding 3：与 json 路径（sort_values("timestamp").head）对称，
+            # 文本路径须先按 timestamp 正序再 head，否则同一查询 text/json 返回不同行。
             if "timestamp" in df_display.columns:
+                df_display = df_display.sort_values("timestamp")
                 df_display["timestamp"] = df_display["timestamp"].astype(str).str[:10]
 
             # ADR-021 第 2 维 + 任务4 核实：adjustfactor = 低频事件型（全量列表语义），

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -503,6 +503,46 @@ class TestGetOtherTypes:
         assert prices == [10.05]
 
     @patch("ginkgo.data.containers.container")
+    def test_get_tick_format_json_default_limit(self, mock_container, cli_runner):
+        """#6579 review finding 2：tick ``--format json`` 无 ``--limit`` 时须有默认上限。
+
+        tick 默认 7 天窗单股可达 10-50 万行，json 无上限会爆 stdout。取 1000 作默认
+        （与文本路径 50 解耦——机读场景需更多样本）。``metadata.limit`` 报实际阈值
+        （用户值或默认 1000），让下游知边界而非 ``None``（无限制假象）。
+        """
+        import pandas as pd
+
+        mock_service = MagicMock()
+        # 1500 行 > 默认上限 1000，验证截断生效
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ"] * 1500,
+                "timestamp": [f"2026-07-01 09:{i // 60:02d}:{i % 60:02d}:00" for i in range(1500)],
+                "price": [10.0 + i * 0.001 for i in range(1500)],
+                "volume": [100 + i for i in range(1500)],
+                "amount": [1000.0 + i for i in range(1500)],
+                "direction": [1] * 1500,
+            }
+        )
+        mock_service.get_ticks_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.tick_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "tick", "--code", "000001.SZ", "--format", "json"]
+        )
+        assert result.exit_code == 0, f"exit≠0, output:\n{result.output}"
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON:\n{result.output}"
+        payload = json.loads(json_line)
+        # 默认上限 1000 生效：count 截断、total 仍是全量 1500、metadata.limit 报阈值
+        assert payload["count"] == 1000, f"expected default limit 1000, got count={payload['count']}"
+        assert payload["metadata"]["total"] == 1500
+        assert payload["metadata"]["limit"] == 1000
+
+    @patch("ginkgo.data.containers.container")
     def test_get_adjustfactor_format_json(self, mock_container, cli_runner):
         """--format json：adjustfactor 分支走 format_result list 契约（ADR-021 第 5/9 维）。
 
@@ -547,15 +587,20 @@ class TestGetOtherTypes:
         复权因子是低频事件型数据（一年通常 ≤3 条除权事件），归"全量列表"语义（与
         stockinfo 一致），head 取最早 N 条除权事件。改自原 tail 行为（从 day/tick
         复制的遗留逻辑）；业务理由：复权因子全量条数少，按时间正序阅读除权轨迹更直观。
+
+        #6579 review finding 3：mock df 用**倒序输入**（最新在前），复现 review 实测的
+        覆盖盲区——文本路径缺 ``sort_values`` 时 head 取到的是最新 N 条而非承诺的最早 N 条。
+        正序 mock 会掩盖此 bug（review 指出原测试 mock 恰好预排序）。
         """
         mock_service = MagicMock()
         mock_df = pd.DataFrame(
             {
                 "code": ["000001.SZ"] * 5,
-                "timestamp": ["2024-01-15", "2024-04-15", "2024-07-15", "2024-10-15", "2025-01-15"],
-                "foreadjustfactor": [1.0, 0.95, 0.92, 0.88, 0.85],
-                "backadjustfactor": [1.0, 1.05, 1.08, 1.12, 1.15],
-                "adjustfactor": [1.0, 1.05, 1.08, 1.12, 1.15],
+                # 倒序输入（最新在前）：修复前 head(2) 会错误返回 2025-01/2024-10
+                "timestamp": ["2025-01-15", "2024-10-15", "2024-07-15", "2024-04-15", "2024-01-15"],
+                "foreadjustfactor": [0.85, 0.88, 0.92, 0.95, 1.0],
+                "backadjustfactor": [1.15, 1.12, 1.08, 1.05, 1.0],
+                "adjustfactor": [1.15, 1.12, 1.08, 1.05, 1.0],
             }
         )
         mock_service.get_adjustfactors_df.return_value = ServiceResult.success(data=mock_df)
@@ -570,6 +615,27 @@ class TestGetOtherTypes:
         assert "2024-04-15" in result.output
         assert "2024-10-15" not in result.output
         assert "2025-01-15" not in result.output
+
+    def test_get_invalid_format_exits_with_code_2(self, cli_runner):
+        """#6579 review finding 1：无效 --format 须 exit 2（BAD_PARAMS，ADR-021 第 6 维）。
+
+        typer.Exit(2) 不能被 get 末尾的 ``except Exception`` 吞成 ``Exit(1)``
+        （typer.Exit MRO = Exit→RuntimeError→Exception，是 Exception 子类）。
+        校验在 service 调用前发生，无需 mock container。
+        """
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--format", "xml"])
+        assert result.exit_code == 2, (
+            f"expected exit 2 (BAD_PARAMS), got {result.exit_code}\noutput:\n{result.output}"
+        )
+        assert "Invalid --format" in result.output
+
+    def test_get_invalid_limit_exits_with_code_2(self, cli_runner):
+        """#6579 review finding 1：--limit < 1 须 exit 2（BAD_PARAMS），不被吞成 Exit(1)。"""
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--limit", "0"])
+        assert result.exit_code == 2, (
+            f"expected exit 2 (BAD_PARAMS), got {result.exit_code}\noutput:\n{result.output}"
+        )
+        assert "--limit must be greater than 0" in result.output
 
     def test_get_sources_format_json(self, cli_runner):
         """--format json：sources 分支走 format_result list 契约（ADR-021 第 5/9 维）。

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -32,13 +32,15 @@ def cli_runner():
 @pytest.fixture
 def mock_stockinfo_df():
     """标准 stockinfo 测试数据"""
-    return pd.DataFrame({
-        "code": ["000001.SZ", "000002.SZ", "600000.SH"],
-        "code_name": ["平安银行", "万科A", "浦发银行"],
-        "industry": ["银行", "房地产", "银行"],
-        "market": ["SZ", "SZ", "SH"],
-        "list_date": ["1991-04-03", "1991-01-29", "1999-11-10"],
-    })
+    return pd.DataFrame(
+        {
+            "code": ["000001.SZ", "000002.SZ", "600000.SH"],
+            "code_name": ["平安银行", "万科A", "浦发银行"],
+            "industry": ["银行", "房地产", "银行"],
+            "market": ["SZ", "SZ", "SH"],
+            "list_date": ["1991-04-03", "1991-01-29", "1999-11-10"],
+        }
+    )
 
 
 # ============================================================================
@@ -179,6 +181,61 @@ class TestGetStockinfo:
         assert "000001.SZ" in result.output
 
     @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_format_json(self, mock_container, cli_runner, mock_stockinfo_df):
+        """--format json：stdout 输出 format_result 契约（ADR-021 第 5/9 维 list 结构）。
+
+        list 结构：``{"success": true, "data": [...], "count": N, "metadata": {}}``。
+        显式 ``--format json`` 才走 JSON；auto/default 保持 text 兼容旧脚本。
+        """
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--format", "json"])
+        assert result.exit_code == 0
+        # 从 output 提取 format_result 的 JSON 行（stdout 可能混 [GCONF] 等日志噪音）
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON，实际 output:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert isinstance(payload["data"], list)
+        assert payload["count"] == 3  # mock_stockinfo_df 3 条
+        assert payload["metadata"]["total"] == 3
+        codes = [r["code"] for r in payload["data"]]
+        assert "000001.SZ" in codes
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_limit_head(self, mock_container, cli_runner):
+        """--limit N：stockinfo 分支取前 N 条（head，按 code 排序），ADR-021 第 2 维 order。
+
+        stockinfo = 全量列表（非时序），head 取 code 字典序前 N。任务3：非交互模式
+        截断改用 ``--limit``，``--page-size`` 收窄为 TTY 翻页（此处 CliRunner 非 TTY）。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ", "000002.SZ", "000003.SZ", "600000.SH", "600001.SH"],
+                "code_name": ["平安银行", "万科A", "A 股票", "浦发银行", "B 股票"],
+                "industry": ["银行", "房地产", "科技", "银行", "科技"],
+                "market": ["SZ", "SZ", "SZ", "SH", "SH"],
+                "list_date": ["1991-04-03", "1991-01-29", "2020-01-01", "1999-11-10", "2021-01-01"],
+            }
+        )
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--format", "text", "--limit", "2"])
+        assert result.exit_code == 0, f"exit≠0, output:\n{result.output}"
+        # head sort by code：000001 < 000002 < 000003 < 600000 < 600001，head 2 = 前两条
+        assert "000001" in result.output
+        assert "000002" in result.output
+        assert "000003" not in result.output
+        assert "600000" not in result.output
+
+    @patch("ginkgo.data.containers.container")
     def test_get_stockinfo_service_error(self, mock_container, cli_runner):
         """服务返回错误时显示错误信息（DF 出口 else 分支）"""
         mock_service = MagicMock()
@@ -229,16 +286,22 @@ class TestGetStockinfo:
         assert "n/p/q" not in result.output
 
     @patch("ginkgo.data.containers.container")
-    def test_get_stockinfo_pagesize_nontty_limits_output(self, mock_container, cli_runner, mock_stockinfo_df):
-        """非 TTY + --page-size N 退化为 head(N) 输出，size 生效（#5280）"""
+    def test_get_stockinfo_pagesize_nontty_keeps_text_output(self, mock_container, cli_runner, mock_stockinfo_df):
+        """非 TTY + --page-size N：ADR-021 任务3，page-size 仅 TTY 交互翻页生效。
+
+        auto/default 保持 text 输出兼容旧脚本，page-size 不再承担非 TTY 截断语义。
+        #5280 的"非 TTY 不阻塞"核心保证仍成立（exit_code==0 不 hang），但输出形式
+        仍是 text；截断改由 --limit 承担（见 test_get_stockinfo_limit_head）。
+        """
         mock_service = MagicMock()
         mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
         mock_container.stockinfo_service.return_value = mock_service
 
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--page-size", "2"])
-        assert result.exit_code == 0
-        # mock_stockinfo_df 共 3 条，page_size=2 退化 head(2)
-        assert "Showing first 2 of 3 records" in result.output
+        assert result.exit_code == 0  # #5280：非 TTY 不阻塞、不 hang
+        assert "Interactive mode enabled" not in result.output
+        assert '{"success"' not in result.output
+        assert "000001" in result.output
 
 
 # ============================================================================
@@ -297,6 +360,282 @@ class TestGetOtherTypes:
         assert "not yet implemented" not in result.output
         # 容器注入了 tushare/tdx（containers.py），应被列出
         assert "tushare" in result.output.lower()
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_day_format_json(self, mock_container, cli_runner):
+        """--format json：day 分支走 format_result list 契约（ADR-021 第 5/9 维）。
+
+        list 结构：``{"success": true, "data": [...], "count": N, "metadata": {}}``。
+        无 --limit 时全量 records 进 data。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ", "000001.SZ"],
+                "timestamp": ["2026-07-01", "2026-07-02"],
+                "open": [10.0, 10.5],
+                "high": [10.8, 10.9],
+                "low": [9.9, 10.3],
+                "close": [10.5, 10.7],
+                "volume": [100000, 120000],
+                "amount": [1050000.0, 1284000.0],
+            }
+        )
+        mock_service.get_bars_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.bar_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "day", "--code", "000001.SZ", "--format", "json"])
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert isinstance(payload["data"], list)
+        assert payload["count"] == 2
+        assert payload["metadata"]["total"] == 2
+        codes = [r["code"] for r in payload["data"]]
+        assert "000001.SZ" in codes
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_day_limit_tail(self, mock_container, cli_runner):
+        """--limit N：day 分支取最新 N 条（tail），ADR-021 第 2 维 order。
+
+        day = 时序行情，交易员关心近期 → tail。同时修复 day 分支隐藏 bug：原 text
+        模式直接 ``iterrows()`` 全量打印表格，``--page-size`` 只打印 "Showing N of M"
+        提示却**不实际截断**；``--limit`` 落地真正的 tail 截断。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ"] * 5,
+                "timestamp": [f"2026-07-0{i}" for i in range(1, 6)],
+                "open": [10.0] * 5,
+                "high": [10.5] * 5,
+                "low": [9.5] * 5,
+                "close": [10.2] * 5,
+                "volume": [100000] * 5,
+                "amount": [1020000.0] * 5,
+            }
+        )
+        mock_service.get_bars_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.bar_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "day", "--code", "000001.SZ", "--format", "text", "--limit", "2"]
+        )
+        assert result.exit_code == 0, f"exit≠0, output:\n{result.output}"
+        # tail：只含最新 2 条 (07-04, 07-05)，不含前 3 条
+        assert "2026-07-04" in result.output
+        assert "2026-07-05" in result.output
+        assert "2026-07-01" not in result.output
+        assert "2026-07-03" not in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_tick_limit_tail(self, mock_container, cli_runner):
+        """--limit N：tick 分支取最新 N 条（tail），ADR-021 第 2 维 order。
+
+        tick = 分笔时序，最新成交更受关注 → tail。``--limit`` 取代旧 ``--page-size``
+        双关用法（任务3：page-size 收窄为交互翻页语义）。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ"] * 5,
+                "timestamp": [f"2026-07-01 09:3{i}:00" for i in range(5)],
+                "price": [10.0 + i * 0.01 for i in range(5)],
+                "volume": [100 + i * 10 for i in range(5)],
+                "amount": [1000.0 + i * 100 for i in range(5)],
+                "direction": [1] * 5,
+            }
+        )
+        mock_service.get_ticks_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.tick_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "tick", "--code", "000001.SZ", "--format", "text", "--limit", "2"]
+        )
+        assert result.exit_code == 0, f"exit≠0, output:\n{result.output}"
+        # tail：只含最新 2 条 (09:33, 09:34)
+        assert "09:33" in result.output
+        assert "09:34" in result.output
+        assert "09:30" not in result.output
+        assert "09:31" not in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_tick_format_json(self, mock_container, cli_runner):
+        """--format json：tick 分支走 format_result list 契约（ADR-021 第 5/9 维）。
+
+        --limit 对 json 同样生效，避免机器输出无限膨胀。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ", "000001.SZ"],
+                "timestamp": ["2026-07-01 09:30:00", "2026-07-01 09:31:00"],
+                "price": [10.0, 10.05],
+                "volume": [100, 200],
+                "amount": [1000.0, 2010.0],
+                "direction": [1, 1],
+            }
+        )
+        mock_service.get_ticks_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.tick_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "tick", "--code", "000001.SZ", "--format", "json", "--limit", "1"]
+        )
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert isinstance(payload["data"], list)
+        assert payload["count"] == 1
+        assert payload["metadata"]["total"] == 2
+        assert payload["metadata"]["limit"] == 1
+        prices = [r["price"] for r in payload["data"]]
+        assert prices == [10.05]
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_adjustfactor_format_json(self, mock_container, cli_runner):
+        """--format json：adjustfactor 分支走 format_result list 契约（ADR-021 第 5/9 维）。
+
+        --format json 优先于 --raw（format 是显式格式选择，raw 是旧 alias，
+        task #16 会把 --raw 别名到 --format json）。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ", "000001.SZ"],
+                "timestamp": ["2026-07-01", "2026-07-02"],
+                "foreadjustfactor": [1.0, 1.001],
+                "backadjustfactor": [1.0, 0.999],
+                "adjustfactor": [1.0, 1.0005],
+            }
+        )
+        mock_service.get_adjustfactors_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.adjustfactor_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app,
+            ["get", "adjustfactor", "--code", "000001.SZ", "--format", "json"],
+        )
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert isinstance(payload["data"], list)
+        assert payload["count"] == 2
+        # 因子列正确序列化（非空、是数值）
+        factors = [r["foreadjustfactor"] for r in payload["data"]]
+        assert 1.0 in factors
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_adjustfactor_limit_head(self, mock_container, cli_runner):
+        """--limit N：adjustfactor 分支取前 N 条（head），ADR-021 第 2 维 + 任务4 核实结论。
+
+        复权因子是低频事件型数据（一年通常 ≤3 条除权事件），归"全量列表"语义（与
+        stockinfo 一致），head 取最早 N 条除权事件。改自原 tail 行为（从 day/tick
+        复制的遗留逻辑）；业务理由：复权因子全量条数少，按时间正序阅读除权轨迹更直观。
+        """
+        mock_service = MagicMock()
+        mock_df = pd.DataFrame(
+            {
+                "code": ["000001.SZ"] * 5,
+                "timestamp": ["2024-01-15", "2024-04-15", "2024-07-15", "2024-10-15", "2025-01-15"],
+                "foreadjustfactor": [1.0, 0.95, 0.92, 0.88, 0.85],
+                "backadjustfactor": [1.0, 1.05, 1.08, 1.12, 1.15],
+                "adjustfactor": [1.0, 1.05, 1.08, 1.12, 1.15],
+            }
+        )
+        mock_service.get_adjustfactors_df.return_value = ServiceResult.success(data=mock_df)
+        mock_container.adjustfactor_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "adjustfactor", "--code", "000001.SZ", "--format", "text", "--limit", "2"]
+        )
+        assert result.exit_code == 0, f"exit≠0, output:\n{result.output}"
+        # head：最早 2 条除权事件 (2024-01, 2024-04)
+        assert "2024-01-15" in result.output
+        assert "2024-04-15" in result.output
+        assert "2024-10-15" not in result.output
+        assert "2025-01-15" not in result.output
+
+    def test_get_sources_format_json(self, cli_runner):
+        """--format json：sources 分支走 format_result list 契约（ADR-021 第 5/9 维）。
+
+        sources 是静态列表（非 service/DF），json 分叉直接构造 records。
+        不 mock（同 test_get_sources_lists_configured_sources）：容器注入了 tushare/tdx。
+        """
+        result = cli_runner.invoke(data_cli.app, ["get", "sources", "--format", "json"])
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert isinstance(payload["data"], list)
+        assert payload["count"] >= 2  # 至少 tushare + tdx
+        names = [r["name"] for r in payload["data"]]
+        assert "tushare" in names
+
+    def test_get_sources_limit_ignored(self, cli_runner):
+        """--limit 对 sources 不截断（ADR-021 任务2：资源列表本就少）。
+
+        sources 是静态数据源列表（非查询结果），--limit 语义不适用。验证 --limit 1
+        仍输出全部已配置数据源（tushare + tdx），不被截断。
+        """
+        result = cli_runner.invoke(data_cli.app, ["get", "sources", "--format", "text", "--limit", "1"])
+        assert result.exit_code == 0, f"exit≠0, output:\n{result.output}"
+        out = result.output.lower()
+        # containers 注入 tushare + tdx，--limit 1 仍全量显示（不截断）
+        assert "tushare" in out
+        assert "tdx" in out
+
+    def test_get_sources_format_auto_nontty(self, cli_runner):
+        """--format 缺省 → auto/default 保持 text 输出（ADR-021 第 1 维）。
+
+        JSON 必须显式传 ``--format json``，避免旧脚本在非 TTY 下突然收到 JSON。
+        """
+        result = cli_runner.invoke(data_cli.app, ["get", "sources"])
+        assert result.exit_code == 0
+        assert '{"success"' not in result.output
+        assert "tushare" in result.output.lower()
+
+    def test_get_no_color_wires_to_console(self, cli_runner):
+        """--no-color → console.no_color=True（ADR-021 任务1：flag wiring）。
+
+        Rich 非 TTY 本就无前景色输出，硬断言输出 ANSI 不可靠（Rich Table 在
+        force_terminal 下只产 bold(1m)/italic(3m)，Segment.remove_color 本就不剥这两种）。
+        改测契约：--no-color 真正抵达 console.no_color 属性。配对验证不带 flag 不误置。
+        """
+        from rich.console import Console
+
+        # 带 --no-color：置位
+        forced_on = Console(force_terminal=True, no_color=False)
+        with patch("ginkgo.client.data_cli.console", forced_on):
+            r = cli_runner.invoke(data_cli.app, ["get", "sources", "--no-color", "--format", "text"])
+        assert r.exit_code == 0, f"exit≠0:\n{r.output}"
+        assert forced_on.no_color is True, "--no-color 未置 console.no_color=True"
+
+        # 不带 --no-color：保持默认（不误置）
+        forced_off = Console(force_terminal=True, no_color=False)
+        with patch("ginkgo.client.data_cli.console", forced_off):
+            r2 = cli_runner.invoke(data_cli.app, ["get", "sources", "--format", "text"])
+        assert r2.exit_code == 0
+        assert not forced_off.no_color, "未传 --no-color 却误置 no_color"
 
 
 # ============================================================================
@@ -389,7 +728,8 @@ class TestSync:
         result = cli_runner.invoke(data_cli.app, ["sync", "day", "--code", "000001.SZ"])
         assert result.exit_code == 0
         import re
-        output_clean = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
+
+        output_clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         assert "000001.SZ" in output_clean
 
     @patch("ginkgo.service_hub")
@@ -421,7 +761,7 @@ class TestSync:
 
         result = cli_runner.invoke(data_cli.app, ["sync", "day", "--code", "SH999999"])
         assert result.exit_code == 0
-        output_clean = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
+        output_clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         # 第三态：源无数据，计入 Skipped 而非漏统计
         assert "Skipped: 1" in output_clean
         assert "Success: 0" in output_clean
@@ -561,7 +901,8 @@ class TestSync:
         result = cli_runner.invoke(data_cli.app, ["sync", "day", "--code", "600000.SH"])
         assert result.exit_code == 0
         import re
-        output_clean = re.sub(r'\x1b\[[0-9;]*m', '', result.output)
+
+        output_clean = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
         assert "600000.SH" in output_clean
         assert "120" in output_clean or "sync completed" in output_clean
 


### PR DESCRIPTION
## Summary
- Add `--format auto/text/json`, `--limit`, and `--no-color` to `ginkgo data get`.
- Wire JSON output for stockinfo/day/tick/adjustfactor/sources through ADR-021 `format_result`, including list `count` and pagination metadata.
- Split `--page-size` back to interactive text paging only; `--limit` now owns head/tail truncation.
- Keep default/auto output as text for backwards compatibility; JSON requires explicit `--format json`.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_data_cli.py -n auto -q -o addopts= --no-header --tb=short`
- py_compile over `src` and `api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o addopts= --no-header --tb=short`

Closes #6579
