### PR TITLE
fix: derive portfolio list status from state (#4718)

### DIFF
--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -21,7 +21,7 @@ from rich.table import Table
 from rich.tree import Tree
 from rich import print as rprint
 
-from ginkgo.enums import PORTFOLIO_MODE_TYPES
+from ginkgo.enums import PORTFOLIO_MODE_TYPES, PORTFOLIO_RUNSTATE_TYPES
 from ginkgo.libs import GLOG
 
 app = typer.Typer(help=":bank: Portfolio management", rich_markup_mode="rich")
@@ -34,6 +34,18 @@ def _format_portfolio_mode(mode_value) -> str:
         return "N/A"
     enum_val = PORTFOLIO_MODE_TYPES.from_int(mode_value)
     return enum_val.name if enum_val else str(mode_value)
+
+
+def _format_portfolio_status(portfolio) -> str:
+    """Use explicit status when present, otherwise derive display status from state."""
+    status_value = portfolio.get("status", None)
+    if status_value is not None and not pd.isna(status_value):
+        status_text = str(status_value).strip()
+        if status_text and status_text.lower() != "unknown":
+            return status_text
+
+    enum_val = PORTFOLIO_RUNSTATE_TYPES.from_int(portfolio.get("state", None))
+    return enum_val.name if enum_val else "Unknown"
 
 
 def display_component_tree(console, component_data: dict):
@@ -151,7 +163,7 @@ def list(
             for _, portfolio in portfolios_df.iterrows():
                 initial_capital = f"¥{float(portfolio.get('initial_capital', 0)):,.2f}"
                 portfolio_type = "Live" if portfolio.get('is_live', False) else "Backtest"
-                status = portfolio.get('status', 'Unknown')
+                status = _format_portfolio_status(portfolio)
 
                 table.add_row(
                     str(portfolio.get('uuid', '')),

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -133,6 +133,27 @@ class TestPortfolioList:
         assert "LivePortfolio" in result.output
 
     @patch("ginkgo.data.containers.container")
+    def test_list_uses_state_when_status_missing(self, mock_container, cli_runner):
+        """status 字段缺失时使用 state 枚举显示运行状态"""
+        mock_service = MagicMock()
+        mock_service.get_portfolios_df.return_value = ServiceResult.success(
+            data=pd.DataFrame({
+                "uuid": ["portfolio-uuid-001"],
+                "name": ["StatePortfolio"],
+                "initial_capital": [1000000.0],
+                "is_live": [False],
+                "state": [1],
+            })
+        )
+        mock_container.portfolio_service.return_value = mock_service
+
+        result = cli_runner.invoke(portfolio_cli.app, ["list"])
+
+        assert result.exit_code == 0
+        assert "RUNNING" in result.output
+        assert "Unknown" not in result.output
+
+    @patch("ginkgo.data.containers.container")
     def test_list_empty_portfolios(self, mock_container, cli_runner):
         """没有 portfolio 时显示提示"""
         mock_service = MagicMock()


### PR DESCRIPTION
## Summary
- Keep explicit portfolio `status` display when present.
- When `status` is missing or `Unknown`, derive the display value from the existing `state` field via `PORTFOLIO_RUNSTATE_TYPES`.
- Add a regression test for `portfolio list` rows that have `state` but no `status`.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_portfolio_cli.py::TestPortfolioList::test_list_uses_state_when_status_missing -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_portfolio_cli.py::TestPortfolioList -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src api`
- `git diff --check`

Known unrelated failures observed in the full `tests/unit/client/test_portfolio_cli.py` file:
- `TestPortfolioDelete::test_delete_with_yes_short_flag`
- `TestGenerateBaselinePagination::test_extracts_task_id_from_paginated_result`

Closes #4718
