### PR TITLE
test: use unique engine transition name (#6233)

### DIFF
--- a/tests/unit/data/services/test_engine_service.py
+++ b/tests/unit/data/services/test_engine_service.py
@@ -466,14 +466,14 @@ class TestEngineServiceIntegration:
         verify = engine_service.get(engine_id=uuid)
         assert len(verify.data) == 0
 
-    def test_backtest_to_live_transition(self, engine_service):
+    def test_backtest_to_live_transition(self, engine_service, unique_name):
         """测试回测到实盘的转换流程"""
         # 1. 创建回测引擎
         create = engine_service.add(
-            name="integration_transition",
+            name=f"integration_transition_{unique_name}",
             is_live=False
         )
-        assert create.is_success()
+        assert create.is_success(), f"Create failed: {create.error}"
         uuid = create.data["engine_info"]["uuid"]
 
         # 2. 升级为实盘


### PR DESCRIPTION
## Summary
- Make `test_backtest_to_live_transition` use the existing `unique_name` fixture instead of the fixed `integration_transition` name.
- Preserve the public EngineService behavior: duplicate names still fail; the test no longer collides with persisted integration data.
- Include the service error in the assertion to make future failures actionable.

## Root cause
The failure was caused by test data/name collision. `EngineService.add(name="integration_transition")` correctly returned `引擎名称 'integration_transition' 已存在` when a prior row was present.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/services/test_engine_service.py::TestEngineServiceIntegration::test_backtest_to_live_transition -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/services/test_engine_service.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src api`
- `git diff --check`

Closes #6233
