### PR TITLE
fix: label logging error time window (#5028)

### DIFF
--- a/src/ginkgo/client/logging_cli.py
+++ b/src/ginkgo/client/logging_cli.py
@@ -245,6 +245,7 @@ def view_errors(
     task_id: Optional[str] = typer.Option(None, "--task", "-t", help="Backtest task ID"),
     portfolio_id: Optional[str] = typer.Option(None, "--portfolio", "-p", help="Portfolio ID"),
     limit: int = typer.Option(30, "--limit", "-n", help="Max results"),
+    hours: Optional[int] = typer.Option(None, "--hours", help="Lookback hours (default: all history)"),
 ):
     """
     :exclamation: View backtest error logs.
@@ -254,21 +255,30 @@ def view_errors(
         ginkgo logging errors --portfolio <id>
     """
     from ginkgo.services.logging.containers import container
+    from datetime import datetime, timedelta
 
     log_service = container.log_service()
+    end_time = datetime.utcnow() if hours is not None else None
+    start_time = end_time - timedelta(hours=hours) if end_time is not None else None
+    range_label = f"last {hours}h" if hours is not None else "all history"
 
-    logs = log_service.query_backtest_logs(
-        portfolio_id=portfolio_id,
-        task_id=task_id,
-        level="ERROR",
-        limit=limit,
-    )
+    query_kwargs = {
+        "portfolio_id": portfolio_id,
+        "task_id": task_id,
+        "level": "ERROR",
+        "limit": limit,
+    }
+    if start_time is not None:
+        query_kwargs["start_time"] = start_time
+        query_kwargs["end_time"] = end_time
+
+    logs = log_service.query_backtest_logs(**query_kwargs)
 
     if not logs:
-        console.print(":white_check_mark: No errors found.")
+        console.print(f":white_check_mark: No errors found ({range_label}).")
         return
 
-    console.print(f":exclamation: [red]{len(logs)} error(s) found[/red]")
+    console.print(f":exclamation: [red]{len(logs)} error(s) found[/red] ({range_label})")
 
     for entry in logs[-10:]:
         ts = str(entry.get("timestamp", ""))[:19]

--- a/tests/unit/client/test_logging_cli.py
+++ b/tests/unit/client/test_logging_cli.py
@@ -174,6 +174,42 @@ class TestWhitelist:
             assert mod in result.output
 
 
+@pytest.mark.unit
+@pytest.mark.cli
+class TestViewErrors:
+    """Tests for the 'errors' command."""
+
+    def test_errors_default_labels_all_history(self, cli_runner):
+        mock_service = MagicMock()
+        mock_service.query_backtest_logs.return_value = [
+            {"timestamp": "2026-05-06 12:00:00", "event_type": "BACKTEST", "message": "boom"}
+        ]
+
+        with patch("ginkgo.services.logging.containers.container") as mock_container:
+            mock_container.log_service.return_value = mock_service
+            result = cli_runner.invoke(logging_cli.app, ["errors"])
+
+        assert result.exit_code == 0
+        assert "all history" in result.output
+        assert "boom" in result.output
+        call_kwargs = mock_service.query_backtest_logs.call_args.kwargs
+        assert "start_time" not in call_kwargs
+
+    def test_errors_hours_filters_and_labels_time_window(self, cli_runner):
+        mock_service = MagicMock()
+        mock_service.query_backtest_logs.return_value = []
+
+        with patch("ginkgo.services.logging.containers.container") as mock_container:
+            mock_container.log_service.return_value = mock_service
+            result = cli_runner.invoke(logging_cli.app, ["errors", "--hours", "24"])
+
+        assert result.exit_code == 0
+        assert "last 24h" in result.output
+        call_kwargs = mock_service.query_backtest_logs.call_args.kwargs
+        assert call_kwargs["start_time"] is not None
+        assert call_kwargs["end_time"] is not None
+
+
 # ============================================================================
 # 3. Validation / errors (5)
 # ============================================================================


### PR DESCRIPTION
## Summary
- Add `ginkgo logging errors --hours` to query the same lookback window style as `logging stats`.
- Label `logging errors` output with either `all history` or `last Nh`, including the empty-result case.
- Preserve existing defaults: `errors` still scans all history unless `--hours` is provided; `stats` still defaults to last 24h.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_logging_cli.py::TestViewErrors -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_logging_cli.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src api`
- `git diff --check`

Closes #5028
