### PR TITLE
fix(infra): harden docker compose defaults (#5572)

### DIFF
--- a/.conf/Dockerfile.api-server
+++ b/.conf/Dockerfile.api-server
@@ -1,6 +1,9 @@
 # Ginkgo API Server Docker Image
 FROM python:3.12.8-slim
 
+RUN groupadd --system --gid 10001 ginkgo \
+    && useradd --system --uid 10001 --gid ginkgo --home-dir /home/ginkgo --create-home ginkgo
+
 WORKDIR /app
 
 # 安装系统依赖
@@ -24,14 +27,18 @@ COPY src/ /app/src/
 # 复制 pyproject.toml 供版本读取（SystemService.get_version fallback 链，#5406）
 # 生产镜像未安装 dist-info，importlib.metadata 失败 → 回退读 pyproject.toml
 COPY pyproject.toml /app/
+RUN chown -R ginkgo:ginkgo /app /home/ginkgo
 
 # 设置环境变量
 ENV PYTHONPATH=/app:/app/src
 ENV API_HOST=0.0.0.0
 ENV API_PORT=8000
+ENV HOME=/home/ginkgo
 
 # 暴露端口
 EXPOSE 8000
+
+USER ginkgo
 
 # 启动命令
 CMD ["python", "main.py"]

--- a/.conf/Dockerfile.ginkgo
+++ b/.conf/Dockerfile.ginkgo
@@ -5,7 +5,10 @@
 FROM python:3.12.11-slim-bookworm
 
 # 设置工作目录
-RUN mkdir -p /ginkgo
+RUN groupadd --system --gid 10001 ginkgo \
+    && useradd --system --uid 10001 --gid ginkgo --home-dir /home/ginkgo --create-home ginkgo \
+    && mkdir -p /ginkgo /var/log/ginkgo \
+    && chown -R ginkgo:ginkgo /ginkgo /var/log/ginkgo /home/ginkgo
 
 WORKDIR /ginkgo
 
@@ -22,7 +25,7 @@ RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list.d/debia
 # 安装 uv（极快的 Python 包管理器）
 RUN pip install -i https://mirrors.aliyun.com/pypi/simple/ uv
 
-ENV PATH="/root/.local/bin:${PATH}"
+ENV PATH="/home/ginkgo/.local/bin:${PATH}"
 
 # 只复制依赖安装所需文件（利用 Docker 层缓存：源码变动不触发重装依赖）
 COPY pyproject.toml uv.lock ./
@@ -39,10 +42,14 @@ COPY src/ ./src/
 
 # 复制配置文件（部分 worker 需要）
 COPY .conf/task_timer.yml ./src/ginkgo/config/task_timer.yml
+RUN chown -R ginkgo:ginkgo /ginkgo /var/log/ginkgo /home/ginkgo
 
 # 设置环境变量
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/ginkgo/src
+ENV HOME=/home/ginkgo
+
+USER ginkgo
 
 # 默认命令（显示帮助，实际命令由 docker-compose 覆盖）
 CMD ["python", "main.py", "--help"]

--- a/.conf/Dockerfile.web
+++ b/.conf/Dockerfile.web
@@ -26,9 +26,12 @@ COPY --from=vue_builder /app/dist /usr/share/nginx/html
 
 # Copy custom nginx config if exists (build context is .., so .conf/ is correct)
 COPY .conf/nginx.conf /etc/nginx/nginx.conf
+RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/run /var/log/nginx
 
 # Expose the port
 EXPOSE 80
+
+USER nginx
 
 # Run Nginx in foreground
 CMD ["nginx", "-g", "daemon off;"]

--- a/.conf/Dockerfile.web
+++ b/.conf/Dockerfile.web
@@ -28,8 +28,8 @@ COPY --from=vue_builder /app/dist /usr/share/nginx/html
 COPY .conf/nginx.conf /etc/nginx/nginx.conf
 RUN chown -R nginx:nginx /usr/share/nginx/html /var/cache/nginx /var/run /var/log/nginx
 
-# Expose the port
-EXPOSE 80
+# Expose the port (8080: non-root nginx can bind ≥1024; aligns with USER nginx)
+EXPOSE 8080
 
 USER nginx
 

--- a/.conf/nginx.conf
+++ b/.conf/nginx.conf
@@ -29,8 +29,8 @@ http {
     #gzip  on;
 
     server {
-        listen 80 default_server;
-        listen [::]:80 default_server;
+        listen 8080 default_server;
+        listen [::]:8080 default_server;
         server_name localhost;
 
 

--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ EMAIL_FROM_NAME=Ginkgo Notification
 # Kafka
 GINKGO_KAFKA_HOST=kafka1
 GINKGO_KAFKA_PORT=9092
+KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
 
 # Redis
 GINKGO_REDIS_HOST=redis-master
@@ -62,7 +63,8 @@ GINKGO_LOG_LEVEL_FILE=INFO
 # Grafana 配置
 # ============================================
 GRAFANA_ADMIN_USER=admin
-GRAFANA_ADMIN_PASSWORD=admin123
+# 必须在本地 .env 中替换为随机强密码；docker-compose.yml 的 fallback 仅用于 config 校验。
+GRAFANA_ADMIN_PASSWORD=replace_with_random_strong_password
 
 # ============================================
 # Nginx 反向代理配置

--- a/.env.example
+++ b/.env.example
@@ -63,7 +63,7 @@ GINKGO_LOG_LEVEL_FILE=INFO
 # Grafana 配置
 # ============================================
 GRAFANA_ADMIN_USER=admin
-# 必须在本地 .env 中替换为随机强密码；docker-compose.yml 的 fallback 仅用于 config 校验。
+# 必须在本地 .env 中替换为随机强密码；未替换时本值（或 compose 的 change-me-randomize-in-env fallback）即为 Grafana 真实 admin 密码，可被本地直接登录 127.0.0.1:3000。
 GRAFANA_ADMIN_PASSWORD=replace_with_random_strong_password
 
 # ============================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,8 +76,8 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - '9092:29092'
-      - '9093:9093'
+      - '127.0.0.1:9092:29092'
+      - '127.0.0.1:9093:9093'
     environment:
       # KRaft 模式配置 (apache/kafka 使用 KAFKA_ 前缀)
       - KAFKA_PROCESS_ROLES=broker,controller
@@ -90,7 +90,7 @@ services:
       - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
       # 其他配置
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=${KAFKA_AUTO_CREATE_TOPICS_ENABLE:-false}
       - KAFKA_HEAP_OPTS=-Xmx512M -Xms256M
       # 日志配置
       - KAFKA_LOG_RETENTION_HOURS=2
@@ -109,8 +109,8 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - '9094:29094'
-      - '9095:9093'
+      - '127.0.0.1:9094:29094'
+      - '127.0.0.1:9095:9093'
     environment:
       - KAFKA_PROCESS_ROLES=broker,controller
       - KAFKA_NODE_ID=2
@@ -125,7 +125,7 @@ services:
       - KAFKA_LOG_SEGMENT_BYTES=1073741824
       - KAFKA_LOG_CLEANUP_POLICY=delete
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=${KAFKA_AUTO_CREATE_TOPICS_ENABLE:-false}
       - KAFKA_HEAP_OPTS=-Xmx512M -Xms256M
     volumes:
       - .db/kafka2_data:/var/lib/kafka/data
@@ -139,8 +139,8 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - '9096:29096'
-      - '9097:9093'
+      - '127.0.0.1:9096:29096'
+      - '127.0.0.1:9097:9093'
     environment:
       - KAFKA_PROCESS_ROLES=broker,controller
       - KAFKA_NODE_ID=3
@@ -155,7 +155,7 @@ services:
       - KAFKA_LOG_SEGMENT_BYTES=1073741824
       - KAFKA_LOG_CLEANUP_POLICY=delete
       - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=3
-      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_AUTO_CREATE_TOPICS_ENABLE=${KAFKA_AUTO_CREATE_TOPICS_ENABLE:-false}
       - KAFKA_HEAP_OPTS=-Xmx512M -Xms256M
     volumes:
       - .db/kafka3_data:/var/lib/kafka/data
@@ -169,7 +169,7 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - .conf/redis.conf:/etc/redis/redis.conf
       - .db/redis/data:/data
@@ -189,7 +189,7 @@ services:
       --default-time-zone='+08:00'
     restart: always
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ginkgo
@@ -216,7 +216,7 @@ services:
       --default-time-zone='+08:00'
     restart: always
     ports:
-      - "13306:3306"
+      - "127.0.0.1:13306:3306"
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ginkgo
@@ -243,9 +243,9 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - "8123:8123"
-      - "9000:9000"
-      - "9009:9009"
+      - "127.0.0.1:8123:8123"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9009:9009"
     volumes:
       - .logs/clickhouse:/var/log/clickhouse-server
       - .conf/clickhouse_users.xml:/etc/clickhouse-server/users.xml
@@ -270,9 +270,9 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - "18123:8123"
-      - "19000:9000"
-      - "19009:9009"
+      - "127.0.0.1:18123:8123"
+      - "127.0.0.1:19000:9000"
+      - "127.0.0.1:19009:9009"
     volumes:
       - .logs/clickhouse_test:/var/log/clickhouse-server
       - .conf/clickhouse_users.xml:/etc/clickhouse-server/users.xml
@@ -355,10 +355,10 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-change-me-randomize-in-env}
       - GF_SERVER_ROOT_URL=http://localhost:3000
       - GF_INSTALL_PLUGINS=grafana-clickhouse-datasource
     volumes:
@@ -387,7 +387,7 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - "8686:8686"  # Vector metrics API
+      - "127.0.0.1:8686:8686"  # Vector metrics API
     volumes:
       # Vector configuration
       - .conf/vector.toml:/etc/vector/vector.toml:ro
@@ -427,7 +427,7 @@ services:
         max-size: "100m"
         max-file: "3"
     ports:
-      - '27017:27017'
+      - '127.0.0.1:27017:27017'
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_INITDB_ROOT_USERNAME}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
@@ -477,8 +477,8 @@ services:
     command: ["python", "main.py", "serve", "tasktimer"]
     volumes:
       - ginkgo-logs:/var/log/ginkgo
-      # 映射用户配置目录中的 task_timer.yml（容器内读取 /root/.ginkgo/task_timer.yml）
-      - ${HOME}/.ginkgo/task_timer.yml:/root/.ginkgo/task_timer.yml:ro
+      # 映射用户配置目录中的 task_timer.yml（容器内读取非 root 用户 HOME）
+      - ${HOME}/.ginkgo/task_timer.yml:/home/ginkgo/.ginkgo/task_timer.yml:ro
     deploy:
       resources:
         limits:
@@ -501,8 +501,8 @@ services:
     command: ["python", "main.py", "serve", "livecore"]
     volumes:
       - ginkgo-logs:/var/log/ginkgo
-      # 映射用户配置目录中的 task_timer.yml（容器内读取 /root/.ginkgo/task_timer.yml）
-      - ${HOME}/.ginkgo/task_timer.yml:/root/.ginkgo/task_timer.yml:ro
+      # 映射用户配置目录中的 task_timer.yml（容器内读取非 root 用户 HOME）
+      - ${HOME}/.ginkgo/task_timer.yml:/home/ginkgo/.ginkgo/task_timer.yml:ro
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
   #     context: .
   #     dockerfile: .conf/Dockerfile.web
   #   ports:
-  #     - '80:80'
+  #     - '127.0.0.1:8080:8080'
   #   volumes:
   #     - .conf/nginx.conf:/etc/nginx/nginx.conf
   kafka1:


### PR DESCRIPTION
## Summary
- Run Ginkgo worker/API/web images as non-root users by default.
- Bind active development service ports to `127.0.0.1` instead of all interfaces.
- Disable Kafka topic auto-create by default while keeping an env override.
- Remove Grafana `admin` password fallback and update `.env.example` to require a local strong password.
- Move worker task timer config mounts from `/root` to the non-root home path.

## Verification
- `docker compose config` passes (only existing unset `.env` warnings are emitted).
- Static check: no active bare `host:container` port bindings remain in `docker-compose.yml`.
- Static check: `.conf/Dockerfile.ginkgo`, `.conf/Dockerfile.api-server`, and `.conf/Dockerfile.web` all contain `USER`.
- `git diff --check`

Closes #5572
