### PR TITLE
fix: route MomentumSelector through bar service (#6033)

### DIFF
--- a/src/ginkgo/trading/selectors/momentum_selector.py
+++ b/src/ginkgo/trading/selectors/momentum_selector.py
@@ -28,9 +28,7 @@ class MomentumSelector(BaseSelector):
         # 源头校验：window 必须为 [1, MAX_WINDOW] 内 int，避免 timedelta(days=) 语义错
         # 或批量查询取全表 OOM。bool 是 int 子类，一并拒绝。
         if isinstance(window, bool) or not isinstance(window, int) or not (1 <= window <= MAX_WINDOW):
-            raise ValueError(
-                f"window must be int in [1, {MAX_WINDOW}], got {window!r}"
-            )
+            raise ValueError(f"window must be int in [1, {MAX_WINDOW}], got {window!r}")
         self._interested = []
         self._interval = interval
         self._rank = rank
@@ -64,9 +62,16 @@ class MomentumSelector(BaseSelector):
             if end_date - datetime_normalize(self._last_pick) > datetime.timedelta(days=self._interval):
                 self._last_pick = end_date
 
-        # Get all stock codes instead of just 50
-        stockinfo_crud = container.cruds.stock_info()
-        codes = stockinfo_crud.get_all_codes()
+        bar_service = container.bar_service()
+
+        # Use the actual bar universe instead of stock metadata. In small/test DBs,
+        # most listed stocks have no bar rows, so scanning stock_info creates empty work.
+        codes_result = bar_service.get_available_codes()
+        if not codes_result or not codes_result.is_success():
+            GLOG.WARN(f"MomentumSelector: failed to load available bar codes: {getattr(codes_result, 'error', '')}")
+            return self._interested
+
+        codes = codes_result.data or []
         if not codes:
             return self._interested
 
@@ -74,15 +79,16 @@ class MomentumSelector(BaseSelector):
 
         # 批量查询：一次取全市场窗口内全部 bar，内存 groupby 算动量。
         # 将 DB 查询次数从 O(universe) 降到 O(1)，避免逐股 round-trip。
-        bar_crud = container.cruds.bar()
-        bars = bar_crud.find(
-            filters={"timestamp__gte": start_date, "timestamp__lte": end_date},
+        bars_result = bar_service.get_bars_df(
+            start_date=start_date,
+            end_date=end_date,
             order_by="timestamp",
         )
-        # 空结果短路：ModelList 实现 __bool__/__len__，空时不调 to_dataframe。
-        if not bars:
+        if not bars_result or not bars_result.is_success():
+            GLOG.WARN(f"MomentumSelector: failed to load bar data: {getattr(bars_result, 'error', '')}")
             return self._interested
-        df = bars.to_dataframe()
+
+        df = bars_result.data
         if df is None or df.empty:
             return self._interested
 
@@ -90,11 +96,7 @@ class MomentumSelector(BaseSelector):
         # 不依赖 DB 隐式排序（原逐股版未指定 order_by，属脆弱行为，此处一并修正）。
         valid_codes = set(codes)
         df = df.sort_values(["code", "timestamp"])
-        grouped = (
-            df[df["code"].isin(valid_codes)]
-            .groupby("code")["close"]
-            .agg(["first", "last", "count"])
-        )
+        grouped = df[df["code"].isin(valid_codes)].groupby("code")["close"].agg(["first", "last", "count"])
         # 过滤无效股票：窗口内不足两条 bar，或首条收盘价非正（动量无意义/除零）。
         grouped = grouped[(grouped["count"] >= 2) & (grouped["first"] > 0)]
         if grouped.empty:

--- a/tests/unit/lab/test_momentum_selector.py
+++ b/tests/unit/lab/test_momentum_selector.py
@@ -8,9 +8,15 @@ import datetime
 from time import sleep
 import pandas as pd
 from unittest.mock import patch, MagicMock
+from ginkgo.data.services.base_service import ServiceResult
 from ginkgo.trading.selectors.momentum_selector import MomentumSelector
 
 engine_id = "backtest_example_001"
+
+
+class _ForbiddenCruds:
+    def __getattr__(self, name):
+        raise AssertionError(f"MomentumSelector must use services, not container.cruds.{name}")
 
 
 class MomentumSelectorTest(unittest.TestCase):
@@ -29,12 +35,36 @@ class MomentumSelectorTest(unittest.TestCase):
         print(s)
 
     @patch("ginkgo.trading.selectors.momentum_selector.container")
+    def test_pick_uses_bar_service_and_available_codes(self, mock_container):
+        """pick() uses the data service boundary and scans only codes with bar data."""
+        df = pd.DataFrame(
+            [
+                {"code": "A", "close": 10.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "B", "close": 5.0, "timestamp": pd.Timestamp("2019-12-10")},
+                {"code": "A", "close": 20.0, "timestamp": pd.Timestamp("2019-12-30")},
+                {"code": "B", "close": 100.0, "timestamp": pd.Timestamp("2019-12-30")},
+                {"code": "NO_BAR_METADATA_ONLY", "close": 1.0, "timestamp": pd.Timestamp("2019-12-30")},
+            ]
+        )
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=["A", "B"])
+        mock_bar_service.get_bars_df.return_value = ServiceResult.success(data=df)
+        mock_container.cruds = _ForbiddenCruds()
+        mock_container.bar_service.return_value = mock_bar_service
+
+        s = MomentumSelector(name="test_selector", window=30, rank=1)
+        res = s.pick(time="2020-01-01")
+
+        self.assertEqual(res, ["B"])
+        mock_bar_service.get_available_codes.assert_called_once()
+        mock_bar_service.get_bars_df.assert_called_once()
+
+    @patch("ginkgo.trading.selectors.momentum_selector.container")
     def test_pick(self, mock_container):
         """测试pick方法 - mock数据库依赖."""
-        # Mock stockinfo_crud返回空DataFrame（无股票信息）
-        mock_stockinfo_crud = MagicMock()
-        mock_stockinfo_crud.get_all_codes.return_value = []
-        mock_container.cruds.stock_info.return_value = mock_stockinfo_crud
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=[])
+        mock_container.bar_service.return_value = mock_bar_service
 
         s = MomentumSelector(name="test_selector", window=30, rank=2)
         res = s.pick(time="2020-01-01")
@@ -65,12 +95,10 @@ class MomentumSelectorTest(unittest.TestCase):
                 {"code": "C", "close": 10.0, "timestamp": pd.Timestamp("2019-12-30")},
             ]
         )
-        mock_si = MagicMock()
-        mock_si.get_all_codes.return_value = ["A", "B", "C"]
-        mock_bar = MagicMock()
-        mock_bar.find.return_value.to_dataframe.return_value = df
-        mock_container.cruds.stock_info.return_value = mock_si
-        mock_container.cruds.bar.return_value = mock_bar
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=["A", "B", "C"])
+        mock_bar_service.get_bars_df.return_value = ServiceResult.success(data=df)
+        mock_container.bar_service.return_value = mock_bar_service
 
         s = MomentumSelector(name="test_selector", window=30, rank=2)
         res = s.pick(time="2020-01-01")
@@ -90,19 +118,17 @@ class MomentumSelectorTest(unittest.TestCase):
                 {"code": "B", "close": 100.0, "timestamp": pd.Timestamp("2019-12-30")},
             ]
         )
-        mock_si = MagicMock()
-        mock_si.get_all_codes.return_value = ["A", "B"]
-        mock_bar = MagicMock()
-        mock_bar.find.return_value.to_dataframe.return_value = df
-        mock_container.cruds.stock_info.return_value = mock_si
-        mock_container.cruds.bar.return_value = mock_bar
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=["A", "B"])
+        mock_bar_service.get_bars_df.return_value = ServiceResult.success(data=df)
+        mock_container.bar_service.return_value = mock_bar_service
 
         s = MomentumSelector(name="test_selector", window=30, rank=2)
         s.pick(time="2020-01-01")
         self.assertEqual(
-            mock_bar.find.call_count,
+            mock_bar_service.get_bars_df.call_count,
             1,
-            "pick() 应只发起一次批量 bar 查询，而非逐股查询",
+            "pick() 应只通过 service 发起一次批量 bar 查询，而非逐股查询",
         )
 
     @patch("ginkgo.trading.selectors.momentum_selector.container")
@@ -123,12 +149,10 @@ class MomentumSelectorTest(unittest.TestCase):
                 {"code": "Y", "close": 10.0, "timestamp": pd.Timestamp("2019-12-30")},
             ]
         )
-        mock_si = MagicMock()
-        mock_si.get_all_codes.return_value = ["Z", "X", "Y"]
-        mock_bar = MagicMock()
-        mock_bar.find.return_value.to_dataframe.return_value = df
-        mock_container.cruds.stock_info.return_value = mock_si
-        mock_container.cruds.bar.return_value = mock_bar
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=["Z", "X", "Y"])
+        mock_bar_service.get_bars_df.return_value = ServiceResult.success(data=df)
+        mock_container.bar_service.return_value = mock_bar_service
 
         s = MomentumSelector(name="test_selector", window=30, rank=2)
         res = s.pick(time="2020-01-01")

--- a/tests/unit/trading/selectors/test_momentum_popularity_hasattr.py
+++ b/tests/unit/trading/selectors/test_momentum_popularity_hasattr.py
@@ -13,6 +13,7 @@ from unittest.mock import patch, MagicMock
 
 import pandas as pd
 
+from ginkgo.data.services.base_service import ServiceResult
 from ginkgo.trading.selectors.momentum_selector import MomentumSelector
 from ginkgo.trading.selectors.popularity_selector import PopularitySelector
 
@@ -28,16 +29,12 @@ def _make_bars(df: pd.DataFrame):
 
 class MomentumSelectorHasattrRemovalTest(unittest.TestCase):
     @patch("ginkgo.trading.selectors.momentum_selector.container")
-    def test_non_empty_bars_uses_to_dataframe(self, mock_container):
-        """非空 bars：直接调 to_dataframe，按 momentum 排序产出 code。
+    def test_non_empty_bars_uses_service_dataframe(self, mock_container):
+        """非空 bars：消费 service 的 DataFrame 出口，按 momentum 排序产出 code。
 
         批量实现（#4650）按 code 列 groupby，故 df 需含真实 bar 的 code/timestamp 列
         （旧逐股实现 code 来自循环变量，fixture 曾省略 code 列）。
         """
-        mock_stockinfo = MagicMock()
-        mock_stockinfo.get_all_codes.return_value = ["000001"]
-        mock_container.cruds.stock_info.return_value = mock_stockinfo
-
         df = pd.DataFrame(
             {
                 "code": ["000001", "000001"],
@@ -46,30 +43,28 @@ class MomentumSelectorHasattrRemovalTest(unittest.TestCase):
                 "timestamp": [pd.Timestamp("2020-05-01"), pd.Timestamp("2020-05-31")],
             }
         )
-        mock_bar = MagicMock()
-        mock_bar.find.return_value = _make_bars(df)
-        mock_container.cruds.bar.return_value = mock_bar
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=["000001"])
+        mock_bar_service.get_bars_df.return_value = ServiceResult.success(data=df)
+        mock_container.bar_service.return_value = mock_bar_service
 
         s = MomentumSelector(name="t", window=30, rank=2)
         res = s.pick(time=datetime.datetime(2020, 6, 1))
         self.assertEqual(res, ["000001"])
-        mock_bar.find.return_value.to_dataframe.assert_called_once()
+        mock_bar_service.get_bars_df.assert_called_once()
 
     @patch("ginkgo.trading.selectors.momentum_selector.container")
     def test_empty_bars_continues(self, mock_container):
-        """空 bars：len < 2 守卫触发 continue，不调 to_dataframe。"""
-        mock_stockinfo = MagicMock()
-        mock_stockinfo.get_all_codes.return_value = ["000001"]
-        mock_container.cruds.stock_info.return_value = mock_stockinfo
-
-        mock_bar = MagicMock()
-        mock_bar.find.return_value = _make_bars(pd.DataFrame())
-        mock_container.cruds.bar.return_value = mock_bar
+        """空 bars：DataFrame 空结果短路。"""
+        mock_bar_service = MagicMock()
+        mock_bar_service.get_available_codes.return_value = ServiceResult.success(data=["000001"])
+        mock_bar_service.get_bars_df.return_value = ServiceResult.success(data=pd.DataFrame())
+        mock_container.bar_service.return_value = mock_bar_service
 
         s = MomentumSelector(name="t", window=30, rank=2)
         res = s.pick(time=datetime.datetime(2020, 6, 1))
         self.assertEqual(res, [])
-        mock_bar.find.return_value.to_dataframe.assert_not_called()
+        mock_bar_service.get_bars_df.assert_called_once()
 
 
 class PopularitySelectorHasattrRemovalTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Route MomentumSelector through `container.bar_service()` instead of `container.cruds.*`.
- Use `bar_service.get_available_codes()` as the selector universe so stocks with no bar data are not scanned from stock metadata.
- Load the window bars through the service DataFrame exit and keep the existing in-memory momentum ranking behavior.
- Add regression coverage that fails if MomentumSelector reaches `container.cruds`.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/lab/test_momentum_selector.py tests/unit/trading/selectors/test_selector_param_validation.py tests/unit/trading/selectors/test_momentum_popularity_hasattr.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m black --check src/ginkgo/trading/selectors/momentum_selector.py tests/unit/lab/test_momentum_selector.py tests/unit/trading/selectors/test_momentum_popularity_hasattr.py`
- changed-file coverage check: `src/ginkgo/trading/selectors/momentum_selector.py -> tests/unit/lab/test_momentum_selector.py`
- `py_compile` over `src api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `git diff --check`
- `rg -n "container\.cruds|cruds\." src/ginkgo/trading/selectors/momentum_selector.py` returned no matches

Closes #6033