### PR TITLE
refactor: stabilize FactorService data contract (#6626)

### DIFF
--- a/src/ginkgo/data/services/factor_service.py
+++ b/src/ginkgo/data/services/factor_service.py
@@ -3,11 +3,6 @@
 # Role: FactorService因子管理业务服务支持股票/市场/国家/行业/商品/货币/债券/基金/指数等因子
 
 
-
-
-
-
-
 """
 Factor Management Service
 
@@ -71,10 +66,7 @@ class FactorService(BaseService):
     # ============================================================================
 
     @retry(max_try=3)
-    def add_factor_batch(
-        self,
-        factors_data: List[Dict[str, Any]]
-    ) -> ServiceResult:
+    def add_factor_batch(self, factors_data: List[Dict[str, Any]]) -> ServiceResult:
         """
         Batch add factor data
 
@@ -85,52 +77,52 @@ class FactorService(BaseService):
             ServiceResult: Operation result
         """
         result = self.create_result()
-        
+
         try:
             # Data validation and conversion
             validated_factors = []
             for i, factor_data in enumerate(factors_data):
                 try:
                     # Ensure required fields exist
-                    required_fields = ['entity_type', 'entity_id', 'factor_name', 'factor_value']
+                    required_fields = ["entity_type", "entity_id", "factor_name", "factor_value"]
                     for field in required_fields:
                         if field not in factor_data:
                             raise ValueError(f"Missing required field: {field}")
 
                     # Type conversion
                     processed_factor = {
-                        'entity_type': factor_data['entity_type'],
-                        'entity_id': str(factor_data['entity_id']),
-                        'factor_name': str(factor_data['factor_name']),
-                        'factor_value': to_decimal(factor_data['factor_value']),
-                        'factor_category': str(factor_data.get('factor_category', '')),
-                        'timestamp': datetime_normalize(factor_data.get('timestamp', datetime.now())),
-                        'source': factor_data.get('source', SOURCE_TYPES.OTHER)
+                        "entity_type": factor_data["entity_type"],
+                        "entity_id": str(factor_data["entity_id"]),
+                        "factor_name": str(factor_data["factor_name"]),
+                        "factor_value": to_decimal(factor_data["factor_value"]),
+                        "factor_category": str(factor_data.get("factor_category", "")),
+                        "timestamp": datetime_normalize(factor_data.get("timestamp", datetime.now())),
+                        "source": factor_data.get("source", SOURCE_TYPES.OTHER),
                     }
-                    
+
                     validated_factors.append(processed_factor)
-                    
+
                 except Exception as e:
                     self._logger.ERROR(f"Failed to validate factor data at index {i}: {e}")
                     continue
-            
+
             if not validated_factors:
                 result.error = "No valid factor data to add"
                 return result
-            
+
             # Batch add to database
             add_result = self.factor_crud.add_batch(validated_factors)
-            
+
             result.success = True
             result.set_data("records_added", len(validated_factors))
             result.set_data("add_result", add_result)
-            
+
             self._logger.INFO(f"Successfully added {len(validated_factors)} factors")
-            
+
         except Exception as e:
             result.error = f"Failed to add factor batch: {str(e)}"
             self._logger.ERROR(f"Factor batch addition failed: {e}")
-        
+
         return result
 
     def get_factors_by_entity(
@@ -167,17 +159,19 @@ class FactorService(BaseService):
                 end_time=end_time,
                 factor_category=factor_category,
             )
-            
+
             result.success = True
-            result.set_data("factors", factors)
-            result.set_data("count", len(factors) if isinstance(factors, list) else factors.shape[0])
-            
+            result.data = {
+                "factors": factors,
+                "count": len(factors),
+            }
+
             self._logger.DEBUG(f"Retrieved factors for entity {entity_type}:{entity_id}")
-            
+
         except Exception as e:
             result.error = f"Failed to get factors: {str(e)}"
             self._logger.ERROR(f"Factor query failed: {e}")
-            
+
         return result
 
     def get_latest_factors_by_entity(
@@ -208,17 +202,19 @@ class FactorService(BaseService):
                 factor_names=factor_names,
                 factor_category=factor_category,
             )
-            
+
             result.success = True
-            result.set_data("latest_factors", latest_factors)
-            result.set_data("count", len(latest_factors) if isinstance(latest_factors, list) else latest_factors.shape[0])
-            
+            result.data = {
+                "latest_factors": latest_factors,
+                "count": len(latest_factors),
+            }
+
             self._logger.DEBUG(f"Retrieved latest factors for entity {entity_type}:{entity_id}")
-            
+
         except Exception as e:
             result.error = f"Failed to get latest factors: {str(e)}"
             self._logger.ERROR(f"Latest factor query failed: {e}")
-            
+
         return result
 
     # ============================================================================
@@ -231,27 +227,27 @@ class FactorService(BaseService):
         entity_ids: List[str],
         factor_names: List[str],
         start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None
+        end_time: Optional[datetime] = None,
     ) -> ServiceResult:
         """
         计算因子相关性矩阵
-        
+
         Args:
             entity_type: 实体类型
             entity_ids: 实体标识列表
             factor_names: 因子名称列表
             start_time: 开始时间
             end_time: 结束时间
-            
+
         Returns:
             ServiceResult: 包含相关性矩阵的结果
         """
         result = self.create_result()
-        
+
         try:
             # 收集所有因子数据
             all_factor_data = []
-            
+
             for entity_id in entity_ids:
                 factors_result = self.get_factors_by_entity(
                     entity_type=entity_type,
@@ -260,44 +256,48 @@ class FactorService(BaseService):
                     start_time=start_time,
                     end_time=end_time,
                 )
-                
+
                 if factors_result.success:
-                    factors_data = factors_result.get_data("factors")
+                    factors_data = factors_result.data["factors"] if factors_result.data else None
                     if factors_data is not None and len(factors_data) > 0:
-                        factors_df = factors_data.to_dataframe() if hasattr(factors_data, 'to_dataframe') else pd.DataFrame(factors_data)
-                        factors_df['entity_factor'] = factors_df['entity_id'] + '_' + factors_df['factor_name']
+                        factors_df = factors_data.to_dataframe()
+                        factors_df["entity_factor"] = factors_df["entity_id"] + "_" + factors_df["factor_name"]
                         all_factor_data.append(factors_df)
-            
+
             if not all_factor_data:
                 result.error = "No factor data found for correlation analysis"
                 return result
-            
+
             # 合并所有数据
             combined_df = pd.concat(all_factor_data, ignore_index=True)
-            
+
             # 构建因子值矩阵
             pivot_df = combined_df.pivot_table(
-                index='timestamp',
-                columns='entity_factor',
-                values='factor_value',
-                aggfunc='last'  # 如果同一时间有多个值，取最后一个
+                index="timestamp",
+                columns="entity_factor",
+                values="factor_value",
+                aggfunc="last",  # 如果同一时间有多个值，取最后一个
             )
-            
+
             # 计算相关性矩阵
             correlation_matrix = pivot_df.corr()
-            
+
             result.success = True
-            result.set_data("correlation_matrix", correlation_matrix)
-            result.set_data("factor_data", pivot_df)
-            result.set_data("entity_count", len(entity_ids))
-            result.set_data("factor_count", len(factor_names))
-            
-            self._logger.INFO(f"Calculated correlation matrix for {len(entity_ids)} entities and {len(factor_names)} factors")
-            
+            result.data = {
+                "correlation_matrix": correlation_matrix,
+                "factor_data": pivot_df,
+                "entity_count": len(entity_ids),
+                "factor_count": len(factor_names),
+            }
+
+            self._logger.INFO(
+                f"Calculated correlation matrix for {len(entity_ids)} entities and {len(factor_names)} factors"
+            )
+
         except Exception as e:
             result.error = f"Failed to calculate factor correlation: {str(e)}"
             self._logger.ERROR(f"Factor correlation calculation failed: {e}")
-            
+
         return result
 
     def analyze_factor_distribution(
@@ -305,28 +305,26 @@ class FactorService(BaseService):
         entity_type: Union[ENTITY_TYPES, str, int],
         factor_name: str,
         start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None
+        end_time: Optional[datetime] = None,
     ) -> ServiceResult:
         """
         分析因子分布特征
-        
+
         Args:
             entity_type: 实体类型
             factor_name: 因子名称
             start_time: 开始时间
             end_time: 结束时间
-            
+
         Returns:
             ServiceResult: 包含分布统计信息的结果
         """
         result = self.create_result()
-        
+
         try:
             # 查询因子数据
-            filters = {
-                "factor_name": factor_name
-            }
-            
+            filters = {"factor_name": factor_name}
+
             # 实体类型处理
             if isinstance(entity_type, ENTITY_TYPES):
                 filters["entity_type"] = entity_type.value
@@ -336,13 +334,13 @@ class FactorService(BaseService):
                     filters["entity_type"] = entity_enum.value
             elif isinstance(entity_type, int):
                 filters["entity_type"] = entity_type
-            
+
             # 时间范围
             if start_time:
                 filters["timestamp__gte"] = start_time
             if end_time:
                 filters["timestamp__lte"] = end_time
-            
+
             factors_result = self.factor_crud.find(filters=filters)
 
             if not factors_result:
@@ -352,43 +350,43 @@ class FactorService(BaseService):
             factors_df = factors_result.to_dataframe()
 
             # 计算分布统计
-            factor_values = factors_df['factor_value'].astype(float)
-            
+            factor_values = factors_df["factor_value"].astype(float)
+
             distribution_stats = {
-                'count': len(factor_values),
-                'mean': float(factor_values.mean()),
-                'std': float(factor_values.std()),
-                'min': float(factor_values.min()),
-                'max': float(factor_values.max()),
-                'median': float(factor_values.median()),
-                'q25': float(factor_values.quantile(0.25)),
-                'q75': float(factor_values.quantile(0.75)),
-                'skewness': float(factor_values.skew()),
-                'kurtosis': float(factor_values.kurtosis())
+                "count": len(factor_values),
+                "mean": float(factor_values.mean()),
+                "std": float(factor_values.std()),
+                "min": float(factor_values.min()),
+                "max": float(factor_values.max()),
+                "median": float(factor_values.median()),
+                "q25": float(factor_values.quantile(0.25)),
+                "q75": float(factor_values.quantile(0.75)),
+                "skewness": float(factor_values.skew()),
+                "kurtosis": float(factor_values.kurtosis()),
             }
-            
+
             # 异常值检测（IQR方法）
             q1 = factor_values.quantile(0.25)
             q3 = factor_values.quantile(0.75)
             iqr = q3 - q1
             lower_bound = q1 - 1.5 * iqr
             upper_bound = q3 + 1.5 * iqr
-            
+
             outliers = factor_values[(factor_values < lower_bound) | (factor_values > upper_bound)]
-            distribution_stats['outlier_count'] = len(outliers)
-            distribution_stats['outlier_percentage'] = len(outliers) / len(factor_values) * 100
-            
+            distribution_stats["outlier_count"] = len(outliers)
+            distribution_stats["outlier_percentage"] = len(outliers) / len(factor_values) * 100
+
             result.success = True
             result.set_data("distribution_stats", distribution_stats)
             result.set_data("factor_data", factors_df)
             result.set_data("outliers", outliers.tolist())
-            
+
             self._logger.INFO(f"Analyzed distribution for factor {factor_name}: {distribution_stats['count']} records")
-            
+
         except Exception as e:
             result.error = f"Failed to analyze factor distribution: {str(e)}"
             self._logger.ERROR(f"Factor distribution analysis failed: {e}")
-            
+
         return result
 
     # ============================================================================
@@ -396,70 +394,62 @@ class FactorService(BaseService):
     # ============================================================================
 
     @cache_with_expiration(expiration_seconds=300)  # Cache for 5 minutes
-    def get_available_entities(
-        self, 
-        entity_type: Optional[Union[ENTITY_TYPES, str, int]] = None
-    ) -> ServiceResult:
+    def get_available_entities(self, entity_type: Optional[Union[ENTITY_TYPES, str, int]] = None) -> ServiceResult:
         """
         获取可用的实体列表
-        
+
         Args:
             entity_type: 实体类型过滤
-            
+
         Returns:
             ServiceResult: 可用实体列表
         """
         result = self.create_result()
-        
+
         try:
             entities = self.factor_crud.get_available_entities(entity_type=entity_type)
-            
+
             result.success = True
             result.set_data("entities", entities)
             result.set_data("count", len(entities))
-            
+
             self._logger.DEBUG(f"Retrieved {len(entities)} available entities")
-            
+
         except Exception as e:
             result.error = f"Failed to get available entities: {str(e)}"
             self._logger.ERROR(f"Available entities query failed: {e}")
-            
+
         return result
 
     @cache_with_expiration(expiration_seconds=300)  # Cache for 5 minutes
     def get_available_factors(
-        self,
-        entity_type: Optional[Union[ENTITY_TYPES, str, int]] = None,
-        factor_category: Optional[str] = None
+        self, entity_type: Optional[Union[ENTITY_TYPES, str, int]] = None, factor_category: Optional[str] = None
     ) -> ServiceResult:
         """
         获取可用的因子列表
-        
+
         Args:
             entity_type: 实体类型过滤
             factor_category: 因子分类过滤
-            
+
         Returns:
             ServiceResult: 可用因子列表
         """
         result = self.create_result()
-        
+
         try:
-            factors = self.factor_crud.get_available_factors(
-                entity_type=entity_type,
-                factor_category=factor_category
-            )
-            
+            factors = self.factor_crud.get_available_factors(entity_type=entity_type, factor_category=factor_category)
+
             result.success = True
             result.set_data("factors", factors)
             result.set_data("count", len(factors))
-            
+
             self._logger.DEBUG(f"Retrieved {len(factors)} available factors")
-            
+
         except Exception as e:
             result.error = f"Failed to get available factors: {str(e)}"
             self._logger.ERROR(f"Available factors query failed: {e}")
-            
+
         return result
 
     def delete_factors_by_entity(
@@ -468,67 +458,69 @@ class FactorService(BaseService):
         entity_id: str,
         factor_names: Optional[List[str]] = None,
         start_time: Optional[datetime] = None,
-        end_time: Optional[datetime] = None
+        end_time: Optional[datetime] = None,
     ) -> ServiceResult:
         """
         删除指定实体的因子数据
-        
+
         Args:
             entity_type: 实体类型
             entity_id: 实体标识
             factor_names: 因子名称列表
             start_time: 开始时间
             end_time: 结束时间
-            
+
         Returns:
             ServiceResult: 删除操作结果
         """
         result = self.create_result()
-        
+
         try:
             self.factor_crud.remove_factors_by_entity(
                 entity_type=entity_type,
                 entity_id=entity_id,
                 factor_names=factor_names,
                 start_time=start_time,
-                end_time=end_time
+                end_time=end_time,
             )
-            
+
             result.success = True
             self._logger.INFO(f"Deleted factors for entity {entity_type}:{entity_id}")
-            
+
         except Exception as e:
             result.error = f"Failed to delete factors: {str(e)}"
             self._logger.ERROR(f"Factor deletion failed: {e}")
-            
+
         return result
 
     def get_health_status(self) -> Dict[str, Any]:
         """
         获取因子服务健康状态
-        
+
         Returns:
             服务健康状态信息
         """
         base_status = super().get_health_status()
-        
+
         try:
             # 检查因子数据总数
             total_factors = self.factor_crud.count()
-            
+
             # 检查各实体类型的因子数量
             entity_type_counts = {}
             for entity_type in ENTITY_TYPES:
                 if entity_type != ENTITY_TYPES.VOID:
                     count = self.factor_crud.count({"entity_type": entity_type.value})
                     entity_type_counts[entity_type.name] = count
-            
-            base_status.update({
-                "total_factors": total_factors,
-                "entity_type_counts": entity_type_counts,
-            })
-            
+
+            base_status.update(
+                {
+                    "total_factors": total_factors,
+                    "entity_type_counts": entity_type_counts,
+                }
+            )
+
         except Exception as e:
             base_status["health_check_error"] = str(e)
-            
+
         return base_status

--- a/tests/unit/data/services/test_factor_service.py
+++ b/tests/unit/data/services/test_factor_service.py
@@ -1,0 +1,98 @@
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from ginkgo.data.crud.model_conversion import ModelList
+from ginkgo.data.services.factor_service import FactorService
+
+
+def _model_list(rows, dataframe=None):
+    crud = MagicMock()
+    crud._convert_models_to_dataframe.return_value = dataframe if dataframe is not None else pd.DataFrame(rows)
+    return ModelList(rows, crud)
+
+
+@pytest.fixture
+def factor_crud():
+    return MagicMock()
+
+
+@pytest.fixture
+def service(factor_crud):
+    with patch("ginkgo.libs.GLOG"):
+        return FactorService(factor_crud=factor_crud)
+
+
+class TestFactorServiceDfContract:
+    def test_get_factors_by_entity_returns_stable_modellist_contract(self, service, factor_crud):
+        factors = _model_list([MagicMock(), MagicMock()])
+        factor_crud.get_factors_by_entity.return_value = factors
+
+        result = service.get_factors_by_entity(entity_type=1, entity_id="000001.SZ")
+
+        assert result.success is True
+        assert result.data["factors"] is factors
+        assert result.data["count"] == 2
+
+    def test_get_factors_by_entity_empty_modellist_count_zero(self, service, factor_crud):
+        factors = _model_list([])
+        factor_crud.get_factors_by_entity.return_value = factors
+
+        result = service.get_factors_by_entity(entity_type=1, entity_id="missing")
+
+        assert result.success is True
+        assert result.data["factors"] is factors
+        assert result.data["count"] == 0
+
+    def test_calculate_factor_correlation_consumes_modellist_dataframe_contract(self, service, factor_crud):
+        df_a = pd.DataFrame(
+            [
+                {"timestamp": "2024-01-01", "entity_id": "A", "factor_name": "momentum", "factor_value": 1.0},
+                {"timestamp": "2024-01-02", "entity_id": "A", "factor_name": "momentum", "factor_value": 2.0},
+            ]
+        )
+        df_b = pd.DataFrame(
+            [
+                {"timestamp": "2024-01-01", "entity_id": "B", "factor_name": "momentum", "factor_value": 2.0},
+                {"timestamp": "2024-01-02", "entity_id": "B", "factor_name": "momentum", "factor_value": 4.0},
+            ]
+        )
+        factor_crud.get_factors_by_entity.side_effect = [
+            _model_list([MagicMock(), MagicMock()], df_a),
+            _model_list([MagicMock(), MagicMock()], df_b),
+        ]
+
+        result = service.calculate_factor_correlation(
+            entity_type=1,
+            entity_ids=["A", "B"],
+            factor_names=["momentum"],
+        )
+
+        assert result.success is True
+        matrix = result.data["correlation_matrix"]
+        assert list(matrix.columns) == ["A_momentum", "B_momentum"]
+        assert matrix.loc["A_momentum", "B_momentum"] == pytest.approx(1.0)
+
+    def test_calculate_factor_correlation_empty_data_returns_clear_error(self, service, factor_crud):
+        factor_crud.get_factors_by_entity.return_value = _model_list([])
+
+        result = service.calculate_factor_correlation(
+            entity_type=1,
+            entity_ids=["missing"],
+            factor_names=["momentum"],
+        )
+
+        assert result.success is False
+        assert result.error == "No factor data found for correlation analysis"
+
+    def test_factor_service_has_no_factor_shape_duck_typing(self):
+        get_source = inspect.getsource(FactorService.get_factors_by_entity)
+        latest_source = inspect.getsource(FactorService.get_latest_factors_by_entity)
+        correlation_source = inspect.getsource(FactorService.calculate_factor_correlation)
+
+        assert "isinstance(factors, list)" not in get_source
+        assert "isinstance(latest_factors, list)" not in latest_source
+        assert "hasattr(factors_data" not in correlation_source
+        assert "to_dataframe') else" not in correlation_source


### PR DESCRIPTION
## Summary

- Stabilize FactorService factor query outputs as `ServiceResult.data` dictionaries.
- Remove factor-path shape duck typing: no `hasattr(..., "to_dataframe")`, no `isinstance(..., list)` count branches for factor query outputs.
- Make factor correlation consume the stable ModelList contract directly via `to_dataframe()`.
- Add unit coverage for non-empty and empty factor query/correlation paths plus a regression guard for the removed duck typing.

## Test plan

- RED check before implementation: `tests/unit/data/services/test_factor_service.py` failed on current master due old `set_data/get_data` use and factor shape duck typing.
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/services/test_factor_service.py -q -o "addopts=" --no-header --tb=short` → 5 passed
- `rg -n 'hasattr\(.*to_dataframe|isinstance\(factors, list\)|isinstance\(latest_factors, list\)|get_data\(' src/ginkgo/data/services/factor_service.py` → no matches
- `/home/kaoru/.ginkgo/.venv/bin/python -m black --check src/ginkgo/data/services/factor_service.py tests/unit/data/services/test_factor_service.py` → passed
- `git diff --check` → passed
- `/home/kaoru/.ginkgo/.venv/bin/python -m py_compile` over `src api` → passed
- startup smoke: `test_user_crud_mock.py test_containers.py test_user_cli.py` → 36 passed

Closes #6626
