### PR TITLE
fix: accept portfolio_uuid in deploy request (#5718)

### DIFF
--- a/api/api/deployment.py
+++ b/api/api/deployment.py
@@ -1,7 +1,7 @@
 """部署 API 路由"""
 from fastapi import APIRouter, HTTPException, Query
 from typing import Optional
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 from core.response import ok
 from core.exceptions import BusinessError
 from core.logging import logger
@@ -10,7 +10,11 @@ router = APIRouter()
 
 
 class DeployRequest(BaseModel):
-    portfolio_id: str = Field(..., description="源组合 UUID")
+    portfolio_id: str = Field(
+        ...,
+        validation_alias=AliasChoices("portfolio_id", "portfolio_uuid"),
+        description="源组合 UUID; also accepts portfolio_uuid for API consistency",
+    )
     mode: str = Field(..., description="部署模式: paper / live")
     account_id: Optional[str] = Field(None, description="实盘账号 ID（live 模式必填）")
     name: Optional[str] = Field(None, description="新组合名称")

--- a/tests/api/test_deployment_api.py
+++ b/tests/api/test_deployment_api.py
@@ -2,6 +2,24 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 
+def test_deploy_request_accepts_portfolio_uuid_alias():
+    """#5718: deploy request accepts the public portfolio_uuid field name."""
+    from api.deployment import DeployRequest
+
+    req = DeployRequest(name="test", portfolio_uuid="portfolio-123", mode="paper")
+
+    assert req.portfolio_id == "portfolio-123"
+
+
+def test_deploy_request_keeps_portfolio_id_compatibility():
+    """Existing callers using portfolio_id remain compatible."""
+    from api.deployment import DeployRequest
+
+    req = DeployRequest(name="test", portfolio_id="portfolio-123", mode="paper")
+
+    assert req.portfolio_id == "portfolio-123"
+
+
 def test_update_saga_rejects_frozen_portfolio():
     """update_portfolio_saga 应拒绝冻结组合"""
     from services.saga_transaction import PortfolioSagaFactory


### PR DESCRIPTION
## Summary
- Allow deploy requests to use `portfolio_uuid` as a validation alias for the existing `portfolio_id` field.
- Preserve existing `portfolio_id` callers and keep route internals unchanged.
- Add schema regression tests for both accepted field names.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/api/test_deployment_api.py::test_deploy_request_accepts_portfolio_uuid_alias tests/api/test_deployment_api.py::test_deploy_request_keeps_portfolio_id_compatibility -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/api/test_deployment_api.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src api`
- `git diff --check`

Closes #5718
