### PR TITLE
fix(#6085): 组件参数端点加内置源码 fallback

### DIFF
--- a/api/api/components.py
+++ b/api/api/components.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
 from datetime import datetime
 import ast
+from pathlib import Path
 
 from ginkgo.data.containers import container
 from ginkgo.enums import FILE_TYPES
@@ -18,8 +19,10 @@ router = APIRouter()
 
 # ==================== 数据模型 ====================
 
+
 class ComponentSummary(BaseModel):
     """组件摘要"""
+
     uuid: str
     name: str
     component_type: str  # strategy, analyzer, risk, sizer, selector
@@ -32,6 +35,7 @@ class ComponentSummary(BaseModel):
 
 class ComponentDetail(BaseModel):
     """组件详情"""
+
     uuid: str
     name: str
     component_type: str
@@ -45,6 +49,7 @@ class ComponentDetail(BaseModel):
 
 class ComponentCreate(BaseModel):
     """创建组件请求"""
+
     name: str
     component_type: str  # strategy, analyzer, risk, sizer, selector
     code: str
@@ -53,6 +58,7 @@ class ComponentCreate(BaseModel):
 
 class ComponentUpdate(BaseModel):
     """更新组件请求"""
+
     name: Optional[str] = None
     code: Optional[str] = None
     description: Optional[str] = None
@@ -85,7 +91,57 @@ def get_file_service():
     return container.file_service()
 
 
+BUILTIN_COMPONENT_DIRS = {
+    "strategy": "strategies",
+    "selector": "selectors",
+    "sizer": "sizers",
+    "risk": "risk_management",
+    "analyzer": "analysis/analyzers",
+}
+
+SKIP_BUILTIN_COMPONENT_FILES = {
+    "__init__",
+    "base_analyzer",
+    "ml_strategy_base",
+    "registry",
+    "strategy_base",
+}
+
+
+def _builtin_trading_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "src" / "ginkgo" / "trading"
+
+
+def _normalize_component_name(name: str) -> str:
+    return "".join(ch for ch in str(name).lower() if ch.isalnum())
+
+
+def _iter_builtin_component_sources():
+    """Yield built-in component source files as (name, code, component_type)."""
+    trading_root = _builtin_trading_root()
+    for component_type, relative_dir in BUILTIN_COMPONENT_DIRS.items():
+        component_dir = trading_root / relative_dir
+        if not component_dir.exists():
+            continue
+        for path in sorted(component_dir.glob("*.py")):
+            if path.stem in SKIP_BUILTIN_COMPONENT_FILES:
+                continue
+            try:
+                yield path.stem, path.read_text(encoding="utf-8"), component_type
+            except OSError as e:
+                logger.warning(f"Failed to read built-in component source {path}: {e}")
+
+
+def _get_builtin_component_source(component_name: str):
+    normalized_name = _normalize_component_name(component_name)
+    for name, code, component_type in _iter_builtin_component_sources():
+        if _normalize_component_name(name) == normalized_name:
+            return name, code, component_type
+    return None
+
+
 # ==================== API路由 ====================
+
 
 @router.get("")
 async def list_components(
@@ -111,10 +167,7 @@ async def list_components(
         # 构建类型列表
         if component_type:
             if component_type not in COMPONENT_FILE_TYPE_MAP:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Invalid component type: {component_type}"
-                )
+                raise HTTPException(status_code=400, detail=f"Invalid component type: {component_type}")
             types_to_check = [COMPONENT_FILE_TYPE_MAP[component_type]]
         else:
             types_to_check = list(COMPONENT_FILE_TYPE_MAP.values())
@@ -137,23 +190,25 @@ async def list_components(
 
         items = []
         for file_record in files:
-            file_type_value = file_record.type if hasattr(file_record, 'type') else 0
+            file_type_value = file_record.type if hasattr(file_record, "type") else 0
             component_type_name = FILE_TYPE_TO_COMPONENT_TYPE.get(file_type_value, "unknown")
-            created_at = file_record.create_at if hasattr(file_record, 'create_at') else None
-            updated_at = file_record.update_at if hasattr(file_record, 'update_at') else None
+            created_at = file_record.create_at if hasattr(file_record, "create_at") else None
+            updated_at = file_record.update_at if hasattr(file_record, "update_at") else None
             if not created_at:
                 created_at = datetime.utcnow()
-            is_del = file_record.is_del if hasattr(file_record, 'is_del') else False
-            items.append({
-                "uuid": file_record.uuid,
-                "name": file_record.name,
-                "component_type": component_type_name,
-                "file_type": file_type_value,
-                "description": f"{component_type_name.capitalize()} component",
-                "created_at": created_at.isoformat(),
-                "updated_at": updated_at.isoformat() if updated_at else None,
-                "is_active": not is_del,
-            })
+            is_del = file_record.is_del if hasattr(file_record, "is_del") else False
+            items.append(
+                {
+                    "uuid": file_record.uuid,
+                    "name": file_record.name,
+                    "component_type": component_type_name,
+                    "file_type": file_type_value,
+                    "description": f"{component_type_name.capitalize()} component",
+                    "created_at": created_at.isoformat(),
+                    "updated_at": updated_at.isoformat() if updated_at else None,
+                    "is_active": not is_del,
+                }
+            )
 
         return paginated(items=items, total=total_count, page=page, page_size=page_size)
 
@@ -161,10 +216,7 @@ async def list_components(
         raise
     except Exception as e:
         logger.error(f"Error listing components: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to list components"
-        )
+        raise HTTPException(status_code=500, detail="Failed to list components")
 
 
 # ==================== 组件参数端点 ====================
@@ -179,9 +231,9 @@ async def get_all_component_parameters():
         file_service = get_file_service()
 
         list_result = file_service.list_components(page=0, page_size=10000)
-        if not list_result.is_success() or not list_result.data:
-            return ok(data={})
-        files = list_result.data.get("data", []) or []
+        files = []
+        if list_result.is_success() and list_result.data:
+            files = list_result.data.get("data", []) or []
 
         definitions: Dict[str, List[Dict[str, Any]]] = {}
         for file_record in files:
@@ -196,13 +248,17 @@ async def get_all_component_parameters():
             params = extract_component_parameters(file_record.name, code, component_type)
             if params:
                 definitions[file_record.name] = params
+
+        for name, code, component_type in _iter_builtin_component_sources():
+            if name in definitions:
+                continue
+            params = extract_component_parameters(name, code, component_type)
+            if params:
+                definitions[name] = params
         return ok(data=definitions)
     except Exception as e:
         logger.error(f"Error getting all component parameters: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to get component parameters: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to get component parameters: {str(e)}")
 
 
 @router.get("/parameters/{component_name}")
@@ -213,48 +269,37 @@ async def get_component_parameters(component_name: str):
 
         # 按文件名查 MFile（get_by_name 返回复数列表，取首条）
         name_result = file_service.get_by_name(component_name)
-        if not name_result.is_success() or not name_result.data:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component not found: {component_name}"
-            )
-        files = name_result.data.get("files", [])
-        if not files:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component not found: {component_name}"
-            )
-        file_record = files[0]
+        if name_result.is_success() and name_result.data:
+            files = name_result.data.get("files", [])
+            if files:
+                file_record = files[0]
 
-        # 读源码
-        content_result = file_service.get_content(file_record.uuid)
-        code = None
-        if content_result.is_success() and content_result.data:
-            raw = content_result.data
-            code = raw.decode("utf-8", errors="ignore") if isinstance(raw, bytes) else str(raw)
-        if not code:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component source empty: {component_name}"
-            )
+                # 读源码
+                content_result = file_service.get_content(file_record.uuid)
+                code = None
+                if content_result.is_success() and content_result.data:
+                    raw = content_result.data
+                    code = raw.decode("utf-8", errors="ignore") if isinstance(raw, bytes) else str(raw)
+                if code:
+                    # 动态提取参数（复用 /components/{uuid} 同一提取器，废弃过时硬编码表）
+                    component_type = FILE_TYPE_TO_COMPONENT_TYPE.get(file_record.type, "unknown")
+                    params = extract_component_parameters(component_name, code, component_type)
+                    if params:
+                        return ok(data=params)
 
-        # 动态提取参数（复用 /components/{uuid} 同一提取器，废弃过时硬编码表）
-        component_type = FILE_TYPE_TO_COMPONENT_TYPE.get(file_record.type, "unknown")
-        params = extract_component_parameters(component_name, code, component_type)
-        if not params:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component parameters not found: {component_name}"
-            )
-        return ok(data=params)
+        builtin_source = _get_builtin_component_source(component_name)
+        if builtin_source:
+            builtin_name, code, component_type = builtin_source
+            params = extract_component_parameters(builtin_name, code, component_type)
+            if params:
+                return ok(data=params)
+
+        raise HTTPException(status_code=404, detail=f"Component parameters not found: {component_name}")
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting component parameters for {component_name}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to get component parameters: {str(e)}"
-        )
+        raise HTTPException(status_code=500, detail=f"Failed to get component parameters: {str(e)}")
 
 
 @router.get("/{uuid}")
@@ -267,19 +312,13 @@ async def get_component(uuid: str):
         result = file_service.get_by_uuid(uuid)
 
         if not result.is_success() or not result.data:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component not found: {uuid}"
-            )
+            raise HTTPException(status_code=404, detail=f"Component not found: {uuid}")
 
         # result.data 是字典，'file' 键才是 MFile 对象
         file_record = result.data.get("file")
 
         if not file_record:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component file not found: {uuid}"
-            )
+            raise HTTPException(status_code=404, detail=f"Component file not found: {uuid}")
 
         # 处理文件类型 - MFile.type 是整数值
         file_type_value = file_record.type
@@ -291,9 +330,9 @@ async def get_component(uuid: str):
         file_data = content_result.data if content_result.is_success() else None
         if file_data:
             try:
-                code = file_data.decode('utf-8')
+                code = file_data.decode("utf-8")
             except:
-                code = file_data.decode('latin-1', errors='ignore')
+                code = file_data.decode("latin-1", errors="ignore")
 
         # 提取组件参数
         parameters = []
@@ -306,26 +345,25 @@ async def get_component(uuid: str):
         created_at = file_record.create_at if file_record.create_at else datetime.utcnow()
         updated_at = file_record.update_at if file_record.update_at else None
 
-        return ok(data={
-            "uuid": file_record.uuid,
-            "name": file_record.name,
-            "component_type": component_type,
-            "file_type": file_type_value,
-            "code": code,
-            "description": file_record.desc if file_record.desc else f"{component_type.capitalize()} component",
-            "parameters": parameters,
-            "created_at": created_at.isoformat(),
-            "updated_at": updated_at.isoformat() if updated_at else None
-        })
+        return ok(
+            data={
+                "uuid": file_record.uuid,
+                "name": file_record.name,
+                "component_type": component_type,
+                "file_type": file_type_value,
+                "code": code,
+                "description": file_record.desc if file_record.desc else f"{component_type.capitalize()} component",
+                "parameters": parameters,
+                "created_at": created_at.isoformat(),
+                "updated_at": updated_at.isoformat() if updated_at else None,
+            }
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting component {uuid}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get component"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get component")
 
 
 @router.post("")
@@ -336,10 +374,7 @@ async def create_component(data: ComponentCreate):
 
         # 获取对应的文件类型
         if data.component_type not in COMPONENT_FILE_TYPE_MAP:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Invalid component type: {data.component_type}"
-            )
+            raise HTTPException(status_code=400, detail=f"Invalid component type: {data.component_type}")
 
         file_type = COMPONENT_FILE_TYPE_MAP[data.component_type]
 
@@ -347,15 +382,12 @@ async def create_component(data: ComponentCreate):
         result = file_service.add(
             name=data.name,
             file_type=file_type,
-            data=data.code.encode('utf-8') if data.code else b'',
-            description=data.description
+            data=data.code.encode("utf-8") if data.code else b"",
+            description=data.description,
         )
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=500,
-                detail=f"Failed to create component: {result.message}"
-            )
+            raise HTTPException(status_code=500, detail=f"Failed to create component: {result.message}")
 
         # 获取创建的文件记录
         # #5885: FileService.add 返回 data={"file_info": {"uuid": ...}}，
@@ -364,10 +396,7 @@ async def create_component(data: ComponentCreate):
         file_info = result.data.get("file_info") if result.data else None
         file_uuid = file_info.get("uuid") if file_info else None
         if not file_uuid:
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to get created component UUID"
-            )
+            raise HTTPException(status_code=500, detail="Failed to get created component UUID")
 
         # 返回创建的组件详情
         return await get_component(file_uuid)
@@ -376,10 +405,7 @@ async def create_component(data: ComponentCreate):
         raise
     except Exception as e:
         logger.error(f"Error creating component: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to create component"
-        )
+        raise HTTPException(status_code=500, detail="Failed to create component")
 
 
 @router.put("/{uuid}")
@@ -391,10 +417,7 @@ async def update_component(uuid: str, data: ComponentUpdate):
         # 验证存在
         result = file_service.get_by_uuid(uuid)
         if not result.is_success() or not result.data or not result.data.get("exists"):
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component not found: {uuid}"
-            )
+            raise HTTPException(status_code=404, detail=f"Component not found: {uuid}")
 
         # 准备更新
         updates = {}
@@ -403,7 +426,7 @@ async def update_component(uuid: str, data: ComponentUpdate):
         if data.description is not None:
             updates["desc"] = data.description
         if data.code is not None:
-            updates["data"] = data.code.encode('utf-8')
+            updates["data"] = data.code.encode("utf-8")
 
         if updates:
             file_service.update(uuid, updates)
@@ -414,10 +437,7 @@ async def update_component(uuid: str, data: ComponentUpdate):
         raise
     except Exception as e:
         logger.error(f"Error updating component {uuid}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to update component"
-        )
+        raise HTTPException(status_code=500, detail="Failed to update component")
 
 
 @router.delete("/{uuid}")
@@ -430,10 +450,7 @@ async def delete_component(uuid: str):
         result = file_service.soft_delete(uuid)
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=404,
-                detail=f"Component not found or already deleted: {uuid}"
-            )
+            raise HTTPException(status_code=404, detail=f"Component not found or already deleted: {uuid}")
 
         return ok(message="Component deleted successfully")
 
@@ -441,13 +458,11 @@ async def delete_component(uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error deleting component {uuid}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to delete component"
-        )
+        raise HTTPException(status_code=500, detail="Failed to delete component")
 
 
 # ==================== 辅助函数 ====================
+
 
 def extract_component_parameters(component_name: str, code: str, component_type: str) -> List[Dict[str, Any]]:
     """
@@ -476,8 +491,8 @@ def extract_component_parameters(component_name: str, code: str, component_type:
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
                 # 查找包含component名称的类
-                class_name = node.name.lower().replace('_', '')
-                comp_name = component_name.lower().replace('_', '')
+                class_name = node.name.lower().replace("_", "")
+                comp_name = component_name.lower().replace("_", "")
                 if comp_name in class_name or class_name in comp_name:
                     component_class = node
                     break
@@ -485,13 +500,13 @@ def extract_component_parameters(component_name: str, code: str, component_type:
         # 如果没找到精确匹配，查找第一个包含组件类型关键词的类
         if not component_class:
             type_keywords = {
-                'strategy': 'strategy',
-                'selector': 'selector',
-                'sizer': 'sizer',
-                'risk': 'risk',
-                'analyzer': 'analyzer'
+                "strategy": "strategy",
+                "selector": "selector",
+                "sizer": "sizer",
+                "risk": "risk",
+                "analyzer": "analyzer",
             }
-            keyword = type_keywords.get(component_type.lower(), '')
+            keyword = type_keywords.get(component_type.lower(), "")
 
             for node in ast.walk(tree):
                 if isinstance(node, ast.ClassDef):
@@ -505,7 +520,7 @@ def extract_component_parameters(component_name: str, code: str, component_type:
         # 查找__init__方法
         init_method = None
         for node in component_class.body:
-            if isinstance(node, ast.FunctionDef) and node.name == '__init__':
+            if isinstance(node, ast.FunctionDef) and node.name == "__init__":
                 init_method = node
                 break
 
@@ -517,7 +532,7 @@ def extract_component_parameters(component_name: str, code: str, component_type:
             arg_name = arg.arg
 
             # 跳过self
-            if arg_name == 'self':
+            if arg_name == "self":
                 continue
 
             # name参数保留，确保索引与构造函数位置一致
@@ -556,7 +571,7 @@ def extract_component_parameters(component_name: str, code: str, component_type:
                 "type": param_type,
                 "default": actual_default,
                 "required": not has_default,
-                "description": f"{_format_parameter_label(arg_name)}参数"
+                "description": f"{_format_parameter_label(arg_name)}参数",
             }
 
             # 根据参数名添加额外约束
@@ -595,10 +610,7 @@ def _get_default_value(node):
         elif isinstance(node, ast.List):
             return [_get_default_value(item) for item in node.elts]
         elif isinstance(node, ast.Dict):
-            return {
-                _get_default_value(k): _get_default_value(v)
-                for k, v in zip(node.keys, node.values)
-            }
+            return {_get_default_value(k): _get_default_value(v) for k, v in zip(node.keys, node.values)}
         elif isinstance(node, ast.Call):
             return None
         return None
@@ -610,12 +622,32 @@ def _infer_parameter_type(param_name: str, default_value: Any) -> str:
     """推断参数类型"""
     # 根据参数名推断是否为数字/布尔/数组类型
     name_lower = param_name.lower()
-    is_numeric_name = any(kw in name_lower for kw in [
-        'period', 'length', 'window', 'day', 'count', 'num',
-        'volume', 'amount', 'ratio', 'percent', 'rate',
-        'limit', 'max', 'min', 'threshold', 'level',
-        'cash', 'weight', 'size', 'price', 'fee',
-    ])
+    is_numeric_name = any(
+        kw in name_lower
+        for kw in [
+            "period",
+            "length",
+            "window",
+            "day",
+            "count",
+            "num",
+            "volume",
+            "amount",
+            "ratio",
+            "percent",
+            "rate",
+            "limit",
+            "max",
+            "min",
+            "threshold",
+            "level",
+            "cash",
+            "weight",
+            "size",
+            "price",
+            "fee",
+        ]
+    )
 
     if default_value is not None:
         if isinstance(default_value, bool):
@@ -640,10 +672,10 @@ def _infer_parameter_type(param_name: str, default_value: Any) -> str:
     if is_numeric_name:
         return "number"
 
-    if any(kw in name_lower for kw in ['enable', 'disable', 'use', 'is_', 'has_']):
+    if any(kw in name_lower for kw in ["enable", "disable", "use", "is_", "has_"]):
         return "boolean"
 
-    if any(kw in name_lower for kw in ['codes', 'symbols', 'list', 'array']):
+    if any(kw in name_lower for kw in ["codes", "symbols", "list", "array"]):
         return "array"
 
     return "string"
@@ -653,46 +685,46 @@ def _format_parameter_label(param_name: str) -> str:
     """格式化参数标签（将参数名转为可读的中文或英文标签）"""
     # 常见参数名的中文映射
     label_map = {
-        'codes': '股票代码',
-        'symbols': '股票代码',
-        'volume': '数量',
-        'amount': '金额',
-        'period': '周期',
-        'length': '长度',
-        'window': '窗口',
-        'ratio': '比例',
-        'percent': '百分比',
-        'rate': '比率',
-        'count': '数量',
-        'limit': '限制',
-        'max': '最大值',
-        'min': '最小值',
-        'threshold': '阈值',
-        'level': '水平',
-        'probability': '概率',
-        'buy_probability': '买入概率',
-        'sell_probability': '卖出概率',
-        'short_period': '短期周期',
-        'long_period': '长期周期',
-        'std_dev': '标准差',
-        'overbought': '超买',
-        'oversold': '超卖',
-        'fast_period': '快线周期',
-        'slow_period': '慢线周期',
-        'signal_period': '信号周期',
-        'atr_multiplier': 'ATR倍数',
-        'risk_percent': '风险比例',
-        'loss_limit': '止损限制',
-        'profit_limit': '止盈限制',
-        'max_drawdown': '最大回撤',
-        'win_rate': '胜率',
+        "codes": "股票代码",
+        "symbols": "股票代码",
+        "volume": "数量",
+        "amount": "金额",
+        "period": "周期",
+        "length": "长度",
+        "window": "窗口",
+        "ratio": "比例",
+        "percent": "百分比",
+        "rate": "比率",
+        "count": "数量",
+        "limit": "限制",
+        "max": "最大值",
+        "min": "最小值",
+        "threshold": "阈值",
+        "level": "水平",
+        "probability": "概率",
+        "buy_probability": "买入概率",
+        "sell_probability": "卖出概率",
+        "short_period": "短期周期",
+        "long_period": "长期周期",
+        "std_dev": "标准差",
+        "overbought": "超买",
+        "oversold": "超卖",
+        "fast_period": "快线周期",
+        "slow_period": "慢线周期",
+        "signal_period": "信号周期",
+        "atr_multiplier": "ATR倍数",
+        "risk_percent": "风险比例",
+        "loss_limit": "止损限制",
+        "profit_limit": "止盈限制",
+        "max_drawdown": "最大回撤",
+        "win_rate": "胜率",
     }
 
     if param_name in label_map:
         return label_map[param_name]
 
     # 转换为驼峰命名
-    return ''.join(word.capitalize() for word in param_name.split('_'))
+    return "".join(word.capitalize() for word in param_name.split("_"))
 
 
 def _get_parameter_constraints(param_name: str, param_type: str) -> Dict[str, Any]:
@@ -703,36 +735,16 @@ def _get_parameter_constraints(param_name: str, param_type: str) -> Dict[str, An
         name_lower = param_name.lower()
 
         # 比例/百分比参数
-        if any(kw in name_lower for kw in ['ratio', 'percent', 'probability', 'rate']):
-            constraints.update({
-                'min': 0,
-                'max': 100 if 'percent' in name_lower else 1,
-                'step': 0.01,
-                'precision': 2
-            })
+        if any(kw in name_lower for kw in ["ratio", "percent", "probability", "rate"]):
+            constraints.update({"min": 0, "max": 100 if "percent" in name_lower else 1, "step": 0.01, "precision": 2})
         # 周期参数
-        elif any(kw in name_lower for kw in ['period', 'length', 'window']):
-            constraints.update({
-                'min': 1,
-                'max': 1000,
-                'step': 1,
-                'precision': 0
-            })
+        elif any(kw in name_lower for kw in ["period", "length", "window"]):
+            constraints.update({"min": 1, "max": 1000, "step": 1, "precision": 0})
         # 数量/金额参数
-        elif any(kw in name_lower for kw in ['volume', 'amount', 'count']):
-            constraints.update({
-                'min': 0,
-                'max': 1000000,
-                'step': 1,
-                'precision': 0
-            })
+        elif any(kw in name_lower for kw in ["volume", "amount", "count"]):
+            constraints.update({"min": 0, "max": 1000000, "step": 1, "precision": 0})
         else:
             # 默认数字约束
-            constraints.update({
-                'min': 0,
-                'max': 10000,
-                'step': 1,
-                'precision': 0
-            })
+            constraints.update({"min": 0, "max": 10000, "step": 1, "precision": 0})
 
     return constraints

--- a/tests/api/test_component_parameters_5408.py
+++ b/tests/api/test_component_parameters_5408.py
@@ -48,8 +48,7 @@ class TestRouteOrderNotSwallowingParameters:
             resp = client.get("/components/parameters")
 
         assert resp.status_code == 200, (
-            f"应命中 get_all_component_parameters(200)，实际 {resp.status_code} "
-            f"(疑似被 /{{uuid}} 路由吞掉)"
+            f"应命中 get_all_component_parameters(200)，实际 {resp.status_code} " f"(疑似被 /{{uuid}} 路由吞掉)"
         )
 
 
@@ -107,16 +106,8 @@ class TestDynamicExtractionFromSource:
         from fastapi.testclient import TestClient
         from api import components
 
-        code_a = (
-            "class FakeStratA:\n"
-            "    def __init__(self, fast=5):\n"
-            "        self.fast = fast\n"
-        )
-        code_b = (
-            "class FakeStratB:\n"
-            "    def __init__(self, slow=20):\n"
-            "        self.slow = slow\n"
-        )
+        code_a = "class FakeStratA:\n" "    def __init__(self, fast=5):\n" "        self.fast = fast\n"
+        code_b = "class FakeStratB:\n" "    def __init__(self, slow=20):\n" "        self.slow = slow\n"
 
         mock_file_a = MagicMock()
         mock_file_a.name = "fake_strat_a"
@@ -156,3 +147,57 @@ class TestDynamicExtractionFromSource:
         assert "fake_strat_a" in data, f"key 应为文件名，实际 {list(data.keys())}"
         assert "fake_strat_b" in data
         assert any(p["name"] == "fast" for p in data["fake_strat_a"])
+
+
+class TestBuiltinComponentParameterFallback:
+    """#6085/#5758/#5836: DB 未同步内置组件时，参数端点仍应从源码发现内置组件。"""
+
+    def test_get_all_parameters_falls_back_to_builtin_sources_when_db_empty(self):
+        """GET /components/parameters 不应在 DB 为空时返回空系统。"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api import components
+
+        mock_list_result = MagicMock()
+        mock_list_result.is_success.return_value = True
+        mock_list_result.data = {"data": [], "total": 0}
+
+        mock_fs = MagicMock()
+        mock_fs.list_components.return_value = mock_list_result
+
+        app = FastAPI()
+        app.include_router(components.router, prefix="/components")
+        client = TestClient(app)
+
+        with patch.object(components, "get_file_service", return_value=mock_fs):
+            resp = client.get("/components/parameters")
+
+        assert resp.status_code == 200, f"实际 {resp.status_code}: {resp.text}"
+        data = resp.json()["data"]
+        assert "moving_average_crossover" in data
+        assert any(p["name"] == "short_period" for p in data["moving_average_crossover"])
+
+    def test_get_builtin_parameters_by_file_name_when_db_misses(self):
+        """GET /components/parameters/{name} 应支持内置组件文件名查询。"""
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+        from api import components
+
+        mock_name_result = MagicMock()
+        mock_name_result.is_success.return_value = False
+        mock_name_result.data = None
+
+        mock_fs = MagicMock()
+        mock_fs.get_by_name.return_value = mock_name_result
+
+        app = FastAPI()
+        app.include_router(components.router, prefix="/components")
+        client = TestClient(app)
+
+        with patch.object(components, "get_file_service", return_value=mock_fs):
+            resp = client.get("/components/parameters/moving_average_crossover")
+
+        assert resp.status_code == 200, f"实际 {resp.status_code}: {resp.text}"
+        param_names = [p["name"] for p in resp.json()["data"]]
+        assert "short_period" in param_names
+        assert "long_period" in param_names


### PR DESCRIPTION
## Summary

落地伞 issue #6085 的 AC#6（built-in component parameter definitions generated from source consistently），对应已被吸收关闭的子 issue #5758 / #5836。

## Root cause

`GET /components/parameters` 与 `GET /components/parameters/{name}` 的参数发现**完全耦合于 DB MFile 同步状态**：DB 为空时 `list_components` 返回空 → 端点直接 `return ok(data={})`；单查 `get_by_name` miss → `raise 404`。内置组件源码始终存在于 `src/ginkgo/trading/`，但端点从不读源码，导致新环境/未同步场景参数系统为空，下游 `bind-component` 参数索引错配。

## Change

- 新增 `_iter_builtin_component_sources()`：遍历 `src/ginkgo/trading/{strategies,selectors,sizers,risk_management,analysis/analyzers}` 读源码（跳过 base/registry/__init__ 等非组件文件）
- `GET /components/parameters`：DB 列表为空或缺失时，fallback 到内置源码提取参数
- `GET /components/parameters/{name}`：DB miss 时 fallback 到内置源码（按文件名归一化匹配）
- 控制流扁平化：DB 命中走 DB、miss 走内置、两者都无才 404

## Test plan

- [x] RED 验证：stash 源码保留新测试 → TestBuiltinComponentParameterFallback 2 例复现 `{}` 与 404
- [x] GREEN：恢复源码 → 全文件 5 passed（原 3 + 新 2）
- [x] Layer1 py_compile src+api 通过
- [x] Layer2 启动路径 smoke：test_user_crud_mock / test_containers / test_user_cli 36 passed
- [x] Layer3 变更相关：test_component_parameters_5408.py 5 passed

## Issue 关系

本 PR 为伞 issue #6085 的 AC#6 切片，**不关闭** #6085（其余 AC：node-graph 读一致性、路由优先级、501 stub 端点等仍待后续 PR）。子 issue #5758 / #5836 已被伞吸收关闭。

> ⚠️ merge 注意：squash commit message 不得含 `#6085` 裸引用或 Refs 关键词（会误关伞 issue），标题式 `fix(#6085)` 括号格式经实测不触发关闭。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
