### PR TITLE
refactor(cli): add ADR-021 JSON output for list/get commands (#6580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,14 @@ jobs:
         run: |
           uv run python -m pytest tests/unit/data/services/test_page_size_passthrough_smoke.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: list count_X smoke (#5009 metadata.total)
+        # count_signals/count_orders/count_records/count_positions + get_positions_df(page=)
+        # 是本 PR 新增可执行行，被 containers import 链触达但 smoke 不调方法体 → 门禁红。
+        # 用 mock 依赖（result count_positions/get_positions_df inline 实例化 PositionRecordCRUD
+        # → patch 类构造）补覆盖信号。
+        run: |
+          uv run python -m pytest tests/unit/data/services/test_list_count_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
@@ -122,6 +130,7 @@ jobs:
             tests/unit/client/test_user_cli.py \
             tests/unit/data/mappers/test_bar_mapper.py \
             tests/unit/data/services/test_page_size_passthrough_smoke.py \
+            tests/unit/data/services/test_list_count_smoke.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,14 @@ jobs:
         run: |
           uv run python -m pytest tests/unit/client/test_user_cli.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: page_size passthrough smoke (#6652 ADR-021 L139)
+        # service 层 page_size 透传 crud 的 3 个出口方法（engine get_engines_df/
+        # fuzzy_search、portfolio get_portfolios_df）被 containers import 链触达
+        # （class 定义行 executed → 非 exempt）但 smoke 不调其方法体，函数体内
+        # page_size 透传行无覆盖信号。此处用 mock 依赖补信号，供 #6685 门禁采集。
+        run: |
+          uv run python -m pytest tests/unit/data/services/test_page_size_passthrough_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
@@ -113,6 +121,7 @@ jobs:
             tests/unit/features/test_containers.py \
             tests/unit/client/test_user_cli.py \
             tests/unit/data/mappers/test_bar_mapper.py \
+            tests/unit/data/services/test_page_size_passthrough_smoke.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,23 @@ jobs:
         run: |
           uv run python -m pytest tests/unit/data/services/test_list_count_smoke.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: deployment_service list/count smoke (#5009 pagination)
+        # DeploymentService.list_deployments(page=,page_size=)→find(order_by/desc) +
+        # count_deployments→count 是本 PR 新增可执行行，被 containers import 链触达但
+        # smoke 不调方法体 → 门禁红。用 mock 依赖补覆盖信号。
+        run: |
+          uv run python -m pytest tests/unit/trading/services/test_deployment_list_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
+      - name: deploy_cli + record_cli list smoke (#5009 pagination CliRunner)
+        # deploy_cli.list_deployments / record_cli(signal,order,position,analyzer) 为本 PR
+        # 重构（offset 分页 + ADR-021 json envelope + count metadata.total）。CliRunner +
+        # mock container 补命令体覆盖信号，使这些文件脱离 diff coverage gate 豁免（非
+        # list 命令仍豁免：portfolio_cli/engine_cli/flat_cli 的 get/create 等需另开 smoke）。
+        run: |
+          uv run python -m pytest \
+            tests/unit/client/test_deploy_cli_list_smoke.py \
+            tests/unit/client/test_record_cli_list_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
@@ -131,6 +148,9 @@ jobs:
             tests/unit/data/mappers/test_bar_mapper.py \
             tests/unit/data/services/test_page_size_passthrough_smoke.py \
             tests/unit/data/services/test_list_count_smoke.py \
+            tests/unit/trading/services/test_deployment_list_smoke.py \
+            tests/unit/client/test_deploy_cli_list_smoke.py \
+            tests/unit/client/test_record_cli_list_smoke.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/docs/adrs/ADR-021-cli-output-layer.md
+++ b/docs/adrs/ADR-021-cli-output-layer.md
@@ -137,6 +137,7 @@ class GinkgoJSONEncoder(json.JSONEncoder):
 ### 翻页条款（补充）
 - `--page-size N`：**表现层交互翻页**，仅 TTY + 非 JSON 模式生效；JSON 模式忽略
 - `--limit N` + `--offset N`：客户端分页，直通 `service.list(page_size=N, page=offset/N+1)`，所有模式生效
+- **过渡态（service 出口未透传 page_size 的命令）**：portfolio/engine/component list 暂用 client-side `head(limit)`/`[:limit]`。CRUD 层 `BaseCRUD.find` 已有 `page`/`page_size` 形参，但 service 出口方法 `get_portfolios_df`/`get_engines_df` 未透传 page_size；component 更绕过 service 直调 `file_crud.find(page_size=10000)` 硬编码。补 service 分页跟踪于 #6690，落地后 CLI 改直通。`data get` 各子类型（#6650）已合规。
 - **三层分页概念**：表现层翻页（--page-size，全量加载后切片显示）/ 截断（--limit，head/tail）/ 服务端分页（service.list page 参数，查一次取一页）
 - 表现层翻页不解决"查询 OOM"（全量加载后才切片），百万级数据靠服务端分页
 

--- a/docs/adrs/ADR-021-cli-output-layer.md
+++ b/docs/adrs/ADR-021-cli-output-layer.md
@@ -137,7 +137,6 @@ class GinkgoJSONEncoder(json.JSONEncoder):
 ### 翻页条款（补充）
 - `--page-size N`：**表现层交互翻页**，仅 TTY + 非 JSON 模式生效；JSON 模式忽略
 - `--limit N` + `--offset N`：客户端分页，直通 `service.list(page_size=N, page=offset/N+1)`，所有模式生效
-- **过渡态（service 出口未透传 page_size 的命令）**：portfolio/engine/component list 暂用 client-side `head(limit)`/`[:limit]`。CRUD 层 `BaseCRUD.find` 已有 `page`/`page_size` 形参，但 service 出口方法 `get_portfolios_df`/`get_engines_df` 未透传 page_size；component 更绕过 service 直调 `file_crud.find(page_size=10000)` 硬编码。补 service 分页跟踪于 #6690，落地后 CLI 改直通。`data get` 各子类型（#6650）已合规。
 - **三层分页概念**：表现层翻页（--page-size，全量加载后切片显示）/ 截断（--limit，head/tail）/ 服务端分页（service.list page 参数，查一次取一页）
 - 表现层翻页不解决"查询 OOM"（全量加载后才切片），百万级数据靠服务端分页
 

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -463,11 +463,29 @@ def list_tasks(
 
     service = container.backtest_task_service()
     effective_page_size = limit or page_size
-    result = service.list(page=page, page_size=effective_page_size, portfolio_id=portfolio, status=status)
+    try:
+        result = service.list(page=page, page_size=effective_page_size, portfolio_id=portfolio, status=status)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        # ADR-021 第 1/5 维：JSON 模式 stdout 永远合法 JSON（异常=INTERNAL 错误对象）+ exit 1。
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="list",
+            )
+        else:
+            console.print(f":x: Error: {e}")
+            raise typer.Exit(1)
 
     if not result.is_success():
-        console.print(f":x: {result.error}")
-        raise typer.Exit(1)
+        # ADR-021 第 5/6 维：JSON 模式发错误 envelope + exit 1；text 模式诊断 + exit 1。
+        if format == "json":
+            format_result(result, format="json", command="list")
+        else:
+            console.print(f":x: {result.error}")
+            raise typer.Exit(1)
 
     data = result.data
     tasks = data.get("data", [])
@@ -537,22 +555,37 @@ def cat_task(
         if fuzzy_result.is_success() and fuzzy_result.data and len(fuzzy_result.data) == 1:
             result = ServiceResult.success(fuzzy_result.data[0])
         elif fuzzy_result.is_success() and fuzzy_result.data and len(fuzzy_result.data) > 1:
-            console.print(f"[yellow]Fuzzy match found {len(fuzzy_result.data)} tasks:[/yellow]\n")
-            table = Table(show_header=True, header_style="bold")
-            table.add_column("UUID", style="cyan")
-            table.add_column("Name")
-            table.add_column("Status")
-            table.add_column("Created")
-            for t in fuzzy_result.data:
-                table.add_row(
-                    t.uuid[:12] + "...",
-                    t.name or "-",
-                    t.status or "-",
-                    str(t.create_at)[:-7] if t.create_at else "-",
+            if format == "json":
+                # ADR-021 第 1/5 维：JSON 模式不发 rich table（非 JSON），改发错误 envelope + exit 1。
+                candidates = ", ".join(
+                    (t.uuid[:12] if hasattr(t, "uuid") else str(t.get("uuid", ""))[:12])
+                    for t in fuzzy_result.data
                 )
-            console.print(table)
-            console.print(f"\n[yellow]Please use a more specific identifier.[/yellow]")
-            raise typer.Exit(1)
+                format_result(
+                    ServiceResult.failure(
+                        message=f"Multiple tasks match '{task_id}': {candidates}",
+                        code="VALIDATION_ERROR",
+                    ),
+                    format="json",
+                    command="get",
+                )
+            else:
+                console.print(f"[yellow]Fuzzy match found {len(fuzzy_result.data)} tasks:[/yellow]\n")
+                table = Table(show_header=True, header_style="bold")
+                table.add_column("UUID", style="cyan")
+                table.add_column("Name")
+                table.add_column("Status")
+                table.add_column("Created")
+                for t in fuzzy_result.data:
+                    table.add_row(
+                        t.uuid[:12] + "...",
+                        t.name or "-",
+                        t.status or "-",
+                        str(t.create_at)[:-7] if t.create_at else "-",
+                    )
+                console.print(table)
+                console.print(f"\n[yellow]Please use a more specific identifier.[/yellow]")
+                raise typer.Exit(1)
 
     if not result.is_success():
         if format == "json":

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -462,10 +462,84 @@ def list_tasks(
     """:clipboard: List backtest tasks."""
     from ginkgo.data.containers import container
 
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope（#6652 review R3-issue1）。
+    if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page must be >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
+        console.print("[red]:x: --page must be >= 0[/red]")
+        raise typer.Exit(2)
+    if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size must be >= 0 (0 = all)", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
+        console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
+        raise typer.Exit(2)
+
     service = container.backtest_task_service()
     effective_page_size = limit or page_size
+    # ADR-021 第 1/5 维：整段包 try，JSON 模式 stdout 永远合法 JSON。
+    # _task_record 逐条 DB enrichment（config_snapshot 查询）异常也走 INTERNAL envelope，非裸 traceback（#6652 review R3-issue2）。
     try:
         result = service.list(page=page, page_size=effective_page_size, portfolio_id=portfolio, status=status)
+
+        if not result.is_success():
+            # ADR-021 第 5/6 维：JSON 模式发错误 envelope + exit 1；text 模式诊断 + exit 1。
+            if format == "json":
+                format_result(result, format="json", command="list")
+            else:
+                console.print(f":x: {result.error}")
+                raise typer.Exit(1)
+
+        data = result.data
+        tasks = data.get("data", [])
+        total = data.get("total", 0)
+
+        if format == "json":
+            records = [_task_record(task) for task in tasks]
+            json_result = build_list_result(
+                records, total=total, limit=effective_page_size, offset=page * effective_page_size
+            )
+            format_result(json_result, format="json", command="list")
+            return
+
+        if not tasks:
+            console.print(":memo: No backtest tasks found.")
+            return
+
+        table = Table(title=":chart_with_upwards_trend: Backtest Tasks")
+        table.add_column("UUID", style="dim", width=12)
+        table.add_column("Name", style="bold", width=20)
+        table.add_column("Portfolio", width=12)
+        table.add_column("Status", width=12)
+        table.add_column("Progress", width=8)
+        table.add_column("Created", width=19)
+
+        for task in tasks:
+            uuid_str = task.uuid[:12] if hasattr(task, "uuid") else str(task.get("uuid", ""))[:12]
+            name = task.name if hasattr(task, "name") else task.get("name", "")
+            portfolio_id = (
+                task.portfolio_id[:12] if hasattr(task, "portfolio_id") else str(task.get("portfolio_id", ""))[:12]
+            )
+            status_val = task.status if hasattr(task, "status") else task.get("status", "")
+            raw_progress = task.progress if hasattr(task, "progress") else task.get("progress", 0)
+            progress = _display_progress(status_val, raw_progress)
+            created = str(task.create_at)[:19] if hasattr(task, "create_at") else ""
+
+            status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(status_val, "white")
+
+            table.add_row(
+                uuid_str,
+                name[:20],
+                portfolio_id,
+                f"[{status_style}]{status_val}[/{status_style}]",
+                f"{int(progress)}%" if isinstance(progress, (int, float)) else str(progress),
+                created,
+            )
+
+        console.print(table)
+        console.print(f"\n  Total: {total} tasks (Page {page}, size {effective_page_size})")
     except typer.Exit:
         raise
     except Exception as e:
@@ -479,63 +553,6 @@ def list_tasks(
         else:
             console.print(f":x: Error: {e}")
             raise typer.Exit(1)
-
-    if not result.is_success():
-        # ADR-021 第 5/6 维：JSON 模式发错误 envelope + exit 1；text 模式诊断 + exit 1。
-        if format == "json":
-            format_result(result, format="json", command="list")
-        else:
-            console.print(f":x: {result.error}")
-            raise typer.Exit(1)
-
-    data = result.data
-    tasks = data.get("data", [])
-    total = data.get("total", 0)
-
-    if format == "json":
-        records = [_task_record(task) for task in tasks]
-        json_result = build_list_result(
-            records, total=total, limit=effective_page_size, offset=page * effective_page_size
-        )
-        format_result(json_result, format="json", command="list")
-        return
-
-    if not tasks:
-        console.print(":memo: No backtest tasks found.")
-        return
-
-    table = Table(title=":chart_with_upwards_trend: Backtest Tasks")
-    table.add_column("UUID", style="dim", width=12)
-    table.add_column("Name", style="bold", width=20)
-    table.add_column("Portfolio", width=12)
-    table.add_column("Status", width=12)
-    table.add_column("Progress", width=8)
-    table.add_column("Created", width=19)
-
-    for task in tasks:
-        uuid_str = task.uuid[:12] if hasattr(task, "uuid") else str(task.get("uuid", ""))[:12]
-        name = task.name if hasattr(task, "name") else task.get("name", "")
-        portfolio_id = (
-            task.portfolio_id[:12] if hasattr(task, "portfolio_id") else str(task.get("portfolio_id", ""))[:12]
-        )
-        status_val = task.status if hasattr(task, "status") else task.get("status", "")
-        raw_progress = task.progress if hasattr(task, "progress") else task.get("progress", 0)
-        progress = _display_progress(status_val, raw_progress)
-        created = str(task.create_at)[:19] if hasattr(task, "create_at") else ""
-
-        status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(status_val, "white")
-
-        table.add_row(
-            uuid_str,
-            name[:20],
-            portfolio_id,
-            f"[{status_style}]{status_val}[/{status_style}]",
-            f"{int(progress)}%" if isinstance(progress, (int, float)) else str(progress),
-            created,
-        )
-
-    console.print(table)
-    console.print(f"\n  Total: {total} tasks (Page {page}, size {effective_page_size})")
 
 
 @app.command("cat")

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -98,6 +98,8 @@ def _task_record(task) -> dict:
         "end_time": str(end_time) if end_time is not None else None,
         "duration_seconds": _get("duration_seconds"),
         "error_message": _get("error_message"),
+        # config_snapshot：回测配置快照（text 路径 Config panel；#6652 review E6 补齐 _task_record 覆盖声明）。
+        "config_snapshot": _get("config_snapshot"),
     }
 
 
@@ -456,7 +458,6 @@ def list_tasks(
     page: int = typer.Option(0, "--page", help="Page number"),
     limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Limit results"),
     format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
-    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """:clipboard: List backtest tasks."""
     from ginkgo.data.containers import container
@@ -541,7 +542,6 @@ def list_tasks(
 def cat_task(
     task_id: str = typer.Argument(help="Task UUID or task_id"),
     format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
-    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """:mag: Show backtest task details."""
     from ginkgo.data.containers import container

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -54,18 +54,50 @@ def _emit_backtest_failure(result):
 
 
 def _task_record(task) -> dict:
+    """序列化 backtest task 为 JSON record。
+
+    覆盖 text 路径（cat_task）渲染的全部字段：元数据 + 回测结果 metrics +
+    statistics + 执行信息。ADR-021：--format json 让机读消费者在 JSON 路径拿到
+    与 text 等量的结构化回测结果，避免 text/json 信息量不对称（#6580 review）。
+    _task_record 被 list/cat 共用，list 每个 record 同步带上 metrics。
+    """
+
+    def _get(name, default=None):
+        # 兼容 model 实例 / MagicMock / dict（fuzzy_search 返回）
+        if hasattr(task, name):
+            return getattr(task, name)
+        return task.get(name, default)
+
+    status_val = _get("status", "")
+    start_time = _get("start_time")
+    end_time = _get("end_time")
     return {
-        "uuid": str(task.uuid if hasattr(task, "uuid") else task.get("uuid", "")),
-        "task_id": str(task.task_id if hasattr(task, "task_id") else task.get("task_id", "")),
-        "name": task.name if hasattr(task, "name") else task.get("name", ""),
-        "portfolio_id": task.portfolio_id if hasattr(task, "portfolio_id") else task.get("portfolio_id", ""),
-        "engine_id": task.engine_id if hasattr(task, "engine_id") else task.get("engine_id", ""),
-        "status": task.status if hasattr(task, "status") else task.get("status", ""),
-        "progress": _display_progress(
-            task.status if hasattr(task, "status") else task.get("status", ""),
-            task.progress if hasattr(task, "progress") else task.get("progress", 0),
-        ),
-        "created_at": str(task.create_at) if hasattr(task, "create_at") else str(task.get("create_at", "")),
+        # 元数据
+        "uuid": str(_get("uuid", "")),
+        "task_id": str(_get("task_id", "")),
+        "name": _get("name", ""),
+        "portfolio_id": _get("portfolio_id", ""),
+        "engine_id": _get("engine_id", ""),
+        "status": status_val,
+        "progress": _display_progress(status_val, _get("progress", 0)),
+        "created_at": str(_get("create_at", "")),
+        # 回测结果 metrics（text 路径 Results panel）
+        "final_portfolio_value": _get("final_portfolio_value", 0.0),
+        "total_pnl": _get("total_pnl", 0.0),
+        "max_drawdown": _get("max_drawdown", 0.0),
+        "sharpe_ratio": _get("sharpe_ratio", 0.0),
+        "annual_return": _get("annual_return", 0.0),
+        "win_rate": _get("win_rate", 0.0),
+        # 回测统计（text 路径 Statistics panel）
+        "total_signals": _get("total_signals", 0),
+        "total_orders": _get("total_orders", 0),
+        "total_positions": _get("total_positions", 0),
+        "total_events": _get("total_events", 0),
+        # 执行信息（None 原样保留，机读判 completed/failed 需要）
+        "start_time": str(start_time) if start_time is not None else None,
+        "end_time": str(end_time) if end_time is not None else None,
+        "duration_seconds": _get("duration_seconds"),
+        "error_message": _get("error_message"),
     }
 
 

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -454,7 +454,7 @@ def list_tasks(
     status: Optional[str] = typer.Option(
         None, "--status", "-s", help="Filter by status (pending/running/completed/failed)"
     ),
-    page_size: int = typer.Option(20, "--page-size", help="Items per page"),
+    page_size: int = typer.Option(20, "--page-size", help="Items per page (0 = all)"),
     page: int = typer.Option(0, "--page", help="Page number"),
     limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Limit results"),
     format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.client.cli_utils import build_list_result, format_result
 
 console = Console(emoji=True, legacy_windows=False)
 app = typer.Typer(
@@ -52,6 +53,22 @@ def _emit_backtest_failure(result):
         console.print(preflight_warning)
 
 
+def _task_record(task) -> dict:
+    return {
+        "uuid": str(task.uuid if hasattr(task, "uuid") else task.get("uuid", "")),
+        "task_id": str(task.task_id if hasattr(task, "task_id") else task.get("task_id", "")),
+        "name": task.name if hasattr(task, "name") else task.get("name", ""),
+        "portfolio_id": task.portfolio_id if hasattr(task, "portfolio_id") else task.get("portfolio_id", ""),
+        "engine_id": task.engine_id if hasattr(task, "engine_id") else task.get("engine_id", ""),
+        "status": task.status if hasattr(task, "status") else task.get("status", ""),
+        "progress": _display_progress(
+            task.status if hasattr(task, "status") else task.get("status", ""),
+            task.progress if hasattr(task, "progress") else task.get("progress", 0),
+        ),
+        "created_at": str(task.create_at) if hasattr(task, "create_at") else str(task.get("create_at", "")),
+    }
+
+
 @app.command("create")
 def create_task(
     portfolio: str = typer.Option(..., "--portfolio", "-p", help="Portfolio UUID (required)"),
@@ -73,9 +90,7 @@ def create_task(
         start_date = datetime.strptime(start, "%Y-%m-%d")
         end_date = datetime.strptime(end, "%Y-%m-%d")
     except ValueError:
-        console.print(
-            f":x: 日期格式无效，要求 YYYY-MM-DD；start={start} end={end}"
-        )
+        console.print(f":x: 日期格式无效，要求 YYYY-MM-DD；start={start} end={end}")
         raise typer.Exit(1)
 
     # 校验日期范围（#5993：end 早于 start 拒绝）
@@ -86,9 +101,7 @@ def create_task(
     # 未来日期警告（#6009：未来日期无历史数据，警告但不阻断）
     today = datetime.now().date()
     if start_date.date() > today or end_date.date() > today:
-        console.print(
-            f":warning: 警告：start={start} 或 end={end} 为未来日期，该区间可能无历史数据"
-        )
+        console.print(f":warning: 警告：start={start} 或 end={end} 为未来日期，该区间可能无历史数据")
 
     # 校验 cash 为正（#5983/#6004：拒绝非正现金，避免回测以零/负资金运行）
     if cash <= 0:
@@ -97,9 +110,7 @@ def create_task(
 
     # 范围外警告（#6004：极端 cash 警告但不阻断，建议合理范围 1,000~10,000,000,000）
     if cash < 1000 or cash > 10_000_000_000:
-        console.print(
-            f":warning: 警告：cash={cash} 超出建议范围（1,000~10,000,000,000），结果可能无意义"
-        )
+        console.print(f":warning: 警告：cash={cash} 超出建议范围（1,000~10,000,000,000），结果可能无意义")
 
     # 校验 portfolio 存在
     portfolio_service = container.portfolio_service()
@@ -198,9 +209,11 @@ def run_task(
         from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAggregator
 
         orchestrator = BacktestOrchestrator(
-            assembly_service=container.engine_assembly_service()
-                if hasattr(container, 'engine_assembly_service')
-                else services.trading.services.engine_assembly_service(),
+            assembly_service=(
+                container.engine_assembly_service()
+                if hasattr(container, "engine_assembly_service")
+                else services.trading.services.engine_assembly_service()
+            ),
             portfolio_service=container.portfolio_service(),
             task_service=service,
             result_aggregator=BacktestResultAggregator(
@@ -232,6 +245,7 @@ def run_task(
         console.print()
 
         if bg:
+
             def _run_in_thread():
                 # #6449 re-review 守卫：bg 线程内 run_from_task 在到达自带 try/except 的
                 # self.run() 之前有未包裹抛异常路径（_json.loads / preflight_data_coverage
@@ -291,6 +305,7 @@ def run_task(
             # 灌入日志到 ClickHouse（静默降级）
             try:
                 from ginkgo.services.logging.log_ingester import LogIngester
+
                 ingester = LogIngester()
                 ingest_result = ingester.ingest_task_logs(task.uuid)
                 if ingest_result.inserted > 0:
@@ -337,7 +352,9 @@ def edit_task(
         console.print(":x: Cannot edit a completed task.")
         raise typer.Exit(1)
 
-    config_snapshot = json.loads(task.config_snapshot) if isinstance(task.config_snapshot, str) else task.config_snapshot
+    config_snapshot = (
+        json.loads(task.config_snapshot) if isinstance(task.config_snapshot, str) else task.config_snapshot
+    )
 
     if start:
         config_snapshot["start_date"] = start
@@ -400,15 +417,21 @@ def delete_task(
 @app.command("list")
 def list_tasks(
     portfolio: Optional[str] = typer.Option(None, "--portfolio", "-p", help="Filter by portfolio UUID"),
-    status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (pending/running/completed/failed)"),
+    status: Optional[str] = typer.Option(
+        None, "--status", "-s", help="Filter by status (pending/running/completed/failed)"
+    ),
     page_size: int = typer.Option(20, "--page-size", help="Items per page"),
     page: int = typer.Option(0, "--page", help="Page number"),
+    limit: Optional[int] = typer.Option(None, "--limit", "-l", help="Limit results"),
+    format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """:clipboard: List backtest tasks."""
     from ginkgo.data.containers import container
 
     service = container.backtest_task_service()
-    result = service.list(page=page, page_size=page_size, portfolio_id=portfolio, status=status)
+    effective_page_size = limit or page_size
+    result = service.list(page=page, page_size=effective_page_size, portfolio_id=portfolio, status=status)
 
     if not result.is_success():
         console.print(f":x: {result.error}")
@@ -417,6 +440,14 @@ def list_tasks(
     data = result.data
     tasks = data.get("data", [])
     total = data.get("total", 0)
+
+    if format == "json":
+        records = [_task_record(task) for task in tasks]
+        json_result = build_list_result(
+            records, total=total, limit=effective_page_size, offset=page * effective_page_size
+        )
+        format_result(json_result, format="json", command="list")
+        return
 
     if not tasks:
         console.print(":memo: No backtest tasks found.")
@@ -434,17 +465,14 @@ def list_tasks(
         uuid_str = task.uuid[:12] if hasattr(task, "uuid") else str(task.get("uuid", ""))[:12]
         name = task.name if hasattr(task, "name") else task.get("name", "")
         portfolio_id = (
-            task.portfolio_id[:12] if hasattr(task, "portfolio_id")
-            else str(task.get("portfolio_id", ""))[:12]
+            task.portfolio_id[:12] if hasattr(task, "portfolio_id") else str(task.get("portfolio_id", ""))[:12]
         )
         status_val = task.status if hasattr(task, "status") else task.get("status", "")
         raw_progress = task.progress if hasattr(task, "progress") else task.get("progress", 0)
         progress = _display_progress(status_val, raw_progress)
         created = str(task.create_at)[:19] if hasattr(task, "create_at") else ""
 
-        status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(
-            status_val, "white"
-        )
+        status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(status_val, "white")
 
         table.add_row(
             uuid_str,
@@ -456,12 +484,14 @@ def list_tasks(
         )
 
     console.print(table)
-    console.print(f"\n  Total: {total} tasks (Page {page}, size {page_size})")
+    console.print(f"\n  Total: {total} tasks (Page {page}, size {effective_page_size})")
 
 
 @app.command("cat")
 def cat_task(
     task_id: str = typer.Argument(help="Task UUID or task_id"),
+    format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """:mag: Show backtest task details."""
     from ginkgo.data.containers import container
@@ -493,10 +523,21 @@ def cat_task(
             raise typer.Exit(1)
 
     if not result.is_success():
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Backtest task not found: {task_id}", code="NOT_FOUND"),
+                format="json",
+                command="get",
+            )
+            return
         console.print(f":x: {result.error}")
         raise typer.Exit(1)
 
     task = result.data
+
+    if format == "json":
+        format_result(ServiceResult.success(data=_task_record(task)), format="json", command="get")
+        return
 
     # -- Basic info --
     info_lines = []
@@ -507,9 +548,7 @@ def cat_task(
     info_lines.append(f"[bold]Portfolio:[/bold]    {task.portfolio_id}")
     info_lines.append(f"[bold]Engine:[/bold]       {task.engine_id}")
     status_val = task.status
-    status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(
-        status_val, "white"
-    )
+    status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(status_val, "white")
     info_lines.append(f"[bold]Status:[/bold]       [{status_style}]{status_val}[/{status_style}]")
     display_progress = _display_progress(status_val, task.progress)
     info_lines.append(f"[bold]Progress:[/bold]     {display_progress}%")
@@ -530,11 +569,7 @@ def cat_task(
     # -- Configuration --
     if task.config_snapshot:
         try:
-            config = (
-                json.loads(task.config_snapshot)
-                if isinstance(task.config_snapshot, str)
-                else task.config_snapshot
-            )
+            config = json.loads(task.config_snapshot) if isinstance(task.config_snapshot, str) else task.config_snapshot
             config_lines = []
             config_lines.append(f"[bold]Start Date:[/bold]     {config.get('start_date', 'N/A')}")
             config_lines.append(f"[bold]End Date:[/bold]       {config.get('end_date', 'N/A')}")
@@ -578,10 +613,12 @@ def cat_task(
                 stats_lines.append(f"[bold]{label}:[/bold] {value}")
         console.print(Panel("\n".join(stats_lines), title=":1234: Statistics"))
     elif status_val == "completed":
-        console.print(Panel(
-            "[yellow]⚠️ No trades generated — selector may have returned empty symbols.[/yellow]",
-            title=":warning: Warning",
-        ))
+        console.print(
+            Panel(
+                "[yellow]⚠️ No trades generated — selector may have returned empty symbols.[/yellow]",
+                title=":warning: Warning",
+            )
+        )
 
 
 def _save_results(service, task_uuid: str, engine, portfolio_id: str):
@@ -603,8 +640,10 @@ def _save_results(service, task_uuid: str, engine, portfolio_id: str):
         )
         if not result.is_success():
             from ginkgo.libs import GLOG
+
             GLOG.ERROR(f"Failed to aggregate results for {task_uuid[:8]}: {result.error}")
 
     except Exception as e:
         from ginkgo.libs import GLOG
+
         GLOG.ERROR(f"Failed to save results for {task_uuid[:8]}: {e}")

--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -4,6 +4,7 @@
 
 
 import json
+import math
 import os
 import sys
 from datetime import date, datetime
@@ -223,6 +224,9 @@ class GinkgoJSONEncoder(json.JSONEncoder):
     - SQLAlchemy DeclarativeBase → 列字典（isinstance 判定，非 ``hasattr(__table__)``）
     - 未识别类型 → ``raise TypeError``（响亮失败，json 标准契约；非 ``super().default()`` 兜底）
     - DataFrame → ``to_dict('records')``（每行一对象，jq 友好）
+    - NaN/±Inf → ``None``（``allow_nan=False`` 标准 JSON 契约；float 是原生类型，
+      ``default()`` 在 C 层直出非法 ``NaN``/``Infinity`` token 前拦不到，故各分支
+      返回值 + 出口 payload 双重 ``_sanitize_json`` 预处理）
     """
 
     def default(self, obj):
@@ -236,19 +240,21 @@ class GinkgoJSONEncoder(json.JSONEncoder):
         if isinstance(obj, UUID):
             return str(obj)
         if isinstance(obj, pd.DataFrame):
-            return obj.to_dict("records")
+            return _sanitize_json(obj.to_dict("records"))
         # pydantic v2 BaseModel —— isinstance 替代 hasattr，防 MagicMock duck-trap 无限递归
         try:
             from pydantic import BaseModel
             if isinstance(obj, BaseModel):
-                return obj.model_dump(mode="json")
+                return _sanitize_json(obj.model_dump(mode="json"))
         except ImportError:
             pass
         # SQLAlchemy ORM Model —— isinstance(DeclarativeBase) 替代 hasattr(__table__)
         try:
             from sqlalchemy.orm import DeclarativeBase
             if isinstance(obj, DeclarativeBase):
-                return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+                return _sanitize_json(
+                    {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+                )
         except ImportError:
             pass
         # 未识别类型：显式 TypeError（json 标准契约，响亮失败而非无限递归 OOM）
@@ -328,6 +334,25 @@ def make_progress(*, format: str, isatty: bool) -> Optional["Progress"]:
     )
 
 
+def _sanitize_json(obj):
+    """递归将非有限浮点（NaN / +Inf / -Inf）转为 ``None``。
+
+    ``json.dumps`` 默认 ``allow_nan=True`` 会在 C 层直出 ``NaN`` / ``Infinity`` token，
+    非合法 JSON（jq / JS ``JSON.parse`` / Java 严格解析均失败）。``float`` 是原生可
+    序列化类型，``GinkgoJSONEncoder.default()`` 在 C 层输出 token 前拦不到，故序列化
+    前显式清洗；配合 ``json.dumps(..., allow_nan=False)`` 作硬断言（sanitizer 漏网时
+    响亮报错而非静默吐非法 token）。命中场景：ClickHouse 稀疏数值（record_cli 的
+    signal/order/position/analyzer）、新建组合未设 current_capital/cash（portfolio list）。
+    """
+    if isinstance(obj, float):
+        return None if not math.isfinite(obj) else obj
+    if isinstance(obj, dict):
+        return {k: _sanitize_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize_json(v) for v in obj]
+    return obj
+
+
 def format_result(result, *, format: str, command: str) -> None:
     """统一 ServiceResult → stdout JSON 输出 + exit code 映射（ADR-021 第 5/6/9 维）。
 
@@ -378,7 +403,7 @@ def format_result(result, *, format: str, command: str) -> None:
         else:
             # get 结构（ADR-021 第 9 维 get 类）
             payload = {"success": True, "data": data}
-        print(json.dumps(payload, cls=GinkgoJSONEncoder))
+        print(json.dumps(_sanitize_json(payload), cls=GinkgoJSONEncoder, allow_nan=False))
         # ADR-021 第 6 维：成功 = 正常 return（不显式 Exit），typer 自然 exit 0
         return
 
@@ -390,7 +415,7 @@ def format_result(result, *, format: str, command: str) -> None:
         "data": None,
         "warnings": getattr(result, "warnings", None) or [],
     }
-    print(json.dumps(payload, cls=GinkgoJSONEncoder))
+    print(json.dumps(_sanitize_json(payload), cls=GinkgoJSONEncoder, allow_nan=False))
 
     # exit code 映射（ADR-021 第 6 维）
     if code == "BAD_PARAMS":

--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -3,10 +3,6 @@
 # Role: 提供CLI通用工具函数包括获取参数/添加组件/显示树结构等辅助方法
 
 
-
-
-
-
 import json
 import os
 import sys
@@ -23,49 +19,45 @@ from ginkgo.enums import FILE_TYPES
 
 console = Console()
 
+
 def _get_component_parameters(mapping_id: str, file_id: str, file_type: FILE_TYPES) -> dict:
     """获取组件的参数信息"""
     try:
         from ginkgo.data.containers import container
-        
+
         # 从params表获取所有构造参数
         param_crud = container.cruds.param()
         params_df = param_crud.find(filters={"mapping_id": mapping_id}, order_by="index")
         params_dict = {}
-        
+
         if params_df.shape[0] > 0:
             # 显示所有参数，使用索引作为键名
             for i, param_value in enumerate(params_df["value"].values):
                 params_dict[f"param_{i}"] = param_value
-        
+
         return params_dict
-        
+
     except Exception as e:
         console.print(f"[red]Error getting parameters for {file_id}: {e}[/red]")
         return {}
 
+
 def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filter_type: Optional[FILE_TYPES]):
     """添加Portfolio的组件到树节点"""
     from ginkgo.data.containers import container
-    
+
     # 获取portfolio的文件映射（#6136: 走 mapping_service._df 出口，data 即 DataFrame）
     mapping_service = container.mapping_service()
     mappings_result = mapping_service.get_portfolio_file_mappings_df(portfolio_uuid=portfolio_id)
     portfolio_files = mappings_result.data if mappings_result.success else pd.DataFrame()
-    
+
     if portfolio_files.shape[0] == 0:
         parent_node.add("[dim]No components bound to this portfolio[/dim]")
         return
-    
+
     # 按文件类型分组
-    components = {
-        "selectors": [],
-        "sizers": [],
-        "strategies": [],
-        "risks": [],
-        "analyzers": []
-    }
-    
+    components = {"selectors": [], "sizers": [], "strategies": [], "risks": [], "analyzers": []}
+
     for _, mapping in portfolio_files.iterrows():
         file_type_value = mapping["type"]
         # 将数字转换为枚举
@@ -74,9 +66,9 @@ def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filt
             "name": mapping["name"],
             "id": mapping["file_id"],
             "mapping_id": mapping["uuid"],
-            "type": file_type
+            "type": file_type,
         }
-        
+
         if file_type == FILE_TYPES.SELECTOR:
             components["selectors"].append(component_info)
         elif file_type == FILE_TYPES.SIZER:
@@ -87,7 +79,7 @@ def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filt
             components["risks"].append(component_info)
         elif file_type == FILE_TYPES.ANALYZER:
             components["analyzers"].append(component_info)
-    
+
     # 根据filter_type筛选要显示的组件类型
     component_sections = []
     if filter_type is None:
@@ -96,7 +88,7 @@ def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filt
             ("sizers", ":balance_scale: Sizers", "sizer"),
             ("strategies", ":chart_with_upwards_trend: Strategies", "strategy"),
             ("risks", ":shield: Risk Managements", "risk"),
-            ("analyzers", ":bar_chart: Analyzers", "analyzer")
+            ("analyzers", ":bar_chart: Analyzers", "analyzer"),
         ]
     else:
         type_mapping = {
@@ -104,11 +96,11 @@ def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filt
             FILE_TYPES.SIZER: ("sizers", ":balance_scale: Sizers", "sizer"),
             FILE_TYPES.STRATEGY: ("strategies", ":chart_with_upwards_trend: Strategies", "strategy"),
             FILE_TYPES.RISKMANAGER: ("risks", ":shield: Risk Managements", "risk"),
-            FILE_TYPES.ANALYZER: ("analyzers", ":bar_chart: Analyzers", "analyzer")
+            FILE_TYPES.ANALYZER: ("analyzers", ":bar_chart: Analyzers", "analyzer"),
         }
         if filter_type in type_mapping:
             component_sections = [type_mapping[filter_type]]
-    
+
     # 显示各类组件
     for component_key, section_title, _ in component_sections:
         component_list = components[component_key]
@@ -116,33 +108,37 @@ def _add_portfolio_components(parent_node, portfolio_id: str, detail: bool, filt
             section_node = parent_node.add(f"[bold]{section_title}[/bold]")
             for component in component_list:
                 component_node = section_node.add(f"{component['name']} [dim]ID:{component['id']}[/dim]")
-                
+
                 if detail:
                     # 获取并显示组件参数详情
-                    params = _get_component_parameters(component['mapping_id'], component['id'], component['type'])
+                    params = _get_component_parameters(component["mapping_id"], component["id"], component["type"])
                     if params:
                         for param_name, param_value in params.items():
                             component_node.add(f"[cyan]{param_name}[/cyan]: [green]{param_value}[/green]")
                     else:
                         component_node.add("[dim]No parameters found[/dim]")
 
+
 def _show_portfolio_tree(portfolio_row, detail: bool, filter_type: Optional[FILE_TYPES]):
     """显示Portfolio树结构"""
-    tree = Tree(f"[bold green]Portfolio:[/bold green] {portfolio_row['name']} ([yellow]{portfolio_row['uuid']}[/yellow])")
-    _add_portfolio_components(tree, portfolio_row['uuid'], detail, filter_type)
+    tree = Tree(
+        f"[bold green]Portfolio:[/bold green] {portfolio_row['name']} ([yellow]{portfolio_row['uuid']}[/yellow])"
+    )
+    _add_portfolio_components(tree, portfolio_row["uuid"], detail, filter_type)
     console.print(tree)
+
 
 def _show_engine_tree(engine_row, detail: bool, filter_type: Optional[FILE_TYPES]):
     """显示Engine树结构"""
     from ginkgo.data.containers import container
-    
+
     tree = Tree(f"[bold blue]Engine:[/bold blue] {engine_row['name']} ([cyan]{engine_row['uuid']}[/cyan])")
-    
+
     # 获取engine关联的portfolios（#6136: 走 mapping_service._df 出口，data 即 DataFrame）
     mapping_service = container.mapping_service()
     mappings_result = mapping_service.get_engine_portfolio_mappings_df(engine_uuid=engine_row["uuid"])
     engine_portfolios = mappings_result.data if mappings_result.success else pd.DataFrame()
-    
+
     if engine_portfolios.shape[0] == 0:
         tree.add("[dim]No portfolios bound to this engine[/dim]")
     else:
@@ -153,7 +149,9 @@ def _show_engine_tree(engine_row, detail: bool, filter_type: Optional[FILE_TYPES
             portfolio_df = portfolio_service.get_portfolio(portfolio_id)
             if portfolio_df.shape[0] > 0:
                 portfolio_row = portfolio_df.iloc[0]
-                portfolio_branch = tree.add(f"[bold green]Portfolio:[/bold green] {portfolio_row['name']} ([yellow]{portfolio_id}[/yellow])")
+                portfolio_branch = tree.add(
+                    f"[bold green]Portfolio:[/bold green] {portfolio_row['name']} ([yellow]{portfolio_id}[/yellow])"
+                )
                 _add_portfolio_components(portfolio_branch, portfolio_id, detail, filter_type)
 
     console.print(tree)
@@ -276,9 +274,7 @@ def safe_confirm(
     if sys.stdin.isatty():
         return bool(typer.confirm(message, default=default))
     if require_tty:
-        raise CliConfirmError(
-            f"需要交互确认但当前非 TTY：{message!r}（用 --yes 显式跳过）"
-        )
+        raise CliConfirmError(f"需要交互确认但当前非 TTY：{message!r}（用 --yes 显式跳过）")
     return bool(default)
 
 
@@ -376,6 +372,7 @@ def format_result(result, *, format: str, command: str) -> None:
                 "success": True,
                 "data": data,
                 "count": len(data),
+                "warnings": getattr(result, "warnings", None) or [],
                 "metadata": getattr(result, "metadata", None) or {},
             }
         else:
@@ -391,6 +388,7 @@ def format_result(result, *, format: str, command: str) -> None:
         "success": False,
         "error": {"code": code, "message": error_message},
         "data": None,
+        "warnings": getattr(result, "warnings", None) or [],
     }
     print(json.dumps(payload, cls=GinkgoJSONEncoder))
 
@@ -402,3 +400,27 @@ def format_result(result, *, format: str, command: str) -> None:
     else:
         exit_code = 1
     raise typer.Exit(code=exit_code)
+
+
+def build_list_result(
+    records: list,
+    *,
+    total: Optional[int] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
+    order: Optional[str] = None,
+):
+    """Build the ADR-021 list-shaped ServiceResult used by CLI list commands.
+
+    调用方拿到 result 后自行 ``format_result(result, format="json", command=...)``，
+    统一 list 输出 helper（取代 data_cli 旧 ``_emit_json_records``）。
+    """
+    from ginkgo.data.services.base_service import ServiceResult
+
+    result = ServiceResult.success(data=records)
+    result.set_metadata("total", len(records) if total is None else total)
+    result.set_metadata("limit", limit if limit is not None else len(records))
+    result.set_metadata("offset", offset)
+    if order:
+        result.set_metadata("order", order)
+    return result

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -414,6 +414,15 @@ def get(
             df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
             if df.empty:
+                if format == "json":
+                    # ADR-021 第 9 维：空结果 exit 0 + envelope（与 stockinfo 对称），
+                    # 机读消费者拿得到结构，不能纯文本零 envelope
+                    format_result(
+                        build_list_result([], total=0, limit=limit, order="tail"),
+                        format="json",
+                        command="get",
+                    )
+                    return
                 console.print(f":information: No bar data found for {code} ({start}-{end})")
                 return
 
@@ -484,6 +493,14 @@ def get(
             df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
             if df.empty:
+                if format == "json":
+                    # ADR-021 第 9 维：空结果 exit 0 + envelope（与 stockinfo/day 对称）
+                    format_result(
+                        build_list_result([], total=0, limit=limit, order="tail"),
+                        format="json",
+                        command="get",
+                    )
+                    return
                 console.print(f":information: No tick data found for {code} ({start}-{end})")
                 return
 
@@ -560,6 +577,14 @@ def get(
             df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
             if df.empty:
+                if format == "json":
+                    # ADR-021 第 9 维：空结果 exit 0 + envelope（与 stockinfo/day/tick 对称）
+                    format_result(
+                        build_list_result([], total=0, limit=limit, order="head"),
+                        format="json",
+                        command="get",
+                    )
+                    return
                 console.print(f":information: No adjustfactor data found for {code} ({start}-{end})")
                 return
 

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -135,7 +135,9 @@ def get(
 
                 # 应用模糊过滤
                 if filter:
-                    console.print(f":mag: Applying filter: '{filter}'")
+                    # ADR-021 第1维：json 模式隔离 filter 诊断 print，stdout 保持纯 JSON（jq/json.loads 不崩）
+                    if format != "json":
+                        console.print(f":mag: Applying filter: '{filter}'")
                     filter_lower = filter.lower()
 
                     # 创建过滤条件
@@ -156,10 +158,19 @@ def get(
                     df = df[mask]
 
                     if df.empty:
+                        if format == "json":
+                            # ADR-021 第9维：空结果 exit 0 + envelope，机读消费者拿得到结构
+                            format_result(
+                                build_list_result([], total=0, limit=limit, order="head"),
+                                format="json",
+                                command="get",
+                            )
+                            return
                         console.print(":memo: No matching records found for the filter.")
                         return
 
-                    console.print(f":white_check_mark: Filter matched {len(df)} records")
+                    if format != "json":
+                        console.print(f":white_check_mark: Filter matched {len(df)} records")
 
                 # 配置列显示
                 columns_config = {

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -12,6 +12,8 @@ from typing import Optional
 from rich.console import Console
 from rich.table import Table
 
+from ginkgo.client.cli_utils import build_list_result, format_result
+
 app = typer.Typer(help=":page_facing_up: Data management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
 
@@ -64,19 +66,6 @@ class SyncStats:
         return (
             f"{type_name} sync completed. " f"Success: {self.success}, Skipped: {self.skipped}, Errors: {self.errors}"
         )
-
-
-def _emit_json_records(records: list, *, total: int, limit: Optional[int], order: Optional[str] = None) -> None:
-    from ginkgo.client.cli_utils import format_result
-    from ginkgo.data.services.base_service import ServiceResult
-
-    result = ServiceResult.success(data=records)
-    result.set_metadata("total", total)
-    result.set_metadata("limit", limit)
-    result.set_metadata("offset", 0)
-    if order:
-        result.set_metadata("order", order)
-    format_result(result, format="json", command="get")
 
 
 @app.command()
@@ -219,12 +208,13 @@ def get(
 
                 if format == "json":
                     json_df = formatted_df.head(limit) if limit is not None else formatted_df
-                    _emit_json_records(
+                    _list_result = build_list_result(
                         json_df.to_dict("records"),
                         total=total_records,
                         limit=limit,
                         order="head",
                     )
+                    format_result(_list_result, format="json", command="get")
                     return
 
                 # 交互式翻页仅在 TTY 下启用；非 TTY（CI/脚本/管道）退化为 limit 输出（#5280）
@@ -398,12 +388,13 @@ def get(
 
             if format == "json":
                 json_df = df.sort_values("timestamp").tail(limit) if limit is not None else df
-                _emit_json_records(
+                _list_result = build_list_result(
                     json_df.to_dict("records"),
                     total=len(df),
                     limit=limit,
                     order="tail",
                 )
+                format_result(_list_result, format="json", command="get")
                 return
 
             display_cols = ["code", "timestamp", "open", "high", "low", "close", "volume", "amount"]
@@ -461,12 +452,13 @@ def get(
                 # 解耦——机读场景需更多样本，1000 兼顾样本量与 stdout 友好）。
                 json_limit = limit if limit is not None else 1000
                 json_df = df.tail(json_limit) if len(df) > json_limit else df
-                _emit_json_records(
+                _list_result = build_list_result(
                     json_df.to_dict("records"),
                     total=len(df),
                     limit=json_limit,
                     order="tail",
                 )
+                format_result(_list_result, format="json", command="get")
                 return
 
             # ADR-021 第 2/3 维：tick = 分笔时序，--limit 取最新 N（tail）
@@ -522,12 +514,13 @@ def get(
 
             if format == "json":
                 json_df = df.sort_values("timestamp").head(limit) if limit is not None else df
-                _emit_json_records(
+                _list_result = build_list_result(
                     json_df.to_dict("records"),
                     total=len(df),
                     limit=limit,
                     order="head",
                 )
+                format_result(_list_result, format="json", command="get")
                 return
 
             # Raw JSON 输出（对齐 stockinfo 分支）
@@ -580,11 +573,13 @@ def get(
                     {
                         "name": name,
                         "type": cls.__name__,
-                        "configured": "yes" if token is None or token else "no",
+                        # bool 对齐既有 JSON 字段先例（notifier check_kafka_health "configured": False）
+                        "configured": token is None or bool(token),
                     }
                     for name, cls, token in configured_sources
                 ]
-                _emit_json_records(records, total=len(records), limit=None)
+                _list_result = build_list_result(records, total=len(records), limit=None)
+                format_result(_list_result, format="json", command="get")
                 return
 
             table = Table(title=":plug: Configured Data Sources", show_lines=False)

--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ginkgo.client.cli_utils import build_list_result, format_result
+from ginkgo.data.services.base_service import ServiceResult
 
 app = typer.Typer(help=":page_facing_up: Data management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -352,12 +353,27 @@ def get(
                     console.print(table)
                     console.print(f"\n:information_source: [dim]总记录数: {len(formatted_df)}[/dim]")
             else:
-                console.print(f":x: Failed to get stock info: {result.error}")
+                # ADR-021 第 5/6 维：service 失败时 JSON 模式发错误 envelope + exit 1；
+                # text 模式诊断 + exit 1（原隐式 exit 0 是 false-success，违反第 6 维）。
+                if format == "json":
+                    format_result(result, format="json", command="get")
+                else:
+                    console.print(f":x: Failed to get stock info: {result.error}")
+                    raise typer.Exit(1)
 
         elif data_type in ["day", "bars"]:
             if not code:
-                console.print(":x: Stock code required for bar data")
-                raise typer.Exit(1)
+                # ADR-021 第 5/6 维：JSON 模式发 envelope（code=None → exit 1，与 text 一致，
+                # 不升级为 BAD_PARAMS/exit 2，避免跨模式 exit 漂移破坏既有 exit-1 契约）。
+                if format == "json":
+                    format_result(
+                        ServiceResult.failure(message="Stock code required for bar data"),
+                        format="json",
+                        command="get",
+                    )
+                else:
+                    console.print(":x: Stock code required for bar data")
+                    raise typer.Exit(1)
 
             # #5920: 前缀 SH600000 → 后缀 600000.SH（DB 存后缀），与策略/回测组件格式对齐
             code = _normalize_stock_code(code)
@@ -375,8 +391,12 @@ def get(
             result = bar_service.get_bars_df(code=code, start_date=start, end_date=end)
 
             if not result.success:
-                console.print(f":x: Failed to get bar data: {result.error}")
-                raise typer.Exit(1)
+                # ADR-021 第 5/6 维：service 失败，JSON 模式发错误 envelope + exit 1。
+                if format == "json":
+                    format_result(result, format="json", command="get")
+                else:
+                    console.print(f":x: Failed to get bar data: {result.error}")
+                    raise typer.Exit(1)
 
             import pandas as pd
 
@@ -418,8 +438,15 @@ def get(
 
         elif data_type == "tick":
             if not code:
-                console.print(":x: Stock code required for tick data")
-                raise typer.Exit(1)
+                if format == "json":
+                    format_result(
+                        ServiceResult.failure(message="Stock code required for tick data"),
+                        format="json",
+                        command="get",
+                    )
+                else:
+                    console.print(":x: Stock code required for tick data")
+                    raise typer.Exit(1)
 
             from datetime import datetime, timedelta
 
@@ -435,8 +462,11 @@ def get(
             result = tick_service.get_ticks_df(code=code, start_date=start, end_date=end)
 
             if not result.success:
-                console.print(f":x: Failed to get tick data: {result.error}")
-                raise typer.Exit(1)
+                if format == "json":
+                    format_result(result, format="json", command="get")
+                else:
+                    console.print(f":x: Failed to get tick data: {result.error}")
+                    raise typer.Exit(1)
 
             import pandas as pd
 
@@ -479,8 +509,15 @@ def get(
 
         elif data_type == "adjustfactor":
             if not code:
-                console.print(":x: Stock code required for adjustfactor data")
-                raise typer.Exit(1)
+                if format == "json":
+                    format_result(
+                        ServiceResult.failure(message="Stock code required for adjustfactor data"),
+                        format="json",
+                        command="get",
+                    )
+                else:
+                    console.print(":x: Stock code required for adjustfactor data")
+                    raise typer.Exit(1)
 
             # 默认时间范围（对齐 day 分支：end 缺省补 now，start 缺省补 now-365d）
             from datetime import datetime, timedelta
@@ -501,8 +538,11 @@ def get(
             result = adjustfactor_service.get_adjustfactors_df(code=code, start_date=start_dt, end_date=end_dt)
 
             if not result.success:
-                console.print(f":x: Failed to get adjustfactor data: {result.message}")
-                raise typer.Exit(1)
+                if format == "json":
+                    format_result(result, format="json", command="get")
+                else:
+                    console.print(f":x: Failed to get adjustfactor data: {result.message}")
+                    raise typer.Exit(1)
 
             import pandas as pd
 
@@ -607,12 +647,31 @@ def get(
             console.print(":information: Data status check not yet implemented. Use 'ginkgo data status'.")
 
         else:
-            console.print(f":x: Unknown data type: {data_type}")
-            raise typer.Exit(1)
+            if format == "json":
+                format_result(
+                    ServiceResult.failure(message=f"Unknown data type: {data_type}"),
+                    format="json",
+                    command="get",
+                )
+            else:
+                console.print(f":x: Unknown data type: {data_type}")
+                raise typer.Exit(1)
 
+    except typer.Exit:
+        # ADR-021 第 6 维：typer.Exit 是 Exception 子类，须在 except Exception 前透传，
+        # 否则上面的 raise typer.Exit(N) 被吞成 exit 1 + "Error getting data" 污染。
+        raise
     except Exception as e:
-        console.print(f":x: Error getting data: {e}")
-        raise typer.Exit(1)
+        # 兜底：service 之外的意外异常（如容器装配失败）。
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Error getting data: {e}", code="INTERNAL"),
+                format="json",
+                command="get",
+            )
+        else:
+            console.print(f":x: Error getting data: {e}")
+            raise typer.Exit(1)
 
 
 @app.command()

--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -169,8 +169,11 @@ def list_deployments(
         result = svc.list_deployments(portfolio_id=portfolio_id, page=q_page, page_size=q_page_size)
 
         if not result.success:
-            console.print(f"[red]{result.error}[/red]")
-            raise typer.Exit(1)
+            if format == "json":
+                format_result(result, format="json", command="list")
+            else:
+                console.print(f"[red]{result.error}[/red]")
+                raise typer.Exit(1)
 
         records = result.data or []
         # #5009：metadata.total = count() 真实总数（非 len(records)，records 已被 page_size 截断）
@@ -214,5 +217,14 @@ def list_deployments(
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f"[red]Error: {e}[/red]")
-        raise typer.Exit(1)
+        if format == "json":
+            from ginkgo.data.services.base_service import ServiceResult
+
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="list",
+            )
+        else:
+            console.print(f"[red]Error: {e}[/red]")
+            raise typer.Exit(1)

--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -152,14 +152,22 @@ def list_deployments(
     """列出部署记录"""
     from ginkgo.trading.containers import trading_container
     from ginkgo.client.cli_utils import build_list_result, format_result
+    from ginkgo.data.services.base_service import ServiceResult
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page 必须 >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]--page 必须 >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size 必须 >= 0（0=全部）", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]--page-size 必须 >= 0（0=全部）[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size

--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -144,16 +144,46 @@ def undeploy(
 
 @app.command("list")
 def list_deployments(
-    portfolio_id: Annotated[Optional[str], typer.Option("--portfolio", "-p", help="按Portfolio ID筛选")] = None,
+    portfolio_id: Annotated[Optional[str], typer.Option("--portfolio", "-p", help="按 Portfolio ID 筛选")] = None,
+    page: int = typer.Option(0, "--page", help="页码（0-based）"),
+    page_size: int = typer.Option(20, "--page-size", help="每页条数（0=全部）"),
+    format: str = typer.Option("text", "--format", "-F", help="输出格式: text/json"),
 ):
     """列出部署记录"""
+    from ginkgo.trading.containers import trading_container
+    from ginkgo.client.cli_utils import build_list_result, format_result
+
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    if page < 0:
+        console.print("[red]--page 必须 >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]--page-size 必须 >= 0（0=全部）[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
+
     try:
-        from ginkgo.trading.containers import trading_container
-
         svc = trading_container.deployment_service()
-        result = svc.list_deployments(portfolio_id=portfolio_id)
+        result = svc.list_deployments(portfolio_id=portfolio_id, page=q_page, page_size=q_page_size)
 
-        if result.success and result.data:
+        if not result.success:
+            console.print(f"[red]{result.error}[/red]")
+            raise typer.Exit(1)
+
+        records = result.data or []
+        # #5009：metadata.total = count() 真实总数（非 len(records)，records 已被 page_size 截断）
+        count_res = svc.count_deployments(portfolio_id=portfolio_id)
+        total = count_res.data.get("count", 0) if count_res.success and isinstance(count_res.data, dict) else len(records)
+
+        if format == "json":
+            offset = 0 if unlimited else page * page_size
+            json_result = build_list_result(records, total=total, limit=q_page_size, offset=offset)
+            format_result(json_result, format="json", command="list")
+            return
+
+        if result.success and records:
             table = Table(title="部署记录")
             # #4719: id 列 overflow="fold"——rich 默认 ellipsis 会用 … 截断长 UUID，
             # 导致终端用户也看不到完整 id；fold 折行完整显示，终端宽时单行、窄时多行
@@ -164,7 +194,7 @@ def list_deployments(
             table.add_column("状态")
             table.add_column("创建时间")
 
-            for d in result.data:
+            for d in records:
                 mode_str = "纸上" if d["mode"] == 1 else "实盘"
                 # #4719: 输出完整 UUID，list→info round-trip 可直接复制；rich Table 自适应列宽
                 table.add_row(
@@ -176,9 +206,13 @@ def list_deployments(
                     d.get("create_at", "")[:19] if d.get("create_at") else "",
                 )
             console.print(table)
+            if unlimited is False and total > len(records):
+                console.print(f"[dim]共 {total} 条，当前第 {page + 1} 页（每页 {page_size} 条）。使用 --page 翻页。[/dim]")
         else:
             console.print("[yellow]无部署记录[/yellow]")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"[red]Error: {e}[/red]")
         raise typer.Exit(1)

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -41,7 +41,8 @@ def list_engines(
     filter: Optional[str] = typer.Option(
         None, "--filter", "-f", help="Filter engines (search in id, name, type, status)"
     ),
-    limit: int = typer.Option(20, "--limit", "-l", help="Page size"),
+    page: int = typer.Option(0, "--page", help="Page number (0-based)"),
+    page_size: int = typer.Option(20, "--page-size", help="Items per page (0 = all)"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
     format: str = typer.Option("text", "--format", "-F", help="Output format: text/json"),
     no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
@@ -53,6 +54,18 @@ def list_engines(
 
     if format != "json":
         console.print(":clipboard: Listing engines...")
+
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    if page < 0:
+        console.print("[red]:x: --page must be >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    # DB 层分页参数：全量时 page/page_size 均传 None（find 默认全量）
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
 
     # 用于 json total 计算：status 分支解析出的枚举（None 表示无 status 过滤）。
     resolved_status = None
@@ -66,7 +79,9 @@ def list_engines(
             filter_str = str(filter) if not isinstance(filter, str) else filter
             # fuzzy_search 无 df 出口（仍返 ModelList）；就地转 DataFrame 使 result.data
             # 与 get_engines_df 出口语义对齐（data=DataFrame），下游统一不再 hasattr。
-            fs_result = engine_service.fuzzy_search(filter_str, fields=["uuid", "name", "is_live", "status"], page_size=limit)
+            # fuzzy_search CRUD 层只支持 limit（无 offset），故只下推 page_size；
+            # 搜索结果通常较小，total 取当前匹配页行数（精确总数不可得）。
+            fs_result = engine_service.fuzzy_search(filter_str, fields=["uuid", "name", "is_live", "status"], page_size=q_page_size)
             if fs_result.success:
                 # fuzzy_search 契约返 ModelList，直接转 DataFrame（参考 cli_utils.py:44 同款模式）
                 engines_df = fs_result.data.to_dataframe() if fs_result.data is not None else pd.DataFrame()
@@ -81,7 +96,7 @@ def list_engines(
                 # Try to convert status string to enum
                 status_enum = ENGINESTATUS_TYPES.validate_input(status.upper())
                 resolved_status = status_enum
-                result = engine_service.get_engines_df(status=status_enum, page_size=limit)
+                result = engine_service.get_engines_df(status=status_enum, page=q_page, page_size=q_page_size)
             except Exception as e:
                 from ginkgo.libs import GLOG
 
@@ -89,10 +104,10 @@ def list_engines(
                     f"Failed to convert status filter '{status}' to enum, falling back to application-level filtering: {e}"
                 )
                 # If conversion fails, fall back to application-level filtering
-                result = engine_service.get_engines_df(page_size=limit)
+                result = engine_service.get_engines_df(page=q_page, page_size=q_page_size)
         else:
             # Get all engines
-            result = engine_service.get_engines_df(page_size=limit)
+            result = engine_service.get_engines_df(page=q_page, page_size=q_page_size)
 
         if result.success:
             engines_data = result.data
@@ -125,7 +140,11 @@ def list_engines(
                     else:
                         total = len(engines_df)
                 records = engines_df.to_dict("records")
-                json_result = build_list_result(records, total=total, limit=limit, offset=0)
+                # offset = page × page_size；全量时 offset=0、limit=None（ADR-021 metadata）。
+                json_result = build_list_result(
+                    records, total=total, limit=q_page_size,
+                    offset=0 if unlimited else page * page_size,
+                )
                 format_result(json_result, format="json", command="list")
                 return
 
@@ -285,7 +304,7 @@ def cat(
         console.print()
 
         # 调用list_engines函数显示可用引擎，传递所有默认参数
-        list_engines(status=None, portfolio_id=None, filter=None, limit=20, raw=False)
+        list_engines(status=None, portfolio_id=None, filter=None, page=0, page_size=20, raw=False)
         console.print()
         console.print(":information: Use 'ginkgo engine cat <engine_uuid_or_name>' to see detailed information")
         raise typer.Exit(0)
@@ -810,7 +829,7 @@ def bind_portfolio(
         console.print(":information: [bold]No engine ID provided.[/bold]")
         console.print(":clipboard: Listing available engines:")
         console.print()
-        list_engines(status=None, portfolio_id=None, filter=None, limit=20, raw=False)
+        list_engines(status=None, portfolio_id=None, filter=None, page=0, page_size=20, raw=False)
         console.print()
         console.print(
             ":information: Use 'ginkgo engine bind-portfolio <engine_uuid_or_name> <portfolio_uuid_or_name>' to create binding"

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -45,7 +45,6 @@ def list_engines(
     page_size: int = typer.Option(20, "--page-size", help="Items per page (0 = all)"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
     format: str = typer.Option("text", "--format", "-F", help="Output format: text/json"),
-    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :clipboard: List all engines.
@@ -141,9 +140,11 @@ def list_engines(
                         total = len(engines_df)
                 records = engines_df.to_dict("records")
                 # offset = page × page_size；全量时 offset=0、limit=None（ADR-021 metadata）。
+                # fuzzy_search 无 offset 支持：filter 分支诚实标 offset=0（#6652 review B3）。
+                effective_offset = 0 if (unlimited or filter) else page * page_size
                 json_result = build_list_result(
                     records, total=total, limit=q_page_size,
-                    offset=0 if unlimited else page * page_size,
+                    offset=effective_offset,
                 )
                 format_result(json_result, format="json", command="list")
                 return

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -54,6 +54,9 @@ def list_engines(
     if format != "json":
         console.print(":clipboard: Listing engines...")
 
+    # 用于 json total 计算：status 分支解析出的枚举（None 表示无 status 过滤）。
+    resolved_status = None
+
     try:
         engine_service = container.engine_service()
 
@@ -77,6 +80,7 @@ def list_engines(
             try:
                 # Try to convert status string to enum
                 status_enum = ENGINESTATUS_TYPES.validate_input(status.upper())
+                resolved_status = status_enum
                 result = engine_service.get_engines_df(status=status_enum, page_size=limit)
             except Exception as e:
                 from ginkgo.libs import GLOG
@@ -108,8 +112,13 @@ def list_engines(
             engines_df = engines_data if isinstance(engines_data, pd.DataFrame) else pd.DataFrame()
 
             if format == "json":
-                total = len(engines_df)
-                # ADR-021 L139：--limit 已下推 service page_size（DB 层截断），此处不再 head(limit)。
+                # ADR-021：metadata.total 必须是未截断的匹配总数（engines_df 已被 page_size 截断）。
+                if filter:
+                    # fuzzy_search 无 count 出口，total 用当前匹配页行数（搜索场景精确总数不可得）。
+                    total = len(engines_df)
+                else:
+                    count_result = engine_service.count(status=resolved_status)
+                    total = count_result.data if (count_result.success and isinstance(count_result.data, int)) else len(engines_df)
                 records = engines_df.to_dict("records")
                 json_result = build_list_result(records, total=total, limit=limit, offset=0)
                 format_result(json_result, format="json", command="list")
@@ -417,6 +426,7 @@ def run(
     ),
     background: bool = typer.Option(False, "--bg", help="Run in background"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Validate only, don't run"),
+    limit: int = typer.Option(20, "--limit", "-l", help="Page size when listing available engines"),
 ):
     """
     :rocket: Run engine with assembled components.

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -118,7 +118,12 @@ def list_engines(
                     total = len(engines_df)
                 else:
                     count_result = engine_service.count(status=resolved_status)
-                    total = count_result.data if (count_result.success and isinstance(count_result.data, int)) else len(engines_df)
+                    # EngineService.count() 返回 ServiceResult.success({"count": N})（dict 契约，见 engine_service.py:169）。
+                    # 须解 dict 取 key；isinstance(int) 对 dict 恒 False 会导致 total 静默回退截断计数 len(df)。
+                    if count_result.success and isinstance(count_result.data, dict) and "count" in count_result.data:
+                        total = count_result.data["count"]
+                    else:
+                        total = len(engines_df)
                 records = engines_df.to_dict("records")
                 json_result = build_list_result(records, total=total, limit=limit, offset=0)
                 format_result(json_result, format="json", command="list")

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -172,10 +172,28 @@ def list_engines(
 
             console.print(table)
         else:
-            console.print(f":x: Failed to get engines: {result.error}")
+            # ADR-021 第 5/6 维：service 失败时，JSON 模式发错误 envelope + exit 1；
+            # text 模式打印诊断 + exit 1（失败 exit code 跨格式一致，非隐式 exit 0）。
+            if format == "json":
+                format_result(result, format="json", command="list")
+            else:
+                console.print(f":x: Failed to get engines: {result.error}")
+                raise typer.Exit(1)
 
+    # typer.Exit 是 Exception 子类，须在 broad except 前透传 format_result 的 Exit(1)。
+    except typer.Exit:
+        raise
     except Exception as e:
-        console.print(f":x: Error: {e}")
+        # ADR-021 第 1/5 维：JSON 模式 stdout 永远合法 JSON（异常=INTERNAL 错误对象）。
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="list",
+            )
+        else:
+            console.print(f":x: Error: {e}")
+            raise typer.Exit(1)
 
 
 @app.command()

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -3,10 +3,6 @@
 # Role: 引擎管理CLI提供列表/创建/查看/状态/运行/删除/绑定/解绑等生命周期管理
 
 
-
-
-
-
 """
 Ginkgo Engine CLI - 引擎管理命令
 """
@@ -22,6 +18,7 @@ from decimal import Decimal
 import pandas as pd
 
 from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.client.cli_utils import build_list_result, format_result
 
 # 导入辅助函数（从 engine_cli_helpers.py 提取）
 from ginkgo.client.engine_cli_helpers import (
@@ -41,16 +38,21 @@ console = Console(emoji=True, legacy_windows=False)
 def list_engines(
     status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status"),
     portfolio_id: Optional[str] = typer.Option(None, "--portfolio", "-p", help="Filter by portfolio ID"),
-    filter: Optional[str] = typer.Option(None, "--filter", "-f", help="Filter engines (search in id, name, type, status)"),
+    filter: Optional[str] = typer.Option(
+        None, "--filter", "-f", help="Filter engines (search in id, name, type, status)"
+    ),
     limit: int = typer.Option(20, "--limit", "-l", help="Page size"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
+    format: str = typer.Option("text", "--format", "-F", help="Output format: text/json"),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :clipboard: List all engines.
     """
     from ginkgo.data.containers import container
 
-    console.print(":clipboard: Listing engines...")
+    if format != "json":
+        console.print(":clipboard: Listing engines...")
 
     try:
         engine_service = container.engine_service()
@@ -61,7 +63,7 @@ def list_engines(
             filter_str = str(filter) if not isinstance(filter, str) else filter
             # fuzzy_search 无 df 出口（仍返 ModelList）；就地转 DataFrame 使 result.data
             # 与 get_engines_df 出口语义对齐（data=DataFrame），下游统一不再 hasattr。
-            fs_result = engine_service.fuzzy_search(filter_str, fields=['uuid', 'name', 'is_live', 'status'])
+            fs_result = engine_service.fuzzy_search(filter_str, fields=["uuid", "name", "is_live", "status"])
             if fs_result.success:
                 # fuzzy_search 契约返 ModelList，直接转 DataFrame（参考 cli_utils.py:44 同款模式）
                 engines_df = fs_result.data.to_dataframe() if fs_result.data is not None else pd.DataFrame()
@@ -71,13 +73,17 @@ def list_engines(
         elif status:
             # If only status filter, use database-level filtering
             from ginkgo.enums import ENGINESTATUS_TYPES
+
             try:
                 # Try to convert status string to enum
                 status_enum = ENGINESTATUS_TYPES.validate_input(status.upper())
                 result = engine_service.get_engines_df(status=status_enum)
             except Exception as e:
                 from ginkgo.libs import GLOG
-                GLOG.ERROR(f"Failed to convert status filter '{status}' to enum, falling back to application-level filtering: {e}")
+
+                GLOG.ERROR(
+                    f"Failed to convert status filter '{status}' to enum, falling back to application-level filtering: {e}"
+                )
                 # If conversion fails, fall back to application-level filtering
                 result = engine_service.get_engines_df()
         else:
@@ -90,15 +96,23 @@ def list_engines(
             # Raw output mode
             if raw:
                 import json
+
                 # ADR-010 R2a: result.data 已是 DataFrame（get_engines_df 出口契约）
                 engines_df = engines_data if isinstance(engines_data, pd.DataFrame) else pd.DataFrame()
-                raw_data = engines_df.to_dict('records')
+                raw_data = engines_df.to_dict("records")
 
                 console.print(json.dumps(raw_data, indent=2, ensure_ascii=False, default=str))
                 return
 
             # ADR-010 R2a: result.data 已是 DataFrame（类型即契约，无需鸭子探测）
             engines_df = engines_data if isinstance(engines_data, pd.DataFrame) else pd.DataFrame()
+
+            if format == "json":
+                total = len(engines_df)
+                records = engines_df.head(limit).to_dict("records")
+                json_result = build_list_result(records, total=total, limit=limit, offset=0)
+                format_result(json_result, format="json", command="list")
+                return
 
             if engines_df.empty:
                 console.print(":memo: No engines found.")
@@ -118,40 +132,41 @@ def list_engines(
 
             for _, engine in engines_df.iterrows():
                 # Format the update_at timestamp (simplified)
-                update_at = engine.get('update_at')
+                update_at = engine.get("update_at")
                 try:
-                    if update_at is None or (hasattr(update_at, '__len__') and len(str(update_at)) == 0):
-                        update_at_str = 'N/A'
+                    if update_at is None or (hasattr(update_at, "__len__") and len(str(update_at)) == 0):
+                        update_at_str = "N/A"
                     else:
                         update_at_str = str(update_at)[:20]  # Simple string conversion
                 except Exception as e:
                     from ginkgo.libs import GLOG
+
                     GLOG.ERROR(f"Failed to format update_at timestamp: {e}")
-                    update_at_str = 'N/A'
+                    update_at_str = "N/A"
 
                 # Extract clean status name (simplified)
-                status_raw = str(engine.get('status', 'Unknown'))
-                if 'ENGINESTATUS_TYPES.' in status_raw:
-                    status_clean = status_raw.split('ENGINESTATUS_TYPES.')[-1]
-                elif '.' in status_raw:
-                    status_clean = status_raw.split('.')[-1]
+                status_raw = str(engine.get("status", "Unknown"))
+                if "ENGINESTATUS_TYPES." in status_raw:
+                    status_clean = status_raw.split("ENGINESTATUS_TYPES.")[-1]
+                elif "." in status_raw:
+                    status_clean = status_raw.split(".")[-1]
                 else:
                     status_clean = status_raw
 
                 # Format the Type column properly
-                is_live_value = engine.get('is_live', False)
+                is_live_value = engine.get("is_live", False)
                 if isinstance(is_live_value, bool):
                     engine_type = "Live" if is_live_value else "History"
                 else:
                     # Handle string representation
-                    engine_type = "Live" if str(is_live_value).lower() in ['true', '1', 'live'] else "History"
+                    engine_type = "Live" if str(is_live_value).lower() in ["true", "1", "live"] else "History"
 
                 table.add_row(
-                    str(engine.get('uuid', ''))[:36],
-                    str(engine.get('name', ''))[:18],
+                    str(engine.get("uuid", ""))[:36],
+                    str(engine.get("name", ""))[:18],
                     engine_type,
                     status_clean,
-                    update_at_str
+                    update_at_str,
                 )
 
             console.print(table)
@@ -208,7 +223,9 @@ def create(
 
 @app.command()
 def cat(
-    engine_id: Optional[str] = typer.Argument(None, help="Engine UUID or name (if not provided, will list available engines)"),
+    engine_id: Optional[str] = typer.Argument(
+        None, help="Engine UUID or name (if not provided, will list available engines)"
+    ),
 ):
     """
     :cat: Show detailed engine information.
@@ -252,10 +269,10 @@ def cat(
             engines = result.data
 
             # Handle both ModelList and single object
-            if hasattr(engines, '__len__') and len(engines) > 0:
+            if hasattr(engines, "__len__") and len(engines) > 0:
                 # ModelList - get the first engine
                 engine = engines[0]
-            elif hasattr(engines, 'uuid'):
+            elif hasattr(engines, "uuid"):
                 # Single engine object
                 engine = engines
             else:
@@ -271,11 +288,11 @@ def cat(
             info_table.add_row("Name", str(engine.name))
             info_table.add_row("Type", "Live" if engine.is_live else "History")
             info_table.add_row("Status", str(engine.status))
-            info_table.add_row("Run Count", str(getattr(engine, 'run_count', 0)))
+            info_table.add_row("Run Count", str(getattr(engine, "run_count", 0)))
 
             # 显示时间范围
-            start_date = getattr(engine, 'backtest_start_date', None)
-            end_date = getattr(engine, 'backtest_end_date', None)
+            start_date = getattr(engine, "backtest_start_date", None)
+            end_date = getattr(engine, "backtest_end_date", None)
             if start_date and end_date:
                 time_range = f"{start_date.strftime('%Y-%m-%d %H:%M:%S')} to {end_date.strftime('%Y-%m-%d %H:%M:%S')}"
                 info_table.add_row("Time Range", time_range)
@@ -288,8 +305,10 @@ def cat(
             else:
                 info_table.add_row("Time Range", "Not configured")
 
-            info_table.add_row("Config Hash", str(getattr(engine, 'config_hash', 'N/A')))
-            info_table.add_row("Description", str(getattr(engine, 'desc', '') or getattr(engine, 'description', 'No description')))
+            info_table.add_row("Config Hash", str(getattr(engine, "config_hash", "N/A")))
+            info_table.add_row(
+                "Description", str(getattr(engine, "desc", "") or getattr(engine, "description", "No description"))
+            )
 
             console.print(info_table)
 
@@ -301,16 +320,18 @@ def cat(
             display_component_tree(console, component_data)
 
             # 3. 显示配置快照（如果有）
-            config_snapshot = getattr(engine, 'config_snapshot', '{}')
-            if config_snapshot and config_snapshot != '{}':
+            config_snapshot = getattr(engine, "config_snapshot", "{}")
+            if config_snapshot and config_snapshot != "{}":
                 console.print(f"\n📋 Configuration Snapshot:")
                 console.print(f"```json")
                 import json
+
                 try:
                     snapshot_obj = json.loads(config_snapshot)
                     console.print(json.dumps(snapshot_obj, indent=2, ensure_ascii=False))
                 except Exception as e:
                     from ginkgo.libs import GLOG
+
                     GLOG.ERROR(f"Failed to parse configuration snapshot as JSON: {e}")
                     console.print(config_snapshot)
                 console.print(f"```")
@@ -349,10 +370,10 @@ def status(
             engines = result.data
 
             # Handle both ModelList and single object
-            if hasattr(engines, '__len__') and len(engines) > 0:
+            if hasattr(engines, "__len__") and len(engines) > 0:
                 # ModelList - get the first engine
                 engine = engines[0]
-            elif hasattr(engines, 'uuid'):
+            elif hasattr(engines, "uuid"):
                 # Single engine object
                 engine = engines
             else:
@@ -372,7 +393,9 @@ def status(
 
 @app.command()
 def run(
-    engine_id: Optional[str] = typer.Argument(None, help="Engine UUID or name (if not provided, will list available engines)"),
+    engine_id: Optional[str] = typer.Argument(
+        None, help="Engine UUID or name (if not provided, will list available engines)"
+    ),
     background: bool = typer.Option(False, "--bg", help="Run in background"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Validate only, don't run"),
 ):
@@ -380,7 +403,9 @@ def run(
     :rocket: Run engine with assembled components.
     """
     # Deprecated warning
-    console.print(":warning: [bold yellow]Deprecated:[/bold yellow] 'ginkgo engine run' will be removed in a future version.")
+    console.print(
+        ":warning: [bold yellow]Deprecated:[/bold yellow] 'ginkgo engine run' will be removed in a future version."
+    )
     console.print("   Use [cyan]'ginkgo backtest run <task_id>'[/cyan] instead.")
     console.print()
 
@@ -433,36 +458,37 @@ def run(
 
                 for _, engine in engines_df.iterrows():
                     # Format the update_at timestamp
-                    update_at = engine.get('update_at')
+                    update_at = engine.get("update_at")
                     try:
-                        if update_at is None or (hasattr(update_at, '__len__') and len(str(update_at)) == 0):
-                            update_at_str = 'N/A'
+                        if update_at is None or (hasattr(update_at, "__len__") and len(str(update_at)) == 0):
+                            update_at_str = "N/A"
                         else:
                             update_at_str = str(update_at)[:20]
                     except Exception as e:
                         from ginkgo.libs import GLOG
+
                         GLOG.ERROR(f"Failed to format update_at timestamp: {e}")
-                        update_at_str = 'N/A'
+                        update_at_str = "N/A"
 
                     # Extract clean status name
-                    status_raw = str(engine.get('status', 'Unknown'))
-                    if 'ENGINESTATUS_TYPES.' in status_raw:
-                        status_clean = status_raw.split('ENGINESTATUS_TYPES.')[-1]
-                    elif '.' in status_raw:
-                        status_clean = status_raw.split('.')[-1]
+                    status_raw = str(engine.get("status", "Unknown"))
+                    if "ENGINESTATUS_TYPES." in status_raw:
+                        status_clean = status_raw.split("ENGINESTATUS_TYPES.")[-1]
+                    elif "." in status_raw:
+                        status_clean = status_raw.split(".")[-1]
                     else:
                         status_clean = status_raw
 
                     # Format the Type column properly
-                    is_live = engine.get('is_live', False)
+                    is_live = engine.get("is_live", False)
                     engine_type = "Live" if is_live else "Backtest"
 
                     table.add_row(
-                        str(engine.get('uuid', 'N/A')),
-                        str(engine.get('name', 'N/A')),
+                        str(engine.get("uuid", "N/A")),
+                        str(engine.get("name", "N/A")),
                         engine_type,
                         status_clean,
-                        update_at_str
+                        update_at_str,
                     )
 
                 console.print(table)
@@ -484,6 +510,7 @@ def run(
         console.print(f":mag: [bold]Dry run[/bold]: Validating engine assembly for {engine_id}...")
         try:
             from ginkgo.trading.core.containers import container
+
             assembly_service = container.services.engine_assembly_service()
             result = assembly_service.assemble_backtest_engine(engine_id=engine_id)
             if not result.success:
@@ -531,11 +558,12 @@ def run(
         console.print(f"Engine ID: {engine.engine_id}")
         try:
             mode_str = str(engine.mode)
-            engine_mode = 'BACKTEST' if 'BACKTEST' in mode_str else mode_str
+            engine_mode = "BACKTEST" if "BACKTEST" in mode_str else mode_str
         except Exception as e:
             from ginkgo.libs import GLOG
+
             GLOG.ERROR(f"Failed to determine engine mode: {e}")
-            engine_mode = 'UNKNOWN'
+            engine_mode = "UNKNOWN"
         console.print(f"Engine mode: {engine_mode}")
 
         # 🔧 在start前返回检查拼装逻辑
@@ -545,6 +573,7 @@ def run(
             portfolio_count = len(engine.portfolios)
         except Exception as e:
             from ginkgo.libs import GLOG
+
             GLOG.ERROR(f"Failed to count engine portfolios: {e}")
             portfolio_count = 0
         console.print(f"Portfolio数量: {portfolio_count}")
@@ -638,12 +667,11 @@ def run(
 
                 try:
                     # 获取Portfolio进行统计分析
-                    if hasattr(engine, 'portfolios') and engine.portfolios:
+                    if hasattr(engine, "portfolios") and engine.portfolios:
                         try:
                             # engine.portfolios可能是list或dict，统一处理
                             portfolio = None
 
-                            
                             if isinstance(engine.portfolios, dict):
                                 # 如果是字典，取第一个值
                                 if engine.portfolios:
@@ -693,6 +721,7 @@ def run(
                 GCONF.set_debug(False)
         except Exception as e:
             from ginkgo.libs import GLOG
+
             GLOG.ERROR(f"Failed to restore debug config after engine run error: {e}")
         raise typer.Exit(1)
 
@@ -713,6 +742,7 @@ def delete(
 
     try:
         from ginkgo.data.containers import container
+
         engine_service = container.engine_service()
         result = engine_service.delete(engine_id)
 
@@ -729,8 +759,12 @@ def delete(
 
 @app.command("bind-portfolio")
 def bind_portfolio(
-    engine_id: Optional[str] = typer.Argument(None, help="Engine UUID or name (if not provided, will list available engines)"),
-    portfolio_id: Optional[str] = typer.Argument(None, help="Portfolio UUID or name (if not provided, will list available portfolios)"),
+    engine_id: Optional[str] = typer.Argument(
+        None, help="Engine UUID or name (if not provided, will list available engines)"
+    ),
+    portfolio_id: Optional[str] = typer.Argument(
+        None, help="Portfolio UUID or name (if not provided, will list available portfolios)"
+    ),
 ):
     """
     :link: Bind an engine to a portfolio.
@@ -744,7 +778,9 @@ def bind_portfolio(
         console.print()
         list_engines(status=None, portfolio_id=None, filter=None, limit=20, raw=False)
         console.print()
-        console.print(":information: Use 'ginkgo engine bind-portfolio <engine_uuid_or_name> <portfolio_uuid_or_name>' to create binding")
+        console.print(
+            ":information: Use 'ginkgo engine bind-portfolio <engine_uuid_or_name> <portfolio_uuid_or_name>' to create binding"
+        )
         raise typer.Exit(0)
 
     # 如果没有提供 portfolio_id，显示可用的投资组合
@@ -773,11 +809,11 @@ def bind_portfolio(
                 table.add_column("Status", style="blue")
 
                 for _, row in portfolios_df.iterrows():
-                    uuid_str = str(row.get('uuid', ''))[:40]
-                    name = str(row.get('name', ''))
+                    uuid_str = str(row.get("uuid", ""))[:40]
+                    name = str(row.get("name", ""))
                     capital = f"¥{float(row.get('initial_capital', 0)):,.2f}"
-                    ptype = "Live" if row.get('is_live', False) else "Backtest"
-                    status = "Active" if not row.get('is_del', True) else "Deleted"
+                    ptype = "Live" if row.get("is_live", False) else "Backtest"
+                    status = "Active" if not row.get("is_del", True) else "Deleted"
 
                     table.add_row(uuid_str, name, capital, ptype, status)
 
@@ -786,7 +822,9 @@ def bind_portfolio(
             console.print(":memo: No portfolios found.")
 
         console.print()
-        console.print(":information: Use 'ginkgo engine bind-portfolio <engine_uuid_or_name> <portfolio_uuid_or_name>' to create binding")
+        console.print(
+            ":information: Use 'ginkgo engine bind-portfolio <engine_uuid_or_name> <portfolio_uuid_or_name>' to create binding"
+        )
         raise typer.Exit(0)
 
     console.print(f":link: Binding engine {engine_id} to portfolio {portfolio_id}...")
@@ -824,8 +862,7 @@ def bind_portfolio(
         # 先检查绑定是否已存在
         mapping_service = container.mapping_service()
         existing_result = mapping_service.get_engine_portfolio_mapping(
-            engine_uuid=resolved_engine_uuid,
-            portfolio_uuid=resolved_portfolio_uuid
+            engine_uuid=resolved_engine_uuid, portfolio_uuid=resolved_portfolio_uuid
         )
 
         if existing_result.success and existing_result.data and len(existing_result.data) > 0:
@@ -841,7 +878,7 @@ def bind_portfolio(
             engine_uuid=resolved_engine_uuid,
             portfolio_uuid=resolved_portfolio_uuid,
             engine_name=engine_name,
-            portfolio_name=portfolio_name
+            portfolio_name=portfolio_name,
         )
 
         if result.success:
@@ -903,8 +940,7 @@ def unbind_portfolio(
         # 使用 MappingService 删除绑定
         mapping_service = container.mapping_service()
         result = mapping_service.delete_engine_portfolio_mapping(
-            engine_uuid=resolved_engine_uuid,
-            portfolio_uuid=resolved_portfolio_uuid
+            engine_uuid=resolved_engine_uuid, portfolio_uuid=resolved_portfolio_uuid
         )
 
         if result.success:
@@ -916,6 +952,3 @@ def unbind_portfolio(
     except Exception as e:
         console.print(f":x: Error: {e}")
         raise typer.Exit(1)
-
-
-

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -55,12 +55,19 @@ def list_engines(
         console.print(":clipboard: Listing engines...")
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope 而非 Rich 标记（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page must be >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page must be >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size must be >= 0 (0 = all)", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     # DB 层分页参数：全量时 page/page_size 均传 None（find 默认全量）
     q_page = None if unlimited else page

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -63,7 +63,7 @@ def list_engines(
             filter_str = str(filter) if not isinstance(filter, str) else filter
             # fuzzy_search 无 df 出口（仍返 ModelList）；就地转 DataFrame 使 result.data
             # 与 get_engines_df 出口语义对齐（data=DataFrame），下游统一不再 hasattr。
-            fs_result = engine_service.fuzzy_search(filter_str, fields=["uuid", "name", "is_live", "status"])
+            fs_result = engine_service.fuzzy_search(filter_str, fields=["uuid", "name", "is_live", "status"], page_size=limit)
             if fs_result.success:
                 # fuzzy_search 契约返 ModelList，直接转 DataFrame（参考 cli_utils.py:44 同款模式）
                 engines_df = fs_result.data.to_dataframe() if fs_result.data is not None else pd.DataFrame()
@@ -77,7 +77,7 @@ def list_engines(
             try:
                 # Try to convert status string to enum
                 status_enum = ENGINESTATUS_TYPES.validate_input(status.upper())
-                result = engine_service.get_engines_df(status=status_enum)
+                result = engine_service.get_engines_df(status=status_enum, page_size=limit)
             except Exception as e:
                 from ginkgo.libs import GLOG
 
@@ -85,10 +85,10 @@ def list_engines(
                     f"Failed to convert status filter '{status}' to enum, falling back to application-level filtering: {e}"
                 )
                 # If conversion fails, fall back to application-level filtering
-                result = engine_service.get_engines_df()
+                result = engine_service.get_engines_df(page_size=limit)
         else:
             # Get all engines
-            result = engine_service.get_engines_df()
+            result = engine_service.get_engines_df(page_size=limit)
 
         if result.success:
             engines_data = result.data
@@ -109,7 +109,8 @@ def list_engines(
 
             if format == "json":
                 total = len(engines_df)
-                records = engines_df.head(limit).to_dict("records")
+                # ADR-021 L139：--limit 已下推 service page_size（DB 层截断），此处不再 head(limit)。
+                records = engines_df.to_dict("records")
                 json_result = build_list_result(records, total=total, limit=limit, offset=0)
                 format_result(json_result, format="json", command="list")
                 return
@@ -435,7 +436,7 @@ def run(
             from ginkgo.data.containers import container
 
             engine_service = container.engine_service()
-            result = engine_service.get_engines_df()
+            result = engine_service.get_engines_df(page_size=limit)
 
             if result.success:
                 engines_data = result.data

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -218,7 +218,6 @@ def list(
     page: int = typer.Option(0, "--page", help="Page number (0-based)"),
     page_size: int = typer.Option(100, "--page-size", help="Items per page (0 = all)"),
     format: str = typer.Option("text", "--format", "-F", help="Output format: text/json"),
-    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :clipboard: List all components from database.
@@ -247,6 +246,11 @@ def list(
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size
+    # filter 模式：name 是客户端 fuzzy 过滤，全量查再过滤保证 total 准确（#6652 review B1）。
+    if filter:
+        q_page = None
+        q_page_size = None
+        unlimited = True
 
     try:
         # Get file_crud to query database
@@ -297,9 +301,9 @@ def list(
         value_to_type = {v.value: k for k, v in type_mapping.items()}
 
         if format == "json":
-            # ADR-021：metadata.total = 未截断的匹配总数（components 已被 page_size 截断）。
+            # ADR-021：metadata.total = 未截断的匹配总数。
             if filter:
-                # name 是客户端 fuzzy 过滤，count 无法精确匹配 → 用当前过滤后行数。
+                # filter 模式全量查 + 客户端 fuzzy 过滤，total = 过滤后全量行数（准确）。
                 total = len(components)
             elif component_type and component_type.lower() in type_mapping:
                 ft = type_mapping[component_type.lower()]

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -253,11 +253,11 @@ def list(
         if component_type and component_type.lower() in type_mapping:
             # Single type query: filter by type (1 query)
             file_type = type_mapping[component_type.lower()]
-            components = file_crud.find(filters={"type": file_type.value}, page_size=10000)
+            components = file_crud.find(filters={"type": file_type.value}, page_size=limit)
         else:
             # All types query: get all components in ONE query, then filter client-side
             # Query without type filter to get all components at once
-            all_components = file_crud.find(filters={}, page_size=10000)
+            all_components = file_crud.find(filters={}, page_size=limit)
 
             # Filter to only include component types (exclude OTHER, VOID, ENGINE, HANDLER, INDEX)
             component_type_values = {
@@ -284,7 +284,8 @@ def list(
         if format == "json":
             total = len(components)
             records = []
-            for comp in components[:limit]:
+            # ADR-021 L139：--limit 已下推 file_crud.find page_size（DB 层截断），此处不再 [:limit]。
+            for comp in components:
                 type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
                 records.append(
                     {

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -283,7 +283,25 @@ def list(
         value_to_type = {v.value: k for k, v in type_mapping.items()}
 
         if format == "json":
-            total = len(components)
+            # ADR-021：metadata.total = 未截断的匹配总数（components 已被 page_size 截断）。
+            if filter:
+                # name 是客户端 fuzzy 过滤，count 无法精确匹配 → 用当前过滤后行数。
+                total = len(components)
+            elif component_type and component_type.lower() in type_mapping:
+                ft = type_mapping[component_type.lower()]
+                total = file_crud.count(filters={"type": ft.value})
+            else:
+                # 全类型：sum 各组件类型 count（find(filters={}) 含非组件类型，须按类型聚合）。
+                total = sum(
+                    file_crud.count(filters={"type": t.value})
+                    for t in (
+                        FILE_TYPES.STRATEGY,
+                        FILE_TYPES.RISKMANAGER,
+                        FILE_TYPES.SELECTOR,
+                        FILE_TYPES.SIZER,
+                        FILE_TYPES.ANALYZER,
+                    )
+                )
             records = []
             # ADR-021 L139：--limit 已下推 file_crud.find page_size（DB 层截断），此处不再 [:limit]。
             for comp in components:

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -3,10 +3,6 @@
 # Role: 扁平化命令CLI，提供_get_engine_status_name状态转换等工具函数，简化命令行操作和数据访问
 
 
-
-
-
-
 """
 Ginkgo Flat CLI - 扁平化的顶级命令
 包含未迁移到独立文件的CLI功能
@@ -19,7 +15,10 @@ from rich.table import Table
 import json
 import datetime
 
+from ginkgo.client.cli_utils import build_list_result, format_result
+
 from typing import Optional, List
+
 console = Console(emoji=True, legacy_windows=False)
 
 # 创建顶级命令
@@ -40,8 +39,10 @@ mapping_app = typer.Typer(help=":link: Mapping relationship management", rich_ma
 # Result管理命令
 result_app = typer.Typer(help=":bar_chart: Result management", rich_markup_mode="rich")
 
+
 def _file_type_name(type_val):
     from ginkgo.enums import FILE_TYPES
+
     mapping = {v.value: k.lower() for k, v in FILE_TYPES.__members__.items()}
     return mapping.get(type_val, str(type_val))
 
@@ -52,16 +53,16 @@ def _resolve_file(file_service, identifier):
     result = file_service.get_by_uuid(identifier)
     if result.success and result.data:
         data = result.data
-        if isinstance(data, dict) and data.get('file') is not None:
-            return data['file']
-        if hasattr(data, 'uuid'):
+        if isinstance(data, dict) and data.get("file") is not None:
+            return data["file"]
+        if hasattr(data, "uuid"):
             return data
     # 再按名称
     result = file_service.get_by_name(identifier)
     if result.success and result.data:
         data = result.data
-        files = data.get('files', data) if isinstance(data, dict) else data
-        if hasattr(files, '__len__') and len(files) > 0:
+        files = data.get("files", data) if isinstance(data, dict) else data
+        if hasattr(files, "__len__") and len(files) > 0:
             return files[0]
     raise ValueError(f"Component not found: '{identifier}'")
 
@@ -200,16 +201,22 @@ def _get_engine_status_name(status):
         ENGINESTATUS_TYPES.INITIALIZING.value: "Initializing",
         ENGINESTATUS_TYPES.RUNNING.value: "Running",
         ENGINESTATUS_TYPES.PAUSED.value: "Paused",
-        ENGINESTATUS_TYPES.STOPPED.value: "Stopped"
+        ENGINESTATUS_TYPES.STOPPED.value: "Stopped",
     }
     return status_map.get(status, f"Unknown({status})")
+
 
 # Component 相关命令
 @component_app.command()
 def list(
-    component_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by component type (strategy/risk/sizer/selector/analyzer)"),
+    component_type: Optional[str] = typer.Option(
+        None, "--type", "-t", help="Filter by component type (strategy/risk/sizer/selector/analyzer)"
+    ),
     filter: Optional[str] = typer.Option(None, "--filter", "-f", help="Filter by component name (fuzzy search)"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output in JSON format"),
+    limit: int = typer.Option(10000, "--limit", "-l", help="Limit results"),
+    format: str = typer.Option("text", "--format", "-F", help="Output format: text/json"),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :clipboard: List all components from database.
@@ -225,7 +232,8 @@ def list(
     from ginkgo.enums import FILE_TYPES
     import json
 
-    console.print(":clipboard: Listing components...")
+    if format != "json":
+        console.print(":clipboard: Listing components...")
 
     try:
         # Get file_crud to query database
@@ -262,7 +270,7 @@ def list(
 
             components = []
             for comp in all_components:
-                type_value = comp.type.value if hasattr(comp.type, 'value') else comp.type
+                type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
                 if type_value in component_type_values:
                     components.append(comp)
 
@@ -271,16 +279,32 @@ def list(
             filter_lower = filter.lower()
             components = [c for c in components if filter_lower in str(c.name).lower()]
 
+        value_to_type = {v.value: k for k, v in type_mapping.items()}
+
+        if format == "json":
+            total = len(components)
+            records = []
+            for comp in components[:limit]:
+                type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
+                records.append(
+                    {
+                        "uuid": str(comp.uuid),
+                        "name": str(comp.name),
+                        "type": value_to_type.get(type_value, "unknown"),
+                        "created_at": str(comp.create_at) if hasattr(comp, "create_at") and comp.create_at else None,
+                        "updated_at": str(comp.update_at) if hasattr(comp, "update_at") and comp.update_at else None,
+                    }
+                )
+            json_result = build_list_result(records, total=total, limit=limit, offset=0)
+            format_result(json_result, format="json", command="list")
+            return
+
         if components:
             # Reverse type mapping for display
-            value_to_type = {v.value: k for k, v in type_mapping.items()}
 
             if raw:
                 # JSON output format
-                result = {
-                    "total": len(components),
-                    "components": []
-                }
+                result = {"total": len(components), "components": []}
 
                 if component_type:
                     result["type"] = component_type
@@ -289,15 +313,15 @@ def list(
 
                 for comp in components:
                     # Get type value - handle both enum and int
-                    type_value = comp.type.value if hasattr(comp.type, 'value') else comp.type
+                    type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
                     type_name = value_to_type.get(type_value, "unknown")
 
                     component_data = {
                         "uuid": str(comp.uuid),
                         "name": str(comp.name),
                         "type": type_name,
-                        "created_at": str(comp.create_at) if hasattr(comp, 'create_at') and comp.create_at else None,
-                        "updated_at": str(comp.update_at) if hasattr(comp, 'update_at') and comp.update_at else None,
+                        "created_at": str(comp.create_at) if hasattr(comp, "create_at") and comp.create_at else None,
+                        "updated_at": str(comp.update_at) if hasattr(comp, "update_at") and comp.update_at else None,
                     }
                     result["components"].append(component_data)
 
@@ -312,14 +336,10 @@ def list(
 
                 for comp in components:
                     # Get type value - handle both enum and int
-                    type_value = comp.type.value if hasattr(comp.type, 'value') else comp.type
+                    type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
                     type_name = value_to_type.get(type_value, "unknown")
 
-                    table.add_row(
-                        str(comp.uuid),
-                        str(comp.name)[:29],
-                        type_name
-                    )
+                    table.add_row(str(comp.uuid), str(comp.name)[:29], type_name)
 
                 console.print(table)
                 console.print(f"\n:information_source: [dim]Total: {len(components)} components[/dim]")
@@ -336,12 +356,15 @@ def list(
     except Exception as e:
         console.print(f":x: Error: {e}")
         import traceback
+
         traceback.print_exc()
 
 
 @component_app.command()
 def create(
-    component_type: str = typer.Option(..., "--type", "-t", help="Component type (strategy/risk/riskmanager/sizer/selector/analyzer)"),
+    component_type: str = typer.Option(
+        ..., "--type", "-t", help="Component type (strategy/risk/riskmanager/sizer/selector/analyzer)"
+    ),
     name: str = typer.Option(..., "--name", "-n", help="Component name"),
     template: str = typer.Option("basic", "--template", help="Template type (basic)"),
     description: Optional[str] = typer.Option(None, "--description", "-d", help="Component description"),
@@ -369,11 +392,12 @@ def create(
             raise typer.Exit(1)
 
         from ginkgo.data.containers import container
+
         file_service = container.file_service()
 
         # 检查重名
         existing = file_service.get_by_name(name, file_type)
-        if existing.success and existing.data.get('count', 0) > 0:
+        if existing.success and existing.data.get("count", 0) > 0:
             console.print(f":x: Component '{name}' already exists")
             raise typer.Exit(1)
 
@@ -384,12 +408,12 @@ def create(
         result = file_service.add(
             name=name,
             file_type=file_type,
-            data=code.encode('utf-8'),
+            data=code.encode("utf-8"),
             description=description or f"{component_type}: {name}",
         )
 
         if result.success:
-            uuid = result.data.get('file_info', {}).get('uuid', 'N/A')
+            uuid = result.data.get("file_info", {}).get("uuid", "N/A")
             console.print(f":white_check_mark: Component '{name}' created successfully")
             console.print(f"  • UUID: {uuid}")
             console.print(f"  • Type: {component_type}")
@@ -447,7 +471,7 @@ def show(
         file_service = container.file_service()
         mfile = _resolve_file(file_service, identifier)
 
-        code = mfile.data.decode('utf-8') if isinstance(mfile.data, bytes) else str(mfile.data)
+        code = mfile.data.decode("utf-8") if isinstance(mfile.data, bytes) else str(mfile.data)
         console.print(f":eyes: Component: {mfile.name} ({mfile.uuid[:8]}...)")
         console.print(f"   Type: {_file_type_name(mfile.type)}")
         console.print(f"   Description: {mfile.desc or 'N/A'}")
@@ -464,7 +488,9 @@ def edit(
     identifier: str = typer.Argument(..., help="Component UUID or name"),
     file: Optional[str] = typer.Option(None, "--file", "-f", help="Import source code from local .py file"),
     name: Optional[str] = typer.Option(None, "--name", "-n", help="Update component name"),
-    type: Optional[str] = typer.Option(None, "--type", "-t", help="Update component type (strategy/selector/sizer/risk/analyzer)"),
+    type: Optional[str] = typer.Option(
+        None, "--type", "-t", help="Update component type (strategy/selector/sizer/risk/analyzer)"
+    ),
     desc: Optional[str] = typer.Option(None, "--desc", "-d", help="Update component description"),
 ):
     """
@@ -489,22 +515,22 @@ def edit(
 
         # 更新源码
         if file:
-            with open(file, 'r', encoding='utf-8') as f:
-                new_data = f.read().encode('utf-8')
+            with open(file, "r", encoding="utf-8") as f:
+                new_data = f.read().encode("utf-8")
             updates.append(f"source: {file}")
         elif not (name or type or desc):
             # 没有任何参数 → 打开编辑器
-            code = mfile.data.decode('utf-8') if isinstance(mfile.data, bytes) else str(mfile.data)
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False, encoding='utf-8') as tmp:
+            code = mfile.data.decode("utf-8") if isinstance(mfile.data, bytes) else str(mfile.data)
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False, encoding="utf-8") as tmp:
                 tmp.write(code)
                 tmp_path = tmp.name
             try:
-                editor = os.environ.get('EDITOR', 'nano')
+                editor = os.environ.get("EDITOR", "nano")
                 subprocess.run([editor, tmp_path])
-                with open(tmp_path, 'r', encoding='utf-8') as f:
+                with open(tmp_path, "r", encoding="utf-8") as f:
                     edited = f.read()
                 if edited != code:
-                    new_data = edited.encode('utf-8')
+                    new_data = edited.encode("utf-8")
                     updates.append("source: editor")
                 else:
                     console.print(":information_source: No changes made")
@@ -522,13 +548,14 @@ def edit(
             updates.append(f"desc: {desc}")
         if type:
             from ginkgo.enums import FILE_TYPES
+
             type_map = {k.lower(): v for k, v in FILE_TYPES.__members__.items()}
-            type_key = type.lower().replace(' ', '_')
+            type_key = type.lower().replace(" ", "_")
             if type_key in type_map:
                 svc_kwargs["file_type"] = type_map[type_key].value
                 updates.append(f"type: {type}")
             else:
-                valid = ', '.join(sorted(type_map.keys()))
+                valid = ", ".join(sorted(type_map.keys()))
                 console.print(f":x: Invalid type '{type}'. Valid: {valid}")
                 raise typer.Exit(1)
         if new_data:
@@ -614,7 +641,9 @@ def priority(
 def list(
     task_id: Optional[str] = typer.Option(None, "--task-id", help=":mag: 按任务ID过滤 (uuid 或 task_id)"),
     portfolio: Optional[str] = typer.Option(None, "--portfolio", "-p", help="Filter by portfolio ID"),
-    status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status (pending/running/completed/failed)"),
+    status: Optional[str] = typer.Option(
+        None, "--status", "-s", help="Filter by status (pending/running/completed/failed)"
+    ),
     page: int = typer.Option(0, "--page", "-P", help="Page number"),
     page_size: int = typer.Option(20, "--page-size", help="Items per page"),
 ):
@@ -634,9 +663,7 @@ def list(
         tasks = [result.data]
         total = 1
     else:
-        result = service.list(
-            page=page, page_size=page_size, portfolio_id=portfolio, status=status
-        )
+        result = service.list(page=page, page_size=page_size, portfolio_id=portfolio, status=status)
         if not result.is_success():
             console.print(f":x: {result.error}")
             raise typer.Exit(1)
@@ -664,14 +691,11 @@ def list(
         uuid_str = task.uuid[:12] if hasattr(task, "uuid") else str(task.get("uuid", ""))[:12]
         name = task.name if hasattr(task, "name") else task.get("name", "")
         portfolio_id = (
-            task.portfolio_id[:12] if hasattr(task, "portfolio_id")
-            else str(task.get("portfolio_id", ""))[:12]
+            task.portfolio_id[:12] if hasattr(task, "portfolio_id") else str(task.get("portfolio_id", ""))[:12]
         )
         status_val = task.status if hasattr(task, "status") else task.get("status", "")
         created = str(task.create_at)[:19] if hasattr(task, "create_at") else ""
-        status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(
-            status_val, "white"
-        )
+        status_style = {"completed": "green", "running": "yellow", "failed": "red"}.get(status_val, "white")
         table.add_row(
             uuid_str,
             name[:20],
@@ -765,8 +789,7 @@ def get(
 @result_app.command("show")
 def show(
     task_id: Optional[str] = typer.Option(None, "--task-id", "-t", help=":abc: 回测任务ID (统一参数名)"),
-    run_id: Optional[str] = typer.Option(
-        None, "--run-id", "-r", help="⚠ 已弃用, 请改用 --task-id", hidden=True),
+    run_id: Optional[str] = typer.Option(None, "--run-id", "-r", help="⚠ 已弃用, 请改用 --task-id", hidden=True),
     portfolio_id: Optional[str] = typer.Option(None, "--portfolio", "-p", help=":bank: Portfolio ID"),
     analyzer: Optional[str] = typer.Option(None, "--analyzer", "-a", help=":bar_chart: Analyzer name"),
     mode: str = typer.Option("table", "--mode", "-m", help=":display: Display mode (table/terminal/plot)"),
@@ -818,14 +841,14 @@ def show(
             "task_id": {"display_name": "Run ID", "style": "cyan"},
             "portfolio_name": {"display_name": "Portfolio", "style": "yellow"},
             "timestamp": {"display_name": "Run Time", "style": "dim"},
-            "record_count": {"display_name": "Records", "style": "blue"}
+            "record_count": {"display_name": "Records", "style": "blue"},
         }
 
         display_dataframe(
             data=df,
             columns_config=columns_config,
             title=":chart_with_upwards_trend: [bold]可用的运行会话[/bold]",
-            console=console
+            console=console,
         )
         console.print("\n[yellow]使用 --task-id 参数查看详细结果[/yellow]")
         console.print("[dim]示例: ginkgo result show --task-id <task_id>[/dim]")
@@ -847,15 +870,15 @@ def show(
 
     # 自动选择 portfolio（如果只有一个）
     if portfolio_id is None:
-        if summary['portfolio_count'] > 1:
+        if summary["portfolio_count"] > 1:
             console.print(f":briefcase: [bold]可用的投资组合 ({summary['portfolio_count']}个):[/bold]")
-            for pid in summary['portfolios']:
+            for pid in summary["portfolios"]:
                 console.print(f"  - {pid}")
             console.print("")
             console.print("[yellow]请使用 --portfolio 参数指定投资组合[/yellow]")
             raise typer.Exit(0)
         else:
-            portfolio_id = summary['portfolios'][0]
+            portfolio_id = summary["portfolios"][0]
             console.print(f":briefcase: [cyan]使用投资组合: {portfolio_id}[/cyan]")
             console.print("")
 
@@ -878,9 +901,7 @@ def show(
 
     # 获取数据
     data_result = result_service.get_analyzer_values_df(
-        task_id=task_id,
-        portfolio_id=portfolio_id,
-        analyzer_name=analyzer
+        task_id=task_id, portfolio_id=portfolio_id, analyzer_name=analyzer
     )
 
     if not data_result.success:
@@ -890,6 +911,7 @@ def show(
 
     # 转换为 DataFrame
     import pandas as pd
+
     result_df = data_result.data if isinstance(data_result.data, pd.DataFrame) else pd.DataFrame()
 
     if result_df is None or result_df.shape[0] == 0:
@@ -900,15 +922,10 @@ def show(
     if mode == "table":
         columns_config = {
             "timestamp": {"display_name": "Date", "style": "cyan"},
-            "value": {"display_name": "Value", "style": "yellow"}
+            "value": {"display_name": "Value", "style": "yellow"},
         }
         title = f":bar_chart: [bold]{analyzer}[/bold] [dim]({task_id})[/dim]"
-        display_dataframe(
-            data=result_df.head(limit),
-            columns_config=columns_config,
-            title=title,
-            console=console
-        )
+        display_dataframe(data=result_df.head(limit), columns_config=columns_config, title=title, console=console)
 
     elif mode == "terminal":
         console.print(f"[dim]显示 {result_df.shape[0]} 条记录[/dim]")
@@ -916,7 +933,7 @@ def show(
             data=result_df.head(limit) if limit > 0 else result_df,
             title=f"{analyzer} [{task_id}]",
             max_points=limit,
-            console=console
+            console=console,
         )
 
     else:
@@ -999,6 +1016,8 @@ def segment_stability(
 
         console.print(table)
         console.print("")
+
+
 get_app.add_typer(component_app, name="component", help=":wrench: Get component information")
 get_app.add_typer(mapping_app, name="mapping", help=":link: Get mapping information")
 get_app.add_typer(result_app, name="result", help=":bar_chart: Get result information")

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -237,12 +237,19 @@ def list(
         console.print(":clipboard: Listing components...")
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope 而非 Rich 标记（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page must be >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page must be >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size must be >= 0 (0 = all)", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -215,7 +215,8 @@ def list(
     ),
     filter: Optional[str] = typer.Option(None, "--filter", "-f", help="Filter by component name (fuzzy search)"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output in JSON format"),
-    limit: int = typer.Option(10000, "--limit", "-l", help="Limit results"),
+    page: int = typer.Option(0, "--page", help="Page number (0-based)"),
+    page_size: int = typer.Option(100, "--page-size", help="Items per page (0 = all)"),
     format: str = typer.Option("text", "--format", "-F", help="Output format: text/json"),
     no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
@@ -236,6 +237,17 @@ def list(
     if format != "json":
         console.print(":clipboard: Listing components...")
 
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    if page < 0:
+        console.print("[red]:x: --page must be >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
+
     try:
         # Get file_crud to query database
         file_crud = container.file_crud()
@@ -250,30 +262,32 @@ def list(
             "analyzer": FILE_TYPES.ANALYZER,
         }
 
+        # 组件类型值集合（全类型路径的 type__in 过滤用）
+        component_type_values = [
+            FILE_TYPES.STRATEGY.value,
+            FILE_TYPES.RISKMANAGER.value,
+            FILE_TYPES.SELECTOR.value,
+            FILE_TYPES.SIZER.value,
+            FILE_TYPES.ANALYZER.value,
+        ]
+
         # Query components from database
+        # #5009 契约硬规则：type 过滤必须下推 find()（DB 层），禁先 page_size 截断再客户端过滤。
+        # 旧实现 find(filters={}, page_size=limit) 取 limit 行（含 ENGINE/OTHER 等非组件类型）
+        # 再客户端筛组件类型 → 非组件类型占满 limit 时返回 0 组件（即便组件存在）。
         if component_type and component_type.lower() in type_mapping:
             # Single type query: filter by type (1 query)
             file_type = type_mapping[component_type.lower()]
-            components = file_crud.find(filters={"type": file_type.value}, page_size=limit)
+            components = file_crud.find(
+                filters={"type": file_type.value}, page=q_page, page_size=q_page_size,
+                order_by="create_at", desc_order=True,
+            )
         else:
-            # All types query: get all components in ONE query, then filter client-side
-            # Query without type filter to get all components at once
-            all_components = file_crud.find(filters={}, page_size=limit)
-
-            # Filter to only include component types (exclude OTHER, VOID, ENGINE, HANDLER, INDEX)
-            component_type_values = {
-                FILE_TYPES.STRATEGY.value,
-                FILE_TYPES.RISKMANAGER.value,
-                FILE_TYPES.SELECTOR.value,
-                FILE_TYPES.SIZER.value,
-                FILE_TYPES.ANALYZER.value,
-            }
-
-            components = []
-            for comp in all_components:
-                type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
-                if type_value in component_type_values:
-                    components.append(comp)
+            # All types query: 用 type__in 在 DB 层过滤组件类型，再分页（修 #5009 截断前未过滤 bug）
+            components = file_crud.find(
+                filters={"type__in": component_type_values}, page=q_page, page_size=q_page_size,
+                order_by="create_at", desc_order=True,
+            )
 
         # Apply name filter if provided
         if filter:
@@ -303,7 +317,7 @@ def list(
                     )
                 )
             records = []
-            # ADR-021 L139：--limit 已下推 file_crud.find page_size（DB 层截断），此处不再 [:limit]。
+            # #5009 契约：page_size 已下推 file_crud.find（DB 层截断），此处不再二次截断。
             for comp in components:
                 type_value = comp.type.value if hasattr(comp.type, "value") else comp.type
                 records.append(
@@ -315,7 +329,8 @@ def list(
                         "updated_at": str(comp.update_at) if hasattr(comp, "update_at") and comp.update_at else None,
                     }
                 )
-            json_result = build_list_result(records, total=total, limit=limit, offset=0)
+            offset = 0 if unlimited else page * page_size
+            json_result = build_list_result(records, total=total, limit=q_page_size, offset=offset)
             format_result(json_result, format="json", command="list")
             return
 

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -16,6 +16,7 @@ import json
 import datetime
 
 from ginkgo.client.cli_utils import build_list_result, format_result
+from ginkgo.data.services.base_service import ServiceResult
 
 from typing import Optional, List
 
@@ -354,11 +355,24 @@ def list(
             if filter:
                 console.print(f"[dim]Try a different filter term[/dim]")
 
+    # typer.Exit 是 Exception 子类，须在 broad except 前透传 format_result 的 Exit(1)。
+    except typer.Exit:
+        raise
     except Exception as e:
-        console.print(f":x: Error: {e}")
-        import traceback
+        # ADR-021 第 1/5 维：JSON 模式 stdout 永远合法 JSON（异常=INTERNAL 错误对象）+ exit 1；
+        # text 模式打印诊断 + traceback（stderr）+ exit 1（原隐式 exit 0 是 bug）。
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="list",
+            )
+        else:
+            console.print(f":x: Error: {e}")
+            import traceback
 
-        traceback.print_exc()
+            traceback.print_exc()
+            raise typer.Exit(1)
 
 
 @component_app.command()

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -3,10 +3,6 @@
 # Role: 投资组合管理CLI，提供 list/create/get/delete/status/bind/unbind/deploy/unload/baseline 命令
 
 
-
-
-
-
 """
 Ginkgo Portfolio CLI - 投资组合管理命令
 """
@@ -23,6 +19,8 @@ from rich import print as rprint
 
 from ginkgo.enums import PORTFOLIO_MODE_TYPES, PORTFOLIO_RUNSTATE_TYPES
 from ginkgo.libs import GLOG
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.client.cli_utils import build_list_result, format_result
 
 app = typer.Typer(help=":bank: Portfolio management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -48,20 +46,32 @@ def _format_portfolio_status(portfolio) -> str:
     return enum_val.name if enum_val else "Unknown"
 
 
+def _portfolio_record(portfolio) -> dict:
+    return {
+        "uuid": str(getattr(portfolio, "uuid", "")),
+        "name": str(getattr(portfolio, "name", "")),
+        "initial_capital": getattr(portfolio, "initial_capital", None),
+        "current_capital": getattr(portfolio, "current_capital", None),
+        "cash": getattr(portfolio, "cash", None),
+        "mode": _format_portfolio_mode(getattr(portfolio, "mode", None)),
+        "description": str(getattr(portfolio, "desc", "") or ""),
+    }
+
+
 def display_component_tree(console, component_data: dict):
     """以文件树结构显示组件信息（与engine cat风格一致）"""
 
     # 计算总的组件类型数量
     component_types = []
-    if component_data['selectors']:
+    if component_data["selectors"]:
         component_types.append(("selectors", "🎯", "Selectors"))
-    if component_data['strategies']:
+    if component_data["strategies"]:
         component_types.append(("strategies", "🎯", "Strategies"))
-    if component_data['sizers']:
+    if component_data["sizers"]:
         component_types.append(("sizers", "📏", "Sizers"))
-    if component_data['risk_managers']:
+    if component_data["risk_managers"]:
         component_types.append(("risk_managers", "🛡️", "Risk Managers"))
-    if component_data['analyzers']:
+    if component_data["analyzers"]:
         component_types.append(("analyzers", "📊", "Analyzers"))
 
     # 如果没有任何组件
@@ -72,18 +82,18 @@ def display_component_tree(console, component_data: dict):
     # 显示各种组件
     for i, (key, icon, label) in enumerate(component_types):
         items = component_data[key]
-        is_last_component = (i == len(component_types) - 1)
+        is_last_component = i == len(component_types) - 1
 
         # 组件类型前缀
         component_prefix = "└──" if is_last_component else "├──"
         console.print(f"{component_prefix} {icon} {label} ({len(items)})")
 
         # 检查是否有组件有参数
-        has_params_in_this_component = any(item.get('parameters') for item in items)
+        has_params_in_this_component = any(item.get("parameters") for item in items)
 
         for j, item in enumerate(items):
-            is_last_file = (j == len(items) - 1)
-            has_file_params = item.get('parameters')
+            is_last_file = j == len(items) - 1
+            has_file_params = item.get("parameters")
 
             # 文件前缀：如果这个组件类型下有参数，或者这个文件有参数，需要保留垂直线
             if has_params_in_this_component or has_file_params:
@@ -95,8 +105,8 @@ def display_component_tree(console, component_data: dict):
 
             # 显示该组件的参数
             if has_file_params:
-                for k, param in enumerate(item['parameters']):
-                    is_last_param = (k == len(item['parameters']) - 1)
+                for k, param in enumerate(item["parameters"]):
+                    is_last_param = k == len(item["parameters"]) - 1
 
                     # 参数前缀：只需要文件层的垂直线
                     if is_last_file and is_last_param:
@@ -120,13 +130,16 @@ def list(
     status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status"),
     limit: int = typer.Option(20, "--limit", "-l", help="Page size"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
+    format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :clipboard: List all portfolios.
     """
     from ginkgo.data.containers import container
 
-    console.print(":clipboard: Listing portfolios...")
+    if format != "json":
+        console.print(":clipboard: Listing portfolios...")
 
     try:
         portfolio_service = container.portfolio_service()
@@ -138,15 +151,23 @@ def list(
             # Raw output mode
             if raw:
                 import json
+
                 # ADR-010 R2a: get_portfolios_df 出口已保证 data 为 DataFrame
                 portfolios_df = portfolios_data if isinstance(portfolios_data, pd.DataFrame) else pd.DataFrame()
-                raw_data = portfolios_df.to_dict('records')
+                raw_data = portfolios_df.to_dict("records")
 
                 console.print(json.dumps(raw_data, indent=2, ensure_ascii=False, default=str))
                 return
 
             # ADR-010 R2a: get_portfolios_df 出口已保证 data 为 DataFrame（类型即契约，无需鸭子探测）
             portfolios_df = portfolios_data if isinstance(portfolios_data, pd.DataFrame) else pd.DataFrame()
+
+            if format == "json":
+                total = len(portfolios_df)
+                records = portfolios_df.head(limit).to_dict("records")
+                json_result = build_list_result(records, total=total, limit=limit, offset=0)
+                format_result(json_result, format="json", command="list")
+                return
 
             if portfolios_df.empty:
                 console.print(":memo: No portfolios found.")
@@ -166,11 +187,11 @@ def list(
                 status = _format_portfolio_status(portfolio)
 
                 table.add_row(
-                    str(portfolio.get('uuid', '')),
-                    str(portfolio.get('name', ''))[:18],
+                    str(portfolio.get("uuid", "")),
+                    str(portfolio.get("name", ""))[:18],
                     initial_capital,
                     portfolio_type,
-                    status
+                    status,
                 )
 
             console.print(table)
@@ -195,9 +216,7 @@ def create(
 
     # #5984: 初始资本必须为正，拒绝非正输入（负数/零）。
     if initial_capital <= 0:
-        console.print(
-            f":x: Invalid --capital: must be greater than 0 (got {initial_capital})"
-        )
+        console.print(f":x: Invalid --capital: must be greater than 0 (got {initial_capital})")
         raise typer.Exit(1)
 
     console.print(f":heavy_plus_sign: Creating portfolio: {name}")
@@ -212,7 +231,11 @@ def create(
 
         if result.success:
             data = result.data
-            portfolio_uuid = data.get('uuid', data) if isinstance(data, dict) else (data.uuid if hasattr(data, 'uuid') else str(data))
+            portfolio_uuid = (
+                data.get("uuid", data)
+                if isinstance(data, dict)
+                else (data.uuid if hasattr(data, "uuid") else str(data))
+            )
             console.print(f":white_check_mark: Portfolio '{name}' created successfully")
             console.print(f"  • Portfolio ID: {portfolio_uuid}")
             console.print(f"  • Initial Capital: ¥{initial_capital:,.2f}")
@@ -232,13 +255,16 @@ def get(
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID or name"),
     details: bool = typer.Option(False, "--details", "-d", help="Show detailed portfolio information"),
     performance: bool = typer.Option(False, "--performance", "-p", help="Show performance metrics"),
+    format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
+    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :eyes: Show portfolio details and composition.
     """
     from ginkgo.data.containers import container
 
-    console.print(f":eyes: Showing portfolio {portfolio_id}...")
+    if format != "json":
+        console.print(f":eyes: Showing portfolio {portfolio_id}...")
 
     try:
         portfolio_service = container.portfolio_service()
@@ -246,18 +272,22 @@ def get(
         # 先尝试按 UUID 查找
         result = portfolio_service.get(portfolio_id=portfolio_id)
         # 如果 UUID 查找失败，尝试按名称查找
-        if not result.success or not result.data or (hasattr(result.data, '__len__') and len(result.data) == 0):
+        if not result.success or not result.data or (hasattr(result.data, "__len__") and len(result.data) == 0):
             result = portfolio_service.get(name=portfolio_id)
 
         if result.success and result.data:
             # 获取第一个 portfolio 实体（ModelList 支持）
-            if hasattr(result.data, '__len__') and len(result.data) > 0:
+            if hasattr(result.data, "__len__") and len(result.data) > 0:
                 portfolio = result.data[0]
-            elif hasattr(result.data, 'uuid'):
+            elif hasattr(result.data, "uuid"):
                 portfolio = result.data
             else:
                 console.print(":x: Portfolio data format error")
                 raise typer.Exit(1)
+
+            if format == "json":
+                format_result(ServiceResult.success(data=_portfolio_record(portfolio)), format="json", command="get")
+                return
 
             table = Table(title=f":bank: Portfolio Details")
             table.add_column("Property", style="cyan", width=15)
@@ -268,7 +298,7 @@ def get(
             table.add_row("Initial Capital", f"¥{portfolio.initial_capital:,.2f}")
             table.add_row("Current Capital", f"¥{portfolio.current_capital:,.2f}")
             table.add_row("Cash", f"¥{portfolio.cash:,.2f}")
-            table.add_row("Mode", _format_portfolio_mode(getattr(portfolio, 'mode', None)))
+            table.add_row("Mode", _format_portfolio_mode(getattr(portfolio, "mode", None)))
             table.add_row("Description", str(portfolio.desc or "No description"))
 
             console.print(table)
@@ -283,8 +313,11 @@ def get(
                 else:
                     console.print(f"[yellow]:warning: Failed to collect components: {result.error}[/yellow]")
                     component_data = {
-                        'strategies': [], 'risk_managers': [],
-                        'analyzers': [], 'selectors': [], 'sizers': [],
+                        "strategies": [],
+                        "risk_managers": [],
+                        "analyzers": [],
+                        "selectors": [],
+                        "sizers": [],
                     }
 
                 # 检查是否有任何组件绑定
@@ -302,9 +335,18 @@ def get(
                 console.print(":information: Performance metrics not yet implemented")
 
         else:
+            if format == "json":
+                format_result(
+                    ServiceResult.failure(message=f"Portfolio not found: {portfolio_id}", code="NOT_FOUND"),
+                    format="json",
+                    command="get",
+                )
+                return
             console.print(f":x: Failed to get portfolio: {result.error}")
             raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: Error: {e}")
         raise typer.Exit(1)
@@ -326,14 +368,14 @@ def status(
 
         # 先尝试按 UUID 查找，失败后按名称查找
         result = portfolio_service.get(portfolio_id=portfolio_id)
-        if not result.success or not result.data or (hasattr(result.data, '__len__') and len(result.data) == 0):
+        if not result.success or not result.data or (hasattr(result.data, "__len__") and len(result.data) == 0):
             result = portfolio_service.get(name=portfolio_id)
 
         if result.success and result.data:
             # 获取第一个 portfolio 实体（ModelList 支持）
-            if hasattr(result.data, '__len__') and len(result.data) > 0:
+            if hasattr(result.data, "__len__") and len(result.data) > 0:
                 portfolio = result.data[0]
-            elif hasattr(result.data, 'uuid'):
+            elif hasattr(result.data, "uuid"):
                 portfolio = result.data
             else:
                 console.print(":x: Portfolio data format error")
@@ -370,8 +412,9 @@ def _resolve_portfolio_identifier(portfolio_service, identifier: str):
     Returns:
         (uuid, None) 命中唯一；(None, error_msg) 未命中或歧义。
     """
+
     def _has_match(r) -> bool:
-        return r is not None and getattr(r, 'success', False) and bool(getattr(r, 'data', None))
+        return r is not None and getattr(r, "success", False) and bool(getattr(r, "data", None))
 
     def _first_uuid(data):
         if not data:
@@ -413,6 +456,7 @@ def delete(
 
     try:
         from ginkgo.data.containers import container
+
         portfolio_service = container.portfolio_service()
 
         # #5995: 名称/部分UUID 解析（精确 UUID → 名称 → fuzzy）
@@ -443,8 +487,12 @@ def delete(
 def bind_component(
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID or name"),
     file_id: str = typer.Argument(..., help="File UUID or name"),
-    component_type: str = typer.Option(..., "--type", "-t", help="Component type (strategy/risk/selector/sizer/analyzer)"),
-    params: List[str] = typer.Option([], "--param", "-p", help="Component parameters in format 'index:value', can be used multiple times"),
+    component_type: str = typer.Option(
+        ..., "--type", "-t", help="Component type (strategy/risk/selector/sizer/analyzer)"
+    ),
+    params: List[str] = typer.Option(
+        [], "--param", "-p", help="Component parameters in format 'index:value', can be used multiple times"
+    ),
 ):
     """
     :link: Bind a component to a portfolio.
@@ -485,11 +533,11 @@ def bind_component(
         file_result = file_service.get_by_uuid(file_id)
         if file_result.success and file_result.data:
             data = file_result.data
-            if isinstance(data, dict) and data.get('file') is not None:
-                resolved_file_uuid = data['file'].uuid
-                file_name = data['file'].name
+            if isinstance(data, dict) and data.get("file") is not None:
+                resolved_file_uuid = data["file"].uuid
+                file_name = data["file"].name
                 _file_resolved = True
-            elif hasattr(data, 'uuid'):
+            elif hasattr(data, "uuid"):
                 resolved_file_uuid = data.uuid
                 file_name = data.name
                 _file_resolved = True
@@ -499,8 +547,8 @@ def bind_component(
             file_result = file_service.get_by_name(file_id)
             if file_result.success and file_result.data:
                 data = file_result.data
-                files = data.get('files', data) if isinstance(data, dict) else data
-                if hasattr(files, '__len__') and len(files) > 0:
+                files = data.get("files", data) if isinstance(data, dict) else data
+                if hasattr(files, "__len__") and len(files) > 0:
                     resolved_file_uuid = files[0].uuid
                     file_name = files[0].name
                     _file_resolved = True
@@ -530,10 +578,10 @@ def bind_component(
         parameters = {}
         if params:
             for param in params:
-                if ':' not in param:
+                if ":" not in param:
                     console.print(f":x: Invalid parameter format: '{param}'. Use 'index:value' format.")
                     raise typer.Exit(1)
-                key_str, value = param.split(':', 1)
+                key_str, value = param.split(":", 1)
                 try:
                     index = int(key_str)
                 except ValueError:
@@ -547,7 +595,7 @@ def bind_component(
             portfolio_uuid=resolved_portfolio_uuid,
             file_uuid=resolved_file_uuid,
             file_name=file_name,
-            file_type=file_type
+            file_type=file_type,
         )
 
         if result.success:
@@ -560,9 +608,7 @@ def bind_component(
             if parameters:
                 mapping = result.data  # MPortfolioFileMapping 对象
                 param_result = mapping_service.create_component_parameters(
-                    mapping_uuid=mapping.uuid,
-                    file_uuid=resolved_file_uuid,
-                    parameters=parameters
+                    mapping_uuid=mapping.uuid, file_uuid=resolved_file_uuid, parameters=parameters
                 )
 
                 if param_result.success:
@@ -620,8 +666,8 @@ def unbind_component(
         file_result = file_service.get_by_uuid(file_id)
         if file_result.success and file_result.data:
             # 处理字典格式 {"file": MFile, "exists": True}
-            if isinstance(file_result.data, dict) and 'file' in file_result.data:
-                resolved_file_uuid = file_result.data['file'].uuid
+            if isinstance(file_result.data, dict) and "file" in file_result.data:
+                resolved_file_uuid = file_result.data["file"].uuid
             else:
                 resolved_file_uuid = file_result.data.uuid
         else:
@@ -636,8 +682,7 @@ def unbind_component(
         # 使用 MappingService 删除绑定
         mapping_service = container.mapping_service()
         result = mapping_service.delete_portfolio_file_binding(
-            portfolio_uuid=resolved_portfolio_uuid,
-            file_uuid=resolved_file_uuid
+            portfolio_uuid=resolved_portfolio_uuid, file_uuid=resolved_file_uuid
         )
 
         if result.success:
@@ -670,14 +715,16 @@ def deploy_portfolio(
             name=name,
         )
 
-        console.print(Panel(
-            f"[bold green]Paper trading deployed[/bold green]\n\n"
-            f"Portfolio ID: {portfolio_id}\n"
-            f"Source: {source}\n"
-            f"Mode: PAPER\n"
-            f"Notification sent to PaperTradingWorker via Kafka",
-            title="Deploy Success",
-        ))
+        console.print(
+            Panel(
+                f"[bold green]Paper trading deployed[/bold green]\n\n"
+                f"Portfolio ID: {portfolio_id}\n"
+                f"Source: {source}\n"
+                f"Mode: PAPER\n"
+                f"Notification sent to PaperTradingWorker via Kafka",
+                title="Deploy Success",
+            )
+        )
     except Exception as e:
         GLOG.ERROR(f"[DEPLOY] Deploy failed: {e}")
         console.print(f"[bold red]Deploy failed: {e}[/bold red]")
@@ -697,12 +744,14 @@ def unload_portfolio(
         success = _send_unload_command(portfolio_id)
 
         if success:
-            console.print(Panel(
-                f"[bold yellow]Unload command sent[/bold yellow]\n\n"
-                f"Portfolio ID: {portfolio_id}\n"
-                f"Notification sent to PaperTradingWorker via Kafka",
-                title="Unload Success",
-            ))
+            console.print(
+                Panel(
+                    f"[bold yellow]Unload command sent[/bold yellow]\n\n"
+                    f"Portfolio ID: {portfolio_id}\n"
+                    f"Notification sent to PaperTradingWorker via Kafka",
+                    title="Unload Success",
+                )
+            )
         else:
             console.print(f"[bold red]Failed to send unload command via Kafka[/bold red]")
             raise typer.Exit(1)
@@ -744,7 +793,7 @@ def _deploy_paper_trading(
         raise ValueError(f"Source portfolio not found: {source_portfolio_id}")
 
     source_data = source_result.data
-    if hasattr(source_data, '__len__') and not isinstance(source_data, dict):
+    if hasattr(source_data, "__len__") and not isinstance(source_data, dict):
         source_portfolio = source_data[0]
     else:
         source_portfolio = source_data
@@ -769,7 +818,7 @@ def _deploy_paper_trading(
     mappings = mapping_crud.find(filters={"portfolio_id": source_portfolio_id, "is_del": False})
     param_count = 0
     for mapping in mappings:
-        mapping_type = mapping.type.value if hasattr(mapping.type, 'value') else mapping.type
+        mapping_type = mapping.type.value if hasattr(mapping.type, "value") else mapping.type
         # create(**kwargs) 返回带 uuid 的新 mapping（add 收 model 对象，传 kwargs 会 TypeError）
         new_mapping = mapping_crud.create(
             portfolio_id=new_portfolio_id,
@@ -789,8 +838,7 @@ def _deploy_paper_trading(
             param_count += 1
 
     GLOG.INFO(
-        f"[DEPLOY] Copied {len(mappings)} component mapping(s) "
-        f"and {param_count} param(s) to {new_portfolio_id}"
+        f"[DEPLOY] Copied {len(mappings)} component mapping(s) " f"and {param_count} param(s) to {new_portfolio_id}"
     )
 
     # 4. 存储 source_portfolio_id 映射 + 计算 baseline
@@ -837,6 +885,7 @@ def _store_deploy_source(paper_portfolio_id: str, source_portfolio_id: str) -> N
     """将 source_portfolio_id 映射存入 Redis"""
     try:
         from ginkgo import services
+
         redis_svc = services.data.redis_service()
         if redis_svc:
             redis_svc.set_cache(f"deviation:source:{paper_portfolio_id}", source_portfolio_id)
@@ -870,7 +919,7 @@ def _generate_baseline_if_possible(paper_portfolio_id: str, source_portfolio_id:
             return
 
         latest_task = tasks[0]
-        task_id = getattr(latest_task, 'task_id', None)
+        task_id = getattr(latest_task, "task_id", None)
 
         if not task_id:
             GLOG.WARN(f"[DEPLOY] Backtest task has no task_id, skipping baseline")
@@ -897,8 +946,10 @@ def _generate_baseline_if_possible(paper_portfolio_id: str, source_portfolio_id:
         redis_svc = services.data.redis_service()
         if redis_svc:
             redis_svc.set_cache(f"deviation:baseline:{paper_portfolio_id}", json.dumps(baseline, default=str))
-            GLOG.INFO(f"[DEPLOY] Baseline cached: slice_period={baseline.get('slice_period_days')}, "
-                       f"metrics={len(baseline.get('baseline_stats', {}))}")
+            GLOG.INFO(
+                f"[DEPLOY] Baseline cached: slice_period={baseline.get('slice_period_days')}, "
+                f"metrics={len(baseline.get('baseline_stats', {}))}"
+            )
 
     except Exception as e:
         GLOG.WARN(f"[DEPLOY] Baseline generation failed (non-blocking): {e}")
@@ -921,6 +972,7 @@ def generate_baseline(
 
     # 从 Redis 读取 source_portfolio_id
     from ginkgo import services
+
     redis_svc = services.data.redis_service()
     source_id = None
     if redis_svc:
@@ -936,12 +988,14 @@ def generate_baseline(
 
     try:
         _generate_baseline_if_possible(portfolio_id, source_id)
-        console.print(Panel(
-            f"[bold green]Baseline generated/refreshed[/bold green]\n\n"
-            f"Portfolio ID: {portfolio_id}\n"
-            f"Source: {source_id}",
-            title="Baseline",
-        ))
+        console.print(
+            Panel(
+                f"[bold green]Baseline generated/refreshed[/bold green]\n\n"
+                f"Portfolio ID: {portfolio_id}\n"
+                f"Source: {source_id}",
+                title="Baseline",
+            )
+        )
     except Exception as e:
         GLOG.ERROR(f"[BASELINE] Generation failed: {e}")
         console.print(f"[bold red]Failed: {e}[/bold red]")

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -197,10 +197,29 @@ def list(
 
             console.print(table)
         else:
-            console.print(f":x: Failed to get portfolios: {result.error}")
+            # ADR-021 第 5/6 维：service 失败时，JSON 模式发错误 envelope + exit 1；
+            # text 模式打印诊断 + exit 1（失败 exit code 跨格式一致，非隐式 exit 0）。
+            if format == "json":
+                format_result(result, format="json", command="list")
+            else:
+                console.print(f":x: Failed to get portfolios: {result.error}")
+                raise typer.Exit(1)
 
+    # typer.Exit 是 Exception 子类（[[arch_typer_exit_swallowed_by_except_exception]]），
+    # 必须在 broad except 前透传 format_result 抛出的 Exit(1)，否则被吞成 exit 0。
+    except typer.Exit:
+        raise
     except Exception as e:
-        console.print(f":x: Error: {e}")
+        # ADR-021 第 1/5 维：JSON 模式 stdout 永远合法 JSON（异常=INTERNAL 错误对象）。
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="list",
+            )
+        else:
+            console.print(f":x: Error: {e}")
+            raise typer.Exit(1)
 
 
 @app.command()

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -35,7 +35,7 @@ def _format_portfolio_mode(mode_value) -> str:
 
 
 def _format_portfolio_status(portfolio) -> str:
-    """Use explicit status when present, otherwise derive display status from state."""
+    """Use explicit status when present, otherwise derive display status from state. (#6661)"""
     status_value = portfolio.get("status", None)
     if status_value is not None and not pd.isna(status_value):
         status_text = str(status_value).strip()
@@ -132,7 +132,6 @@ def list(
     page_size: int = typer.Option(20, "--page-size", help="Items per page (0 = all)"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
     format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
-    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :clipboard: List all portfolios.
@@ -143,12 +142,22 @@ def list(
         console.print(":clipboard: Listing portfolios...")
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope 而非纯文本（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page must be >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page must be >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size must be >= 0 (0 = all)", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
+    # --raw 语义为全量导出（旧契约），强制 unlimited 避免分页截断（#6652 review C2）。
+    if raw:
+        page_size = 0
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size
@@ -207,7 +216,7 @@ def list(
 
             for _, portfolio in portfolios_df.iterrows():
                 initial_capital = f"¥{float(portfolio.get('initial_capital', 0)):,.2f}"
-                portfolio_type = "Live" if portfolio.get('is_live', False) else "Backtest"
+                portfolio_type = "Live" if portfolio.get("is_live", False) else "Backtest"
                 status = _format_portfolio_status(portfolio)
 
                 table.add_row(
@@ -299,7 +308,6 @@ def get(
     details: bool = typer.Option(False, "--details", "-d", help="Show detailed portfolio information"),
     performance: bool = typer.Option(False, "--performance", "-p", help="Show performance metrics"),
     format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
-    no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
 ):
     """
     :eyes: Show portfolio details and composition.

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -128,7 +128,8 @@ def display_component_tree(console, component_data: dict):
 @app.command()
 def list(
     status: Optional[str] = typer.Option(None, "--status", "-s", help="Filter by status"),
-    limit: int = typer.Option(20, "--limit", "-l", help="Page size"),
+    page: int = typer.Option(0, "--page", help="Page number (0-based)"),
+    page_size: int = typer.Option(20, "--page-size", help="Items per page (0 = all)"),
     raw: bool = typer.Option(False, "--raw", "-r", help="Output raw data as JSON"),
     format: str = typer.Option("text", "--format", "-f", help="Output format: text/json"),
     no_color: bool = typer.Option(False, "--no-color", help="Disable color output"),
@@ -141,9 +142,20 @@ def list(
     if format != "json":
         console.print(":clipboard: Listing portfolios...")
 
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）。
+    if page < 0:
+        console.print("[red]:x: --page must be >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size must be >= 0 (0 = all)[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
+
     try:
         portfolio_service = container.portfolio_service()
-        result = portfolio_service.get_portfolios_df(page_size=limit)
+        result = portfolio_service.get_portfolios_df(page=q_page, page_size=q_page_size)
 
         if result.success:
             portfolios_data = result.data
@@ -173,7 +185,11 @@ def list(
                 else:
                     total = len(portfolios_df)
                 records = portfolios_df.to_dict("records")
-                json_result = build_list_result(records, total=total, limit=limit, offset=0)
+                # offset = page × page_size；全量时 offset=0、limit=None（ADR-021 metadata）。
+                json_result = build_list_result(
+                    records, total=total, limit=q_page_size,
+                    offset=0 if unlimited else page * page_size,
+                )
                 format_result(json_result, format="json", command="list")
                 return
 

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -143,7 +143,7 @@ def list(
 
     try:
         portfolio_service = container.portfolio_service()
-        result = portfolio_service.get_portfolios_df()
+        result = portfolio_service.get_portfolios_df(page_size=limit)
 
         if result.success:
             portfolios_data = result.data
@@ -164,7 +164,8 @@ def list(
 
             if format == "json":
                 total = len(portfolios_df)
-                records = portfolios_df.head(limit).to_dict("records")
+                # ADR-021 L139：--limit 已下推 service page_size（DB 层截断），此处不再 head(limit)。
+                records = portfolios_df.to_dict("records")
                 json_result = build_list_result(records, total=total, limit=limit, offset=0)
                 format_result(json_result, format="json", command="list")
                 return

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -391,8 +391,15 @@ def get(
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f":x: Error: {e}")
-        raise typer.Exit(1)
+        if format == "json":
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="get",
+            )
+        else:
+            console.print(f":x: Error: {e}")
+            raise typer.Exit(1)
 
 
 @app.command()

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -166,8 +166,10 @@ def list(
                 # ADR-021：metadata.total 必须是未截断的匹配总数。
                 # portfolios_df 已被 page_size 截断，len(df) 是当前页记录数而非总数 → 用 service.count()。
                 count_result = portfolio_service.count()
-                if count_result.success and isinstance(count_result.data, int):
-                    total = count_result.data
+                # PortfolioService.count() 返回 ServiceResult.success({"count": N})（dict 契约，见 portfolio_service.py:1133）。
+                # 须解 dict 取 key；isinstance(int) 对 dict 恒 False 会导致 total 静默回退截断计数 len(df)。
+                if count_result.success and isinstance(count_result.data, dict) and "count" in count_result.data:
+                    total = count_result.data["count"]
                 else:
                     total = len(portfolios_df)
                 records = portfolios_df.to_dict("records")

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -163,8 +163,13 @@ def list(
             portfolios_df = portfolios_data if isinstance(portfolios_data, pd.DataFrame) else pd.DataFrame()
 
             if format == "json":
-                total = len(portfolios_df)
-                # ADR-021 L139：--limit 已下推 service page_size（DB 层截断），此处不再 head(limit)。
+                # ADR-021：metadata.total 必须是未截断的匹配总数。
+                # portfolios_df 已被 page_size 截断，len(df) 是当前页记录数而非总数 → 用 service.count()。
+                count_result = portfolio_service.count()
+                if count_result.success and isinstance(count_result.data, int):
+                    total = count_result.data
+                else:
+                    total = len(portfolios_df)
                 records = portfolios_df.to_dict("records")
                 json_result = build_list_result(records, total=total, limit=limit, offset=0)
                 format_result(json_result, format="json", command="list")

--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -23,7 +23,9 @@ def signal(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
+    format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
     """
     :satellite_antenna: List trading signals.
@@ -32,6 +34,18 @@ def signal(
     """
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
+    from ginkgo.client.cli_utils import build_list_result, format_result
+
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    if page < 0:
+        console.print("[red]:x: --page 必须 >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
 
     try:
         signal_svc = container.signal_service()
@@ -39,7 +53,8 @@ def signal(
             portfolio_id=portfolio,
             engine_id=engine,
             task_id=task,
-            page_size=page,
+            page=q_page,
+            page_size=q_page_size,
         )
         if not result.success:
             console.print(f":x: [red]{result.error}[/red]")
@@ -47,6 +62,16 @@ def signal(
 
         # ADR-010 R2b: get_signals_df 出口已保证 data 为 DataFrame（类型即契约）
         signals_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
+
+        # #5009：metadata.total = count_signals 真实总数（signals_df 已被 page_size 截断）
+        count_res = signal_svc.count_signals(portfolio_id=portfolio, engine_id=engine, task_id=task)
+        total = count_res.data.get("count", 0) if count_res.success and isinstance(count_res.data, dict) else len(signals_df)
+
+        if format == "json":
+            records = signals_df.to_dict("records") if not signals_df.empty else []
+            json_result = build_list_result(records, total=total, limit=q_page_size, offset=0 if unlimited else page * page_size)
+            format_result(json_result, format="json", command="signal")
+            return
 
         if signals_df.shape[0] == 0:
             console.print(":exclamation: [yellow]No signals found.[/yellow]")
@@ -71,9 +96,11 @@ def signal(
             console=console
         )
 
-        if signals_df.shape[0] == page and page > 0:
-            console.print(f"[dim]Showing first {page} records. Use --page 0 to see all records.[/dim]")
+        if unlimited is False and total > signals_df.shape[0]:
+            console.print(f"[dim]共 {total} 条，当前第 {page + 1} 页（每页 {page_size} 条）。使用 --page 翻页，--page-size 0 看全部。[/dim]")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: [bold red]Failed to fetch signals:[/bold red] {e}")
 
@@ -83,13 +110,27 @@ def order(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
+    format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
     """
     :clipboard: List order records.
     """
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
+    from ginkgo.client.cli_utils import build_list_result, format_result
+
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    if page < 0:
+        console.print("[red]:x: --page 必须 >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
 
     try:
         order_svc = container.order_service()
@@ -97,7 +138,8 @@ def order(
             portfolio_id=portfolio,
             engine_id=engine,
             task_id=task,
-            page_size=page,
+            page=q_page,
+            page_size=q_page_size,
         )
         if not result.success:
             console.print(f":x: [red]{result.error}[/red]")
@@ -105,6 +147,20 @@ def order(
 
         # ADR-010 R2b: get_orders_df 出口已保证 data 为 DataFrame（类型即契约）
         orders_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
+
+        # #5009：metadata.total = count_orders 真实总数
+        count_res = order_svc.count_orders(portfolio_id=portfolio, engine_id=engine, task_id=task)
+        total = count_res.data.get("count", 0) if count_res.success and isinstance(count_res.data, dict) else len(orders_df)
+
+        if format == "json":
+            records = orders_df.to_dict("records") if not orders_df.empty else []
+            json_result = build_list_result(records, total=total, limit=q_page_size, offset=0 if unlimited else page * page_size)
+            format_result(json_result, format="json", command="order")
+            return
+
+        if orders_df.shape[0] == 0:
+            console.print(":exclamation: [yellow]No orders found.[/yellow]")
+            return
 
         order_columns_config = {
             "uuid": {"display_name": "Order ID", "style": "dim"},
@@ -126,9 +182,11 @@ def order(
             console=console
         )
 
-        if orders_df.shape[0] == page and page > 0:
-            console.print(f"[dim]Showing first {page} records. Use --page 0 to see all records.[/dim]")
+        if unlimited is False and total > orders_df.shape[0]:
+            console.print(f"[dim]共 {total} 条，当前第 {page + 1} 页（每页 {page_size} 条）。使用 --page 翻页，--page-size 0 看全部。[/dim]")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: [bold red]Failed to fetch orders:[/bold red] {e}")
 
@@ -138,13 +196,27 @@ def position(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
+    format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
     """
     :bar_chart: List position records.
     """
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
+    from ginkgo.client.cli_utils import build_list_result, format_result
+
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    if page < 0:
+        console.print("[red]:x: --page 必须 >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
 
     try:
         # #5341: 回测持仓经 create_position_record 写 MPositionRecord（流水表），
@@ -155,7 +227,8 @@ def position(
             portfolio_id=portfolio,
             engine_id=engine,
             task_id=task,
-            page_size=page,
+            page=q_page,
+            page_size=q_page_size,
         )
         if not result.success:
             console.print(f":x: [red]{result.error}[/red]")
@@ -163,6 +236,20 @@ def position(
 
         # ADR-010 R2b: get_positions_df 出口已保证 data 为 DataFrame（类型即契约）
         positions_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
+
+        # #5009：metadata.total = count_positions 真实总数（MPositionRecord ClickHouse 流水）
+        count_res = result_svc.count_positions(portfolio_id=portfolio, engine_id=engine, task_id=task)
+        total = count_res.data.get("count", 0) if count_res.success and isinstance(count_res.data, dict) else len(positions_df)
+
+        if format == "json":
+            records = positions_df.to_dict("records") if not positions_df.empty else []
+            json_result = build_list_result(records, total=total, limit=q_page_size, offset=0 if unlimited else page * page_size)
+            format_result(json_result, format="json", command="position")
+            return
+
+        if positions_df.shape[0] == 0:
+            console.print(":exclamation: [yellow]No positions found.[/yellow]")
+            return
 
         # MPositionRecord 流水字段（volume/cost/price/fee），非 MPosition 当前态字段
         position_columns_config = {
@@ -184,9 +271,11 @@ def position(
             console=console
         )
 
-        if positions_df.shape[0] == page and page > 0:
-            console.print(f"[dim]Showing first {page} records. Use --page 0 to see all records.[/dim]")
+        if unlimited is False and total > positions_df.shape[0]:
+            console.print(f"[dim]共 {total} 条，当前第 {page + 1} 页（每页 {page_size} 条）。使用 --page 翻页，--page-size 0 看全部。[/dim]")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: [bold red]Failed to fetch positions:[/bold red] {e}")
 
@@ -195,26 +284,55 @@ def position(
 def analyzer(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":page_facing_up: Items per page (0=no pagination)")] = 50,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
+    format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
     """
     :bar_chart: List analyzer records.
     """
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
+    from ginkgo.client.cli_utils import build_list_result, format_result
+
+    # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    if page < 0:
+        console.print("[red]:x: --page 必须 >= 0[/red]")
+        raise typer.Exit(1)
+    if page_size < 0:
+        console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
+        raise typer.Exit(1)
+    unlimited = page_size == 0
+    q_page = None if unlimited else page
+    q_page_size = None if unlimited else page_size
 
     try:
         analyzer_svc = container.analyzer_service()
         result = analyzer_svc.get_records_df(
             portfolio_id=portfolio,
             engine_id=engine,
-            page_size=page,
+            page=q_page,
+            page_size=q_page_size,
         )
         if not result.success:
             console.print(f":x: [red]{result.error}[/red]")
             return
 
         analyzer_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
+
+        # #5009：metadata.total = count_records 真实总数
+        count_res = analyzer_svc.count_records(portfolio_id=portfolio, engine_id=engine)
+        total = count_res.data.get("count", 0) if count_res.success and isinstance(count_res.data, dict) else len(analyzer_df)
+
+        if format == "json":
+            records = analyzer_df.to_dict("records") if not analyzer_df.empty else []
+            json_result = build_list_result(records, total=total, limit=q_page_size, offset=0 if unlimited else page * page_size)
+            format_result(json_result, format="json", command="analyzer")
+            return
+
+        if analyzer_df.shape[0] == 0:
+            console.print(":exclamation: [yellow]No analyzer records found.[/yellow]")
+            return
 
         title_parts = []
         if portfolio:
@@ -240,8 +358,10 @@ def analyzer(
             console=console
         )
 
-        if analyzer_df.shape[0] == page and page > 0:
-            console.print(f"[dim]Showing first {page} records. Use --page 0 to see all records.[/dim]")
+        if unlimited is False and total > analyzer_df.shape[0]:
+            console.print(f"[dim]共 {total} 条，当前第 {page + 1} 页（每页 {page_size} 条）。使用 --page 翻页，--page-size 0 看全部。[/dim]")
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f":x: [bold red]Failed to fetch analyzer records:[/bold red] {e}")

--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -23,7 +23,7 @@ def signal(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based，旧版 --page 语义为每页条数，已迁移至 --page-size）")] = 0,
     page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
     format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
@@ -123,7 +123,7 @@ def order(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based，旧版 --page 语义为每页条数，已迁移至 --page-size）")] = 0,
     page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
     format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
@@ -222,7 +222,7 @@ def position(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
     task: Annotated[Optional[str], typer.Option("--task", "-t", "--t", help=":id: Task ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based，旧版 --page 语义为每页条数，已迁移至 --page-size）")] = 0,
     page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
     format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):
@@ -323,7 +323,7 @@ def position(
 def analyzer(
     portfolio: Annotated[Optional[str], typer.Option("--portfolio", "-p", "--p", help=":id: Portfolio ID filter")] = None,
     engine: Annotated[Optional[str], typer.Option("--engine", "-e", "--e", help=":id: Engine ID filter")] = None,
-    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based）")] = 0,
+    page: Annotated[int, typer.Option("--page", help=":1234: 页码（0-based，旧版 --page 语义为每页条数，已迁移至 --page-size）")] = 0,
     page_size: Annotated[int, typer.Option("--page-size", help=":page_facing_up: 每页条数（0=全部）")] = 50,
     format: Annotated[str, typer.Option("--format", "-F", help="输出格式: text/json")] = "text",
 ):

--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -57,8 +57,11 @@ def signal(
             page_size=q_page_size,
         )
         if not result.success:
-            console.print(f":x: [red]{result.error}[/red]")
-            return
+            if format == "json":
+                format_result(result, format="json", command="signal")
+            else:
+                console.print(f":x: [red]{result.error}[/red]")
+                raise typer.Exit(1)
 
         # ADR-010 R2b: get_signals_df 出口已保证 data 为 DataFrame（类型即契约）
         signals_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
@@ -102,7 +105,17 @@ def signal(
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f":x: [bold red]Failed to fetch signals:[/bold red] {e}")
+        if format == "json":
+            from ginkgo.data.services.base_service import ServiceResult
+
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="signal",
+            )
+        else:
+            console.print(f":x: [bold red]Failed to fetch signals:[/bold red] {e}")
+            raise typer.Exit(1)
 
 
 @app.command()
@@ -142,8 +155,11 @@ def order(
             page_size=q_page_size,
         )
         if not result.success:
-            console.print(f":x: [red]{result.error}[/red]")
-            return
+            if format == "json":
+                format_result(result, format="json", command="order")
+            else:
+                console.print(f":x: [red]{result.error}[/red]")
+                raise typer.Exit(1)
 
         # ADR-010 R2b: get_orders_df 出口已保证 data 为 DataFrame（类型即契约）
         orders_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
@@ -188,7 +204,17 @@ def order(
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f":x: [bold red]Failed to fetch orders:[/bold red] {e}")
+        if format == "json":
+            from ginkgo.data.services.base_service import ServiceResult
+
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="order",
+            )
+        else:
+            console.print(f":x: [bold red]Failed to fetch orders:[/bold red] {e}")
+            raise typer.Exit(1)
 
 
 @app.command()
@@ -231,8 +257,11 @@ def position(
             page_size=q_page_size,
         )
         if not result.success:
-            console.print(f":x: [red]{result.error}[/red]")
-            return
+            if format == "json":
+                format_result(result, format="json", command="position")
+            else:
+                console.print(f":x: [red]{result.error}[/red]")
+                raise typer.Exit(1)
 
         # ADR-010 R2b: get_positions_df 出口已保证 data 为 DataFrame（类型即契约）
         positions_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
@@ -277,7 +306,17 @@ def position(
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f":x: [bold red]Failed to fetch positions:[/bold red] {e}")
+        if format == "json":
+            from ginkgo.data.services.base_service import ServiceResult
+
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="position",
+            )
+        else:
+            console.print(f":x: [bold red]Failed to fetch positions:[/bold red] {e}")
+            raise typer.Exit(1)
 
 
 @app.command()
@@ -315,8 +354,11 @@ def analyzer(
             page_size=q_page_size,
         )
         if not result.success:
-            console.print(f":x: [red]{result.error}[/red]")
-            return
+            if format == "json":
+                format_result(result, format="json", command="analyzer")
+            else:
+                console.print(f":x: [red]{result.error}[/red]")
+                raise typer.Exit(1)
 
         analyzer_df = result.data if isinstance(result.data, pd.DataFrame) else pd.DataFrame()
 
@@ -364,4 +406,14 @@ def analyzer(
     except typer.Exit:
         raise
     except Exception as e:
-        console.print(f":x: [bold red]Failed to fetch analyzer records:[/bold red] {e}")
+        if format == "json":
+            from ginkgo.data.services.base_service import ServiceResult
+
+            format_result(
+                ServiceResult.failure(message=f"Error: {e}", code="INTERNAL"),
+                format="json",
+                command="analyzer",
+            )
+        else:
+            console.print(f":x: [bold red]Failed to fetch analyzer records:[/bold red] {e}")
+            raise typer.Exit(1)

--- a/src/ginkgo/client/record_cli.py
+++ b/src/ginkgo/client/record_cli.py
@@ -35,14 +35,22 @@ def signal(
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
     from ginkgo.client.cli_utils import build_list_result, format_result
+    from ginkgo.data.services.base_service import ServiceResult
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page 必须 >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page 必须 >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size 必须 >= 0（0=全部）", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size
@@ -133,14 +141,22 @@ def order(
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
     from ginkgo.client.cli_utils import build_list_result, format_result
+    from ginkgo.data.services.base_service import ServiceResult
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page 必须 >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page 必须 >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size 必须 >= 0（0=全部）", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size
@@ -232,14 +248,22 @@ def position(
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
     from ginkgo.client.cli_utils import build_list_result, format_result
+    from ginkgo.data.services.base_service import ServiceResult
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page 必须 >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page 必须 >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size 必须 >= 0（0=全部）", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size
@@ -333,14 +357,22 @@ def analyzer(
     from ginkgo.data.containers import container
     from ginkgo.libs.utils.display import display_dataframe
     from ginkgo.client.cli_utils import build_list_result, format_result
+    from ginkgo.data.services.base_service import ServiceResult
 
     # #5009 契约：--page（0-based）+ --page-size（0=全量）
+    # ADR-021：参数校验失败 exit 2（BAD_PARAMS）；JSON 模式发错误 envelope（#6652 review E2）。
     if page < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page 必须 >= 0", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page 必须 >= 0[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     if page_size < 0:
+        if format == "json":
+            format_result(ServiceResult.failure(message="--page-size 必须 >= 0（0=全部）", code="BAD_PARAMS"), format="json", command="list")
+            raise typer.Exit(2)
         console.print("[red]:x: --page-size 必须 >= 0（0=全部）[/red]")
-        raise typer.Exit(1)
+        raise typer.Exit(2)
     unlimited = page_size == 0
     q_page = None if unlimited else page
     q_page_size = None if unlimited else page_size

--- a/src/ginkgo/data/services/analyzer_service.py
+++ b/src/ginkgo/data/services/analyzer_service.py
@@ -218,6 +218,7 @@ class AnalyzerService(BaseService):
         self,
         portfolio_id: Optional[str] = None,
         engine_id: Optional[str] = None,
+        page: int = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
@@ -225,6 +226,9 @@ class AnalyzerService(BaseService):
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
+
+        #5009：page（0-based）/page_size 分页；MAnalyzerRecord 为 ClickHouse，
+        order_by=timestamp desc 保证分页确定性。
         """
         try:
             filters = self._build_analyzer_record_filters(
@@ -232,7 +236,10 @@ class AnalyzerService(BaseService):
             )
             model_list = self._crud_repo.find(
                 filters=filters,
+                page=page,
                 page_size=page_size if page_size > 0 else None,
+                order_by="timestamp",
+                desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
@@ -242,6 +249,22 @@ class AnalyzerService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"查询 analyzer 记录(df)失败: {e}")
             return ServiceResult.error(f"查询 analyzer 记录(df)失败: {e}")
+
+    def count_records(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+    ) -> ServiceResult:
+        """统计匹配 analyzer 记录总数（#5009：metadata.total 真实总数，非 len(df)）。"""
+        try:
+            filters = self._build_analyzer_record_filters(
+                portfolio_id=portfolio_id, engine_id=engine_id,
+            )
+            count = self._crud_repo.count(filters=filters)
+            return ServiceResult.success({"count": count}, f"Successfully counted analyzer records: {count}")
+        except Exception as e:
+            GLOG.ERROR(f"统计 analyzer 记录失败: {e}")
+            return ServiceResult.error(f"统计 analyzer 记录失败: {e}")
 
     def get_latest_by_portfolio(
         self,

--- a/src/ginkgo/data/services/analyzer_service.py
+++ b/src/ginkgo/data/services/analyzer_service.py
@@ -190,7 +190,7 @@ class AnalyzerService(BaseService):
 
             results = self._crud_repo.find(
                 filters=filters,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
             )
             return ServiceResult.success(data=results)
         except Exception as e:
@@ -237,7 +237,7 @@ class AnalyzerService(BaseService):
             model_list = self._crud_repo.find(
                 filters=filters,
                 page=page,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
                 order_by="timestamp",
                 desc_order=True,
             )

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -180,12 +180,14 @@ class BacktestTaskService(BaseService):
             ServiceResult: 列表结果
         """
         try:
+            # None 守卫：0=全量下推 None（与 signal/engine/portfolio service 一致），
+            # 裸 page_size=0 触发 BaseCRUD.find LIMIT 0 返空，破坏 ADR-021 "0=all" 契约（#6652 review R4）。
             result = self._crud_repo.get_tasks_page_filtered(
                 engine_id=engine_id,
                 portfolio_id=portfolio_id,
                 status=status,
                 page=page,
-                page_size=page_size
+                page_size=page_size if page_size and page_size > 0 else None,
             )
 
             # 获取总数（应用相同的筛选条件）

--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -114,18 +114,22 @@ class EngineService(BaseService):
         return filters
 
     def get_engines_df(self, engine_id: str = None, name: str = None,
-                       is_live: bool = None, status: ENGINESTATUS_TYPES = None) -> ServiceResult:
+                       is_live: bool = None, status: ENGINESTATUS_TYPES = None,
+                       page_size: int = None) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
 
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
+
+        ADR-021 L139：``page_size`` 透传 ``find(page_size=)``，供 CLI ``--limit``
+        下推（替代 client-side ``head(limit)``）；``None`` 保持全量默认。
         """
         try:
             filters = self._build_engine_filters(
                 engine_id=engine_id, name=name, is_live=is_live, status=status,
             )
-            model_list = self._crud_repo.find(filters=filters)
+            model_list = self._crud_repo.find(filters=filters, page_size=page_size)
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
                 data=df,
@@ -1026,7 +1030,8 @@ class EngineService(BaseService):
     def fuzzy_search(
         self,
         query: str,
-        fields: Optional[List[str]] = None
+        fields: Optional[List[str]] = None,
+        page_size: int = None,
     ) -> ServiceResult:
         """
         Fuzzy search engines across multiple fields with OR logic.
@@ -1034,6 +1039,8 @@ class EngineService(BaseService):
         Args:
             query: Search string
             fields: Fields to search in. Default: ['uuid', 'name', 'is_live', 'status']
+            page_size: ADR-021 L139 — ``--limit`` 下推，透传 ``crud.fuzzy_search(limit=)``；
+                ``None`` 保持全量默认。
 
         Returns:
             ServiceResult with list of engines data
@@ -1043,7 +1050,7 @@ class EngineService(BaseService):
                 return ServiceResult.success(ModelList([], self._crud_repo))
 
             # Delegate to CRUD layer for database-level fuzzy search
-            results = self._crud_repo.fuzzy_search(query, fields)
+            results = self._crud_repo.fuzzy_search(query, fields, limit=page_size)
 
             return ServiceResult.success(results)
 

--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -132,8 +132,10 @@ class EngineService(BaseService):
             filters = self._build_engine_filters(
                 engine_id=engine_id, name=name, is_live=is_live, status=status,
             )
+            # None 守卫：0=全量下推 None（与 signal_service 一致），裸 page_size=0 触发 LIMIT 0 返空（#6652 review R3-issue3）。
             model_list = self._crud_repo.find(
-                filters=filters, page=page, page_size=page_size,
+                filters=filters, page=page,
+                page_size=page_size if page_size and page_size > 0 else None,
                 order_by="create_at", desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()

--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -115,21 +115,27 @@ class EngineService(BaseService):
 
     def get_engines_df(self, engine_id: str = None, name: str = None,
                        is_live: bool = None, status: ENGINESTATUS_TYPES = None,
-                       page_size: int = None) -> ServiceResult:
+                       page: int = None, page_size: int = None) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
 
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
 
-        ADR-021 L139：``page_size`` 透传 ``find(page_size=)``，供 CLI ``--limit``
-        下推（替代 client-side ``head(limit)``）；``None`` 保持全量默认。
+        ADR-021 L139（#5009 契约）：``page``/``page_size`` 透传 ``find(page=,
+        page_size=)``，DB 层 offset 分页；``order_by="create_at",
+        desc_order=True`` 保证翻页确定性（MySQL 无 ORDER BY 时 LIMIT/OFFSET
+        行序未定义，跨页可能重叠/丢行）。``page=None``/``page_size=None`` 保持
+        全量默认。fuzzy_search 路径不走此方法（见 ``fuzzy_search``）。
         """
         try:
             filters = self._build_engine_filters(
                 engine_id=engine_id, name=name, is_live=is_live, status=status,
             )
-            model_list = self._crud_repo.find(filters=filters, page_size=page_size)
+            model_list = self._crud_repo.find(
+                filters=filters, page=page, page_size=page_size,
+                order_by="create_at", desc_order=True,
+            )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
                 data=df,

--- a/src/ginkgo/data/services/order_service.py
+++ b/src/ginkgo/data/services/order_service.py
@@ -62,7 +62,7 @@ class OrderService(BaseService):
 
             results = self._crud_repo.find(
                 filters=filters,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
             )
             return ServiceResult.success(data=results)
         except Exception as e:
@@ -113,7 +113,7 @@ class OrderService(BaseService):
             model_list = self._crud_repo.find(
                 filters=filters,
                 page=page,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
                 order_by="create_at",
                 desc_order=True,
             )

--- a/src/ginkgo/data/services/order_service.py
+++ b/src/ginkgo/data/services/order_service.py
@@ -94,6 +94,7 @@ class OrderService(BaseService):
         portfolio_id: Optional[str] = None,
         engine_id: Optional[str] = None,
         task_id: Optional[str] = None,
+        page: int = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
@@ -101,6 +102,9 @@ class OrderService(BaseService):
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
+
+        #5009：page（0-based）/page_size 分页；MOrder 为 MySQL，order_by=create_at
+        desc 保证分页确定性。
         """
         try:
             filters = self._build_order_filters(
@@ -108,7 +112,10 @@ class OrderService(BaseService):
             )
             model_list = self._crud_repo.find(
                 filters=filters,
+                page=page,
                 page_size=page_size if page_size > 0 else None,
+                order_by="create_at",
+                desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
@@ -118,6 +125,23 @@ class OrderService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"查询订单(df)失败: {str(e)}")
             return ServiceResult.error(f"查询订单(df)失败: {str(e)}")
+
+    def count_orders(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> ServiceResult:
+        """统计匹配订单总数（#5009：metadata.total 真实总数，非 len(df)）。"""
+        try:
+            filters = self._build_order_filters(
+                portfolio_id=portfolio_id, engine_id=engine_id, task_id=task_id,
+            )
+            count = self._crud_repo.count(filters=filters)
+            return ServiceResult.success({"count": count}, f"Successfully counted orders: {count}")
+        except Exception as e:
+            GLOG.ERROR(f"统计订单失败: {str(e)}")
+            return ServiceResult.error(f"统计订单失败: {str(e)}")
 
     def get_orders_by_portfolio(
         self,

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -1103,8 +1103,10 @@ class PortfolioService(BaseService):
             filters = self._build_portfolio_filters(
                 portfolio_id=portfolio_id, name=name, mode=mode, state=state,
             )
+            # None 守卫：0=全量下推 None（与 signal_service 一致），裸 page_size=0 触发 LIMIT 0 返空（#6652 review R3-issue3）。
             model_list = self._crud_repo.find(
-                filters=filters, page=page, page_size=page_size,
+                filters=filters, page=page,
+                page_size=page_size if page_size and page_size > 0 else None,
                 order_by="create_at", desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -1086,21 +1086,27 @@ class PortfolioService(BaseService):
     def get_portfolios_df(self, portfolio_id: str = None, name: str = None,
                           mode: PORTFOLIO_MODE_TYPES = None,
                           state: PORTFOLIO_RUNSTATE_TYPES = None,
-                          page_size: int = None) -> ServiceResult:
+                          page: int = None, page_size: int = None) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
 
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
 
-        ADR-021 L139：``page_size`` 透传 ``find(page_size=)``，供 CLI ``--limit``
-        下推（替代 client-side ``head(limit)``）；``None`` 保持全量默认。
+        ADR-021 L139（#5009 契约）：``page``/``page_size`` 透传 ``find(page=,
+        page_size=)``，DB 层 offset 分页；``order_by="create_at",
+        desc_order=True`` 保证翻页确定性（MySQL 无 ORDER BY 时 LIMIT/OFFSET
+        行序未定义，跨页可能重叠/丢行）。``page=None``/``page_size=None`` 保持
+        全量默认。
         """
         try:
             filters = self._build_portfolio_filters(
                 portfolio_id=portfolio_id, name=name, mode=mode, state=state,
             )
-            model_list = self._crud_repo.find(filters=filters, page_size=page_size)
+            model_list = self._crud_repo.find(
+                filters=filters, page=page, page_size=page_size,
+                order_by="create_at", desc_order=True,
+            )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
                 data=df,

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -1085,18 +1085,22 @@ class PortfolioService(BaseService):
 
     def get_portfolios_df(self, portfolio_id: str = None, name: str = None,
                           mode: PORTFOLIO_MODE_TYPES = None,
-                          state: PORTFOLIO_RUNSTATE_TYPES = None) -> ServiceResult:
+                          state: PORTFOLIO_RUNSTATE_TYPES = None,
+                          page_size: int = None) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
 
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
+
+        ADR-021 L139：``page_size`` 透传 ``find(page_size=)``，供 CLI ``--limit``
+        下推（替代 client-side ``head(limit)``）；``None`` 保持全量默认。
         """
         try:
             filters = self._build_portfolio_filters(
                 portfolio_id=portfolio_id, name=name, mode=mode, state=state,
             )
-            model_list = self._crud_repo.find(filters=filters)
+            model_list = self._crud_repo.find(filters=filters, page_size=page_size)
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
                 data=df,

--- a/src/ginkgo/data/services/position_service.py
+++ b/src/ginkgo/data/services/position_service.py
@@ -74,7 +74,7 @@ class PositionService(BaseService):
 
             results = self._crud_repo.find(
                 filters=filters,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
             )
             return ServiceResult.success(data=results)
         except Exception as e:
@@ -120,7 +120,7 @@ class PositionService(BaseService):
             )
             model_list = self._crud_repo.find(
                 filters=filters,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(

--- a/src/ginkgo/data/services/result_service.py
+++ b/src/ginkgo/data/services/result_service.py
@@ -600,7 +600,7 @@ class ResultService(BaseService):
             model_list = position_record_crud.find(
                 filters=filters,
                 page=page,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
                 order_by="timestamp",
                 desc_order=True,
             )

--- a/src/ginkgo/data/services/result_service.py
+++ b/src/ginkgo/data/services/result_service.py
@@ -577,6 +577,7 @@ class ResultService(BaseService):
         portfolio_id: Optional[str] = None,
         engine_id: Optional[str] = None,
         task_id: Optional[str] = None,
+        page: int = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（查 MPositionRecord 流水表）。
@@ -585,22 +586,23 @@ class ResultService(BaseService):
         非 MPosition（当前态表）。record position 读 MPosition 永远空，须查流水表。
         filter 域与 position_service.get_positions_df 对称（portfolio/engine/task），
         出口契约同为 DataFrame（ADR-010）。
+
+        #5009：page（0-based）/page_size 分页；MPositionRecord 为 ClickHouse 流水表，
+        order_by=timestamp desc 保证分页确定性（CH MergeTree 无隐式顺序保证）。
         """
         try:
+            filters = self._build_position_record_filters(
+                portfolio_id=portfolio_id, engine_id=engine_id, task_id=task_id,
+            )
             from ginkgo.data.crud.position_record_crud import PositionRecordCRUD
             position_record_crud = PositionRecordCRUD()
 
-            filters = {"is_del": False}
-            if portfolio_id:
-                filters["portfolio_id"] = portfolio_id
-            if engine_id:
-                filters["engine_id"] = engine_id
-            if task_id:
-                filters["task_id"] = task_id
-
             model_list = position_record_crud.find(
                 filters=filters,
+                page=page,
                 page_size=page_size if page_size > 0 else None,
+                order_by="timestamp",
+                desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
@@ -610,6 +612,37 @@ class ResultService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"查询持仓记录(df)失败: {str(e)}")
             return ServiceResult.error(f"查询持仓记录(df)失败: {str(e)}")
+
+    def count_positions(
+        self,
+        portfolio_id: Optional[str] = None,
+        engine_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> ServiceResult:
+        """统计匹配持仓流水总数（#5009：metadata.total 真实总数，非 len(df)）。"""
+        try:
+            filters = self._build_position_record_filters(
+                portfolio_id=portfolio_id, engine_id=engine_id, task_id=task_id,
+            )
+            from ginkgo.data.crud.position_record_crud import PositionRecordCRUD
+            position_record_crud = PositionRecordCRUD()
+            count = position_record_crud.count(filters=filters)
+            return ServiceResult.success({"count": count}, f"Successfully counted positions: {count}")
+        except Exception as e:
+            GLOG.ERROR(f"统计持仓记录失败: {str(e)}")
+            return ServiceResult.error(f"统计持仓记录失败: {str(e)}")
+
+    @staticmethod
+    def _build_position_record_filters(portfolio_id=None, engine_id=None, task_id=None) -> dict:
+        """MPositionRecord 流水表 filter 构造（get_positions_df/count_positions 共用）。"""
+        filters = {"is_del": False}
+        if portfolio_id:
+            filters["portfolio_id"] = portfolio_id
+        if engine_id:
+            filters["engine_id"] = engine_id
+        if task_id:
+            filters["task_id"] = task_id
+        return filters
 
     @retry(max_try=3)
     def create_order_record(self, **kwargs) -> ServiceResult:

--- a/src/ginkgo/data/services/signal_service.py
+++ b/src/ginkgo/data/services/signal_service.py
@@ -118,8 +118,9 @@ class SignalService(BaseService):
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
 
-        #5009：page（0-based）/page_size 分页；MSignalTracker 为 MySQL，order_by=create_at
-        desc 保证分页确定性（MySQL 无隐式顺序，缺 order_by 则分页结果不稳定）。
+        #5009：page（0-based）/page_size 分页；MSignal 为 ClickHouse（MClickBase），
+        order_by=timestamp desc 保证分页确定性（CH MergeTree 无隐式顺序保证，
+        缺 order_by 则分页结果不稳定；对齐 analyzer/result_service 同族出口）。
         """
         try:
             filters = self._build_signal_filters(
@@ -129,7 +130,7 @@ class SignalService(BaseService):
                 filters=filters,
                 page=page,
                 page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
-                order_by="create_at",
+                order_by="timestamp",
                 desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()

--- a/src/ginkgo/data/services/signal_service.py
+++ b/src/ginkgo/data/services/signal_service.py
@@ -47,7 +47,7 @@ class SignalService(BaseService):
 
             results = self._crud_repo.find(
                 filters=filters,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
             )
             return ServiceResult.success(data=results)
         except Exception as e:
@@ -128,7 +128,7 @@ class SignalService(BaseService):
             model_list = self._crud_repo.find(
                 filters=filters,
                 page=page,
-                page_size=page_size if page_size > 0 else None,
+                page_size=page_size if page_size and page_size > 0 else None,  # None 守卫：0=全量下推 None，裸 >0 对 None 报 TypeError
                 order_by="create_at",
                 desc_order=True,
             )

--- a/src/ginkgo/data/services/signal_service.py
+++ b/src/ginkgo/data/services/signal_service.py
@@ -109,6 +109,7 @@ class SignalService(BaseService):
         engine_id: Optional[str] = None,
         portfolio_id: Optional[str] = None,
         task_id: Optional[str] = None,
+        page: int = None,
         page_size: int = 50,
     ) -> ServiceResult:
         """出口①：data 是 pandas.DataFrame（类型即契约）。
@@ -116,6 +117,9 @@ class SignalService(BaseService):
         ADR-010：API/CLI 消费 DataFrame 语义时走此出口，不接触 ORM ModelList、
         不再绕 ``result.data.to_dataframe()``。内部 find 返 ModelList 后调
         ``to_dataframe()``；空结果返空 ``pd.DataFrame()``。
+
+        #5009：page（0-based）/page_size 分页；MSignalTracker 为 MySQL，order_by=create_at
+        desc 保证分页确定性（MySQL 无隐式顺序，缺 order_by 则分页结果不稳定）。
         """
         try:
             filters = self._build_signal_filters(
@@ -123,7 +127,10 @@ class SignalService(BaseService):
             )
             model_list = self._crud_repo.find(
                 filters=filters,
+                page=page,
                 page_size=page_size if page_size > 0 else None,
+                order_by="create_at",
+                desc_order=True,
             )
             df = model_list.to_dataframe() if model_list else pd.DataFrame()
             return ServiceResult.success(
@@ -133,6 +140,23 @@ class SignalService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"查询信号(df)失败: {str(e)}")
             return ServiceResult.error(f"查询信号(df)失败: {str(e)}")
+
+    def count_signals(
+        self,
+        engine_id: Optional[str] = None,
+        portfolio_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+    ) -> ServiceResult:
+        """统计匹配信号总数（#5009：metadata.total 真实总数，非 len(df)）。"""
+        try:
+            filters = self._build_signal_filters(
+                engine_id=engine_id, portfolio_id=portfolio_id, task_id=task_id,
+            )
+            count = self._crud_repo.count(filters=filters)
+            return ServiceResult.success({"count": count}, f"Successfully counted signals: {count}")
+        except Exception as e:
+            GLOG.ERROR(f"统计信号失败: {str(e)}")
+            return ServiceResult.error(f"统计信号失败: {str(e)}")
 
     def delete_signals_by_portfolio(self, portfolio_id: str) -> ServiceResult:
         """

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -366,12 +366,16 @@ class DeploymentService(BaseService):
         }
         return result
 
-    def list_deployments(self, portfolio_id: str = None) -> ServiceResult:
-        """列出部署记录"""
+    def list_deployments(self, portfolio_id: str = None, page: int = None, page_size: int = None) -> ServiceResult:
+        """列出部署记录（#5009：page/page_size 分页，portfolio 过滤下推 find）"""
+        filters = {}
         if portfolio_id:
-            records = self._deployment_crud.get_by_source_portfolio(portfolio_id)
-        else:
-            records = self._deployment_crud.find()
+            filters["source_portfolio_id"] = portfolio_id
+
+        records = self._deployment_crud.find(
+            filters=filters, page=page, page_size=page_size,
+            order_by="create_at", desc_order=True,
+        )
 
         if not records:
             return ServiceResult(success=True, data=[])
@@ -379,6 +383,14 @@ class DeploymentService(BaseService):
         result = ServiceResult(success=True)
         result.data = [self._deployment_to_dict(r) for r in records]
         return result
+
+    def count_deployments(self, portfolio_id: str = None) -> ServiceResult:
+        """统计部署记录总数（#5009：metadata.total 真实总数，非 len(data)）"""
+        filters = {}
+        if portfolio_id:
+            filters["source_portfolio_id"] = portfolio_id
+        count = self._deployment_crud.count(filters=filters)
+        return ServiceResult.success({"count": count}, f"Successfully counted deployments: {count}")
 
     # #3867: API 层不再直调 CRUD，通过 Service 封装
 

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -687,3 +687,105 @@ class TestBacktestRunTaskPreflightWarningDisplay:
         assert result_arg.data.get("preflight_warning") == full_warning, (
             "传给 helper 的 result 应携带全文 preflight_warning"
         )
+
+
+class TestBacktestCatJsonResultData:
+    """#6580 backtest cat --format json 须输出完整回测结果数据
+
+    text 路径渲染的 final_portfolio_value/total_pnl/max_drawdown/sharpe_ratio
+    等核心指标在 JSON 路径缺失（PR #6652 review 打回）。_task_record 补全字段，
+    让机读消费者在 JSON 路径拿到与 text 等量的结构化回测结果（ADR-021 初衷）。
+    """
+
+    @patch("ginkgo.data.containers.container")
+    def test_cat_json_includes_full_result_data(self, mock_container):
+        """--format json 成功路径输出含 metrics + statistics + 执行信息。"""
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.status = "completed"
+        # 回测结果 metrics（text 路径 Results panel）
+        task.final_portfolio_value = 125000.0
+        task.total_pnl = 25000.0
+        task.max_drawdown = -0.12
+        task.sharpe_ratio = 1.85
+        task.annual_return = 0.23
+        task.win_rate = 0.62
+        # 统计（text 路径 Statistics panel）
+        task.total_signals = 42
+        task.total_orders = 38
+        task.total_positions = 15
+        task.total_events = 500
+        # 执行信息
+        task.start_time = "2025-01-01T10:00:00"
+        task.end_time = "2025-01-01T10:05:00"
+        task.duration_seconds = 300
+        task.error_message = None
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = True
+        result.data = task
+        mock_service.get_by_id.return_value = result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "abc123456789", "--format", "json"])
+
+        assert invoke_result.exit_code == 0
+        payload = json.loads(invoke_result.output)
+        assert payload["success"] is True
+        record = payload["data"]
+        # Results metrics（reviewer 点名的核心指标）
+        assert record["final_portfolio_value"] == 125000.0
+        assert record["total_pnl"] == 25000.0
+        assert record["max_drawdown"] == -0.12
+        assert record["sharpe_ratio"] == 1.85
+        assert record["annual_return"] == 0.23
+        assert record["win_rate"] == 0.62
+        # Statistics
+        assert record["total_signals"] == 42
+        assert record["total_orders"] == 38
+        assert record["total_positions"] == 15
+        assert record["total_events"] == 500
+        # 执行信息
+        assert record["start_time"] == "2025-01-01T10:00:00"
+        assert record["end_time"] == "2025-01-01T10:05:00"
+        assert record["duration_seconds"] == 300
+        assert record["error_message"] is None
+
+
+class TestBacktestListJsonResultMetrics:
+    """#6580 list --format json 也含回测结果 metrics
+
+    _task_record 被 list/cat 共用，扩展后 list 每个 record 同步带上 metrics，
+    回测列表可机读每个任务收益/回撤（ADR-021 机读收益）。
+    """
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_json_includes_metrics(self, mock_container):
+        """--format json list 每个 record 含 final_portfolio_value/sharpe_ratio 等。"""
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        task.status = "completed"
+        task.final_portfolio_value = 125000.0
+        task.total_pnl = 25000.0
+        task.max_drawdown = -0.12
+        task.sharpe_ratio = 1.85
+
+        mock_service = MagicMock()
+        list_result = MagicMock()
+        list_result.is_success.return_value = True
+        list_result.data = {"data": [task], "total": 1}
+        mock_service.list.return_value = list_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["list", "--format", "json", "--limit", "1"])
+
+        assert invoke_result.exit_code == 0
+        payload = json.loads(invoke_result.output)
+        record = payload["data"][0]
+        assert record["final_portfolio_value"] == 125000.0
+        assert record["sharpe_ratio"] == 1.85
+        assert record["total_pnl"] == 25000.0
+        assert record["max_drawdown"] == -0.12

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -177,6 +177,32 @@ class TestBacktestCatNoTradesWarning:
         assert payload["error"] == {"code": "NOT_FOUND", "message": "Backtest task not found: missing-task"}
 
     @patch("ginkgo.data.containers.container")
+    def test_cat_fuzzy_multi_match_json_envelope(self, mock_container):
+        """ADR-021 第 1/5 维：--format json + fuzzy 多匹配 → stdout 合法 JSON VALIDATION_ERROR envelope + exit 1。"""
+        from ginkgo.client.backtest_cli import app
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = False
+        result.error = "Not found"
+        t1 = MagicMock(uuid="aaaa111122223333", name="bt-a", status="completed", create_at=None)
+        t2 = MagicMock(uuid="bbbb555566667777", name="bt-b", status="running", create_at=None)
+        fuzzy_result = MagicMock()
+        fuzzy_result.is_success.return_value = True
+        fuzzy_result.data = [t1, t2]
+        mock_service.get_by_id.return_value = result
+        mock_service.fuzzy_search.return_value = fuzzy_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "abc", "--format", "json"])
+
+        assert invoke_result.exit_code == 1
+        payload = json.loads(invoke_result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "VALIDATION_ERROR"
+        assert "Multiple tasks match 'abc'" in payload["error"]["message"]
+
+    @patch("ginkgo.data.containers.container")
     def test_cat_shows_no_trades_warning_when_zero_stats(self, mock_container):
         """#5322 completed 回测 stats 全为 0 时应显示 'No trades' 提示"""
         from ginkgo.client.backtest_cli import app

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -1,4 +1,5 @@
 # #5329 backtest cat 输出提示 result show 用法
+import json
 import sys
 from pathlib import Path
 
@@ -80,6 +81,28 @@ class TestBacktestListProgressFormat:
     """#5323 list 命令 progress 格式化应为 N% 而非 N00%"""
 
     @patch("ginkgo.data.containers.container")
+    def test_list_json_format_outputs_adr021_contract(self, mock_container):
+        """--format json 输出 list 契约，含 count/metadata。"""
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        mock_service = MagicMock()
+        list_result = MagicMock()
+        list_result.is_success.return_value = True
+        list_result.data = {"data": [task], "total": 1}
+        mock_service.list.return_value = list_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["list", "--format", "json", "--limit", "1"])
+
+        assert invoke_result.exit_code == 0
+        payload = json.loads(invoke_result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        assert payload["metadata"] == {"total": 1, "limit": 1, "offset": 0}
+        assert payload["data"][0]["uuid"] == "abc123456789"
+
+    @patch("ginkgo.data.containers.container")
     def test_list_shows_correct_progress_percentage(self, mock_container):
         """#5323 progress=50 应显示 50% 而非 5000%"""
         from ginkgo.client.backtest_cli import app
@@ -129,6 +152,29 @@ class TestBacktestListProgressFormat:
 
 class TestBacktestCatNoTradesWarning:
     """#5322 completed 回测无交易时应显示警告"""
+
+    @patch("ginkgo.data.containers.container")
+    def test_cat_not_found_json_format_outputs_not_found_contract(self, mock_container):
+        """--format json 下 cat 未找到输出 NOT_FOUND 错误对象。"""
+        from ginkgo.client.backtest_cli import app
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = False
+        result.error = "Not found"
+        fuzzy_result = MagicMock()
+        fuzzy_result.is_success.return_value = True
+        fuzzy_result.data = []
+        mock_service.get_by_id.return_value = result
+        mock_service.fuzzy_search.return_value = fuzzy_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "missing-task", "--format", "json"])
+
+        assert invoke_result.exit_code == 1
+        payload = json.loads(invoke_result.output)
+        assert payload["success"] is False
+        assert payload["error"] == {"code": "NOT_FOUND", "message": "Backtest task not found: missing-task"}
 
     @patch("ginkgo.data.containers.container")
     def test_cat_shows_no_trades_warning_when_zero_stats(self, mock_container):

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -815,3 +815,55 @@ class TestBacktestListJsonResultMetrics:
         assert record["sharpe_ratio"] == 1.85
         assert record["total_pnl"] == 25000.0
         assert record["max_drawdown"] == -0.12
+
+
+class TestBacktestListParamGuardAndEnvelope:
+    """#6652 review R3：backtest list 参数守卫 + JSON 异常 envelope。
+
+    补齐其他 list 命令（portfolio/engine/record/deploy/data）已有的两道契约：
+    ① page<0/page_size<0 → BAD_PARAMS + exit 2；② 整段包 try，JSON 模式 stdout 永远合法 JSON。
+    """
+
+    @pytest.mark.parametrize("bad_arg", ["--page=-1", "--page-size=-1"])
+    @patch("ginkgo.data.containers.container")
+    def test_list_negative_param_json_envelope_exit_2(self, mock_container, bad_arg):
+        """--page/--page-size <0 + --format json → BAD_PARAMS envelope + exit 2（#6652 review R3-issue1，ADR-021 dim 1/6）。
+
+        守卫在 service 调用前拦截，无需 mock service 调用。
+        """
+        from ginkgo.client.backtest_cli import app
+
+        invoke_result = runner.invoke(app, ["list", bad_arg, "--format", "json"])
+
+        assert invoke_result.exit_code == 2, invoke_result.output
+        payload = json.loads(invoke_result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "BAD_PARAMS"
+        # 守卫前置：service.list 不应被调用
+        mock_container.backtest_task_service.assert_not_called()
+
+    @patch("ginkgo.client.backtest_cli._task_record", side_effect=RuntimeError("enrichment boom"))
+    @patch("ginkgo.data.containers.container")
+    def test_list_json_enrichment_exception_internal_envelope(self, mock_container, _mock_record):
+        """_task_record 逐条 enrichment 异常 + --format json → INTERNAL envelope + exit 1，非裸 traceback（#6652 review R3-issue2，ADR-021 dim 1）。
+
+        整段包 try 后，enrichment 异常走 INTERNAL 错误对象，stdout 保持合法 JSON。
+        """
+        from ginkgo.client.backtest_cli import app
+
+        task = _mock_task()
+        mock_service = MagicMock()
+        list_result = MagicMock()
+        list_result.is_success.return_value = True
+        list_result.data = {"data": [task], "total": 1}
+        mock_service.list.return_value = list_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["list", "--format", "json", "--limit", "1"])
+
+        # JSON 模式 stdout 永远合法 JSON：INTERNAL envelope，非裸 traceback
+        assert invoke_result.exit_code == 1, invoke_result.output
+        payload = json.loads(invoke_result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INTERNAL"
+        assert "enrichment boom" in payload["error"]["message"]

--- a/tests/unit/client/test_cli_utils.py
+++ b/tests/unit/client/test_cli_utils.py
@@ -525,3 +525,119 @@ class TestFormatResult:
         out = json.loads(capsys.readouterr().out)
         assert out["success"] is True
         assert out["count"] == 1
+
+
+# ----------------------------------------------------------------------------
+# _sanitize_json + format_result NaN 契约（ADR-021 第 9/10 维标准 JSON）
+# 回归：json.dumps 默认 allow_nan=True 在 C 层直出 NaN/Infinity token，非合法 JSON。
+# Python json.loads 默认宽容（能解析 NaN），故断言须走严格解析或查原始 token。
+# ----------------------------------------------------------------------------
+
+
+def _strict_json_loads(s: str):
+    """严格 JSON 解析：拒绝 NaN/Infinity/-Infinity token（对齐 jq / JS JSON.parse / Java）。"""
+    return json.loads(
+        s,
+        parse_constant=lambda c: (_ for _ in ()).throw(ValueError(f"illegal const {c}")),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSanitizeJson:
+    """_sanitize_json：非有限浮点 → None（float 是原生类型，default() 拦不到）。"""
+
+    def test_nan_to_none(self):
+        assert cli_utils._sanitize_json(float("nan")) is None
+
+    def test_pos_inf_to_none(self):
+        assert cli_utils._sanitize_json(float("inf")) is None
+
+    def test_neg_inf_to_none(self):
+        assert cli_utils._sanitize_json(float("-inf")) is None
+
+    def test_finite_float_passthrough(self):
+        assert cli_utils._sanitize_json(3.14) == 3.14
+        assert cli_utils._sanitize_json(0.0) == 0.0
+        assert cli_utils._sanitize_json(-1.5) == -1.5
+
+    def test_non_float_passthrough(self):
+        assert cli_utils._sanitize_json("x") == "x"
+        assert cli_utils._sanitize_json(42) == 42
+        assert cli_utils._sanitize_json(None) is None
+        assert cli_utils._sanitize_json(True) is True
+
+    def test_recursive_dict(self):
+        out = cli_utils._sanitize_json({"a": float("nan"), "b": 1, "c": float("inf")})
+        assert out == {"a": None, "b": 1, "c": None}
+
+    def test_recursive_list(self):
+        out = cli_utils._sanitize_json([float("nan"), 2, [float("-inf")]])
+        assert out == [None, 2, [None]]
+
+    def test_nested_dict_in_list(self):
+        out = cli_utils._sanitize_json([{"price": float("nan")}, {"price": 1.0}])
+        assert out == [{"price": None}, {"price": 1.0}]
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestFormatResultNanContract:
+    """format_result 出口 NaN → null + 输出严格 JSON 可解析（ADR-021 第 9/10 维）。
+
+    命中场景：ClickHouse 稀疏数值 NaN、新建组合未设 current_capital/cash。
+    """
+
+    def test_nan_in_get_data_emits_null_and_strict_parseable(self, capsys):
+        """get 成功路径：data 含 NaN → 输出 null，严格解析通过（无 NaN token）"""
+        result = ServiceResult.success(data={"price": float("nan"), "name": "x"})
+        cli_utils.format_result(result, format="json", command="get")
+        raw = capsys.readouterr().out
+        # 原始串不含非法 token（Python json.loads 默认宽容，须查 token 本身）
+        assert "NaN" not in raw
+        assert "Infinity" not in raw
+        out = _strict_json_loads(raw)  # 严格解析不抛 = 合法 JSON
+        assert out["data"] == {"price": None, "name": "x"}
+
+    def test_nan_in_list_data_emits_null(self, capsys):
+        """list 成功路径：data 列表内 NaN → null"""
+        result = ServiceResult.success(data=[{"price": float("nan")}, {"price": 1.0}])
+        cli_utils.format_result(result, format="json", command="list")
+        raw = capsys.readouterr().out
+        assert "NaN" not in raw
+        out = _strict_json_loads(raw)
+        assert out["data"] == [{"price": None}, {"price": 1.0}]
+
+    def test_nan_in_dataframe_data_emits_null(self, capsys):
+        """DataFrame data（ClickHouse 稀疏数值）：to_dict 物化的 NaN 须被分支内 sanitize。
+
+        验证 encoder 的 DataFrame 分支 _sanitize_json(df.to_dict('records'))，
+        非 payload 顶层 sanitize（DataFrame 在 json.dumps 内部才物化）。
+        """
+        df = pd.DataFrame({"price": [float("nan"), 1.0], "code": ["A", "B"]})
+        result = ServiceResult.success(data=df)
+        cli_utils.format_result(result, format="json", command="get")
+        raw = capsys.readouterr().out
+        assert "NaN" not in raw
+        out = _strict_json_loads(raw)
+        assert out["data"] == [{"price": None, "code": "A"}, {"price": 1.0, "code": "B"}]
+
+    def test_fail_path_strict_parseable(self, capsys):
+        """失败路径输出亦合法 JSON（L418 sanitize + allow_nan=False 对称）"""
+        result = ServiceResult.failure(message="boom", code="INTERNAL")
+        with pytest.raises(typer.Exit):
+            cli_utils.format_result(result, format="json", command="x")
+        raw = capsys.readouterr().out
+        out = _strict_json_loads(raw)
+        assert out["success"] is False
+        assert out["error"]["code"] == "INTERNAL"
+
+    def test_allow_nan_false_asserts_no_token_escape(self, capsys):
+        """端到端硬断言：即便有未覆盖容器，allow_nan=False 也应响亮报错而非吐 token。
+
+        此处用全 finite 数据确认 happy path 不被 allow_nan=False 误伤。
+        """
+        result = ServiceResult.success(data=[{"id": 1}, {"id": 2}])
+        cli_utils.format_result(result, format="json", command="list")
+        raw = capsys.readouterr().out
+        _strict_json_loads(raw)  # 不抛即通过

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -243,7 +243,7 @@ class TestGetStockinfo:
         mock_container.stockinfo_service.return_value = mock_service
 
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo"])
-        assert result.exit_code == 0  # 不抛异常，只打印错误
+        assert result.exit_code == 1  # ADR-021 第 6 维：service 失败 → exit 1（原隐式 exit 0 是 false-success）
         assert "Database connection failed" in result.output
 
     @patch("ginkgo.data.containers.container")
@@ -254,6 +254,19 @@ class TestGetStockinfo:
         result = cli_runner.invoke(data_cli.app, ["get", "stockinfo"])
         assert result.exit_code == 1
         assert "Service unavailable" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_service_error_json_envelope(self, mock_container, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + service 失败 → stdout 合法 JSON 错误 envelope + exit 1。"""
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.error(error="DB down")
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["get", "stockinfo", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "DB down" in payload["error"]["message"]
 
     @patch("ginkgo.data.containers.container")
     def test_get_stockinfo_filter_no_match(self, mock_container, cli_runner, mock_stockinfo_df):
@@ -319,6 +332,22 @@ class TestGetOtherTypes:
         result = cli_runner.invoke(data_cli.app, ["get", "day"])
         assert result.exit_code == 1
         assert "code" in result.output.lower() or "required" in result.output.lower()
+
+    def test_get_unknown_type_json_envelope(self, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + 未知 data_type → stdout 合法 JSON 错误 envelope + exit 1。"""
+        result = cli_runner.invoke(data_cli.app, ["get", "bogus", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "bogus" in payload["error"]["message"]
+
+    def test_get_bars_requires_code_json_envelope(self, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + 缺 --code → stdout 合法 JSON 错误 envelope + exit 1。"""
+        result = cli_runner.invoke(data_cli.app, ["get", "day", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "code" in payload["error"]["message"].lower()
 
     def test_get_bars_with_code(self, cli_runner):
         """获取 bars 数据提供 code 不崩溃"""

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -492,6 +492,32 @@ class TestGetOtherTypes:
         assert "000001.SZ" in codes
 
     @patch("ginkgo.data.containers.container")
+    def test_get_day_format_json_empty_envelope(self, mock_container, cli_runner):
+        """--format json + day 无数据：发空 envelope exit 0（ADR-021 第 9 维）。
+
+        service 返回空 df 时，stdout 须是 ``{"success":true,"data":[],"count":0}``，
+        不能纯文本 "No bar data found" 零 envelope——机读消费者（回测 worker/CI/脚本）
+        仅检 exit code 会误判成功但拿不到结构。
+        """
+        mock_service = MagicMock()
+        mock_service.get_bars_df.return_value = ServiceResult.success(data=pd.DataFrame())
+        mock_container.bar_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "day", "--code", "000001.SZ", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"空结果未发 JSON envelope:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert payload["count"] == 0
+        assert payload["data"] == []
+
+    @patch("ginkgo.data.containers.container")
     def test_get_day_limit_tail(self, mock_container, cli_runner):
         """--limit N：day 分支取最新 N 条（tail），ADR-021 第 2 维 order。
 
@@ -593,6 +619,32 @@ class TestGetOtherTypes:
         assert payload["metadata"]["limit"] == 1
         prices = [r["price"] for r in payload["data"]]
         assert prices == [10.05]
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_tick_format_json_empty_envelope(self, mock_container, cli_runner):
+        """--format json + tick 无数据：发空 envelope exit 0（ADR-021 第 9 维）。
+
+        service 返回空 df 时，stdout 须是 ``{"success":true,"data":[],"count":0}``，
+        不能纯文本 "No tick data found" 零 envelope——day/tick/adjustfactor 三分支
+        空结果对称，机读消费者拿得到结构。
+        """
+        mock_service = MagicMock()
+        mock_service.get_ticks_df.return_value = ServiceResult.success(data=pd.DataFrame())
+        mock_container.tick_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "tick", "--code", "000001.SZ", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"空结果未发 JSON envelope:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert payload["count"] == 0
+        assert payload["data"] == []
 
     @patch("ginkgo.data.containers.container")
     def test_get_tick_format_json_default_limit(self, mock_container, cli_runner):
@@ -707,6 +759,32 @@ class TestGetOtherTypes:
         assert "2024-04-15" in result.output
         assert "2024-10-15" not in result.output
         assert "2025-01-15" not in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_adjustfactor_format_json_empty_envelope(self, mock_container, cli_runner):
+        """--format json + adjustfactor 无数据：发空 envelope exit 0（ADR-021 第 9 维）。
+
+        service 返回空 df 时，stdout 须是 ``{"success":true,"data":[],"count":0}``，
+        不能纯文本 "No adjustfactor data found" 零 envelope——day/tick/adjustfactor
+        三分支空结果对称，机读消费者拿得到结构。
+        """
+        mock_service = MagicMock()
+        mock_service.get_adjustfactors_df.return_value = ServiceResult.success(data=pd.DataFrame())
+        mock_container.adjustfactor_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "adjustfactor", "--code", "000001.SZ", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"空结果未发 JSON envelope:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert payload["count"] == 0
+        assert payload["data"] == []
 
     def test_get_invalid_format_exits_with_code_2(self, cli_runner):
         """#6579 review finding 1：无效 --format 须 exit 2（BAD_PARAMS，ADR-021 第 6 维）。

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -208,6 +208,69 @@ class TestGetStockinfo:
         assert "000001.SZ" in codes
 
     @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_filter_format_json_no_stdout_pollution(
+        self, mock_container, cli_runner, mock_stockinfo_df
+    ):
+        """--filter 命中 + --format json：stdout 纯 JSON，filter 诊断 print 不污染（ADR-021 第1维）。
+
+        filter 块的诊断输出（🔍 Applying filter / ✅ Filter matched）是 text 时代预存代码，
+        json 模式须隔离——否则 ``jq .`` / ``json.loads(stdout)`` 崩。命中 2 条（平安银行/浦发银行
+        + 银行行业）。
+        """
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "stockinfo", "--filter", "银行", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        # ADR-021 第1维：json 模式 stdout 不得混入 filter 诊断 emoji 文本
+        assert "Applying filter" not in result.output
+        assert "Filter matched" not in result.output
+        # stdout 仍是合法 JSON envelope
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"未找到 format_result JSON，实际 output:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert payload["count"] == 2
+        codes = [r["code"] for r in payload["data"]]
+        assert "000001.SZ" in codes and "600000.SH" in codes
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_stockinfo_filter_format_json_empty_envelope(
+        self, mock_container, cli_runner, mock_stockinfo_df
+    ):
+        """--filter 无命中 + --format json：发空 envelope exit 0（ADR-021 第9维）。
+
+        filter 无命中时 stdout 须是 ``{"success":true,"data":[],"count":0,...}``，不能纯文本
+        return 零 envelope——机读消费者（回测 worker/CI/脚本）仅检 exit code 会误判成功但拿不到结构。
+        """
+        mock_service = MagicMock()
+        mock_service.get_stockinfos_df.return_value = ServiceResult.success(data=mock_stockinfo_df)
+        mock_container.stockinfo_service.return_value = mock_service
+
+        result = cli_runner.invoke(
+            data_cli.app, ["get", "stockinfo", "--filter", "不存在的词xyz", "--format", "json"]
+        )
+        assert result.exit_code == 0
+        # ADR-021 第9维：空结果发 envelope，非纯文本
+        json_line = next(
+            (l for l in result.output.splitlines() if l.strip().startswith('{"success"')),
+            None,
+        )
+        assert json_line is not None, f"空结果未发 JSON envelope，实际 output:\n{result.output}"
+        payload = json.loads(json_line)
+        assert payload["success"] is True
+        assert payload["data"] == []
+        assert payload["count"] == 0
+        # 无命中诊断 print 也不污染 stdout
+        assert "No matching records" not in result.output
+
+    @patch("ginkgo.data.containers.container")
     def test_get_stockinfo_limit_head(self, mock_container, cli_runner):
         """--limit N：stockinfo 分支取前 N 条（head，按 code 排序），ADR-021 第 2 维 order。
 

--- a/tests/unit/client/test_deploy_cli_list_smoke.py
+++ b/tests/unit/client/test_deploy_cli_list_smoke.py
@@ -99,7 +99,7 @@ class TestDeployListJson:
 
 
 class TestDeployListValidation:
-    """#5009 契约守卫：--page/--page-size 负值 → typer.Exit(1)（非 0）。"""
+    """#5009 契约守卫：--page/--page-size 负值 → exit 2（BAD_PARAMS，ADR-021 dim 6）。"""
 
     @pytest.mark.unit
     def test_negative_page_exits_nonzero(self):
@@ -110,6 +110,19 @@ class TestDeployListValidation:
     def test_negative_page_size_exits_nonzero(self):
         result = runner.invoke(app, ["list", "--page-size=-1"])
         assert result.exit_code != 0
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad_arg", ["--page=-1", "--page-size=-1"])
+    def test_negative_param_json_envelope_exit_2(self, bad_arg):
+        """--page/--page-size <0 + --format json → BAD_PARAMS envelope + exit 2（#6652 review E2，ADR-021 dim 1/6）。
+
+        旧实现 JSON 模式 console.print Rich 标记到 stdout + exit 1，stdout 非合法 JSON，jq 崩。
+        """
+        result = runner.invoke(app, ["list", bad_arg, "--format", "json"])
+        assert result.exit_code == 2, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "BAD_PARAMS"
 
 
 class TestDeployListTextAndError:

--- a/tests/unit/client/test_deploy_cli_list_smoke.py
+++ b/tests/unit/client/test_deploy_cli_list_smoke.py
@@ -41,6 +41,8 @@ def _mock_svc(records=None, count=5, list_ok=True):
     list_res.success = list_ok
     list_res.data = records if records is not None else []
     list_res.error = "boom"
+    list_res.code = None  # 真实 failed ServiceResult 形状；避免 MagicMock auto-attr 陷阱
+    list_res.warnings = []  # format_result 失败路径 getattr(result,"warnings") or []；不设则 auto-MagicMock 触发 json 无限递归
     svc.list_deployments.return_value = list_res
 
     count_res = MagicMock()
@@ -132,9 +134,26 @@ class TestDeployListTextAndError:
         assert "无部署记录" in result.output
 
     @pytest.mark.unit
-    def test_list_service_failure_exits_nonzero(self):
+    def test_list_service_failure_json_envelope_exit_nonzero(self):
+        """ADR-021 第 1/5/6 维：--format json + service 失败 → stdout 合法 JSON 错误 envelope + exit 1。"""
         svc = _mock_svc(list_ok=False)
         with patch("ginkgo.trading.containers.trading_container") as tc:
             tc.deployment_service.return_value = svc
             result = runner.invoke(app, ["list", "--format", "json"])
         assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["message"] == "boom"
+
+    @pytest.mark.unit
+    def test_list_service_exception_json_envelope_exit_nonzero(self):
+        """ADR-021 第 1/5/6 维：--format json + service 异常 → INTERNAL envelope + exit 1。"""
+        svc = _mock_svc()
+        svc.list_deployments.side_effect = RuntimeError("db down")
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            result = runner.invoke(app, ["list", "--format", "json"])
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INTERNAL"

--- a/tests/unit/client/test_deploy_cli_list_smoke.py
+++ b/tests/unit/client/test_deploy_cli_list_smoke.py
@@ -1,0 +1,140 @@
+"""#5009 deploy list 分页 CliRunner smoke（#6685 diff coverage gate 采集）。
+
+deploy_cli.list_deployments 为本 PR 重构（--page/--page-size offset 分页 + --format json
+ADR-021 envelope + count_deployments metadata.total）。container import 链触达该模块
+但 smoke 不调命令体 → 改动行无覆盖信号 → 门禁红。本文件用 CliRunner + mock
+trading_container 补信号（不连 DB / 不真起服务）。
+"""
+
+import os
+import sys
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+from typer.testing import CliRunner
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.client.deploy_cli import app
+
+runner = CliRunner()
+
+
+def _record(**over):
+    rec = {
+        "deployment_id": "dep-1",
+        "source_task_id": "task-1",
+        "target_portfolio_id": "pf-tgt",
+        "mode": 1,
+        "status": 0,
+        "create_at": "2026-01-02 03:04:05",
+    }
+    rec.update(over)
+    return rec
+
+
+def _mock_svc(records=None, count=5, list_ok=True):
+    svc = MagicMock()
+    list_res = MagicMock()
+    list_res.success = list_ok
+    list_res.data = records if records is not None else []
+    list_res.error = "boom"
+    svc.list_deployments.return_value = list_res
+
+    count_res = MagicMock()
+    count_res.success = True
+    count_res.data = {"count": count}
+    svc.count_deployments.return_value = count_res
+    return svc
+
+
+class TestDeployListJson:
+    """--format json：ADR-021 envelope + #5009 metadata.total/limit/offset。"""
+
+    @pytest.mark.unit
+    def test_list_json_envelope_pagination(self):
+        svc = _mock_svc(records=[_record()], count=1)
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            result = runner.invoke(app, ["list", "--format", "json", "--page", "1", "--page-size", "5"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        assert payload["metadata"]["total"] == 1
+        assert payload["metadata"]["limit"] == 5
+        assert payload["metadata"]["offset"] == 5  # page1 * size5
+        _, kwargs = svc.list_deployments.call_args
+        assert kwargs["page"] == 1 and kwargs["page_size"] == 5
+
+    @pytest.mark.unit
+    def test_list_json_unlimited(self):
+        # --page-size 0 → unlimited：q_page/q_page_size=None 下推 service；
+        # build_list_result(limit=None) 时 limit 回退 len(records)（cli_utils.py:412）。
+        svc = _mock_svc(records=[_record()], count=1)
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            result = runner.invoke(app, ["list", "--format", "json", "--page-size", "0"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["metadata"]["limit"] == 1  # 回退 len(records)
+        assert payload["metadata"]["offset"] == 0
+        _, kwargs = svc.list_deployments.call_args
+        assert kwargs["page"] is None and kwargs["page_size"] is None
+
+    @pytest.mark.unit
+    def test_list_portfolio_filter_forwarded(self):
+        svc = _mock_svc(records=[], count=0)
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            runner.invoke(app, ["list", "--format", "json", "--portfolio", "pf-42"])
+        _, kwargs = svc.list_deployments.call_args
+        assert kwargs["portfolio_id"] == "pf-42"
+        _, ckwargs = svc.count_deployments.call_args
+        assert ckwargs["portfolio_id"] == "pf-42"
+
+
+class TestDeployListValidation:
+    """#5009 契约守卫：--page/--page-size 负值 → typer.Exit(1)（非 0）。"""
+
+    @pytest.mark.unit
+    def test_negative_page_exits_nonzero(self):
+        result = runner.invoke(app, ["list", "--page=-1"])
+        assert result.exit_code != 0
+
+    @pytest.mark.unit
+    def test_negative_page_size_exits_nonzero(self):
+        result = runner.invoke(app, ["list", "--page-size=-1"])
+        assert result.exit_code != 0
+
+
+class TestDeployListTextAndError:
+    """text 路径（rich Table）+ 空记录分支 + 服务失败分支。"""
+
+    @pytest.mark.unit
+    def test_list_text_renders_table(self):
+        svc = _mock_svc(records=[_record()], count=1)
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            result = runner.invoke(app, ["list", "--page", "0", "--page-size", "5"])
+        assert result.exit_code == 0
+        assert "部署记录" in result.output  # Table title
+
+    @pytest.mark.unit
+    def test_list_text_empty_records(self):
+        svc = _mock_svc(records=[], count=0)
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0
+        assert "无部署记录" in result.output
+
+    @pytest.mark.unit
+    def test_list_service_failure_exits_nonzero(self):
+        svc = _mock_svc(list_ok=False)
+        with patch("ginkgo.trading.containers.trading_container") as tc:
+            tc.deployment_service.return_value = svc
+            result = runner.invoke(app, ["list", "--format", "json"])
+        assert result.exit_code != 0

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -235,7 +235,7 @@ class TestListEngines:
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
             result = cli_runner.invoke(engine_cli.app, ["list"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1  # ADR-021 第 6 维：service 失败 → exit 1（原 exit 0 是 false-success）
         assert "Failed" in result.output or "DB connection lost" in result.output
 
     @pytest.mark.unit
@@ -247,8 +247,35 @@ class TestListEngines:
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
             result = cli_runner.invoke(engine_cli.app, ["list"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1  # ADR-021 第 6 维：异常 → exit 1（原 exit 0 是 false-success）
         assert "Error" in result.output
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_list_service_failure_json_envelope(self, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + service 失败 → stdout 合法 JSON 错误 envelope + exit 1。"""
+        svc = _mock_engine_service(get_engines_df=ServiceResult.error(error="DB connection lost"))
+
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "DB connection lost" in payload["error"]["message"]
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_list_exception_json_envelope(self, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + 异常 → stdout 合法 JSON 错误 envelope + exit 1。"""
+        svc = MagicMock()
+        svc.get_engines_df.side_effect = RuntimeError("container boom")
+
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "container boom" in payload["error"]["message"]
 
 
 # ===========================================================================

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -127,6 +127,35 @@ class TestListEngines:
 
     @pytest.mark.unit
     @pytest.mark.cli
+    def test_list_limit_pushes_page_size_to_get_engines_df(self, cli_runner):
+        """ADR-021 L139：--limit 下推 get_engines_df page_size（all 路径）。"""
+        df = _make_engine_df()
+        svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=df))
+
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(engine_cli.app, ["list", "--limit", "5"])
+
+        assert result.exit_code == 0
+        svc.get_engines_df.assert_called_once_with(page_size=5)
+
+    @pytest.mark.unit
+    @pytest.mark.cli
+    def test_list_filter_pushes_page_size_to_fuzzy_search(self, cli_runner):
+        """ADR-021 L139：filter 模式 --limit 下推 fuzzy_search page_size。"""
+        df = _make_engine_df()
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = df
+        svc = _mock_engine_service(fuzzy_search=ServiceResult.success(data=model_list))
+
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(engine_cli.app, ["list", "--filter", "test", "--limit", "5"])
+
+        assert result.exit_code == 0
+        _, kwargs = svc.fuzzy_search.call_args
+        assert kwargs.get("page_size") == 5
+
+    @pytest.mark.unit
+    @pytest.mark.cli
     def test_list_with_filter(self, cli_runner):
         df = _make_engine_df()
         model_list = MagicMock()

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -12,6 +12,8 @@ Mock strategy:
     are imported at module level -> patch at the engine_cli import site.
 """
 
+import json
+
 import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
 
@@ -25,6 +27,7 @@ from ginkgo.data.services.base_service import ServiceResult
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_engine_df(rows=None):
     """Build a DataFrame mimicking engine_service.get().data.to_dataframe()."""
@@ -82,6 +85,7 @@ def _mock_container(engine_service=None, portfolio_service=None, mapping_service
 # 1. Help tests
 # ===========================================================================
 
+
 class TestHelp:
     """Verify help output for engine commands."""
 
@@ -105,6 +109,7 @@ class TestHelp:
 # ===========================================================================
 # 2. list command
 # ===========================================================================
+
 
 class TestListEngines:
     """Tests for the 'list' command."""
@@ -170,6 +175,22 @@ class TestListEngines:
 
     @pytest.mark.unit
     @pytest.mark.cli
+    def test_list_json_format_outputs_adr021_contract(self, cli_runner):
+        df = _make_engine_df()
+        svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=df))
+
+        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
+            result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json", "--limit", "1"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        assert payload["metadata"] == {"total": 1, "limit": 1, "offset": 0}
+        assert payload["data"][0]["name"] == "TestEngine"
+
+    @pytest.mark.unit
+    @pytest.mark.cli
     def test_list_no_engines_found(self, cli_runner):
         svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=pd.DataFrame()))
 
@@ -204,6 +225,7 @@ class TestListEngines:
 # ===========================================================================
 # 3. create command
 # ===========================================================================
+
 
 class TestCreate:
     """Tests for the 'create' command."""
@@ -264,6 +286,7 @@ class TestCreate:
 # 4. cat command
 # ===========================================================================
 
+
 class TestCat:
     """Tests for the 'cat' command."""
 
@@ -276,10 +299,12 @@ class TestCat:
         model_list.__getitem__ = MagicMock(return_value=engine)
         svc = _mock_engine_service(get=ServiceResult.success(data=model_list))
 
-        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"), \
-             patch("ginkgo.client.engine_cli.collect_component_info", return_value={"has_portfolio": False}), \
-             patch("ginkgo.client.engine_cli.display_component_tree"):
+        with (
+            patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+            patch("ginkgo.client.engine_cli.collect_component_info", return_value={"has_portfolio": False}),
+            patch("ginkgo.client.engine_cli.display_component_tree"),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["cat", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 0
         assert "TestEngine" in result.output
@@ -307,8 +332,10 @@ class TestCat:
     def test_cat_service_failure(self, cli_runner):
         svc = _mock_engine_service(get=ServiceResult.error(error="fetch failed"))
 
-        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["cat", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 1
         assert "Failed" in result.output or "fetch failed" in result.output
@@ -333,10 +360,12 @@ class TestCat:
             "sizers": [],
         }
 
-        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"), \
-             patch("ginkgo.client.engine_cli.collect_component_info", return_value=component_data), \
-             patch("ginkgo.client.engine_cli.display_component_tree") as mock_tree:
+        with (
+            patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+            patch("ginkgo.client.engine_cli.collect_component_info", return_value=component_data),
+            patch("ginkgo.client.engine_cli.display_component_tree") as mock_tree,
+        ):
             result = cli_runner.invoke(engine_cli.app, ["cat", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 0
         mock_tree.assert_called_once()
@@ -345,6 +374,7 @@ class TestCat:
 # ===========================================================================
 # 5. status command
 # ===========================================================================
+
 
 class TestStatus:
     """Tests for the 'status' command."""
@@ -358,8 +388,10 @@ class TestStatus:
         model_list.__getitem__ = MagicMock(return_value=engine)
         svc = _mock_engine_service(get=ServiceResult.success(data=model_list))
 
-        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["status", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 0
         assert "Engine Status" in result.output
@@ -381,8 +413,12 @@ class TestStatus:
         model_list.__getitem__ = MagicMock(return_value=engine)
         svc = _mock_engine_service(get=ServiceResult.success(data=model_list))
 
-        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa") as mock_resolve:
+        with (
+            patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)),
+            patch(
+                "ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"
+            ) as mock_resolve,
+        ):
             result = cli_runner.invoke(engine_cli.app, ["status", "TestEngine"])
         assert result.exit_code == 0
         mock_resolve.assert_called_with("TestEngine")
@@ -392,8 +428,10 @@ class TestStatus:
     def test_status_service_failure(self, cli_runner):
         svc = _mock_engine_service(get=ServiceResult.error(error="db error"))
 
-        with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["status", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 1
         assert "Failed" in result.output or "db error" in result.output
@@ -402,6 +440,7 @@ class TestStatus:
 # ===========================================================================
 # 6. run command
 # ===========================================================================
+
 
 class TestRun:
     """Tests for the 'run' command."""
@@ -436,8 +475,10 @@ class TestRun:
         trading_container = MagicMock()
         trading_container.services.engine_assembly_service.return_value = assembly_svc
 
-        with patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"), \
-             patch("ginkgo.trading.core.containers.container", trading_container):
+        with (
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+            patch("ginkgo.trading.core.containers.container", trading_container),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["run", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run" in result.output or "Validation" in result.output
@@ -446,12 +487,16 @@ class TestRun:
     @pytest.mark.cli
     def test_run_dry_run_failure(self, cli_runner):
         assembly_svc = MagicMock()
-        assembly_svc.assemble_backtest_engine.return_value = ServiceResult.error(error="assembly failed", message="assembly failed")
+        assembly_svc.assemble_backtest_engine.return_value = ServiceResult.error(
+            error="assembly failed", message="assembly failed"
+        )
         trading_container = MagicMock()
         trading_container.services.engine_assembly_service.return_value = assembly_svc
 
-        with patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"), \
-             patch("ginkgo.trading.core.containers.container", trading_container):
+        with (
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+            patch("ginkgo.trading.core.containers.container", trading_container),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["run", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "--dry-run"])
         assert result.exit_code == 0
         assert "Validation error" in result.output
@@ -460,16 +505,20 @@ class TestRun:
     @pytest.mark.cli
     def test_run_assembly_failure(self, cli_runner):
         assembly_svc = MagicMock()
-        assembly_svc.assemble_backtest_engine.return_value = ServiceResult.error(error="missing component", message="missing component")
+        assembly_svc.assemble_backtest_engine.return_value = ServiceResult.error(
+            error="missing component", message="missing component"
+        )
         trading_container = MagicMock()
         trading_container.services.engine_assembly_service.return_value = assembly_svc
 
         mock_gconf = MagicMock()
         mock_gconf.DEBUGMODE = False
 
-        with patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"), \
-             patch("ginkgo.trading.core.containers.container", trading_container), \
-             patch("ginkgo.libs.GCONF", mock_gconf):
+        with (
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+            patch("ginkgo.trading.core.containers.container", trading_container),
+            patch("ginkgo.libs.GCONF", mock_gconf),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["run", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"])
         assert result.exit_code == 0
         assert "assembly failed" in result.output or "Error" in result.output
@@ -478,6 +527,7 @@ class TestRun:
 # ===========================================================================
 # 7. delete command
 # ===========================================================================
+
 
 class TestDelete:
     """Tests for the 'delete' command."""
@@ -538,6 +588,7 @@ class TestDelete:
 # 8. bind-portfolio / unbind-portfolio commands
 # ===========================================================================
 
+
 class TestBindPortfolio:
     """Tests for the 'bind-portfolio' command."""
 
@@ -572,9 +623,13 @@ class TestBindPortfolio:
             mapping_service=mapping_svc,
         )
 
-        with patch("ginkgo.data.containers.container", container), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
-            result = cli_runner.invoke(engine_cli.app, ["bind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid"])
+        with (
+            patch("ginkgo.data.containers.container", container),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
+            result = cli_runner.invoke(
+                engine_cli.app, ["bind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid"]
+            )
         assert result.exit_code == 0
         assert "binding created" in result.output.lower() or "TestEngine" in result.output
 
@@ -610,8 +665,10 @@ class TestBindPortfolio:
     @pytest.mark.unit
     @pytest.mark.cli
     def test_bind_engine_not_found(self, cli_runner):
-        with patch("ginkgo.client.engine_cli.resolve_engine_id", return_value=None), \
-             patch("ginkgo.data.containers.container", _mock_container()):
+        with (
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value=None),
+            patch("ginkgo.data.containers.container", _mock_container()),
+        ):
             result = cli_runner.invoke(engine_cli.app, ["bind-portfolio", "nonexistent", "port-uuid"])
         assert result.exit_code == 1
         assert "not found" in result.output
@@ -649,8 +706,10 @@ class TestBindPortfolio:
             mapping_service=mapping_svc,
         )
 
-        with patch("ginkgo.data.containers.container", container), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", container),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(
                 engine_cli.app,
                 ["bind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid"],
@@ -685,8 +744,10 @@ class TestUnbindPortfolio:
             mapping_service=mapping_svc,
         )
 
-        with patch("ginkgo.data.containers.container", container), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", container),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(
                 engine_cli.app,
                 ["unbind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid", "--confirm"],
@@ -717,8 +778,10 @@ class TestUnbindPortfolio:
             mapping_service=mapping_svc,
         )
 
-        with patch("ginkgo.data.containers.container", container), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", container),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(
                 engine_cli.app,
                 ["unbind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid", "-y"],
@@ -759,8 +822,10 @@ class TestUnbindPortfolio:
             mapping_service=mapping_svc,
         )
 
-        with patch("ginkgo.data.containers.container", container), \
-             patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"):
+        with (
+            patch("ginkgo.data.containers.container", container),
+            patch("ginkgo.client.engine_cli.resolve_engine_id", return_value="aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa"),
+        ):
             result = cli_runner.invoke(
                 engine_cli.app,
                 ["unbind-portfolio", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "port-uuid", "--confirm"],
@@ -772,6 +837,7 @@ class TestUnbindPortfolio:
 # ===========================================================================
 # #5375: resolve_engine_id 的 fuzzy 搜索分支
 # ===========================================================================
+
 
 class TestResolveEngineIdFuzzy:
     """#5375: 模糊搜索命中时 resolve_engine_id 必须返回 UUID，不能崩溃。
@@ -804,6 +870,7 @@ class TestResolveEngineIdFuzzy:
 # #5988: engine create 输出 Engine ID 应为纯 UUID，非 dict repr
 # ---------------------------------------------------------------------------
 
+
 class TestEngineCreate:
     """#5988: ``engine create`` 成功后 ``Engine ID`` 行应只含纯 UUID 字符串。
 
@@ -822,13 +889,9 @@ class TestEngineCreate:
             "status": "IDLE",
             "desc": "回测引擎: test_engine",
         }
-        svc = _mock_engine_service(
-            add=ServiceResult.success(data={"engine_info": engine_info})
-        )
+        svc = _mock_engine_service(add=ServiceResult.success(data={"engine_info": engine_info}))
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
-            result = cli_runner.invoke(
-                engine_cli.app, ["create", "-n", "test_engine", "-t", "backtest"]
-            )
+            result = cli_runner.invoke(engine_cli.app, ["create", "-n", "test_engine", "-t", "backtest"])
 
         assert result.exit_code == 0, result.output
         engine_id_lines = [l for l in result.output.splitlines() if "Engine ID" in l]

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -208,7 +208,8 @@ class TestListEngines:
         # 模拟 DB 截断：get_engines_df 返回当前页（1 行），count 返回未截断总数。
         df = _make_engine_df()
         svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=df))
-        svc.count.return_value = ServiceResult.success(data=50)
+        # 对齐真实 EngineService.count() 契约：返回 ServiceResult.success({"count": N})（dict，非裸 int）。
+        svc.count.return_value = ServiceResult.success(data={"count": 50})
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
             result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json", "--limit", "1"])

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -205,8 +205,10 @@ class TestListEngines:
     @pytest.mark.unit
     @pytest.mark.cli
     def test_list_json_format_outputs_adr021_contract(self, cli_runner):
+        # 模拟 DB 截断：get_engines_df 返回当前页（1 行），count 返回未截断总数。
         df = _make_engine_df()
         svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=df))
+        svc.count.return_value = ServiceResult.success(data=50)
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
             result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json", "--limit", "1"])
@@ -214,8 +216,11 @@ class TestListEngines:
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["success"] is True
+        # ADR-021：count = 当前页记录数，metadata.total = 未截断匹配总数（service.count）。
         assert payload["count"] == 1
-        assert payload["metadata"] == {"total": 1, "limit": 1, "offset": 0}
+        assert payload["metadata"]["total"] == 50
+        assert payload["metadata"]["limit"] == 1
+        assert payload["metadata"]["offset"] == 0
         assert payload["data"][0]["name"] == "TestEngine"
 
     @pytest.mark.unit
@@ -504,14 +509,18 @@ class TestRun:
     @pytest.mark.unit
     @pytest.mark.cli
     def test_run_no_id_shows_list(self, cli_runner):
-        model_list = MagicMock()
-        model_list.to_dataframe.return_value = _make_engine_df()
-        svc = _mock_engine_service(get=ServiceResult.success(data=model_list))
+        # ADR-021: run 无 engine_id 时应列出可用引擎。
+        # 回归护栏：run 签名漏 limit 形参 → get_engines_df(page_size=limit) NameError
+        # 被 try/except 吞 → 静默不出列表却 exit 0。故断言引擎实际渲染 + limit 下推。
+        df = _make_engine_df()
+        svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=df))
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
             result = cli_runner.invoke(engine_cli.app, ["run"])
         assert result.exit_code == 0
         assert "No engine ID" in result.output
+        assert "TestEngine" in result.output
+        assert svc.get_engines_df.call_args.kwargs["page_size"] == 20
 
     @pytest.mark.unit
     @pytest.mark.cli

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -102,7 +102,7 @@ class TestHelp:
     def test_list_help(self, cli_runner):
         result = cli_runner.invoke(engine_cli.app, ["list", "--help"])
         assert result.exit_code == 0
-        for opt in ("--status", "--portfolio", "--filter", "--limit", "--raw"):
+        for opt in ("--status", "--portfolio", "--filter", "--page", "--page-size", "--raw"):
             assert opt in result.output
 
 
@@ -127,28 +127,28 @@ class TestListEngines:
 
     @pytest.mark.unit
     @pytest.mark.cli
-    def test_list_limit_pushes_page_size_to_get_engines_df(self, cli_runner):
-        """ADR-021 L139：--limit 下推 get_engines_df page_size（all 路径）。"""
+    def test_list_page_size_pushes_to_get_engines_df(self, cli_runner):
+        """#5009：--page-size 下推 get_engines_df page_size（all 路径，page 默认 0）。"""
         df = _make_engine_df()
         svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=df))
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
-            result = cli_runner.invoke(engine_cli.app, ["list", "--limit", "5"])
+            result = cli_runner.invoke(engine_cli.app, ["list", "--page-size", "5"])
 
         assert result.exit_code == 0
-        svc.get_engines_df.assert_called_once_with(page_size=5)
+        svc.get_engines_df.assert_called_once_with(page=0, page_size=5)
 
     @pytest.mark.unit
     @pytest.mark.cli
     def test_list_filter_pushes_page_size_to_fuzzy_search(self, cli_runner):
-        """ADR-021 L139：filter 模式 --limit 下推 fuzzy_search page_size。"""
+        """#5009：filter 模式 --page-size 下推 fuzzy_search page_size。"""
         df = _make_engine_df()
         model_list = MagicMock()
         model_list.to_dataframe.return_value = df
         svc = _mock_engine_service(fuzzy_search=ServiceResult.success(data=model_list))
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
-            result = cli_runner.invoke(engine_cli.app, ["list", "--filter", "test", "--limit", "5"])
+            result = cli_runner.invoke(engine_cli.app, ["list", "--filter", "test", "--page-size", "5"])
 
         assert result.exit_code == 0
         _, kwargs = svc.fuzzy_search.call_args
@@ -212,7 +212,7 @@ class TestListEngines:
         svc.count.return_value = ServiceResult.success(data={"count": 50})
 
         with patch("ginkgo.data.containers.container", _mock_container(engine_service=svc)):
-            result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json", "--limit", "1"])
+            result = cli_runner.invoke(engine_cli.app, ["list", "--format", "json", "--page-size", "1"])
 
         assert result.exit_code == 0
         payload = json.loads(result.output)

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -226,6 +226,20 @@ class TestListEngines:
 
     @pytest.mark.unit
     @pytest.mark.cli
+    @pytest.mark.parametrize("bad_arg", ["--page=-1", "--page-size=-1"])
+    def test_list_negative_param_json_envelope_exit_2(self, cli_runner, bad_arg):
+        """--page/--page-size <0 + --format json → BAD_PARAMS envelope + exit 2（#6652 review E2，ADR-021 dim 1/6）。
+
+        守卫在 service 调用前拦截，无需 mock；JSON 模式 stdout 须为合法 JSON（listing 文本被 format!=json 守卫跳过）。
+        """
+        result = cli_runner.invoke(engine_cli.app, ["list", bad_arg, "--format", "json"])
+        assert result.exit_code == 2, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "BAD_PARAMS"
+
+    @pytest.mark.unit
+    @pytest.mark.cli
     def test_list_no_engines_found(self, cli_runner):
         svc = _mock_engine_service(get_engines_df=ServiceResult.success(data=pd.DataFrame()))
 

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -173,14 +173,19 @@ class TestComponentList:
         assert '"total"' in result.output
 
     def test_list_components_json_format_outputs_adr021_contract(self, cli_runner, mock_file_crud):
+        # 模拟 DB 截断：find 返回当前页（1 个），count 返回未截断总数（每类型 7）。
+        mock_file_crud.count.return_value = 7
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.file_crud.return_value = mock_file_crud
             result = cli_runner.invoke(flat_cli.component_app, ["list", "--format", "json", "--limit", "1"])
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["success"] is True
+        # ADR-021：count = 当前页记录数，metadata.total = 未截断匹配总数（全类型 sum 5×7=35）。
         assert payload["count"] == 1
-        assert payload["metadata"] == {"total": 1, "limit": 1, "offset": 0}
+        assert payload["metadata"]["total"] == 35
+        assert payload["metadata"]["limit"] == 1
+        assert payload["metadata"]["offset"] == 0
         assert payload["data"][0]["name"] == "TestStrategy"
 
     def test_list_limit_pushes_page_size_to_file_crud(self, cli_runner, mock_component):

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -183,6 +183,17 @@ class TestComponentList:
         assert payload["metadata"] == {"total": 1, "limit": 1, "offset": 0}
         assert payload["data"][0]["name"] == "TestStrategy"
 
+    def test_list_limit_pushes_page_size_to_file_crud(self, cli_runner, mock_component):
+        """ADR-021 L139：--limit 下推 file_crud.find page_size（all 路径，替代 page_size=10000 + [:limit]）。"""
+        crud = MagicMock()
+        crud.find.return_value = [mock_component]
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.file_crud.return_value = crud
+            result = cli_runner.invoke(flat_cli.component_app, ["list", "--limit", "5"])
+        assert result.exit_code == 0
+        _, kwargs = crud.find.call_args
+        assert kwargs.get("page_size") == 5
+
     def test_list_components_filter_by_type(self, cli_runner, mock_component):
         mock_component.type = FILE_TYPES.RISKMANAGER
         mock_component.name = "TestRisk"

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -177,7 +177,7 @@ class TestComponentList:
         mock_file_crud.count.return_value = 7
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.file_crud.return_value = mock_file_crud
-            result = cli_runner.invoke(flat_cli.component_app, ["list", "--format", "json", "--limit", "1"])
+            result = cli_runner.invoke(flat_cli.component_app, ["list", "--format", "json", "--page-size", "1"])
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["success"] is True
@@ -188,13 +188,13 @@ class TestComponentList:
         assert payload["metadata"]["offset"] == 0
         assert payload["data"][0]["name"] == "TestStrategy"
 
-    def test_list_limit_pushes_page_size_to_file_crud(self, cli_runner, mock_component):
-        """ADR-021 L139：--limit 下推 file_crud.find page_size（all 路径，替代 page_size=10000 + [:limit]）。"""
+    def test_list_page_size_pushes_to_file_crud(self, cli_runner, mock_component):
+        """#5009：--page-size 下推 file_crud.find page_size（all 路径，type__in DB 层过滤后分页）。"""
         crud = MagicMock()
         crud.find.return_value = [mock_component]
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.file_crud.return_value = crud
-            result = cli_runner.invoke(flat_cli.component_app, ["list", "--limit", "5"])
+            result = cli_runner.invoke(flat_cli.component_app, ["list", "--page-size", "5"])
         assert result.exit_code == 0
         _, kwargs = crud.find.call_args
         assert kwargs.get("page_size") == 5

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -15,6 +15,7 @@ import os
 
 os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
 
+import json
 import uuid
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -134,8 +135,10 @@ class TestResultListParamConflict:
             data={"data": [], "total": 0, "page": 0, "page_size": 20}
         )
         for argv in (["list", "--portfolio", "abc123"], ["list", "--page", "2"]):
-            with patch("ginkgo.data.containers.container") as mock_container, \
-                 warnings.catch_warnings(record=True) as caught:
+            with (
+                patch("ginkgo.data.containers.container") as mock_container,
+                warnings.catch_warnings(record=True) as caught,
+            ):
                 mock_container.backtest_task_service.return_value = mock_service
                 warnings.simplefilter("always")
                 result = cli_runner.invoke(flat_cli.result_app, argv)
@@ -168,6 +171,17 @@ class TestComponentList:
         assert result.exit_code == 0
         assert "TestStrategy" in result.output
         assert '"total"' in result.output
+
+    def test_list_components_json_format_outputs_adr021_contract(self, cli_runner, mock_file_crud):
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.file_crud.return_value = mock_file_crud
+            result = cli_runner.invoke(flat_cli.component_app, ["list", "--format", "json", "--limit", "1"])
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        assert payload["metadata"] == {"total": 1, "limit": 1, "offset": 0}
+        assert payload["data"][0]["name"] == "TestStrategy"
 
     def test_list_components_filter_by_type(self, cli_runner, mock_component):
         mock_component.type = FILE_TYPES.RISKMANAGER
@@ -215,23 +229,33 @@ class TestComponentCreate:
     """Tests for 'component create' command."""
 
     def test_create_component_with_required_options(self, cli_runner):
-        result = cli_runner.invoke(flat_cli.component_app, [
-            "create", "--type", "strategy", "--name", "MyStrategy", "--class", "MyStrategyClass"
-        ])
+        result = cli_runner.invoke(
+            flat_cli.component_app,
+            ["create", "--type", "strategy", "--name", "MyStrategy", "--class", "MyStrategyClass"],
+        )
         assert result.exit_code == 0
         assert "MyStrategy" in result.output
         assert "created successfully" in result.output
 
     def test_create_component_with_all_options(self, cli_runner):
-        result = cli_runner.invoke(flat_cli.component_app, [
-            "create",
-            "--type", "risk",
-            "--name", "StopLoss",
-            "--class", "StopLossRisk",
-            "--description", "Stop loss risk manager",
-            "--tags", "risk,stop",
-            "--author", "testuser",
-        ])
+        result = cli_runner.invoke(
+            flat_cli.component_app,
+            [
+                "create",
+                "--type",
+                "risk",
+                "--name",
+                "StopLoss",
+                "--class",
+                "StopLossRisk",
+                "--description",
+                "Stop loss risk manager",
+                "--tags",
+                "risk,stop",
+                "--author",
+                "testuser",
+            ],
+        )
         assert result.exit_code == 0
         assert "StopLoss" in result.output
         assert "StopLossRisk" in result.output
@@ -258,11 +282,20 @@ class TestMappingCommands:
         assert "not yet implemented" in result.output
 
     def test_mapping_create_shows_not_implemented(self, cli_runner):
-        result = cli_runner.invoke(flat_cli.mapping_app, [
-            "create",
-            "--from-type", "portfolio", "--from-id", "abc",
-            "--to-type", "engine", "--to-id", "def",
-        ])
+        result = cli_runner.invoke(
+            flat_cli.mapping_app,
+            [
+                "create",
+                "--from-type",
+                "portfolio",
+                "--from-id",
+                "abc",
+                "--to-type",
+                "engine",
+                "--to-id",
+                "def",
+            ],
+        )
         assert result.exit_code == 0
         assert "not yet implemented" in result.output
 
@@ -292,6 +325,7 @@ class TestResultCommands:
         """#4634: result list 应调 backtest_task_service.list 返回任务表格，
         而非 'not yet implemented' 占位。"""
         from ginkgo.data.services.base_service import ServiceResult
+
         task = MagicMock()
         task.uuid = "abc123def456"
         task.name = "TestBacktest"
@@ -314,6 +348,7 @@ class TestResultCommands:
     def test_result_list_with_task_id_calls_get_by_id(self, cli_runner):
         """#4634: --task-id 应复用 result get 查询路径(get_by_id), 单条展示。"""
         from ginkgo.data.services.base_service import ServiceResult
+
         task = MagicMock()
         task.uuid = "task-uuid-12345"
         task.name = "SingleBT"
@@ -324,9 +359,7 @@ class TestResultCommands:
         mock_service.get_by_id.return_value = ServiceResult.success(data=task)
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.backtest_task_service.return_value = mock_service
-            result = cli_runner.invoke(
-                flat_cli.result_app, ["list", "--task-id", "task-uuid-12345"]
-            )
+            result = cli_runner.invoke(flat_cli.result_app, ["list", "--task-id", "task-uuid-12345"])
         assert result.exit_code == 0, result.output
         assert "SingleBT" in result.output
         mock_service.get_by_id.assert_called_once_with("task-uuid-12345")
@@ -335,6 +368,7 @@ class TestResultCommands:
     def test_result_list_empty_shows_no_results(self, cli_runner):
         """#4634: 空结果应优雅提示, 非 crash。"""
         from ginkgo.data.services.base_service import ServiceResult
+
         mock_service = MagicMock()
         mock_service.list.return_value = ServiceResult.success(
             data={"data": [], "total": 0, "page": 0, "page_size": 20}
@@ -348,6 +382,7 @@ class TestResultCommands:
     def test_result_list_service_error_exits_nonzero(self, cli_runner):
         """#4634: service 失败应 exit 1 + 显示错误, 非 crash。"""
         from ginkgo.data.services.base_service import ServiceResult
+
         mock_service = MagicMock()
         mock_service.list.return_value = ServiceResult.error("DB down")
         with patch("ginkgo.data.containers.container") as mock_container:
@@ -362,11 +397,19 @@ class TestResultCommands:
     def test_result_show_no_task_id_lists_runs(self, cli_runner):
         """result show without --run-id should list available runs."""
         from ginkgo.data.services.base_service import ServiceResult
+
         mock_service = MagicMock()
-        mock_service.list_runs.return_value = ServiceResult.success(data=[
-            {"engine_name": "test_engine", "task_id": "run-1",
-             "portfolio_name": "p1", "timestamp": "2025-01-01", "record_count": 10}
-        ])
+        mock_service.list_runs.return_value = ServiceResult.success(
+            data=[
+                {
+                    "engine_name": "test_engine",
+                    "task_id": "run-1",
+                    "portfolio_name": "p1",
+                    "timestamp": "2025-01-01",
+                    "record_count": 10,
+                }
+            ]
+        )
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.result_service.return_value = mock_service
             result = cli_runner.invoke(flat_cli.result_app, ["show"])
@@ -386,10 +429,12 @@ class TestGetEngineStatusName:
 
     def test_known_status_running(self):
         from ginkgo.enums import ENGINESTATUS_TYPES
+
         assert flat_cli._get_engine_status_name(ENGINESTATUS_TYPES.RUNNING.value) == "Running"
 
     def test_known_status_idle(self):
         from ginkgo.enums import ENGINESTATUS_TYPES
+
         assert flat_cli._get_engine_status_name(ENGINESTATUS_TYPES.IDLE.value) == "Idle"
 
     def test_unknown_status(self):
@@ -442,9 +487,13 @@ class TestResultGetRealData:
         from ginkgo.data.services.backtest_task_schemas import BacktestOrderItem
 
         order = BacktestOrderItem(
-            code="600000.SH", direction="1", status="4",
-            volume=100, transaction_price="12.34",
-            transaction_volume=100, timestamp="2025-06-03 09:30",
+            code="600000.SH",
+            direction="1",
+            status="4",
+            volume=100,
+            transaction_price="12.34",
+            transaction_volume=100,
+            timestamp="2025-06-03 09:30",
         )
         record = MagicMock(name="bt-record")
         record.name = "my-bt"
@@ -452,8 +501,7 @@ class TestResultGetRealData:
 
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.backtest_task_service.return_value = task_svc
-            result = cli_runner.invoke(
-                flat_cli.result_app, ["get", "task-123", "--trades"])
+            result = cli_runner.invoke(flat_cli.result_app, ["get", "task-123", "--trades"])
 
         assert result.exit_code == 0, result.output
         # 参数透传为 task_id
@@ -495,13 +543,19 @@ class TestResultShowTaskIdUnify:
         from ginkgo.data.services.base_service import ServiceResult
         import pandas as pd
 
-        summary = {"task_id": task_id_value, "engine_id": "e1", "total_records": 1,
-                   "portfolio_count": 1, "portfolios": ["p1"]}
+        summary = {
+            "task_id": task_id_value,
+            "engine_id": "e1",
+            "total_records": 1,
+            "portfolio_count": 1,
+            "portfolios": ["p1"],
+        }
         mock_result_svc = MagicMock()
         mock_result_svc.get_run_summary.return_value = ServiceResult.success(data=summary)
         mock_result_svc.get_portfolio_analyzers.return_value = ServiceResult.success(data=["net_value"])
         mock_result_svc.get_analyzer_values_df.return_value = ServiceResult.success(
-            data=pd.DataFrame([{"timestamp": "2025-01-01", "value": 1.05}]))
+            data=pd.DataFrame([{"timestamp": "2025-01-01", "value": 1.05}])
+        )
         return mock_result_svc
 
     def test_show_help_exposes_task_id(self, cli_runner):
@@ -543,6 +597,7 @@ class TestResultGetTaskIdOption:
 
     def _task_svc(self, record=None):
         from ginkgo.data.services.base_service import ServiceResult
+
         svc = MagicMock()
         svc.get_by_id.return_value = ServiceResult(success=True, data=record)
         return svc

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -188,6 +188,19 @@ class TestComponentList:
         assert payload["metadata"]["offset"] == 0
         assert payload["data"][0]["name"] == "TestStrategy"
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize("bad_arg", ["--page=-1", "--page-size=-1"])
+    def test_list_components_negative_param_json_envelope_exit_2(self, cli_runner, bad_arg):
+        """--page/--page-size <0 + --format json → BAD_PARAMS envelope + exit 2（#6652 review E2，ADR-021 dim 1/6）。
+
+        守卫在 CRUD 调用前拦截，无需 mock；JSON 模式 stdout 须为合法 JSON（listing 文本被 format!=json 守卫跳过）。
+        """
+        result = cli_runner.invoke(flat_cli.component_app, ["list", bad_arg, "--format", "json"])
+        assert result.exit_code == 2, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "BAD_PARAMS"
+
     def test_list_page_size_pushes_to_file_crud(self, cli_runner, mock_component):
         """#5009：--page-size 下推 file_crud.find page_size（all 路径，type__in DB 层过滤后分页）。"""
         crud = MagicMock()

--- a/tests/unit/client/test_flat_cli.py
+++ b/tests/unit/client/test_flat_cli.py
@@ -470,8 +470,21 @@ class TestExceptionHandling:
         with patch("ginkgo.data.containers.container") as mock_container:
             mock_container.file_crud.return_value = crud
             result = cli_runner.invoke(flat_cli.component_app, ["list"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1  # ADR-021 第 6 维：异常 → exit 1（原 exit 0 是 false-success）
         assert "Error" in result.output
+
+    def test_component_list_exception_json_envelope(self, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + 异常 → stdout 合法 JSON INTERNAL 错误 envelope + exit 1。"""
+        crud = MagicMock()
+        crud.find.side_effect = Exception("DB connection error")
+        with patch("ginkgo.data.containers.container") as mock_container:
+            mock_container.file_crud.return_value = crud
+            result = cli_runner.invoke(flat_cli.component_app, ["list", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INTERNAL"
+        assert "DB connection error" in payload["error"]["message"]
 
 
 # ============================================================================

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -107,7 +107,8 @@ class TestPortfolioHelp:
         result = cli_runner.invoke(portfolio_cli.app, ["list", "--help"])
         assert result.exit_code == 0
         assert "--status" in result.output
-        assert "--limit" in result.output
+        assert "--page" in result.output
+        assert "--page-size" in result.output
         assert "--raw" in result.output
 
 
@@ -187,7 +188,7 @@ class TestPortfolioList:
         mock_service.count.return_value = ServiceResult.success(data={"count": 100})
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json", "--limit", "1"])
+        result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json", "--page-size", "1"])
 
         assert result.exit_code == 0
         payload = json.loads(result.output)
@@ -201,16 +202,16 @@ class TestPortfolioList:
         assert payload["data"][0]["name"] == "TestPortfolio"
 
     @patch("ginkgo.data.containers.container")
-    def test_list_limit_pushes_page_size_to_service(self, mock_container, cli_runner, mock_portfolio_list_df):
-        """ADR-021 L139：--limit 下推 service page_size，替代 client-side head(limit)。"""
+    def test_list_page_size_pushes_to_service(self, mock_container, cli_runner, mock_portfolio_list_df):
+        """#5009：--page-size 下推 service page_size（page 默认 0）。"""
         mock_service = MagicMock()
         mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, ["list", "--limit", "5"])
+        result = cli_runner.invoke(portfolio_cli.app, ["list", "--page-size", "5"])
 
         assert result.exit_code == 0
-        mock_service.get_portfolios_df.assert_called_once_with(page_size=5)
+        mock_service.get_portfolios_df.assert_called_once_with(page=0, page_size=5)
 
     @patch("ginkgo.data.containers.container")
     def test_list_service_error(self, mock_container, cli_runner):

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -106,10 +106,12 @@ class TestPortfolioHelp:
         """portfolio list --help 显示 list 命令选项"""
         result = cli_runner.invoke(portfolio_cli.app, ["list", "--help"])
         assert result.exit_code == 0
-        assert "--status" in result.output
-        assert "--page" in result.output
-        assert "--page-size" in result.output
-        assert "--raw" in result.output
+        # rich colorize 会把 "--status" 拆成 "-\x1b[1;36m-status"，须先 strip ANSI（见 test_rich_table_width_clirunner）
+        plain = _strip_ansi(result.output)
+        assert "--status" in plain
+        assert "--page" in plain
+        assert "--page-size" in plain
+        assert "--raw" in plain
 
 
 # ============================================================================
@@ -617,6 +619,11 @@ class TestPortfolioDelete:
     def test_delete_with_yes_short_flag(self, mock_container, cli_runner):
         """使用 -y 短标志成功删除（#6006: 统一确认标志跨命令一致）"""
         mock_service = MagicMock()
+        # delete 命令先经 _resolve_portfolio_identifier(portfolio_service.get) 解析 uuid 再删，
+        # 须 mock get 命中，否则 resolved_uuid 为 MagicMock 致断言失败（#5995 resolve 链）。
+        mock_portfolio = MagicMock()
+        mock_portfolio.uuid = "portfolio-uuid-001"
+        mock_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
         mock_service.delete.return_value = ServiceResult.success(data=None)
         mock_container.portfolio_service.return_value = mock_service
 
@@ -905,10 +912,11 @@ class TestGenerateBaselinePagination:
         ):
             _generate_baseline_if_possible("paper-id", "source-id")
 
-        # The evaluator must have been called with the correct engine_id
+        # 代码传 task_id（portfolio_cli.py:991 evaluate_backtest_stability(task_id=task_id)），
+        # 非 engine_id；断言须对齐，否则将来代码真改成传错字段测试反而绿（掩盖回归）。
         mock_evaluator.evaluate_backtest_stability.assert_called_once_with(
             portfolio_id="source-id",
-            engine_id="engine-xyz",
+            task_id="task-abc-123",
         )
 
     def test_handles_empty_paginated_result(self):

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -12,6 +12,7 @@ Portfolio CLI 单元测试
 - unbind-component: 解绑组件
 """
 
+import json
 import os
 import re
 
@@ -29,7 +30,7 @@ from ginkgo.data.services.base_service import ServiceResult
 
 def _strip_ansi(text: str) -> str:
     """去除 ANSI 转义码，便于断言"""
-    return re.sub(r'\x1b\[[0-9;]*m', '', text)
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 @pytest.fixture
@@ -50,16 +51,18 @@ class FakeModelList:
 @pytest.fixture
 def mock_portfolio_list_df():
     """标准 portfolio 测试 DataFrame"""
-    return pd.DataFrame({
-        "uuid": ["portfolio-uuid-001", "portfolio-uuid-002"],
-        "name": ["TestPortfolio", "LivePortfolio"],
-        "initial_capital": [1000000.0, 2000000.0],
-        "current_capital": [950000.0, 2100000.0],
-        "cash": [500000.0, 1000000.0],
-        "is_live": [False, True],
-        "status": ["Ready", "Running"],
-        "desc": ["Test desc", "Live desc"],
-    })
+    return pd.DataFrame(
+        {
+            "uuid": ["portfolio-uuid-001", "portfolio-uuid-002"],
+            "name": ["TestPortfolio", "LivePortfolio"],
+            "initial_capital": [1000000.0, 2000000.0],
+            "current_capital": [950000.0, 2100000.0],
+            "cash": [500000.0, 1000000.0],
+            "is_live": [False, True],
+            "status": ["Ready", "Running"],
+            "desc": ["Test desc", "Live desc"],
+        }
+    )
 
 
 @pytest.fixture
@@ -122,9 +125,7 @@ class TestPortfolioList:
     def test_list_all_portfolios(self, mock_container, cli_runner, mock_portfolio_list_df):
         """成功列出所有 portfolio"""
         mock_service = MagicMock()
-        mock_service.get_portfolios_df.return_value = ServiceResult.success(
-            data=mock_portfolio_list_df
-        )
+        mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, ["list"])
@@ -157,9 +158,7 @@ class TestPortfolioList:
     def test_list_empty_portfolios(self, mock_container, cli_runner):
         """没有 portfolio 时显示提示"""
         mock_service = MagicMock()
-        mock_service.get_portfolios_df.return_value = ServiceResult.success(
-            data=pd.DataFrame()
-        )
+        mock_service.get_portfolios_df.return_value = ServiceResult.success(data=pd.DataFrame())
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, ["list"])
@@ -170,15 +169,30 @@ class TestPortfolioList:
     def test_list_raw_output(self, mock_container, cli_runner, mock_portfolio_list_df):
         """--raw 模式输出 JSON 格式数据"""
         mock_service = MagicMock()
-        mock_service.get_portfolios_df.return_value = ServiceResult.success(
-            data=mock_portfolio_list_df
-        )
+        mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, ["list", "--raw"])
         assert result.exit_code == 0
         assert "TestPortfolio" in result.output
         assert "portfolio-uuid-001" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_json_format_outputs_adr021_contract(self, mock_container, cli_runner, mock_portfolio_list_df):
+        """--format json 输出 ADR-021 list 契约，stdout 仅含 JSON。"""
+        mock_service = MagicMock()
+        mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json", "--limit", "1"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["count"] == 1
+        assert payload["metadata"] == {"total": 2, "limit": 1, "offset": 0}
+        assert payload["warnings"] == []
+        assert payload["data"][0]["name"] == "TestPortfolio"
 
     @patch("ginkgo.data.containers.container")
     def test_list_service_error(self, mock_container, cli_runner):
@@ -221,9 +235,7 @@ class TestPortfolioCreate:
         )
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "MyPortfolio", "--capital", "500000"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "MyPortfolio", "--capital", "500000"])
         assert result.exit_code == 0
         output = _strip_ansi(result.output)
         assert "created successfully" in output
@@ -234,14 +246,10 @@ class TestPortfolioCreate:
     def test_create_passes_initial_capital_to_service(self, mock_container, cli_runner):
         """#5331 create 命令必须将 initial_capital 传给 service.add()"""
         mock_service = MagicMock()
-        mock_service.add.return_value = ServiceResult.success(
-            data={"uuid": "new-uuid", "name": "CapTest"}
-        )
+        mock_service.add.return_value = ServiceResult.success(data={"uuid": "new-uuid", "name": "CapTest"})
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "CapTest", "--capital", "2000000"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "CapTest", "--capital", "2000000"])
         assert result.exit_code == 0
         # 验证 service.add 被调用时传入了 initial_capital
         call_kwargs = mock_service.add.call_args
@@ -257,9 +265,7 @@ class TestPortfolioCreate:
         mock_service.add.return_value = ServiceResult.success(data={"uuid": "live-uuid", "name": "LivePF"})
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "LivePF", "--live"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "LivePF", "--live"])
         assert result.exit_code == 0
         assert "Live" in result.output
 
@@ -276,9 +282,7 @@ class TestPortfolioCreate:
         mock_service.add.return_value = ServiceResult.error(error="Name already exists")
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "DupPortfolio"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "DupPortfolio"])
         assert result.exit_code == 1
         assert "creation failed" in result.output
 
@@ -287,9 +291,7 @@ class TestPortfolioCreate:
         """服务抛出异常时创建失败"""
         mock_container.portfolio_service.side_effect = Exception("DB down")
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "BadPortfolio"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "BadPortfolio"])
         assert result.exit_code == 1
         assert "Error" in result.output
 
@@ -301,9 +303,7 @@ class TestPortfolioCreate:
         mock_service = MagicMock()
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "EdgeNeg", "--capital", "-1"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "EdgeNeg", "--capital", "-1"])
         assert result.exit_code == 1
         assert "capital" in _strip_ansi(result.output).lower()
         # 负资本绝不应触达 service
@@ -315,9 +315,7 @@ class TestPortfolioCreate:
         mock_service = MagicMock()
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "EdgeZero", "--capital", "0"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "EdgeZero", "--capital", "0"])
         assert result.exit_code == 1
         assert "capital" in _strip_ansi(result.output).lower()
         mock_service.add.assert_not_called()
@@ -326,14 +324,10 @@ class TestPortfolioCreate:
     def test_create_accepts_positive_capital(self, mock_container, cli_runner):
         """#5984 正资本仍正常创建（回归守护）"""
         mock_service = MagicMock()
-        mock_service.add.return_value = ServiceResult.success(
-            data={"uuid": "ok-uuid", "name": "Ok"}
-        )
+        mock_service.add.return_value = ServiceResult.success(data={"uuid": "ok-uuid", "name": "Ok"})
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "create", "--name", "Ok", "--capital", "0.01"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["create", "--name", "Ok", "--capital", "0.01"])
         assert result.exit_code == 0
         assert "created successfully" in _strip_ansi(result.output)
 
@@ -385,6 +379,21 @@ class TestPortfolioGet:
         result = cli_runner.invoke(portfolio_cli.app, ["get", "nonexistent-uuid"])
         assert result.exit_code == 1
         assert "Failed to get portfolio" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_get_not_found_json_format_outputs_not_found_contract(self, mock_container, cli_runner):
+        """--format json 下 get 未找到输出 ADR-021 NOT_FOUND 错误对象。"""
+        mock_service = MagicMock()
+        mock_service.get.return_value = ServiceResult.error(error="Not found")
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["get", "nonexistent-uuid", "--format", "json"])
+
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"] == {"code": "NOT_FOUND", "message": "Portfolio not found: nonexistent-uuid"}
+        assert payload["data"] is None
 
     @patch("ginkgo.data.containers.container")
     def test_get_with_details_empty_components(self, mock_container, cli_runner, mock_portfolio):
@@ -459,18 +468,14 @@ class TestPortfolioDelete:
         mock_service.delete.return_value = ServiceResult.success(data=None)
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "portfolio-uuid-001", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "portfolio-uuid-001", "--confirm"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
         mock_service.delete.assert_called_once_with("portfolio-uuid-001")
 
     def test_delete_missing_confirm(self, cli_runner):
         """缺少 --confirm 时拒绝删除"""
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "portfolio-uuid-001"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "portfolio-uuid-001"])
         assert result.exit_code == 1
         assert "--confirm" in result.output
 
@@ -481,15 +486,13 @@ class TestPortfolioDelete:
         named = MagicMock()
         named.uuid = "resolved-uuid-999"
         mock_service.get.side_effect = [
-            ServiceResult.success(data=[]),              # get(portfolio_id=name) 空
-            ServiceResult.success(data=[named]),         # get(name=name) 命中
+            ServiceResult.success(data=[]),  # get(portfolio_id=name) 空
+            ServiceResult.success(data=[named]),  # get(name=name) 命中
         ]
         mock_service.delete.return_value = ServiceResult.success(data=None)
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "deploy_test", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "deploy_test", "--confirm"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
         mock_service.delete.assert_called_once_with("resolved-uuid-999")
@@ -505,9 +508,7 @@ class TestPortfolioDelete:
         mock_service.delete.return_value = ServiceResult.success(data=None)
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "deadbeef", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "deadbeef", "--confirm"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
         mock_service.fuzzy_search.assert_called_once_with("deadbeef")
@@ -523,9 +524,7 @@ class TestPortfolioDelete:
         mock_service.fuzzy_search.return_value = ServiceResult.success(data=[a, b])
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "uuid", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "uuid", "--confirm"])
         assert result.exit_code == 1
         assert "Multiple" in result.output or "多个" in result.output
         mock_service.delete.assert_not_called()
@@ -538,9 +537,7 @@ class TestPortfolioDelete:
         mock_service.fuzzy_search.return_value = ServiceResult.success(data=[])
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "nonexistent", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "nonexistent", "--confirm"])
         assert result.exit_code == 1
         assert "投资组合不存在" in result.output
         mock_service.delete.assert_not_called()
@@ -553,9 +550,7 @@ class TestPortfolioDelete:
         mock_service.delete.return_value = ServiceResult.error(error="Portfolio not found")
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "portfolio-uuid-001", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "portfolio-uuid-001", "--confirm"])
         assert result.exit_code == 1
         assert "Failed to delete portfolio" in result.output
 
@@ -566,9 +561,7 @@ class TestPortfolioDelete:
         mock_service.delete.return_value = ServiceResult.success(data=None)
         mock_container.portfolio_service.return_value = mock_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "delete", "portfolio-uuid-001", "-y"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["delete", "portfolio-uuid-001", "-y"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
         mock_service.delete.assert_called_once_with("portfolio-uuid-001")
@@ -609,9 +602,9 @@ class TestPortfolioBindComponent:
         mock_container.file_service.return_value = mock_file_service
         mock_container.mapping_service.return_value = mock_mapping_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "bind-component", "TestPortfolio", "MyStrategy", "--type", "strategy"
-        ])
+        result = cli_runner.invoke(
+            portfolio_cli.app, ["bind-component", "TestPortfolio", "MyStrategy", "--type", "strategy"]
+        )
         assert result.exit_code == 0
         assert "binding created successfully" in result.output
 
@@ -639,10 +632,10 @@ class TestPortfolioBindComponent:
         mock_container.file_service.return_value = mock_file_service
         mock_container.mapping_service.return_value = mock_mapping_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "bind-component", "TestPortfolio", "RiskMgr",
-            "--type", "risk", "--param", "0:0.1", "--param", "1:100"
-        ])
+        result = cli_runner.invoke(
+            portfolio_cli.app,
+            ["bind-component", "TestPortfolio", "RiskMgr", "--type", "risk", "--param", "0:0.1", "--param", "1:100"],
+        )
         assert result.exit_code == 0
         output = _strip_ansi(result.output)
         assert "binding created successfully" in output
@@ -650,9 +643,7 @@ class TestPortfolioBindComponent:
 
     def test_bind_missing_type(self, cli_runner):
         """缺少 --type 参数时失败"""
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "bind-component", "portfolio-id", "file-id"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["bind-component", "portfolio-id", "file-id"])
         assert result.exit_code != 0
 
     @patch("ginkgo.data.containers.container")
@@ -662,16 +653,14 @@ class TestPortfolioBindComponent:
         mock_pf_service.get.return_value = ServiceResult.success(data=[mock_portfolio])
 
         mock_file_service = MagicMock()
-        mock_file_service.get_by_uuid.return_value = ServiceResult.success(
-            data=MagicMock(uuid="f-1", name="Comp")
-        )
+        mock_file_service.get_by_uuid.return_value = ServiceResult.success(data=MagicMock(uuid="f-1", name="Comp"))
 
         mock_container.portfolio_service.return_value = mock_pf_service
         mock_container.file_service.return_value = mock_file_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "bind-component", "TestPortfolio", "Comp", "--type", "invalid_type"
-        ])
+        result = cli_runner.invoke(
+            portfolio_cli.app, ["bind-component", "TestPortfolio", "Comp", "--type", "invalid_type"]
+        )
         assert result.exit_code == 1
         assert "Invalid component type" in result.output
 
@@ -696,11 +685,18 @@ class TestPortfolioBindComponent:
         mock_container.portfolio_service.return_value = mock_pf_service
         mock_container.file_service.return_value = mock_file_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "bind-component", "TestPortfolio", "moving_average_crossover",
-            "--type", "strategy",
-            "--param", "short_period:20",
-        ])
+        result = cli_runner.invoke(
+            portfolio_cli.app,
+            [
+                "bind-component",
+                "TestPortfolio",
+                "moving_average_crossover",
+                "--type",
+                "strategy",
+                "--param",
+                "short_period:20",
+            ],
+        )
         assert result.exit_code != 0
         assert "仅支持整数 index" in result.output
 
@@ -730,9 +726,7 @@ class TestPortfolioUnbindComponent:
         mock_container.file_service.return_value = mock_file_service
         mock_container.mapping_service.return_value = mock_mapping_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "unbind-component", "TestPortfolio", "MyStrategy", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["unbind-component", "TestPortfolio", "MyStrategy", "--confirm"])
         assert result.exit_code == 0
         assert "binding deleted successfully" in result.output
 
@@ -756,18 +750,14 @@ class TestPortfolioUnbindComponent:
         mock_container.file_service.return_value = mock_file_service
         mock_container.mapping_service.return_value = mock_mapping_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "unbind-component", "TestPortfolio", "MyStrategy", "-y"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["unbind-component", "TestPortfolio", "MyStrategy", "-y"])
         assert result.exit_code == 0
         assert "binding deleted successfully" in result.output
         mock_mapping_service.delete_portfolio_file_binding.assert_called_once()
 
     def test_unbind_missing_confirm(self, cli_runner):
         """缺少 --confirm 时拒绝解绑"""
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "unbind-component", "portfolio-id", "file-id"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["unbind-component", "portfolio-id", "file-id"])
         assert result.exit_code == 1
         assert "--confirm" in result.output
 
@@ -784,17 +774,13 @@ class TestPortfolioUnbindComponent:
         mock_file_service.get_by_uuid.return_value = ServiceResult.success(data=mock_file)
 
         mock_mapping_service = MagicMock()
-        mock_mapping_service.delete_portfolio_file_binding.return_value = ServiceResult.error(
-            error="Binding not found"
-        )
+        mock_mapping_service.delete_portfolio_file_binding.return_value = ServiceResult.error(error="Binding not found")
 
         mock_container.portfolio_service.return_value = mock_pf_service
         mock_container.file_service.return_value = mock_file_service
         mock_container.mapping_service.return_value = mock_mapping_service
 
-        result = cli_runner.invoke(portfolio_cli.app, [
-            "unbind-component", "TestPortfolio", "SomeFile", "--confirm"
-        ])
+        result = cli_runner.invoke(portfolio_cli.app, ["unbind-component", "TestPortfolio", "SomeFile", "--confirm"])
         assert result.exit_code == 1
         assert "Failed to delete binding" in result.output
 
@@ -829,12 +815,14 @@ class TestGenerateBaselinePagination:
         mock_task.engine_id = "engine-xyz"
 
         mock_task_svc = MagicMock()
-        mock_task_svc.list.return_value = ServiceResult.success({
-            "data": [mock_task],
-            "total": 1,
-            "page": 0,
-            "page_size": 20,
-        })
+        mock_task_svc.list.return_value = ServiceResult.success(
+            {
+                "data": [mock_task],
+                "total": 1,
+                "page": 0,
+                "page_size": 20,
+            }
+        )
 
         # Mock evaluator (prevent real evaluation)
         mock_evaluator = MagicMock()
@@ -850,9 +838,12 @@ class TestGenerateBaselinePagination:
         mock_services.data.backtest_task_service.return_value = mock_task_svc
         mock_services.data.redis_service.return_value = mock_redis
 
-        with patch("ginkgo.services", mock_services), \
-             patch("ginkgo.trading.analysis.evaluation.backtest_evaluator.BacktestEvaluator",
-                   return_value=mock_evaluator):
+        with (
+            patch("ginkgo.services", mock_services),
+            patch(
+                "ginkgo.trading.analysis.evaluation.backtest_evaluator.BacktestEvaluator", return_value=mock_evaluator
+            ),
+        ):
             _generate_baseline_if_possible("paper-id", "source-id")
 
         # The evaluator must have been called with the correct engine_id
@@ -866,12 +857,14 @@ class TestGenerateBaselinePagination:
         from ginkgo.client.portfolio_cli import _generate_baseline_if_possible
 
         mock_task_svc = MagicMock()
-        mock_task_svc.list.return_value = ServiceResult.success({
-            "data": [],
-            "total": 0,
-            "page": 0,
-            "page_size": 20,
-        })
+        mock_task_svc.list.return_value = ServiceResult.success(
+            {
+                "data": [],
+                "total": 0,
+                "page": 0,
+                "page_size": 20,
+            }
+        )
 
         mock_services = MagicMock()
         mock_services.data.backtest_task_service.return_value = mock_task_svc

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -183,7 +183,8 @@ class TestPortfolioList:
         mock_service = MagicMock()
         # 模拟 DB 截断：get_portfolios_df 按 page_size 返回当前页（2 行），count 返回未截断总数。
         mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
-        mock_service.count.return_value = ServiceResult.success(data=100)
+        # 对齐真实 PortfolioService.count() 契约：返回 ServiceResult.success({"count": N})（dict，非裸 int）。
+        mock_service.count.return_value = ServiceResult.success(data={"count": 100})
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json", "--limit", "1"])

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -181,7 +181,9 @@ class TestPortfolioList:
     def test_list_json_format_outputs_adr021_contract(self, mock_container, cli_runner, mock_portfolio_list_df):
         """--format json 输出 ADR-021 list 契约，stdout 仅含 JSON。"""
         mock_service = MagicMock()
+        # 模拟 DB 截断：get_portfolios_df 按 page_size 返回当前页（2 行），count 返回未截断总数。
         mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
+        mock_service.count.return_value = ServiceResult.success(data=100)
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json", "--limit", "1"])
@@ -189,10 +191,11 @@ class TestPortfolioList:
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["success"] is True
-        # ADR-021 L139：--limit 下推 service page_size（DB 层截断），CLI 不再 head(limit)。
-        # count = service 返回行数（mock 返 2 行）；截断正确性由 service 层测试保证。
+        # ADR-021：count = 当前页记录数（len records），metadata.total = 未截断匹配总数（service.count）。
         assert payload["count"] == 2
-        assert payload["metadata"] == {"total": 2, "limit": 1, "offset": 0}
+        assert payload["metadata"]["total"] == 100
+        assert payload["metadata"]["limit"] == 1
+        assert payload["metadata"]["offset"] == 0
         assert payload["warnings"] == []
         assert payload["data"][0]["name"] == "TestPortfolio"
 

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -464,6 +464,21 @@ class TestPortfolioGet:
         assert "Error" in result.output
 
     @patch("ginkgo.data.containers.container")
+    def test_get_service_exception_json_envelope(self, mock_container, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + get 服务异常 → stdout 合法 JSON 错误 envelope + exit 1。
+
+        与同函数 NOT_FOUND 路径（test_get_not_found_json_format_outputs_not_found_contract）对称：
+        broad except 也须走 format_result，不能 JSON 模式直出 Rich 红字。"""
+        mock_container.portfolio_service.side_effect = Exception("Connection refused")
+
+        result = cli_runner.invoke(portfolio_cli.app, ["get", "some-uuid", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INTERNAL"
+        assert "Connection refused" in payload["error"]["message"]
+
+    @patch("ginkgo.data.containers.container")
     def test_get_mode_shows_readable_text_backtest(self, mock_container, cli_runner, mock_portfolio):
         """#5326 Mode 字段显示 BACKTEST 而非数字 0"""
         mock_portfolio.mode = 0

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -189,10 +189,24 @@ class TestPortfolioList:
         assert result.exit_code == 0
         payload = json.loads(result.output)
         assert payload["success"] is True
-        assert payload["count"] == 1
+        # ADR-021 L139：--limit 下推 service page_size（DB 层截断），CLI 不再 head(limit)。
+        # count = service 返回行数（mock 返 2 行）；截断正确性由 service 层测试保证。
+        assert payload["count"] == 2
         assert payload["metadata"] == {"total": 2, "limit": 1, "offset": 0}
         assert payload["warnings"] == []
         assert payload["data"][0]["name"] == "TestPortfolio"
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_limit_pushes_page_size_to_service(self, mock_container, cli_runner, mock_portfolio_list_df):
+        """ADR-021 L139：--limit 下推 service page_size，替代 client-side head(limit)。"""
+        mock_service = MagicMock()
+        mock_service.get_portfolios_df.return_value = ServiceResult.success(data=mock_portfolio_list_df)
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["list", "--limit", "5"])
+
+        assert result.exit_code == 0
+        mock_service.get_portfolios_df.assert_called_once_with(page_size=5)
 
     @patch("ginkgo.data.containers.container")
     def test_list_service_error(self, mock_container, cli_runner):

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -216,7 +216,7 @@ class TestPortfolioList:
         mock_container.portfolio_service.return_value = mock_service
 
         result = cli_runner.invoke(portfolio_cli.app, ["list"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1  # ADR-021 第 6 维：service 失败 → exit 1（原 exit 0 是 false-success）
         assert "Failed to get portfolios" in result.output
         assert "Database connection failed" in result.output
 
@@ -226,8 +226,33 @@ class TestPortfolioList:
         mock_container.portfolio_service.side_effect = Exception("Unexpected error")
 
         result = cli_runner.invoke(portfolio_cli.app, ["list"])
-        assert result.exit_code == 0
+        assert result.exit_code == 1  # ADR-021 第 6 维：异常 → exit 1（原 exit 0 是 false-success）
         assert "Error" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_service_error_json_envelope(self, mock_container, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + service 失败 → stdout 合法 JSON
+        ``{"success": false, "error": {...}}`` + exit 1（真实失败路径，非合成）。"""
+        mock_service = MagicMock()
+        mock_service.get_portfolios_df.return_value = ServiceResult.error(error="Database connection failed")
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "Database connection failed" in payload["error"]["message"]
+
+    @patch("ginkgo.data.containers.container")
+    def test_list_service_exception_json_envelope(self, mock_container, cli_runner):
+        """ADR-021 第 1/5/6 维：--format json + 服务异常 → stdout 合法 JSON 错误 envelope + exit 1。"""
+        mock_container.portfolio_service.side_effect = Exception("Unexpected error")
+
+        result = cli_runner.invoke(portfolio_cli.app, ["list", "--format", "json"])
+        assert result.exit_code == 1
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert "Unexpected error" in payload["error"]["message"]
 
 
 # ============================================================================

--- a/tests/unit/client/test_record_cli_list_smoke.py
+++ b/tests/unit/client/test_record_cli_list_smoke.py
@@ -115,13 +115,27 @@ class TestRecordTextAndEmpty:
 
 
 class TestRecordValidation:
-    """#5009 契约守卫：--page 负值 → typer.Exit(1)（4 命令各自独立守卫块）。"""
+    """#5009 契约守卫：--page/--page-size 负值 → exit 2（BAD_PARAMS，ADR-021 dim 6）。4 命令各自独立守卫块。"""
 
     @pytest.mark.unit
     @pytest.mark.parametrize("command", list(_COMMANDS))
     def test_negative_page_exits_nonzero(self, command):
         result, _, _ = _invoke(command, ["--page=-1"])
         assert result.exit_code != 0
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    @pytest.mark.parametrize("bad_arg", ["--page=-1", "--page-size=-1"])
+    def test_negative_param_json_envelope_exit_2(self, command, bad_arg):
+        """--page/--page-size <0 + --format json → BAD_PARAMS envelope + exit 2（#6652 review E2，ADR-021 dim 1/6）。
+
+        旧实现 JSON 模式 console.print Rich 标记到 stdout + exit 1，stdout 非合法 JSON，jq 崩。
+        """
+        result, _, _ = _invoke(command, [bad_arg, "--format", "json"])
+        assert result.exit_code == 2, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "BAD_PARAMS"
 
 
 class TestRecordServiceFailure:

--- a/tests/unit/client/test_record_cli_list_smoke.py
+++ b/tests/unit/client/test_record_cli_list_smoke.py
@@ -2,7 +2,7 @@
 
 record_cli 4 命令为本 PR 重构（--page/--page-size offset 分页 + --format json ADR-021
 envelope + count_X metadata.total）。container import 链触达该模块但 smoke 不调命令体
-→ 改动行无覆盖信号 → 门禁红。本文件用 CliRunner + mock data.containers.Container 补
+→ 改动行无覆盖信号 → 门禁红。本文件用 CliRunner + mock data.containers.container 补
 信号（不连 DB / 不真起服务），覆盖 JSON/text/空记录/负值守卫四条路径 × 4 命令。
 """
 
@@ -40,7 +40,7 @@ def _df(columns):
 
 
 def _setup(command, records_df, count=1, ok=True):
-    """Patch Container.<svc_attr> → 返回 mock service；返回 (patch_ctx, svc, get_method)."""
+    """Patch container.<svc_attr> → 返回 mock service；返回 (patch_ctx, svc, get_method)."""
     svc_attr, get_method, count_method, _cols = _COMMANDS[command]
     svc = MagicMock()
     get_res = MagicMock()
@@ -54,7 +54,7 @@ def _setup(command, records_df, count=1, ok=True):
     count_res.success = True
     count_res.data = {"count": count}
     getattr(svc, count_method).return_value = count_res
-    ctx = patch("ginkgo.data.containers.Container")
+    ctx = patch("ginkgo.data.containers.container")
     return ctx, svc, svc_attr, get_method
 
 
@@ -62,8 +62,8 @@ def _invoke(command, args):
     """command: signal|order|position|analyzer。返回 (result, svc, get_method)。"""
     cols = _COMMANDS[command][3]
     ctx, svc, svc_attr, get_method = _setup(command, _df(cols), count=2)
-    with ctx as Container:
-        getattr(Container, svc_attr).return_value = svc
+    with ctx as container:
+        getattr(container, svc_attr).return_value = svc
         result = runner.invoke(app, [command] + args)
     return result, svc, get_method
 
@@ -107,8 +107,8 @@ class TestRecordTextAndEmpty:
     def test_text_empty_records(self, command):
         cols = _COMMANDS[command][3]
         ctx, svc, svc_attr, _ = _setup(command, pd.DataFrame(), count=0)  # 空 df
-        with ctx as Container:
-            getattr(Container, svc_attr).return_value = svc
+        with ctx as container:
+            getattr(container, svc_attr).return_value = svc
             result = runner.invoke(app, [command])
         assert result.exit_code == 0
         assert "No" in result.output  # "No signals/orders/positions/analyzer records found."
@@ -147,8 +147,8 @@ class TestRecordServiceFailure:
     def test_service_failure_json_envelope_exit_nonzero(self, command):
         cols = _COMMANDS[command][3]
         ctx, svc, svc_attr, get_method = _setup(command, _df(cols), count=0, ok=False)
-        with ctx as Container:
-            getattr(Container, svc_attr).return_value = svc
+        with ctx as container:
+            getattr(container, svc_attr).return_value = svc
             result = runner.invoke(app, [command, "--format", "json"])
         assert result.exit_code != 0  # 失败分支 JSON 模式 raise typer.Exit(1)
         payload = json.loads(result.output)
@@ -160,8 +160,8 @@ class TestRecordServiceFailure:
     def test_service_failure_text_exits_nonzero(self, command):
         cols = _COMMANDS[command][3]
         ctx, svc, svc_attr, _ = _setup(command, _df(cols), count=0, ok=False)
-        with ctx as Container:
-            getattr(Container, svc_attr).return_value = svc
+        with ctx as container:
+            getattr(container, svc_attr).return_value = svc
             result = runner.invoke(app, [command])  # 默认 text
         assert result.exit_code != 0  # text 失败也 exit 1（原隐式 exit 0 是 bug）
 
@@ -172,8 +172,8 @@ class TestRecordServiceFailure:
         cols = _COMMANDS[command][3]
         ctx, svc, svc_attr, get_method = _setup(command, _df(cols), count=0, ok=True)
         getattr(svc, get_method).side_effect = RuntimeError("db down")
-        with ctx as Container:
-            getattr(Container, svc_attr).return_value = svc
+        with ctx as container:
+            getattr(container, svc_attr).return_value = svc
             result = runner.invoke(app, [command, "--format", "json"])
         assert result.exit_code != 0
         payload = json.loads(result.output)

--- a/tests/unit/client/test_record_cli_list_smoke.py
+++ b/tests/unit/client/test_record_cli_list_smoke.py
@@ -47,6 +47,8 @@ def _setup(command, records_df, count=1, ok=True):
     get_res.success = ok
     get_res.data = records_df
     get_res.error = "boom"
+    get_res.code = None  # 真实 failed ServiceResult 形状；避免 MagicMock auto-attr 陷阱
+    get_res.warnings = []  # format_result 失败路径 getattr(result,"warnings") or []；不设则 auto-MagicMock 触发 json 无限递归
     getattr(svc, get_method).return_value = get_res
     count_res = MagicMock()
     count_res.success = True
@@ -123,14 +125,43 @@ class TestRecordValidation:
 
 
 class TestRecordServiceFailure:
-    """get_X_df 失败分支：result.success False → 提示并 return（exit 0，非 raise）。"""
+    """get_X_df 失败分支：result.success False → JSON 模式发 error envelope + exit 1（ADR-021 第 5/6 维）。
+    text 模式打印诊断 + exit 1（原隐式 exit 0 是 bug）。"""
 
     @pytest.mark.unit
     @pytest.mark.parametrize("command", list(_COMMANDS))
-    def test_service_failure_returns_gracefully(self, command):
+    def test_service_failure_json_envelope_exit_nonzero(self, command):
+        cols = _COMMANDS[command][3]
+        ctx, svc, svc_attr, get_method = _setup(command, _df(cols), count=0, ok=False)
+        with ctx as Container:
+            getattr(Container, svc_attr).return_value = svc
+            result = runner.invoke(app, [command, "--format", "json"])
+        assert result.exit_code != 0  # 失败分支 JSON 模式 raise typer.Exit(1)
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["message"] == "boom"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_service_failure_text_exits_nonzero(self, command):
         cols = _COMMANDS[command][3]
         ctx, svc, svc_attr, _ = _setup(command, _df(cols), count=0, ok=False)
         with ctx as Container:
             getattr(Container, svc_attr).return_value = svc
+            result = runner.invoke(app, [command])  # 默认 text
+        assert result.exit_code != 0  # text 失败也 exit 1（原隐式 exit 0 是 bug）
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_service_exception_json_envelope_exit_nonzero(self, command):
+        """service 抛异常 → except 分支 JSON 模式发 INTERNAL envelope + exit 1（ADR-021 第 1 维）。"""
+        cols = _COMMANDS[command][3]
+        ctx, svc, svc_attr, get_method = _setup(command, _df(cols), count=0, ok=True)
+        getattr(svc, get_method).side_effect = RuntimeError("db down")
+        with ctx as Container:
+            getattr(Container, svc_attr).return_value = svc
             result = runner.invoke(app, [command, "--format", "json"])
-        assert result.exit_code == 0  # 失败分支 return（非 typer.Exit）
+        assert result.exit_code != 0
+        payload = json.loads(result.output)
+        assert payload["success"] is False
+        assert payload["error"]["code"] == "INTERNAL"

--- a/tests/unit/client/test_record_cli_list_smoke.py
+++ b/tests/unit/client/test_record_cli_list_smoke.py
@@ -1,0 +1,136 @@
+"""#5009 record_cli signal/order/position/analyzer 分页 CliRunner smoke（#6685 gate 采集）。
+
+record_cli 4 命令为本 PR 重构（--page/--page-size offset 分页 + --format json ADR-021
+envelope + count_X metadata.total）。container import 链触达该模块但 smoke 不调命令体
+→ 改动行无覆盖信号 → 门禁红。本文件用 CliRunner + mock data.containers.Container 补
+信号（不连 DB / 不真起服务），覆盖 JSON/text/空记录/负值守卫四条路径 × 4 命令。
+"""
+
+import os
+import sys
+import json
+import pytest
+import pandas as pd
+from unittest.mock import patch, MagicMock
+from typer.testing import CliRunner
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.client.record_cli import app
+
+runner = CliRunner()
+
+# command → (container attr, get_df method, count method, text-path columns)
+_COMMANDS = {
+    "signal": ("signal_service", "get_signals_df", "count_signals",
+               ["uuid", "engine_id", "portfolio_id", "task_id", "direction", "code", "timestamp", "reason"]),
+    "order": ("order_service", "get_orders_df", "count_orders",
+              ["uuid", "portfolio_id", "code", "direction", "order_type", "quantity", "limit_price", "timestamp", "status"]),
+    "position": ("result_service", "get_positions_df", "count_positions",
+                 ["uuid", "portfolio_id", "code", "volume", "cost", "price", "fee", "timestamp"]),
+    "analyzer": ("analyzer_service", "get_records_df", "count_records",
+                 ["uuid", "portfolio_id", "engine_id", "analyzer_id", "name", "value", "timestamp"]),
+}
+
+
+def _df(columns):
+    return pd.DataFrame([{c: f"v_{c}" for c in columns}])
+
+
+def _setup(command, records_df, count=1, ok=True):
+    """Patch Container.<svc_attr> → 返回 mock service；返回 (patch_ctx, svc, get_method)."""
+    svc_attr, get_method, count_method, _cols = _COMMANDS[command]
+    svc = MagicMock()
+    get_res = MagicMock()
+    get_res.success = ok
+    get_res.data = records_df
+    get_res.error = "boom"
+    getattr(svc, get_method).return_value = get_res
+    count_res = MagicMock()
+    count_res.success = True
+    count_res.data = {"count": count}
+    getattr(svc, count_method).return_value = count_res
+    ctx = patch("ginkgo.data.containers.Container")
+    return ctx, svc, svc_attr, get_method
+
+
+def _invoke(command, args):
+    """command: signal|order|position|analyzer。返回 (result, svc, get_method)。"""
+    cols = _COMMANDS[command][3]
+    ctx, svc, svc_attr, get_method = _setup(command, _df(cols), count=2)
+    with ctx as Container:
+        getattr(Container, svc_attr).return_value = svc
+        result = runner.invoke(app, [command] + args)
+    return result, svc, get_method
+
+
+class TestRecordJson:
+    """--format json：ADR-021 envelope + #5009 metadata.total/limit/offset，4 命令。"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_json_envelope_pagination(self, command):
+        result, svc, get_method = _invoke(command, ["--format", "json", "--page", "1", "--page-size", "5"])
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["success"] is True
+        assert payload["metadata"]["total"] == 2
+        assert payload["metadata"]["offset"] == 5  # page1 * size5
+        _, kwargs = getattr(svc, get_method).call_args
+        assert kwargs["page"] == 1 and kwargs["page_size"] == 5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_json_unlimited_passes_none(self, command):
+        result, svc, get_method = _invoke(command, ["--format", "json", "--page-size", "0"])
+        assert result.exit_code == 0
+        _, kwargs = getattr(svc, get_method).call_args
+        assert kwargs["page"] is None and kwargs["page_size"] is None
+        assert json.loads(result.output)["metadata"]["offset"] == 0
+
+
+class TestRecordTextAndEmpty:
+    """text 路径（display_dataframe + columns_config）+ 空记录分支。"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_text_renders(self, command):
+        result, _, _ = _invoke(command, ["--page", "0", "--page-size", "5"])
+        assert result.exit_code == 0, result.output
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_text_empty_records(self, command):
+        cols = _COMMANDS[command][3]
+        ctx, svc, svc_attr, _ = _setup(command, pd.DataFrame(), count=0)  # 空 df
+        with ctx as Container:
+            getattr(Container, svc_attr).return_value = svc
+            result = runner.invoke(app, [command])
+        assert result.exit_code == 0
+        assert "No" in result.output  # "No signals/orders/positions/analyzer records found."
+
+
+class TestRecordValidation:
+    """#5009 契约守卫：--page 负值 → typer.Exit(1)（4 命令各自独立守卫块）。"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_negative_page_exits_nonzero(self, command):
+        result, _, _ = _invoke(command, ["--page=-1"])
+        assert result.exit_code != 0
+
+
+class TestRecordServiceFailure:
+    """get_X_df 失败分支：result.success False → 提示并 return（exit 0，非 raise）。"""
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("command", list(_COMMANDS))
+    def test_service_failure_returns_gracefully(self, command):
+        cols = _COMMANDS[command][3]
+        ctx, svc, svc_attr, _ = _setup(command, _df(cols), count=0, ok=False)
+        with ctx as Container:
+            getattr(Container, svc_attr).return_value = svc
+            result = runner.invoke(app, [command, "--format", "json"])
+        assert result.exit_code == 0  # 失败分支 return（非 typer.Exit）

--- a/tests/unit/data/services/test_engine_portfolio_multiexit.py
+++ b/tests/unit/data/services/test_engine_portfolio_multiexit.py
@@ -128,6 +128,25 @@ def test_get_engines_df_db_failure():
     assert result.success is False
 
 
+@pytest.mark.unit
+def test_get_engines_df_passes_page_size_to_find():
+    """ADR-021 L139：--limit 下推 service page_size → find(page_size=N)。"""
+    svc = _make_engine_service(_make_engine_modellist())
+    svc.get_engines_df(page_size=5)
+    _, kwargs = svc._crud_repo.find.call_args
+    assert kwargs.get("page_size") == 5
+
+
+@pytest.mark.unit
+def test_fuzzy_search_passes_page_size_to_crud():
+    """ADR-021 L139：filter 模式 --limit 下推 fuzzy_search page_size → crud.fuzzy_search(limit=N)。"""
+    svc = _make_engine_service(_make_engine_modellist())
+    svc._crud_repo.fuzzy_search.return_value = _make_engine_modellist()
+    svc.fuzzy_search("query", page_size=5)
+    _, kwargs = svc._crud_repo.fuzzy_search.call_args
+    assert kwargs.get("limit") == 5
+
+
 # ===== PortfolioService get_portfolios_df =====
 
 
@@ -171,6 +190,15 @@ def test_get_portfolios_df_db_failure():
     svc._crud_repo.find.side_effect = Exception("DB down")
     result = svc.get_portfolios_df()
     assert result.success is False
+
+
+@pytest.mark.unit
+def test_get_portfolios_df_passes_page_size_to_find():
+    """ADR-021 L139：--limit 下推 service page_size → find(page_size=N)。"""
+    svc = _make_portfolio_service(_make_portfolio_modellist())
+    svc.get_portfolios_df(page_size=5)
+    _, kwargs = svc._crud_repo.find.call_args
+    assert kwargs.get("page_size") == 5
 
 
 # ===== filter 构造正确性（_build_*_filters 字段映射 + is_del 固定注入） =====

--- a/tests/unit/data/services/test_list_count_smoke.py
+++ b/tests/unit/data/services/test_list_count_smoke.py
@@ -1,0 +1,142 @@
+"""#5009 list 分页 count_X 出口 smoke（#6685 diff coverage gate 采集）。
+
+count_signals/count_orders/count_records/count_positions 是本 PR 新增可执行行，
+被 containers import 链触达（class 定义行 executed → 非 exempt）但 smoke 不调其
+方法体 → 函数体内 crud.count 调用行 0 覆盖 → 门禁红。本文件用 mock 依赖（不连 DB）
+补足该信号，纳入 smoke 子集供门禁测量。
+
+get_positions_df(page=) 的 ClickHouse 分页行同理需补覆盖（PositionRecordCRUD
+为方法内 inline 实例化，patch 类构造返回 mock）。
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.signal_service import SignalService
+from ginkgo.data.services.order_service import OrderService
+from ginkgo.data.services.analyzer_service import AnalyzerService
+from ginkgo.data.services.result_service import ResultService
+
+
+@pytest.fixture
+def signal_service():
+    with patch("ginkgo.libs.GLOG"):
+        return SignalService(crud_repo=MagicMock())
+
+
+@pytest.fixture
+def order_service():
+    with patch("ginkgo.libs.GLOG"):
+        return OrderService(crud_repo=MagicMock())
+
+
+@pytest.fixture
+def analyzer_service():
+    with patch("ginkgo.libs.GLOG"):
+        return AnalyzerService(analyzer_crud=MagicMock())
+
+
+@pytest.fixture
+def result_service():
+    with patch("ginkgo.libs.GLOG"):
+        return ResultService(analyzer_crud=MagicMock())
+
+
+class TestCountMethodsPassthrough:
+    """count_X → crud.count(filters=)，供 CLI metadata.total 真实总数（#5009）。"""
+
+    @pytest.mark.unit
+    def test_signal_count_signals_calls_crud_count(self, signal_service):
+        signal_service._crud_repo.count.return_value = 42
+        result = signal_service.count_signals(engine_id="e1", portfolio_id="p1", task_id="t1")
+        assert result.success is True
+        assert result.data == {"count": 42}
+        signal_service._crud_repo.count.assert_called_once()
+        assert "engine_id" in signal_service._crud_repo.count.call_args[1]["filters"]
+
+    @pytest.mark.unit
+    def test_order_count_orders_calls_crud_count(self, order_service):
+        order_service._crud_repo.count.return_value = 7
+        result = order_service.count_orders(portfolio_id="p1", engine_id="e1", task_id="t1")
+        assert result.success is True
+        assert result.data == {"count": 7}
+        order_service._crud_repo.count.assert_called_once()
+        assert "portfolio_id" in order_service._crud_repo.count.call_args[1]["filters"]
+
+    @pytest.mark.unit
+    def test_analyzer_count_records_calls_crud_count(self, analyzer_service):
+        analyzer_service._crud_repo.count.return_value = 3
+        result = analyzer_service.count_records(portfolio_id="p1", engine_id="e1")
+        assert result.success is True
+        assert result.data == {"count": 3}
+        analyzer_service._crud_repo.count.assert_called_once()
+        assert "portfolio_id" in analyzer_service._crud_repo.count.call_args[1]["filters"]
+
+    @pytest.mark.unit
+    def test_result_count_positions_calls_position_record_count(self, result_service):
+        """count_positions inline 实例化 PositionRecordCRUD → patch 类构造。"""
+        mock_crud = MagicMock()
+        mock_crud.count.return_value = 11
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD", return_value=mock_crud
+        ):
+            result = result_service.count_positions(portfolio_id="p1", engine_id="e1", task_id="t1")
+        assert result.success is True
+        assert result.data == {"count": 11}
+        mock_crud.count.assert_called_once()
+        assert "is_del" in mock_crud.count.call_args[1]["filters"]
+
+    @pytest.mark.unit
+    def test_result_get_positions_df_passes_page_to_find(self, result_service):
+        """get_positions_df(page=, page_size=) → PositionRecordCRUD.find(page=, page_size=, order_by=timestamp)。"""
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = MagicMock()
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD", return_value=mock_crud
+        ):
+            result = result_service.get_positions_df(portfolio_id="p1", page=2, page_size=10)
+        assert result.success is True
+        _, kwargs = mock_crud.find.call_args
+        assert kwargs["page"] == 2
+        assert kwargs["page_size"] == 10
+        assert kwargs["order_by"] == "timestamp"
+        assert kwargs["desc_order"] is True
+
+
+class TestCountMethodsErrorPath:
+    """count_X 的 except 分支：crud.count 抛异常 → ServiceResult.error（不传播异常）。"""
+
+    @pytest.mark.unit
+    def test_signal_count_signals_handles_crud_error(self, signal_service):
+        signal_service._crud_repo.count.side_effect = RuntimeError("db down")
+        result = signal_service.count_signals()
+        assert result.success is False
+
+    @pytest.mark.unit
+    def test_order_count_orders_handles_crud_error(self, order_service):
+        order_service._crud_repo.count.side_effect = RuntimeError("db down")
+        result = order_service.count_orders()
+        assert result.success is False
+
+    @pytest.mark.unit
+    def test_analyzer_count_records_handles_crud_error(self, analyzer_service):
+        analyzer_service._crud_repo.count.side_effect = RuntimeError("db down")
+        result = analyzer_service.count_records()
+        assert result.success is False
+
+    @pytest.mark.unit
+    def test_result_count_positions_handles_crud_error(self, result_service):
+        mock_crud = MagicMock()
+        mock_crud.count.side_effect = RuntimeError("ch down")
+        with patch(
+            "ginkgo.data.crud.position_record_crud.PositionRecordCRUD", return_value=mock_crud
+        ):
+            result = result_service.count_positions()
+        assert result.success is False
+

--- a/tests/unit/data/services/test_page_size_none_safe.py
+++ b/tests/unit/data/services/test_page_size_none_safe.py
@@ -1,0 +1,69 @@
+"""page_size None-safety 回归（#6652 review E1）。
+
+CLI ``--page-size 0`` → 下推 ``page_size=None`` 给 service。旧守卫
+``page_size if page_size > 0 else None`` 对 ``None`` 求值 ``None > 0`` 触发 TypeError，
+被 ``except Exception`` 吞成"查询失败" exit 1（help 文档承诺的"0=全部"即崩）。
+
+本测试直击守卫：调**真实 service 方法**（只 mock CRUD 层，不 mock 整个 service——
+后者绕过守卫，正是 CLI smoke 测不出该 TypeError 的根因，见 review E1），断言
+``page_size=None`` 不再崩溃、CRUD.find 收到 ``page_size=None``。
+
+Run: pytest tests/unit/data/services/test_page_size_none_safe.py -v -o "addopts="
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.data.services.signal_service import SignalService
+from ginkgo.data.services.order_service import OrderService
+from ginkgo.data.services.analyzer_service import AnalyzerService
+from ginkgo.data.services.result_service import ResultService
+
+
+def _model_list():
+    """CRUD.find 返回的 ModelList mock（带 to_dataframe，空 df 即可）。"""
+    ml = MagicMock()
+    ml.to_dataframe.return_value = pd.DataFrame()
+    return ml
+
+
+# (构造器, df 方法名)：signal/order 走 crud_repo 注入，analyzer 走 analyzer_crud 注入
+# （三者 __init__ 都赋给 self._crud_repo，df 方法经 self._crud_repo.find）。
+_INJECTABLE = [
+    (lambda m: SignalService(crud_repo=m), "get_signals_df"),
+    (lambda m: OrderService(crud_repo=m), "get_orders_df"),
+    (lambda m: AnalyzerService(analyzer_crud=m), "get_records_df"),
+]
+
+
+@pytest.mark.unit
+class TestPageSizeNoneSafe:
+    """page_size=None 不再触发 TypeError（#6652 review E1）。"""
+
+    @pytest.mark.parametrize("ctor, method", _INJECTABLE)
+    def test_df_method_tolerates_none_page_size(self, ctor, method):
+        """self._crud_repo 注入型：None 守卫短路 → CRUD.find 收到 page_size=None，无 TypeError。"""
+        mock_crud = MagicMock()
+        mock_crud.find.return_value = _model_list()
+        svc = ctor(mock_crud)
+
+        result = getattr(svc, method)(page_size=None)
+
+        assert result.success is True  # 未进 except（旧代码 TypeError → ServiceResult.error）
+        _, kwargs = mock_crud.find.call_args
+        assert kwargs["page_size"] is None
+
+    def test_result_get_positions_df_tolerates_none_page_size(self):
+        """result_service.get_positions_df 内部自建 PositionRecordCRUD（不走 self._crud_repo），
+        record position 命令走此路径；patch 该 CRUD 验证同一守卫。"""
+        svc = ResultService(analyzer_crud=MagicMock())
+        # PositionRecordCRUD 在方法内 function-local import，patch 源模块（非 result_service 命名空间）
+        with patch("ginkgo.data.crud.position_record_crud.PositionRecordCRUD") as MockCrud:
+            MockCrud.return_value.find.return_value = _model_list()
+            result = svc.get_positions_df(page_size=None)
+
+        assert result.success is True
+        _, kwargs = MockCrud.return_value.find.call_args
+        assert kwargs["page_size"] is None

--- a/tests/unit/data/services/test_page_size_passthrough_smoke.py
+++ b/tests/unit/data/services/test_page_size_passthrough_smoke.py
@@ -72,3 +72,26 @@ class TestPageSizePassthrough:
 
         assert result.success is True
         assert portfolio_service._crud_repo.find.call_args[1]["page_size"] == 10
+
+    @pytest.mark.unit
+    def test_engine_get_engines_df_page_size_zero_means_all(self, engine_service):
+        """page_size=0 → find(page_size=None)（0=全量守卫，与 signal_service 一致；#6652 review R3-issue3）。
+
+        裸 page_size=0 会触发 SQL LIMIT 0 返空，破坏 "0=all" 契约；service 层下推 None。
+        """
+        engine_service._crud_repo.find.return_value = MagicMock()
+
+        result = engine_service.get_engines_df(page_size=0)
+
+        assert result.success is True
+        assert engine_service._crud_repo.find.call_args[1]["page_size"] is None
+
+    @pytest.mark.unit
+    def test_portfolio_get_portfolios_df_page_size_zero_means_all(self, portfolio_service):
+        """page_size=0 → find(page_size=None)（0=全量守卫；#6652 review R3-issue3）。"""
+        portfolio_service._crud_repo.find.return_value = MagicMock()
+
+        result = portfolio_service.get_portfolios_df(page_size=0)
+
+        assert result.success is True
+        assert portfolio_service._crud_repo.find.call_args[1]["page_size"] is None

--- a/tests/unit/data/services/test_page_size_passthrough_smoke.py
+++ b/tests/unit/data/services/test_page_size_passthrough_smoke.py
@@ -1,0 +1,74 @@
+"""ADR-021 L139: service 层 page_size 透传 smoke。
+
+#6685 diff coverage gate 只采集 smoke 子集的 coverage.json。CLI ``--limit``
+下推到 service 的 3 个出口方法（engine get_engines_df / fuzzy_search、
+portfolio get_portfolios_df）是本 PR 新增可执行行，containers import 链
+虽触达这些 service（class 定义行 executed → 非 exempt）但 smoke 不调用其
+方法体，函数体内 page_size 透传行无覆盖信号。本文件用 mock 依赖（不连 DB）
+补足该信号，纳入 smoke 子集供门禁测量。
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import patch, MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.engine_service import EngineService
+from ginkgo.data.services.portfolio_service import PortfolioService
+
+
+@pytest.fixture
+def engine_service():
+    with patch("ginkgo.libs.GLOG"):
+        return EngineService(
+            crud_repo=MagicMock(),
+            engine_portfolio_mapping_crud=MagicMock(),
+            param_crud=MagicMock(),
+        )
+
+
+@pytest.fixture
+def portfolio_service():
+    with patch("ginkgo.libs.GLOG"):
+        return PortfolioService(
+            crud_repo=MagicMock(),
+            portfolio_file_mapping_crud=MagicMock(),
+        )
+
+
+class TestPageSizePassthrough:
+    """page_size 透传 crud（供 CLI --limit 下推，ADR-021 L139）。"""
+
+    @pytest.mark.unit
+    def test_engine_get_engines_df_passes_page_size_to_find(self, engine_service):
+        """engine.get_engines_df(page_size=) → crud.find(page_size=)。"""
+        engine_service._crud_repo.find.return_value = MagicMock()
+
+        result = engine_service.get_engines_df(page_size=10)
+
+        assert result.success is True
+        assert engine_service._crud_repo.find.call_args[1]["page_size"] == 10
+
+    @pytest.mark.unit
+    def test_engine_fuzzy_search_passes_page_size_as_limit(self, engine_service):
+        """engine.fuzzy_search(page_size=) → crud.fuzzy_search(limit=)。"""
+        engine_service._crud_repo.fuzzy_search.return_value = MagicMock()
+
+        result = engine_service.fuzzy_search(query="momentum", page_size=10)
+
+        assert result.success is True
+        assert engine_service._crud_repo.fuzzy_search.call_args[1]["limit"] == 10
+
+    @pytest.mark.unit
+    def test_portfolio_get_portfolios_df_passes_page_size_to_find(self, portfolio_service):
+        """portfolio.get_portfolios_df(page_size=) → crud.find(page_size=)。"""
+        portfolio_service._crud_repo.find.return_value = MagicMock()
+
+        result = portfolio_service.get_portfolios_df(page_size=10)
+
+        assert result.success is True
+        assert portfolio_service._crud_repo.find.call_args[1]["page_size"] == 10

--- a/tests/unit/data/services/test_page_size_passthrough_smoke.py
+++ b/tests/unit/data/services/test_page_size_passthrough_smoke.py
@@ -19,6 +19,7 @@ if _path not in sys.path:
 
 from ginkgo.data.services.engine_service import EngineService
 from ginkgo.data.services.portfolio_service import PortfolioService
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
 
 
 @pytest.fixture
@@ -38,6 +39,12 @@ def portfolio_service():
             crud_repo=MagicMock(),
             portfolio_file_mapping_crud=MagicMock(),
         )
+
+
+@pytest.fixture
+def backtest_task_service():
+    with patch("ginkgo.libs.GLOG"):
+        return BacktestTaskService(crud_repo=MagicMock())
 
 
 class TestPageSizePassthrough:
@@ -95,3 +102,28 @@ class TestPageSizePassthrough:
 
         assert result.success is True
         assert portfolio_service._crud_repo.find.call_args[1]["page_size"] is None
+
+    @pytest.mark.unit
+    def test_backtest_list_page_size_zero_means_all(self, backtest_task_service):
+        """page_size=0 → get_tasks_page_filtered(page_size=None)（0=全量守卫；#6652 review R4）。
+
+        裸 page_size=0 触发 BaseCRUD.find LIMIT 0 返空，破坏 ADR-021 "0=all" 契约；
+        service 层下推 None（与 signal/engine/portfolio service 对称）。
+        """
+        backtest_task_service._crud_repo.get_tasks_page_filtered.return_value = []
+        backtest_task_service._crud_repo.count.return_value = 0
+
+        result = backtest_task_service.list(page_size=0)
+
+        assert result.success is True
+        assert backtest_task_service._crud_repo.get_tasks_page_filtered.call_args[1]["page_size"] is None
+
+    @pytest.mark.unit
+    def test_backtest_list_passes_positive_page_size(self, backtest_task_service):
+        """page_size=15 → get_tasks_page_filtered(page_size=15)（正常分页下推，非 None 归一）。"""
+        backtest_task_service._crud_repo.get_tasks_page_filtered.return_value = []
+        backtest_task_service._crud_repo.count.return_value = 0
+
+        backtest_task_service.list(page_size=15)
+
+        assert backtest_task_service._crud_repo.get_tasks_page_filtered.call_args[1]["page_size"] == 15

--- a/tests/unit/data/services/test_signal_service.py
+++ b/tests/unit/data/services/test_signal_service.py
@@ -59,6 +59,23 @@ class TestGetSignalsDfFilters:
         _, kwargs = mock_crud.find.call_args
         assert "task_id" not in kwargs["filters"]
 
+    def test_order_by_timestamp_not_create_at(self, signal_svc, mock_crud):
+        """order_by=timestamp（MSignal 是 ClickHouse 模型无 create_at 字段）。
+
+        回归：曾误用 create_at，base_crud._do_find 的 hasattr 守卫静默丢弃，
+        致 ClickHouse MergeTree 分页顺序未定（ADR-021 第 7 维要求分页确定性）。
+        对齐同族 analyzer_service/result_service 的 order_by=timestamp。
+        """
+        model_list = MagicMock()
+        model_list.to_dataframe.return_value = pd.DataFrame()
+        mock_crud.find.return_value = model_list
+
+        signal_svc.get_signals_df(engine_id="e1")
+
+        _, kwargs = mock_crud.find.call_args
+        assert kwargs["order_by"] == "timestamp"
+        assert kwargs["desc_order"] is True
+
 
 @pytest.mark.unit
 class TestGetSignalsByPortfolioDateFilter:

--- a/tests/unit/trading/services/test_deployment_list_smoke.py
+++ b/tests/unit/trading/services/test_deployment_list_smoke.py
@@ -1,0 +1,81 @@
+"""#5009 DeploymentService.list/count 分页 smoke（#6685 diff coverage gate 采集）。
+
+list_deployments(page=, page_size=) → _deployment_crud.find(filters=, page=, page_size=,
+order_by="create_at", desc_order=True)；count_deployments → _deployment_crud.count(filters=)。
+两者为本 PR 新增可执行行，供 CLI metadata.total 真实总数。用 mock 依赖（不连 DB）补
+覆盖信号，纳入 smoke 子集供门禁测量。
+"""
+
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.trading.services.deployment_service import DeploymentService
+
+
+@pytest.fixture
+def service():
+    return DeploymentService(deployment_crud=MagicMock())
+
+
+class TestListDeploymentsPagination:
+    """list_deployments 把 page/page_size/portfolio 下推 find（#5009）。"""
+
+    @pytest.mark.unit
+    def test_list_passes_page_pagesize_order_to_find(self, service):
+        service._deployment_crud.find.return_value = []
+        result = service.list_deployments(page=2, page_size=10)
+        assert result.success is True
+        assert result.data == []
+        _, kwargs = service._deployment_crud.find.call_args
+        assert kwargs["page"] == 2
+        assert kwargs["page_size"] == 10
+        assert kwargs["order_by"] == "create_at"
+        assert kwargs["desc_order"] is True
+
+    @pytest.mark.unit
+    def test_list_unlimited_passes_none(self, service):
+        service._deployment_crud.find.return_value = []
+        service.list_deployments(page=0, page_size=0)
+        _, kwargs = service._deployment_crud.find.call_args
+        # page_size=0 → CLI 侧转 None；service 直传（None = BaseCRUD 不分页）
+        assert kwargs["page_size"] == 0 or kwargs["page_size"] is None
+
+    @pytest.mark.unit
+    def test_list_portfolio_filter_pushed_to_find(self, service):
+        service._deployment_crud.find.return_value = []
+        service.list_deployments(portfolio_id="pf-src")
+        _, kwargs = service._deployment_crud.find.call_args
+        assert kwargs["filters"]["source_portfolio_id"] == "pf-src"
+
+    @pytest.mark.unit
+    def test_list_maps_records_to_dict(self, service):
+        rec = MagicMock()
+        service._deployment_crud.find.return_value = [rec]
+        result = service.list_deployments()
+        assert result.success is True
+        assert len(result.data) == 1
+
+
+class TestCountDeployments:
+    """count_deployments → _deployment_crud.count(filters=)（#5009 metadata.total）。"""
+
+    @pytest.mark.unit
+    def test_count_returns_dict(self, service):
+        service._deployment_crud.count.return_value = 7
+        result = service.count_deployments()
+        assert result.success is True
+        assert result.data == {"count": 7}
+        service._deployment_crud.count.assert_called_once()
+
+    @pytest.mark.unit
+    def test_count_portfolio_filter(self, service):
+        service._deployment_crud.count.return_value = 3
+        service.count_deployments(portfolio_id="pf-src")
+        _, kwargs = service._deployment_crud.count.call_args
+        assert kwargs["filters"]["source_portfolio_id"] == "pf-src"


### PR DESCRIPTION
## Summary
- Add ADR-021 JSON list output support for portfolio, backtest, engine, component, and data source listing paths.
- Add JSON NOT_FOUND output for portfolio get and backtest cat.
- Share list metadata construction through cli_utils so commands emit count, warnings, and pagination metadata consistently.

## Test plan
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_cli_utils.py::TestFormatResult tests/unit/client/test_portfolio_cli.py::TestPortfolioList::test_list_json_format_outputs_adr021_contract tests/unit/client/test_portfolio_cli.py::TestPortfolioGet::test_get_not_found_json_format_outputs_not_found_contract tests/unit/client/test_backtest_cli.py::TestBacktestListProgressFormat::test_list_json_format_outputs_adr021_contract tests/unit/client/test_backtest_cli.py::TestBacktestCatNoTradesWarning::test_cat_not_found_json_format_outputs_not_found_contract tests/unit/client/test_engine_cli.py::TestListEngines::test_list_json_format_outputs_adr021_contract tests/unit/client/test_flat_cli.py::TestComponentList::test_list_components_json_format_outputs_adr021_contract tests/unit/client/test_data_cli.py::TestGetOtherTypes::test_get_sources_json_format_outputs_adr021_contract -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m py_compile <src/api python files>
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short

Closes #6580