### PR TITLE
fix(cli): keep long usernames on one user list row (#5173)

### DIFF
--- a/src/ginkgo/client/user_cli.py
+++ b/src/ginkgo/client/user_cli.py
@@ -117,7 +117,7 @@ def list_users(
 
             table = Table(title=f":bust_in_silhouette: Users ({result.data['count']} found)")
             table.add_column("UUID", style="cyan", no_wrap=True)
-            table.add_column("Username", style="green")
+            table.add_column("Username", style="green", no_wrap=True, max_width=24)
             table.add_column("Display Name", style="blue")
             table.add_column("Description", style="dim", max_width=30)
             table.add_column("Type", style="yellow")
@@ -128,7 +128,7 @@ def list_users(
                 active_style = "green" if user["is_active"] else "red"
                 table.add_row(
                     user["uuid"],
-                    user.get("username", ""),
+                    user.get("username", "")[:24],
                     user.get("display_name", "")[:20],
                     (user.get("description") or "")[:30],
                     user["user_type"],

--- a/tests/unit/client/test_user_cli.py
+++ b/tests/unit/client/test_user_cli.py
@@ -149,6 +149,34 @@ class TestUserList:
         assert "PERSON" in result.output
 
     @patch("ginkgo.data.containers.container")
+    def test_list_users_truncates_long_username_to_one_row(self, mock_container, cli_runner, mock_user_service):
+        """长 username 不应换行撑乱 user list 表格"""
+        mock_container.user_service.return_value = mock_user_service
+        mock_user_service.list_users.return_value = ServiceResult.success(
+            data={
+                "users": [
+                    {
+                        "uuid": "user-uuid-001",
+                        "username": "very long username with many words causing wrapping in table output",
+                        "display_name": "Display",
+                        "description": "Desc",
+                        "user_type": "PERSON",
+                        "is_active": True,
+                        "create_at": "2025-12-11",
+                    }
+                ],
+                "count": 1,
+            }
+        )
+
+        result = cli_runner.invoke(user_cli.app, ["list"])
+
+        assert result.exit_code == 0
+        assert "user-uuid-001" in result.output
+        assert "very long username with" in result.output
+        assert "\n│               │ long" not in result.output
+
+    @patch("ginkgo.data.containers.container")
     def test_list_users_empty(self, mock_container, cli_runner, mock_user_service):
         """无用户时显示提示"""
         mock_container.user_service.return_value = mock_user_service


### PR DESCRIPTION
## Summary
- Add a max width and no-wrap behavior to the `ginkgo user list` Username column.
- Truncate long usernames before rendering so one user does not spill into continuation rows.
- Add a regression test for long usernames with spaces.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src` and `api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `git diff --check`

Closes #5173
