### PR TITLE
fix(api): acknowledge portfolio websocket channel subscriptions (#5735)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -157,8 +157,8 @@ app.include_router(task_timer_router.router, prefix=f"{API_PREFIX}/task-timer", 
 # WebSocket路由
 from websocket.handlers import portfolio_handler, system_handler
 
-app.add_websocket_route("/ws/portfolio", portfolio_handler.websocket_endpoint)
-app.add_websocket_route("/ws/system", system_handler.websocket_endpoint)
+app.add_api_websocket_route("/ws/portfolio", portfolio_handler.websocket_endpoint)
+app.add_api_websocket_route("/ws/system", system_handler.websocket_endpoint)
 
 
 # 自定义 OpenAPI schema：注入 Bearer JWT securityScheme（#5714）

--- a/api/websocket/handlers/portfolio_handler.py
+++ b/api/websocket/handlers/portfolio_handler.py
@@ -71,13 +71,13 @@ class PortfolioHandler:
             await websocket.send_json({"type": "pong"})
 
         elif msg_type == "subscribe":
-            topic = message.get("topic")
+            topic = message.get("topic") or message.get("channel")
             if topic:
                 await connection_manager.subscribe(websocket, topic)
                 await websocket.send_json({"type": "subscribed", "topic": topic})
 
         elif msg_type == "unsubscribe":
-            topic = message.get("topic")
+            topic = message.get("topic") or message.get("channel")
             if topic:
                 await connection_manager.unsubscribe(websocket, topic)
                 await websocket.send_json({"type": "unsubscribed", "topic": topic})

--- a/tests/api/test_portfolio_websocket_5735.py
+++ b/tests/api/test_portfolio_websocket_5735.py
@@ -1,0 +1,57 @@
+"""#5735: portfolio WebSocket subscribe must acknowledge channel payloads."""
+
+import asyncio
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+class _FakeWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_json(self, payload):
+        self.sent.append(payload)
+
+
+class _FakeConnectionManager:
+    def __init__(self):
+        self.subscribed = []
+
+    async def subscribe(self, websocket, topic):
+        self.subscribed.append((websocket, topic))
+
+
+@pytest.mark.unit
+def test_main_registers_portfolio_websocket_route(api_modules):
+    api_main = Path(__file__).resolve().parents[2] / "api" / "main.py"
+    spec = importlib.util.spec_from_file_location("ginkgo_api_main_ws_5735", str(api_main))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    paths = {route.path for route in mod.app.routes}
+
+    assert "/ws/portfolio" in paths
+
+
+@pytest.mark.unit
+def test_portfolio_subscribe_accepts_channel_payload(monkeypatch):
+    from websocket.handlers.portfolio_handler import PortfolioHandler
+
+    portfolio_handler_module = importlib.import_module("websocket.handlers.portfolio_handler")
+    fake_manager = _FakeConnectionManager()
+    fake_ws = _FakeWebSocket()
+    monkeypatch.setattr(portfolio_handler_module, "connection_manager", fake_manager)
+
+    asyncio.run(
+        PortfolioHandler()._handle_message(
+            fake_ws,
+            {"type": "subscribe", "channel": "portfolio_update"},
+            user_uuid="user-1",
+        )
+    )
+
+    assert fake_manager.subscribed == [(fake_ws, "portfolio_update")]
+    assert fake_ws.sent == [{"type": "subscribed", "topic": "portfolio_update"}]


### PR DESCRIPTION
## Summary
- Register API WebSocket routes using the FastAPI-supported `add_api_websocket_route` method so `api/main.py` imports cleanly.
- Accept both `topic` and `channel` keys for portfolio WebSocket subscribe/unsubscribe messages.
- Add #5735 regression coverage for route registration and `channel` subscribe acknowledgement.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/api/test_portfolio_websocket_5735.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/api/test_http_exception_unified_response.py tests/api/test_error_handler_5405.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src` and `api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `git diff --check`

Closes #5735
