### PR TITLE
fix(cli): implement data status command (#5223)

### DIFF
--- a/src/ginkgo/client/data_cli.py
+++ b/src/ginkgo/client/data_cli.py
@@ -493,13 +493,69 @@ def get(
 
 
 @app.command()
-def status():
+def status(
+    sync_type: Optional[str] = typer.Option(None, "--type", "-t", help="Filter by sync type"),
+    limit: int = typer.Option(10, "--limit", "-l", min=1, max=100, help="Recent records to show"),
+):
     """
     :gear: Show data synchronization status.
     """
-    console.print(":gear: Data synchronization status:")
-    # TODO: Implement data status check
-    console.print(":information: Data status check not yet implemented")
+    try:
+        from ginkgo.data.containers import container
+
+        sync_record_service = container.data_sync_record_service()
+        result = sync_record_service.get_history(sync_type=sync_type, page=0, page_size=limit)
+        if not result or not result.is_success():
+            error_msg = result.error if result and hasattr(result, "error") else "unknown error"
+            console.print(f":x: Failed to load data sync status: {error_msg}")
+            raise typer.Exit(1)
+
+        payload = result.data or {}
+        items = payload.get("items", []) if isinstance(payload, dict) else []
+        total = payload.get("total", len(items)) if isinstance(payload, dict) else len(items)
+
+        console.print(":gear: Data synchronization status:")
+        if not items:
+            console.print(":information: No sync records found")
+            return
+
+        counts = {}
+        for item in items:
+            status_value = str(item.get("status") or "unknown")
+            counts[status_value] = counts.get(status_value, 0) + 1
+        summary = ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+        console.print(f":information: Showing {len(items)} of {total} sync record(s); {summary}")
+
+        table = Table(title="Recent Data Sync Records", show_lines=False)
+        table.add_column("Type", style="cyan", no_wrap=True)
+        table.add_column("Code", style="green", no_wrap=True)
+        table.add_column("Status", style="yellow", no_wrap=True)
+        table.add_column("Processed", justify="right")
+        table.add_column("Added", justify="right")
+        table.add_column("Failed", justify="right")
+        table.add_column("Completed", style="dim", no_wrap=True)
+        table.add_column("Strategy", style="dim", no_wrap=True)
+
+        for item in items:
+            completed_at = item.get("completed_at") or item.get("started_at") or ""
+            if isinstance(completed_at, str) and "T" in completed_at:
+                completed_at = completed_at.replace("T", " ")[:19]
+            table.add_row(
+                str(item.get("sync_type") or ""),
+                str(item.get("code") or ""),
+                str(item.get("status") or ""),
+                str(item.get("records_processed") or 0),
+                str(item.get("records_added") or 0),
+                str(item.get("records_failed") or 0),
+                str(completed_at),
+                str(item.get("sync_strategy") or ""),
+            )
+        console.print(table)
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f":x: Error loading data sync status: {e}")
+        raise typer.Exit(1)
 
 
 def _is_valid_stock_code(code: str) -> bool:

--- a/tests/unit/client/test_data_cli.py
+++ b/tests/unit/client/test_data_cli.py
@@ -315,11 +315,63 @@ class TestStatus:
         assert result.exit_code == 0
         assert "status" in result.output.lower()
 
-    def test_status_shows_not_implemented(self, cli_runner):
-        """status 命令显示尚未实现"""
+    @patch("ginkgo.data.containers.container")
+    def test_status_reads_sync_record_service(self, mock_container, cli_runner):
+        """status 命令读取同步记录服务并显示最近同步状态"""
+        mock_service = MagicMock()
+        mock_service.get_history.return_value = ServiceResult.success(
+            data={
+                "total": 2,
+                "items": [
+                    {
+                        "sync_type": "day",
+                        "code": "000001.SZ",
+                        "status": "success",
+                        "started_at": "2026-07-05T10:00:00",
+                        "completed_at": "2026-07-05T10:01:00",
+                        "records_processed": 10,
+                        "records_added": 8,
+                        "records_updated": 2,
+                        "records_failed": 0,
+                        "sync_strategy": "smart",
+                    },
+                    {
+                        "sync_type": "tick",
+                        "code": "000002.SZ",
+                        "status": "failed",
+                        "started_at": "2026-07-05T11:00:00",
+                        "completed_at": "2026-07-05T11:00:30",
+                        "records_processed": 3,
+                        "records_added": 0,
+                        "records_updated": 0,
+                        "records_failed": 3,
+                        "sync_strategy": "full",
+                    },
+                ],
+            }
+        )
+        mock_container.data_sync_record_service.return_value = mock_service
+
         result = cli_runner.invoke(data_cli.app, ["status"])
         assert result.exit_code == 0
-        assert "not yet implemented" in result.output
+        mock_service.get_history.assert_called_once_with(sync_type=None, page=0, page_size=10)
+        assert "not yet implemented" not in result.output
+        assert "000001.SZ" in result.output
+        assert "success" in result.output
+        assert "failed" in result.output
+
+    @patch("ginkgo.data.containers.container")
+    def test_status_supports_type_filter_and_limit(self, mock_container, cli_runner):
+        """status 支持按同步类型和记录数筛选"""
+        mock_service = MagicMock()
+        mock_service.get_history.return_value = ServiceResult.success(data={"items": [], "total": 0})
+        mock_container.data_sync_record_service.return_value = mock_service
+
+        result = cli_runner.invoke(data_cli.app, ["status", "--type", "day", "--limit", "5"])
+
+        assert result.exit_code == 0
+        mock_service.get_history.assert_called_once_with(sync_type="day", page=0, page_size=5)
+        assert "No sync records found" in result.output
 
 
 # ============================================================================


### PR DESCRIPTION
Summary
- Implement `ginkgo data status` using `DataSyncRecordService.get_history`.
- Add `--type/-t` and `--limit/-l` filters and render recent sync records in a Rich table.
- Cover populated and empty status output through the CLI public interface.

Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_data_cli.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m py_compile` over `src` and `api`
- `git diff --check`

Closes #5223