### PR TITLE
fix(cli): explain missing tasktimer config (#5185)

### DIFF
--- a/src/ginkgo/client/tasktimer_cli.py
+++ b/src/ginkgo/client/tasktimer_cli.py
@@ -23,6 +23,7 @@ from ginkgo.libs import GLOG
 from rich.table import Table
 from rich.panel import Panel
 import json
+import os
 import signal
 import sys
 import time
@@ -277,6 +278,13 @@ def validate(
         console.print(f":information: Validating TaskTimer configuration")
         console.print(f":information: Config file: {config_path}\n")
 
+        if not os.path.isfile(config_path):
+            console.print("[red]:x: Configuration file not found[/red]")
+            console.print(f"[yellow]Missing:[/yellow] {config_path}")
+            console.print("[yellow]Create the default config with:[/yellow] ginkgo init")
+            console.print("[dim]Template: src/ginkgo/config/task_timer.yml -> ~/.ginkgo/task_timer.yml[/dim]")
+            raise typer.Exit(1)
+
         timer = TaskTimer(config_path=config_path)
         is_valid = timer.validate_config()
 
@@ -293,6 +301,8 @@ def validate(
             console.print("[red]:x: Configuration is [bold]INVALID[/bold][/red]")
             raise typer.Exit(1)
 
+    except typer.Exit:
+        raise
     except Exception as e:
         console.print(f"[red]:x: Error validating config: {e}[/red]")
         raise typer.Exit(1)

--- a/tests/unit/client/test_tasktimer_cli.py
+++ b/tests/unit/client/test_tasktimer_cli.py
@@ -177,3 +177,20 @@ class TestTaskTimerInitConfig:
         installed = str(tmp_path / "task_timer.yml")
         timer = TaskTimer(config_path=installed)
         assert timer.validate_config() is True, "拷贝的模板未通过 validate_config"
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestTaskTimerValidateCommand:
+    """tasktimer validate 友好处理缺失配置文件 (#5185)"""
+
+    def test_missing_config_prints_creation_hint_not_raw_exit_code(self, tmp_path, cli_runner):
+        missing = tmp_path / "missing-task_timer.yml"
+
+        result = cli_runner.invoke(tasktimer_cli.app, ["validate", "--config", str(missing)])
+
+        assert result.exit_code != 0
+        assert "Configuration file not found" in result.output
+        assert "ginkgo init" in result.output
+        assert "task_timer.yml" in result.output
+        assert "Error validating config: 1" not in result.output


### PR DESCRIPTION
## Summary
- Detect a missing TaskTimer config path before constructing `TaskTimer`.
- Show an actionable message pointing users to `ginkgo init` and the `task_timer.yml` template path.
- Preserve `typer.Exit` so missing config no longer appears as `Error validating config: 1`.
- Add a CLI regression test for the missing-config path.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_tasktimer_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src` and `api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `git diff --check`

Closes #5185
