### PR TITLE
fix(cli): preserve repeated template render variables (#4873)

### DIFF
--- a/src/ginkgo/client/templates_cli.py
+++ b/src/ginkgo/client/templates_cli.py
@@ -341,7 +341,7 @@ def delete_template(
 @app.command("render")
 def render_template(
     template_id: str = typer.Option(..., "--id", "-t", help="Template ID"),
-    variables: Optional[str] = typer.Option(None, "--var", "-v", help="Variables as key=value (can be repeated)"),
+    variables: Optional[List[str]] = typer.Option(None, "--var", "-v", help="Variables as key=value (can be repeated)"),
     preview: bool = typer.Option(False, "--preview", "-p", help="Preview template without rendering"),
 ):
     """
@@ -381,11 +381,13 @@ def render_template(
             for var in variables:
                 if "=" in var:
                     key, value = var.split("=", 1)
-                    # Try to parse as JSON for complex values
-                    try:
-                        context[key] = json.loads(value)
-                    except Exception as e:
-                        GLOG.ERROR(f"解析模板变量JSON失败: {e}")
+                    stripped = value.strip()
+                    if stripped.startswith(("{", "[", '"')):
+                        try:
+                            context[key] = json.loads(value)
+                        except Exception:
+                            context[key] = value
+                    else:
                         context[key] = value
 
         # Render template

--- a/tests/unit/client/test_templates_cli_render.py
+++ b/tests/unit/client/test_templates_cli_render.py
@@ -60,3 +60,44 @@ class TestTemplatesCliRenderFriendlyError:
         assert result.exit_code == 1
         assert "live_signal" in result.output
         assert "Traceback" not in result.output
+
+
+@pytest.mark.unit
+class TestTemplatesCliRenderVariables:
+    """#4873: render -v must pass repeated key=value variables into context."""
+
+    def test_render_repeated_var_options_populate_template_context(self):
+        runner = CliRunner()
+        template = MNotificationTemplate(
+            template_id="long_signal",
+            template_name="Long Signal",
+            content="symbol={{ symbol }} price={{ price }} quantity={{ quantity }}",
+            is_active=True,
+        )
+        mock_crud = MagicMock()
+        mock_crud.get_by_template_id.return_value = template
+
+        with patch(
+            "ginkgo.data.containers.container.notification_template_crud",
+            return_value=mock_crud,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "render",
+                    "--id",
+                    "long_signal",
+                    "-v",
+                    "symbol=000001",
+                    "-v",
+                    "price=10.50",
+                    "-v",
+                    "quantity=100",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "symbol=000001" in result.output
+        assert "price=10.50" in result.output
+        assert "quantity=100" in result.output
+        assert "解析模板变量JSON失败" not in result.output


### PR DESCRIPTION
## Summary
- Treat repeated `templates render -v/--var` options as a list so all key=value pairs reach the render context.
- Preserve ordinary scalar values such as `10.50` as strings, while still allowing explicit JSON object/array/string values.
- Stop logging misleading JSON parse errors for normal string variables.
- Add an end-to-end CLI regression test for repeated `-v` rendering.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_templates_cli.py tests/unit/client/test_templates_cli_render.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src` and `api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `git diff --check`

Closes #4873
