### PR TITLE
fix: add debug status command (#5192)

### DIFF
--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -35,6 +35,8 @@ console = Console()
 class DebugMode(str, Enum):
     ON = "on"
     OFF = "off"
+    STATUS = "status"
+    SHOW = "show"
 
 class DataType(str, Enum):
     STOCKINFO = "stockinfo"
@@ -132,9 +134,9 @@ def status():
         console.print(f"[red]Error getting system status: {e}[/red]")
         console.print("Try: ginkgo system status (full command)")
 
-def debug(mode: Annotated[DebugMode, typer.Argument(help="Debug mode: on/off")]):
+def debug(mode: Annotated[DebugMode, typer.Argument(help="Debug mode: on/off/status")]):
     """
-    :bug: Toggle debug mode (simplified from 'system config set --debug').
+    :bug: Toggle or show debug mode (simplified from 'system config set/get debug').
     """
     try:
         from ginkgo.libs import GCONF
@@ -144,15 +146,17 @@ def debug(mode: Annotated[DebugMode, typer.Argument(help="Debug mode: on/off")])
             console.print("[green]:white_check_mark: Debug mode enabled[/green]")
             console.print("[dim]This enables detailed logging and error information[/dim]")
             console.print("[dim]Configuration saved to ~/.ginkgo/config.yml[/dim]")
-        else:
+        elif mode == DebugMode.OFF:
             GCONF.set_debug(False)  # 正确的调用方式，会写入配置文件
             console.print("[yellow]:muted_speaker: Debug mode disabled[/yellow]")
             console.print("[dim]Switched to production logging level[/dim]")
             console.print("[dim]Configuration saved to ~/.ginkgo/config.yml[/dim]")
+        else:
+            console.print(f"Debug mode: {'[green]ON[/green]' if GCONF.DEBUGMODE else '[red]OFF[/red]'}")
             
     except Exception as e:
         console.print(f"[red]Error setting debug mode: {e}[/red]")
-        console.print("Try: ginkgo system config set --debug on/off")
+        console.print("Try: ginkgo system config set --debug on/off or ginkgo config get debug")
 
 def init():
     """

--- a/tests/unit/client/test_core_cli.py
+++ b/tests/unit/client/test_core_cli.py
@@ -253,6 +253,18 @@ class TestDebug:
 
     @pytest.mark.unit
     @pytest.mark.cli
+    @pytest.mark.parametrize("mode", ["status", "show"])
+    def test_debug_status_aliases_show_current_mode(self, cli_runner, mock_gconf, mode):
+        mock_gconf.DEBUGMODE = True
+        with patch("ginkgo.libs.GCONF", mock_gconf):
+            result = cli_runner.invoke(_get_main_app(), ["debug", mode])
+        assert result.exit_code == 0
+        assert "Debug mode" in result.output
+        assert "ON" in result.output
+        mock_gconf.set_debug.assert_not_called()
+
+    @pytest.mark.unit
+    @pytest.mark.cli
     def test_missing_argument_shows_error(self, cli_runner, mock_gconf):
         with patch("ginkgo.libs.GCONF", mock_gconf):
             result = cli_runner.invoke(_get_main_app(), ["debug"])


### PR DESCRIPTION
## Summary
- Add read-only `ginkgo debug status` and `ginkgo debug show` aliases to report current debug mode.
- Keep existing `ginkgo debug on/off` behavior unchanged and avoid mutating config for status/show.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_core_cli.py::TestDebug -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_core_cli.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src api`
- `git diff --check`

Closes #5192
