### PR TITLE
fix: centralize API page size max (#5566)

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -14,6 +14,7 @@ import json
 import asyncio
 
 from core.logging import logger
+from core.pagination import DEFAULT_MAX_PAGE_SIZE
 from core.redis_client import get_backtest_progress
 from core.response import ok, paginated
 from core.exceptions import APIError, NotFoundError, ValidationError, BusinessError
@@ -694,7 +695,7 @@ async def get_backtest_signals(
 async def get_backtest_orders(
     uuid: str,
     page: int = Query(1, ge=1, description="页码"),
-    page_size: int = Query(50, ge=1, le=500, description="每页数量")
+    page_size: int = Query(50, ge=1, le=DEFAULT_MAX_PAGE_SIZE, description="每页数量")
 ):
     """获取回测订单记录
 
@@ -916,7 +917,7 @@ async def get_backtest_logs(
     event_type: Optional[str] = Query(None, description="事件类型"),
     start_time: Optional[str] = Query(None, description="开始时间 (YYYY-MM-DD)"),
     end_time: Optional[str] = Query(None, description="结束时间 (YYYY-MM-DD)"),
-    limit: int = Query(100, ge=1, le=500, description="每页数量"),
+    limit: int = Query(100, ge=1, le=DEFAULT_MAX_PAGE_SIZE, description="每页数量"),
     offset: int = Query(0, ge=0, description="偏移量"),
 ):
     """获取回测任务的日志"""

--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -23,14 +23,19 @@ from ginkgo.interfaces.kafka_topics import KafkaTopics
 from ginkgo.data.containers import container
 from ginkgo.data.services.result_service import ResultService
 from ginkgo.data.services.backtest_task_schemas import (
-    BacktestTaskSummary, BacktestTaskDetail, BacktestTaskCreate,
-    AnalyzerConfig, EngineConfig, ComponentConfig,
+    BacktestTaskSummary,
+    BacktestTaskDetail,
+    BacktestTaskCreate,
+    AnalyzerConfig,
+    EngineConfig,
+    ComponentConfig,
 )
 
 router = APIRouter()
 
 
 # ==================== Service 辅助函数 ====================
+
 
 def get_backtest_task_service():
     """获取 BacktestTaskService 实例"""
@@ -66,8 +71,10 @@ def get_kafka_producer() -> GinkgoProducer:
 
 # ==================== 仅 API 层使用的模型 ====================
 
+
 class AnalyzerTypeInfo(BaseModel):
     """分析器类型信息"""
+
     name: str
     type: str
     description: str = ""
@@ -75,6 +82,7 @@ class AnalyzerTypeInfo(BaseModel):
 
 
 # ==================== Service 层操作 ====================
+
 
 def get_engine_info(engine_uuid: str) -> dict:
     """从服务层获取Engine信息"""
@@ -92,9 +100,9 @@ def get_engine_info(engine_uuid: str) -> dict:
         raise NotFoundError("Engine", engine_uuid)
 
     return {
-        "uuid": getattr(engine, 'uuid', engine_uuid),
-        "name": getattr(engine, 'name', ''),
-        "is_live": getattr(engine, 'is_live', 0),
+        "uuid": getattr(engine, "uuid", engine_uuid),
+        "name": getattr(engine, "name", ""),
+        "is_live": getattr(engine, "is_live", 0),
     }
 
 
@@ -114,8 +122,8 @@ def get_portfolio_info(portfolio_uuid: str) -> dict:
         raise NotFoundError("Portfolio", portfolio_uuid)
 
     return {
-        "uuid": getattr(portfolio, 'uuid', portfolio_uuid),
-        "name": getattr(portfolio, 'name', 'Unknown Portfolio'),
+        "uuid": getattr(portfolio, "uuid", portfolio_uuid),
+        "name": getattr(portfolio, "name", "Unknown Portfolio"),
     }
 
 
@@ -147,20 +155,24 @@ def build_backtest_config(data: BacktestTaskCreate) -> dict:
     # 添加组件配置（如果有）
     # 注：frequency 已迁移至 EngineConfig，此处不再从 component_config 映射，避免覆盖引擎权威值
     if data.component_config:
-        config.update({
-            "max_position_ratio": data.component_config.max_position_ratio,
-            "stop_loss_ratio": data.component_config.stop_loss_ratio,
-            "take_profit_ratio": data.component_config.take_profit_ratio,
-            "benchmark_return": data.component_config.benchmark_return,
-        })
+        config.update(
+            {
+                "max_position_ratio": data.component_config.max_position_ratio,
+                "stop_loss_ratio": data.component_config.stop_loss_ratio,
+                "take_profit_ratio": data.component_config.take_profit_ratio,
+                "benchmark_return": data.component_config.benchmark_return,
+            }
+        )
 
     # 如果提供了 Engine，获取其信息
     if data.engine_uuid:
         engine_info = get_engine_info(data.engine_uuid)
-        config.update({
-            "engine_uuid": data.engine_uuid,
-            "engine_name": engine_info["name"],
-        })
+        config.update(
+            {
+                "engine_uuid": data.engine_uuid,
+                "engine_name": engine_info["name"],
+            }
+        )
 
     return config
 
@@ -225,7 +237,7 @@ def create_backtest_task(data: BacktestTaskCreate) -> dict:
         "progress": 0.0,
         "engine_uuid": config.get("engine_uuid"),
         "config": config,
-        "created_at": task.created_at if hasattr(task, 'created_at') else datetime.utcnow().isoformat() + "Z",
+        "created_at": task.created_at if hasattr(task, "created_at") else datetime.utcnow().isoformat() + "Z",
         "started_at": None,
         "completed_at": None,
         "result": None,
@@ -258,9 +270,7 @@ async def send_task_to_kafka(task_uuid: str, portfolio_uuids: list, name: str, c
     # 是死代码（#5478 review P0）。False 时显式 raise，让异常进入 asyncio 通道供
     # _on_kafka_dispatch_done 捕获。
     if not result:
-        raise RuntimeError(
-            f"Kafka dispatch failed for backtest task {task_uuid}: producer.send returned False"
-        )
+        raise RuntimeError(f"Kafka dispatch failed for backtest task {task_uuid}: producer.send returned False")
 
     logger.info(f"Task {task_uuid} sent to Kafka with {len(portfolio_uuids)} portfolio(s)")
 
@@ -294,11 +304,14 @@ def _on_kafka_dispatch_done(task_uuid: str, asyncio_task: "asyncio.Future") -> N
 
 # ==================== API 路由 ====================
 
+
 @router.get("")
 async def list_backtests(
     status: Optional[str] = Query(None, description="按状态筛选"),
     portfolio_id: Optional[str] = Query(None, description="按投资组合筛选"),
-    sort_by: Optional[str] = Query(None, description="排序字段: annual_return / sharpe_ratio / max_drawdown / win_rate / created_at"),
+    sort_by: Optional[str] = Query(
+        None, description="排序字段: annual_return / sharpe_ratio / max_drawdown / win_rate / created_at"
+    ),
     sort_order: Optional[str] = Query("desc", description="排序方向: asc / desc"),
     page: int = Query(1, ge=1, description="页码"),
     page_size: int = Query(20, ge=1, le=100, description="每页数量"),
@@ -337,27 +350,31 @@ async def list_backtest_engines(
     try:
         engine_service = get_engine_service()
         # is_live=0 表示回测引擎；page 1-based → service 0-based
-        result = engine_service.get(
-            is_live=0 if not is_live else 1, page=page - 1, page_size=page_size
-        )
+        result = engine_service.get(is_live=0 if not is_live else 1, page=page - 1, page_size=page_size)
 
         if not result.is_success():
             return paginated(items=[], total=0, page=page, page_size=page_size)
 
         engines = []
-        for engine in (result.data or []):
-            engine_dict = engine if isinstance(engine, dict) else {
-                "uuid": getattr(engine, 'uuid', ''),
-                "name": getattr(engine, 'name', ''),
-                "backtest_start_date": getattr(engine, 'backtest_start_date', None),
-                "backtest_end_date": getattr(engine, 'backtest_end_date', None),
-            }
-            engines.append({
-                "uuid": engine_dict["uuid"],
-                "name": engine_dict["name"],
-                "start_date": engine_dict.get("backtest_start_date"),
-                "end_date": engine_dict.get("backtest_end_date"),
-            })
+        for engine in result.data or []:
+            engine_dict = (
+                engine
+                if isinstance(engine, dict)
+                else {
+                    "uuid": getattr(engine, "uuid", ""),
+                    "name": getattr(engine, "name", ""),
+                    "backtest_start_date": getattr(engine, "backtest_start_date", None),
+                    "backtest_end_date": getattr(engine, "backtest_end_date", None),
+                }
+            )
+            engines.append(
+                {
+                    "uuid": engine_dict["uuid"],
+                    "name": engine_dict["name"],
+                    "start_date": engine_dict.get("backtest_start_date"),
+                    "end_date": engine_dict.get("backtest_end_date"),
+                }
+            )
 
         total = result.metadata.get("total", 0)
         return paginated(items=engines, total=total, page=page, page_size=page_size)
@@ -379,9 +396,7 @@ async def cleanup_stale_engines(
     """
     try:
         engine_service = get_engine_service()
-        result = engine_service.cleanup_stale_engines(
-            is_live=0 if not is_live else 1, dry_run=dry_run
-        )
+        result = engine_service.cleanup_stale_engines(is_live=0 if not is_live else 1, dry_run=dry_run)
         if not result.is_success():
             raise BusinessError(f"清理僵尸引擎失败: {result.message}")
         return ok(data=result.data, message=result.message)
@@ -404,6 +419,7 @@ async def list_analyzers():
     try:
         # 从 AnalyzerRegistry 直接获取已注册的分析器
         from ginkgo.trading.analysis.analyzers.registry import AnalyzerRegistry
+
         registry = AnalyzerRegistry()
         count = registry.scan_builtin()
         if count > 0:
@@ -462,18 +478,18 @@ async def create_backtest(data: BacktestTaskCreate):
 
         # 2. 发送到Kafka（后台任务，不阻塞响应）
         # 使用 asyncio.create_task 让 Kafka 发送在后台运行
-        dispatch_task = asyncio.create_task(send_task_to_kafka(
-            task_uuid=task["uuid"],
-            portfolio_uuids=data.portfolio_uuids,
-            name=data.name,
-            config=task["config"],
-        ))
+        dispatch_task = asyncio.create_task(
+            send_task_to_kafka(
+                task_uuid=task["uuid"],
+                portfolio_uuids=data.portfolio_uuids,
+                name=data.name,
+                config=task["config"],
+            )
+        )
         # 派发失败（producer.send 抛异常）不再被静默吞：done_callback 记日志 +
         # 落库 failed，使任务状态可查（#5478）。lambda 用默认参数捕获当前 uuid，
         # 避免闭包在并发/多任务下捕获到漂移后的 task["uuid"]。
-        dispatch_task.add_done_callback(
-            lambda t, _uuid=task["uuid"]: _on_kafka_dispatch_done(_uuid, t)
-        )
+        dispatch_task.add_done_callback(lambda t, _uuid=task["uuid"]: _on_kafka_dispatch_done(_uuid, t))
 
         # 立即返回响应，不等待 Kafka
         return ok(data=task, message="Backtest task created successfully")
@@ -505,8 +521,9 @@ async def start_backtest(uuid: str):
             raise BusinessError(f"Failed to start task: {result.error}")
 
         task_id = result.data.get("task_id", uuid) if isinstance(result.data, dict) else uuid
-        return ok(data={"uuid": uuid, "task_id": task_id, "state": "PENDING"},
-                  message="Backtest task started successfully")
+        return ok(
+            data={"uuid": uuid, "task_id": task_id, "state": "PENDING"}, message="Backtest task started successfully"
+        )
 
     except NotFoundError:
         raise
@@ -535,8 +552,10 @@ async def stop_backtest(uuid: str):
         if not result.is_success():
             raise BusinessError(f"Failed to stop task: {result.error}")
 
-        return ok(data={"uuid": uuid, "task_id": result.data.get("task_id"), "status": "stopped"},
-                  message="Backtest task stopped successfully")
+        return ok(
+            data={"uuid": uuid, "task_id": result.data.get("task_id"), "status": "stopped"},
+            message="Backtest task stopped successfully",
+        )
 
     except NotFoundError:
         raise
@@ -565,8 +584,10 @@ async def cancel_backtest(uuid: str):
         if not result.is_success():
             raise BusinessError(f"Failed to cancel task: {result.error}")
 
-        return ok(data={"uuid": uuid, "task_id": result.data.get("task_id"), "status": "stopped"},
-                  message="Backtest task cancelled successfully")
+        return ok(
+            data={"uuid": uuid, "task_id": result.data.get("task_id"), "status": "stopped"},
+            message="Backtest task cancelled successfully",
+        )
 
     except NotFoundError:
         raise
@@ -668,7 +689,7 @@ async def backtest_events(uuid: str):
 async def get_backtest_signals(
     uuid: str,
     page: int = Query(1, ge=1, description="页码"),
-    page_size: int = Query(100, ge=1, le=1000, description="每页数量")
+    page_size: int = Query(100, ge=1, le=1000, description="每页数量"),
 ):
     """获取回测信号记录"""
     try:
@@ -676,13 +697,19 @@ async def get_backtest_signals(
         result = task_service.list_signals(uuid, page=page, page_size=page_size)
 
         if not result.is_success():
-            return paginated(items=[], total=0, page=page, page_size=page_size,
-                             message=result.error or "Failed to retrieve signals")
+            return paginated(
+                items=[], total=0, page=page, page_size=page_size, message=result.error or "Failed to retrieve signals"
+            )
 
         items = result.data
         total = result.metadata.get("total", 0)
-        return paginated(items=[s.dict() for s in items], total=total, page=page, page_size=page_size,
-                         message="Signals retrieved successfully")
+        return paginated(
+            items=[s.dict() for s in items],
+            total=total,
+            page=page,
+            page_size=page_size,
+            message="Signals retrieved successfully",
+        )
 
     except NotFoundError:
         raise
@@ -695,7 +722,7 @@ async def get_backtest_signals(
 async def get_backtest_orders(
     uuid: str,
     page: int = Query(1, ge=1, description="页码"),
-    page_size: int = Query(50, ge=1, le=DEFAULT_MAX_PAGE_SIZE, description="每页数量")
+    page_size: int = Query(50, ge=1, le=DEFAULT_MAX_PAGE_SIZE, description="每页数量"),
 ):
     """获取回测订单记录
 
@@ -708,14 +735,19 @@ async def get_backtest_orders(
         result = task_service.list_orders(uuid, page=page, page_size=page_size)
 
         if not result.is_success():
-            return paginated(items=[], total=0, page=page, page_size=page_size,
-                             message=result.error or "Failed to retrieve orders")
+            return paginated(
+                items=[], total=0, page=page, page_size=page_size, message=result.error or "Failed to retrieve orders"
+            )
 
         items = result.data
         total = result.metadata.get("total", 0)
-        return paginated(items=[o.dict() for o in items], total=total,
-                         page=page, page_size=page_size,
-                         message="Orders retrieved successfully")
+        return paginated(
+            items=[o.dict() for o in items],
+            total=total,
+            page=page,
+            page_size=page_size,
+            message="Orders retrieved successfully",
+        )
 
     except NotFoundError:
         raise
@@ -736,14 +768,17 @@ async def get_backtest_order_records(uuid: str):
         result = task_service.list_order_records(uuid)
 
         if not result.is_success():
-            return paginated(items=[], total=0,
-                             message=result.error or "Failed to retrieve order records")
+            return paginated(items=[], total=0, message=result.error or "Failed to retrieve order records")
 
         items = result.data
         total = result.metadata.get("total", 0)
-        return paginated(items=[o.dict() for o in items], total=total,
-                         page=1, page_size=max(total, 1),
-                         message="Order records retrieved successfully")
+        return paginated(
+            items=[o.dict() for o in items],
+            total=total,
+            page=1,
+            page_size=max(total, 1),
+            message="Order records retrieved successfully",
+        )
 
     except NotFoundError:
         raise
@@ -764,14 +799,17 @@ async def get_backtest_fills(uuid: str):
         result = task_service.list_fills(uuid)
 
         if not result.is_success():
-            return paginated(items=[], total=0,
-                             message=result.error or "Failed to retrieve fills")
+            return paginated(items=[], total=0, message=result.error or "Failed to retrieve fills")
 
         items = result.data
         total = result.metadata.get("total", 0)
-        return paginated(items=[o.dict() for o in items], total=total,
-                         page=1, page_size=max(total, 1),
-                         message="Fills retrieved successfully")
+        return paginated(
+            items=[o.dict() for o in items],
+            total=total,
+            page=1,
+            page_size=max(total, 1),
+            message="Fills retrieved successfully",
+        )
 
     except NotFoundError:
         raise
@@ -807,14 +845,17 @@ async def get_backtest_positions(uuid: str):
         result = task_service.list_positions(uuid)
 
         if not result.is_success():
-            return paginated(items=[], total=0,
-                             message=result.error or "Failed to retrieve positions")
+            return paginated(items=[], total=0, message=result.error or "Failed to retrieve positions")
 
         items = result.data
         total = result.metadata.get("total", 0)
-        return paginated(items=[p.dict() for p in items], total=total,
-                         page=1, page_size=max(total, 1),
-                         message="Positions retrieved successfully")
+        return paginated(
+            items=[p.dict() for p in items],
+            total=total,
+            page=1,
+            page_size=max(total, 1),
+            message="Positions retrieved successfully",
+        )
 
     except NotFoundError:
         raise
@@ -834,8 +875,7 @@ async def get_backtest_netvalue(uuid: str):
             return ok(data={"strategy": [], "benchmark": []}, message="No net value data")
 
         nv = result.data
-        return ok(data={"strategy": [p.dict() for p in nv.strategy], "benchmark": []},
-                  message="Net value retrieved")
+        return ok(data={"strategy": [p.dict() for p in nv.strategy], "benchmark": []}, message="Net value retrieved")
 
     except NotFoundError:
         raise
@@ -865,10 +905,7 @@ async def get_backtest_analyzers(uuid: str):
 
 
 @router.get("/{uuid}/analyzer/{analyzer_name}")
-async def get_backtest_analyzer_data(
-    uuid: str,
-    analyzer_name: str
-):
+async def get_backtest_analyzer_data(uuid: str, analyzer_name: str):
     """获取回测分析器时序数据和统计信息。
 
     #5847: 指标名为准。权威白名单取自该回测实际产出的指标名
@@ -886,8 +923,7 @@ async def get_backtest_analyzer_data(
         if analyzer_name not in available:
             names = ", ".join(available) if available else "(无)"
             raise APIError(
-                f"Analyzer '{analyzer_name}' not found. "
-                f"Available analyzers: {names}",
+                f"Analyzer '{analyzer_name}' not found. " f"Available analyzers: {names}",
                 code=404,
                 status_code=status.HTTP_404_NOT_FOUND,
             )
@@ -898,8 +934,10 @@ async def get_backtest_analyzer_data(
             return ok(data={"data": [], "stats": None}, message="No analyzer data found")
 
         detail = result.data
-        return ok(data={"data": [p.dict() for p in detail.data], "stats": detail.stats},
-                  message="Analyzer data retrieved successfully")
+        return ok(
+            data={"data": [p.dict() for p in detail.data], "stats": detail.stats},
+            message="Analyzer data retrieved successfully",
+        )
 
     except NotFoundError:
         raise
@@ -928,10 +966,11 @@ async def get_backtest_logs(
             raise NotFoundError("BacktestTask", uuid)
 
         task = task_result.data
-        task_id = getattr(task, 'task_id', None)
-        portfolio_id = getattr(task, 'portfolio_id', None)
+        task_id = getattr(task, "task_id", None)
+        portfolio_id = getattr(task, "portfolio_id", None)
 
         from ginkgo.services.logging.containers import LoggingContainer
+
         logging_container = LoggingContainer()
         log_service = logging_container.log_service()
 
@@ -945,15 +984,16 @@ async def get_backtest_logs(
         )
 
         if start_time:
-            kwargs['start_time'] = datetime.strptime(start_time, "%Y-%m-%d")
+            kwargs["start_time"] = datetime.strptime(start_time, "%Y-%m-%d")
         if end_time:
-            kwargs['end_time'] = datetime.strptime(end_time + " 23:59:59", "%Y-%m-%d %H:%M:%S")
+            kwargs["end_time"] = datetime.strptime(end_time + " 23:59:59", "%Y-%m-%d %H:%M:%S")
 
         logs = log_service.query_backtest_logs(**kwargs)
         total = log_service.get_log_count(log_type="backtest", task_id=task_id, level=level)
 
-        return ok(data={"logs": logs, "total": total, "limit": limit, "offset": offset},
-                  message="Logs retrieved successfully")
+        return ok(
+            data={"logs": logs, "total": total, "limit": limit, "offset": offset}, message="Logs retrieved successfully"
+        )
 
     except NotFoundError:
         raise

--- a/api/api/data.py
+++ b/api/api/data.py
@@ -31,6 +31,7 @@ MARKET_ID_TO_NAME = {
 
 class StockInfoSummary(BaseModel):
     """股票信息摘要"""
+
     uuid: str
     code: str
     name: Optional[str] = None
@@ -42,6 +43,7 @@ class StockInfoSummary(BaseModel):
 
 class BarDataSummary(BaseModel):
     """K线数据摘要"""
+
     uuid: str
     code: str
     date: str
@@ -56,6 +58,7 @@ class BarDataSummary(BaseModel):
 
 class TickDataSummary(BaseModel):
     """Tick数据摘要"""
+
     uuid: str
     code: str
     timestamp: str
@@ -66,6 +69,7 @@ class TickDataSummary(BaseModel):
 
 class AdjustFactorSummary(BaseModel):
     """复权因子摘要"""
+
     uuid: str
     code: str
     timestamp: str
@@ -76,6 +80,7 @@ class AdjustFactorSummary(BaseModel):
 
 class DataStats(BaseModel):
     """数据统计"""
+
     total_stocks: int
     total_bars: int
     total_ticks: int = 0
@@ -91,6 +96,7 @@ class DataUpdateRequest(BaseModel):
     #5784: 同时接受单数 code (str) 与复数 codes (list)。
     单数 code 归一化为 codes=[code]，三种 sync 分支统一消费 codes。
     """
+
     type: str  # stockinfo, bars, ticks, adjustfactor
     code: Optional[str] = None
     codes: Optional[List[str]] = None
@@ -107,6 +113,7 @@ class DataUpdateRequest(BaseModel):
 
 class DataSource(BaseModel):
     """数据源"""
+
     name: str
     enabled: bool
     description: str
@@ -114,6 +121,7 @@ class DataSource(BaseModel):
 
 
 # ==================== 辅助函数 ====================
+
 
 def get_stockinfo_service():
     """获取StockinfoService实例"""
@@ -141,6 +149,7 @@ def get_sync_record_service():
 
 
 # ==================== API路由 ====================
+
 
 @router.get("/stats")
 async def get_data_stats():
@@ -171,22 +180,22 @@ async def get_data_stats():
         tick_count_result = tick_service.count_all()
         total_ticks = tick_count_result.data if tick_count_result.is_success() else 0
 
-        return ok(data={
-            "total_stocks": total_stocks,
-            "total_bars": total_bars,
-            "total_ticks": total_ticks,
-            "total_adjust_factors": total_adjust_factors,
-            "tick_data_summary": tick_data_summary,
-            "data_sources": ["Tushare", "Yahoo", "BaoStock", "TDX"],
-            "latest_update": datetime.utcnow().isoformat()
-        })
+        return ok(
+            data={
+                "total_stocks": total_stocks,
+                "total_bars": total_bars,
+                "total_ticks": total_ticks,
+                "total_adjust_factors": total_adjust_factors,
+                "tick_data_summary": tick_data_summary,
+                "data_sources": ["Tushare", "Yahoo", "BaoStock", "TDX"],
+                "latest_update": datetime.utcnow().isoformat(),
+            }
+        )
 
     except Exception as e:
         logger.error(f"Error getting data stats: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get data stats"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get data stats")
+
 
 async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: int = 10) -> Dict[str, Any]:
     """
@@ -205,17 +214,19 @@ async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: in
             # 限制抽样检查数量，最多5只，避免超时
             check_limit = min(5, len(stocks_result.data))
             for stock in list(stocks_result.data)[:check_limit]:
-                code = stock.code if hasattr(stock, 'code') else None
+                code = stock.code if hasattr(stock, "code") else None
                 if code:
                     try:
                         # 查询该股票的tick数据量（添加超时保护）
                         tick_count_result = tick_service.count(code=code)
                         if tick_count_result.is_success() and tick_count_result.data and tick_count_result.data > 0:
-                            stocks_with_ticks.append({
-                                "code": code,
-                                "name": stock.code_name if hasattr(stock, 'code_name') else "",
-                                "tick_count": tick_count_result.data
-                            })
+                            stocks_with_ticks.append(
+                                {
+                                    "code": code,
+                                    "name": stock.code_name if hasattr(stock, "code_name") else "",
+                                    "tick_count": tick_count_result.data,
+                                }
+                            )
                             total_sampled_ticks += tick_count_result.data
                     except Exception as e:
                         logger.warning(f"Failed to get tick count for {code}: {e}")
@@ -229,16 +240,11 @@ async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: in
             "sample_size": check_limit if stocks_result.is_success() else sample_size,
             "total_sampled_ticks": total_sampled_ticks,
             "top_stocks": top_ticks,
-            "note": "Tick数据按股票分表存储，显示为抽样统计结果"
+            "note": "Tick数据按股票分表存储，显示为抽样统计结果",
         }
     except Exception as e:
         logger.error(f"Error getting tick data summary: {e}")
-        return {
-            "stocks_with_tick_data": 0,
-            "sample_size": sample_size,
-            "total_sampled_ticks": 0,
-            "top_stocks": []
-        }
+        return {"stocks_with_tick_data": 0, "sample_size": sample_size, "total_sampled_ticks": 0, "top_stocks": []}
 
 
 @router.get("/stockinfo")
@@ -246,7 +252,7 @@ async def get_stockinfo(
     search: Optional[str] = None,
     page: int = 1,
     page_size: int = Query(default=50, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
-    limit: Optional[int] = None
+    limit: Optional[int] = None,
 ):
     """获取股票信息列表（分页，搜索下推到DB层）
 
@@ -278,9 +284,7 @@ async def get_stockinfo(
             total_count = count_result.data if count_result.is_success() else 0
 
             result = stockinfo_service.get(
-                limit=effective_page_size,
-                offset=(page - 1) * effective_page_size,
-                order_by="code"
+                limit=effective_page_size, offset=(page - 1) * effective_page_size, order_by="code"
             )
 
             if not result.is_success() or not result.data:
@@ -290,36 +294,35 @@ async def get_stockinfo(
 
         stock_summaries = []
         for stock in items:
-            code = stock.code if hasattr(stock, 'code') else ""
-            code_name = stock.code_name if hasattr(stock, 'code_name') else ""
-            market_value = stock.market if hasattr(stock, 'market') else None
-            is_del = stock.is_del if hasattr(stock, 'is_del') else False
-            industry = stock.industry if hasattr(stock, 'industry') else None
-            uuid_val = stock.uuid if hasattr(stock, 'uuid') else ""
-            update_at = stock.update_at if hasattr(stock, 'update_at') else None
+            code = stock.code if hasattr(stock, "code") else ""
+            code_name = stock.code_name if hasattr(stock, "code_name") else ""
+            market_value = stock.market if hasattr(stock, "market") else None
+            is_del = stock.is_del if hasattr(stock, "is_del") else False
+            industry = stock.industry if hasattr(stock, "industry") else None
+            uuid_val = stock.uuid if hasattr(stock, "uuid") else ""
+            update_at = stock.update_at if hasattr(stock, "update_at") else None
 
             code_str = str(code) if code is not None else ""
             name_str = str(code_name) if code_name is not None else ""
             market_str = MARKET_ID_TO_NAME.get(market_value) if market_value is not None else None
 
-            stock_summaries.append({
-                "uuid": uuid_val,
-                "code": code_str,
-                "name": name_str if name_str else None,
-                "market": market_str,
-                "industry": industry,
-                "is_active": not is_del,
-                "updated_at": update_at.isoformat() if update_at else None
-            })
+            stock_summaries.append(
+                {
+                    "uuid": uuid_val,
+                    "code": code_str,
+                    "name": name_str if name_str else None,
+                    "market": market_str,
+                    "industry": industry,
+                    "is_active": not is_del,
+                    "updated_at": update_at.isoformat() if update_at else None,
+                }
+            )
 
         return paginated(items=stock_summaries, total=total_count, page=page, page_size=effective_page_size)
 
     except Exception as e:
         logger.error(f"Error getting stockinfo: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get stock info"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get stock info")
 
 
 def _normalize_bar_code(code: Optional[str]) -> str:
@@ -372,6 +375,7 @@ async def get_bars(
         # 未提供日期范围时，默认查询最近1年数据
         if not start_dt and not end_dt:
             from datetime import timedelta
+
             end_dt = datetime.utcnow()
             start_dt = end_dt - timedelta(days=365)
 
@@ -403,51 +407,52 @@ async def get_bars(
             page=page - 1,  # Service层page是0-based
             page_size=page_size,
             order_by="timestamp",
-            desc_order=desc_order
+            desc_order=desc_order,
         )
 
         if not result.is_success() or not result.data:
             # items 空仍返回真实 DB total，前端可据此判断其他页有数据（#5689）
             return paginated(
-                items=[], total=db_total if db_total is not None else 0,
-                page=page, page_size=page_size,
+                items=[],
+                total=db_total if db_total is not None else 0,
+                page=page,
+                page_size=page_size,
             )
 
         # 处理返回的数据
         # bar_service.get() 返回裸 list[MBar]（无 to_entities）；
         # ModelList 容器走 to_entities()，裸 list 本身即 entities 列表
         bars_data = result.data
-        bars_list = bars_data.to_entities() if hasattr(bars_data, 'to_entities') else bars_data
+        bars_list = bars_data.to_entities() if hasattr(bars_data, "to_entities") else bars_data
 
         bar_summaries = []
         for bar in bars_list:
-            bar_summaries.append({
-                "uuid": bar.uuid if hasattr(bar, 'uuid') else "",
-                "code": str(bar.code) if hasattr(bar, 'code') else "",
-                "date": bar.timestamp.isoformat() if hasattr(bar, 'timestamp') and bar.timestamp else "",
-                "period": "day",
-                "open": float(bar.open) if hasattr(bar, 'open') else 0.0,
-                "high": float(bar.high) if hasattr(bar, 'high') else 0.0,
-                "low": float(bar.low) if hasattr(bar, 'low') else 0.0,
-                "close": float(bar.close) if hasattr(bar, 'close') else 0.0,
-                "volume": float(bar.volume) if hasattr(bar, 'volume') else 0.0,
-                "amount": float(bar.amount) if hasattr(bar, 'amount') and bar.amount else None
-            })
+            bar_summaries.append(
+                {
+                    "uuid": bar.uuid if hasattr(bar, "uuid") else "",
+                    "code": str(bar.code) if hasattr(bar, "code") else "",
+                    "date": bar.timestamp.isoformat() if hasattr(bar, "timestamp") and bar.timestamp else "",
+                    "period": "day",
+                    "open": float(bar.open) if hasattr(bar, "open") else 0.0,
+                    "high": float(bar.high) if hasattr(bar, "high") else 0.0,
+                    "low": float(bar.low) if hasattr(bar, "low") else 0.0,
+                    "close": float(bar.close) if hasattr(bar, "close") else 0.0,
+                    "volume": float(bar.volume) if hasattr(bar, "volume") else 0.0,
+                    "amount": float(bar.amount) if hasattr(bar, "amount") and bar.amount else None,
+                }
+            )
 
         return paginated(
             items=bar_summaries,
             # #5689: total=DB count（与 page_size 解耦）；count 失败降级为当前页条数
             total=db_total if db_total is not None else len(bar_summaries),
             page=page,
-            page_size=page_size
+            page_size=page_size,
         )
 
     except Exception as e:
         logger.error(f"Error getting bars: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get bars"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get bars")
 
 
 @router.get("/ticks")
@@ -457,7 +462,7 @@ async def get_ticks(
     end_date: Optional[str] = None,
     page: int = 1,
     page_size: int = Query(default=100, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
-    limit: Optional[int] = None  # #5621: 显式约束返回条数，未传沿用 page_size
+    limit: Optional[int] = None,  # #5621: 显式约束返回条数，未传沿用 page_size
 ):
     """获取Tick数据列表（分页）
 
@@ -469,10 +474,7 @@ async def get_ticks(
 
         # Tick数据需要code参数
         if not code:
-            raise HTTPException(
-                status_code=400,
-                detail="Code is required for ticks data"
-            )
+            raise HTTPException(status_code=400, detail="Code is required for ticks data")
 
         # 将字符串日期转换为datetime
         start_dt = datetime.fromisoformat(start_date) if start_date else None
@@ -503,45 +505,39 @@ async def get_ticks(
         else:
             ticks_data = result_data
 
-        ticks_list = ticks_data.to_entities() if hasattr(ticks_data, 'to_entities') else []
+        ticks_list = ticks_data.to_entities() if hasattr(ticks_data, "to_entities") else []
 
         tick_summaries = []
         for tick in ticks_list:
             # 处理direction字段：可能是枚举类型或整数
             direction_value = 0
-            if hasattr(tick, 'direction'):
+            if hasattr(tick, "direction"):
                 dir_val = tick.direction
-                if hasattr(dir_val, 'value'):
+                if hasattr(dir_val, "value"):
                     direction_value = dir_val.value
-                elif hasattr(dir_val, 'to_int'):
+                elif hasattr(dir_val, "to_int"):
                     direction_value = dir_val.to_int()
                 else:
                     direction_value = int(dir_val) if dir_val is not None else 0
 
-            tick_summaries.append({
-                "uuid": tick.uuid if hasattr(tick, 'uuid') else "",
-                "code": code,
-                "timestamp": tick.timestamp.isoformat() if hasattr(tick, 'timestamp') and tick.timestamp else "",
-                "price": float(tick.price) if hasattr(tick, 'price') else 0.0,
-                "volume": int(tick.volume) if hasattr(tick, 'volume') else 0,
-                "direction": direction_value
-            })
+            tick_summaries.append(
+                {
+                    "uuid": tick.uuid if hasattr(tick, "uuid") else "",
+                    "code": code,
+                    "timestamp": tick.timestamp.isoformat() if hasattr(tick, "timestamp") and tick.timestamp else "",
+                    "price": float(tick.price) if hasattr(tick, "price") else 0.0,
+                    "volume": int(tick.volume) if hasattr(tick, "volume") else 0,
+                    "direction": direction_value,
+                }
+            )
 
-        return paginated(
-            items=tick_summaries,
-            total=total_count,
-            page=page,
-            page_size=effective_page_size
-        )
+        return paginated(items=tick_summaries, total=total_count, page=page, page_size=effective_page_size)
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting ticks: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get ticks"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get ticks")
 
 
 @router.get("/adjustfactors")
@@ -550,7 +546,7 @@ async def get_adjust_factors(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=100, ge=1, le=DEFAULT_MAX_PAGE_SIZE)
+    page_size: int = Query(default=100, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
 ):
     """获取复权因子列表（分页）"""
     try:
@@ -581,35 +577,31 @@ async def get_adjust_factors(
         else:
             factors_data = result_data
 
-        if hasattr(factors_data, 'to_entities'):
+        if hasattr(factors_data, "to_entities"):
             factors_list = factors_data.to_entities()
         else:
             factors_list = list(factors_data) if factors_data else []
 
         factor_summaries = []
         for factor in factors_list:
-            factor_summaries.append({
-                "uuid": factor.uuid if hasattr(factor, 'uuid') else "",
-                "code": str(factor.code) if hasattr(factor, 'code') else "",
-                "timestamp": factor.timestamp.isoformat() if hasattr(factor, 'timestamp') and factor.timestamp else "",
-                "foreadjustfactor": float(factor.foreadjustfactor) if hasattr(factor, 'foreadjustfactor') else 1.0,
-                "backadjustfactor": float(factor.backadjustfactor) if hasattr(factor, 'backadjustfactor') else 1.0,
-                "adjustfactor": float(factor.adjustfactor) if hasattr(factor, 'adjustfactor') else 1.0,
-            })
+            factor_summaries.append(
+                {
+                    "uuid": factor.uuid if hasattr(factor, "uuid") else "",
+                    "code": str(factor.code) if hasattr(factor, "code") else "",
+                    "timestamp": (
+                        factor.timestamp.isoformat() if hasattr(factor, "timestamp") and factor.timestamp else ""
+                    ),
+                    "foreadjustfactor": float(factor.foreadjustfactor) if hasattr(factor, "foreadjustfactor") else 1.0,
+                    "backadjustfactor": float(factor.backadjustfactor) if hasattr(factor, "backadjustfactor") else 1.0,
+                    "adjustfactor": float(factor.adjustfactor) if hasattr(factor, "adjustfactor") else 1.0,
+                }
+            )
 
-        return paginated(
-            items=factor_summaries,
-            total=total_count,
-            page=page,
-            page_size=page_size
-        )
+        return paginated(items=factor_summaries, total=total_count, page=page, page_size=page_size)
 
     except Exception as e:
         logger.error(f"Error getting adjust factors: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get adjust factors"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get adjust factors")
 
 
 def _aggregate_dsr_list(dsrs):
@@ -620,18 +612,19 @@ def _aggregate_dsr_list(dsrs):
     避免批量真实成功落入 else 被误降 partial，同时补齐 master 既有的统计丢失。
     """
     from ginkgo.libs.data.results.data_sync_result import DataSyncResult
+
     aggregated_errors = []
     for d in dsrs:
-        aggregated_errors.extend(getattr(d, 'errors', None) or [])
+        aggregated_errors.extend(getattr(d, "errors", None) or [])
     return DataSyncResult(
         entity_type="batch",
         entity_identifier=f"multiple({len(dsrs)})",
         sync_range=(None, None),
-        records_processed=sum(getattr(d, 'records_processed', 0) for d in dsrs),
-        records_added=sum(getattr(d, 'records_added', 0) for d in dsrs),
-        records_updated=sum(getattr(d, 'records_updated', 0) for d in dsrs),
-        records_skipped=sum(getattr(d, 'records_skipped', 0) for d in dsrs),
-        records_failed=sum(getattr(d, 'records_failed', 0) for d in dsrs),
+        records_processed=sum(getattr(d, "records_processed", 0) for d in dsrs),
+        records_added=sum(getattr(d, "records_added", 0) for d in dsrs),
+        records_updated=sum(getattr(d, "records_updated", 0) for d in dsrs),
+        records_skipped=sum(getattr(d, "records_skipped", 0) for d in dsrs),
+        records_failed=sum(getattr(d, "records_failed", 0) for d in dsrs),
         sync_duration=0.0,
         is_idempotent=True,
         sync_strategy="batch",
@@ -645,18 +638,18 @@ def _record_sync_result(service, record_uuid: str, result, started_at: float):
     if result is None:
         service.record_fail(uuid=record_uuid, error_message="sync method returned None")
         return
-    if hasattr(result, 'is_success') and result.is_success() and result.data:
+    if hasattr(result, "is_success") and result.is_success() and result.data:
         dsr = result.data
         # #6217: sync_batch 返回 List[DataSyncResult]（adjustfactor 批量），聚合为
         # 单一统计视图后走统一四态决策，避免 list 落入 else 被误降 partial。
         if isinstance(dsr, list):
             dsr = _aggregate_dsr_list(dsr)
-        if hasattr(dsr, 'records_processed'):
+        if hasattr(dsr, "records_processed"):
             # #5450: 检测 service 层标记的带 reason 的成功语义（如 already_up_to_date）。
             # 此时 records_processed=0/skipped=0，旧 #5893 逻辑会误判 partial；但"数据已最新"
             # 属 success。把 result.message 透传到 error_message（model 唯一 Text 字段，
             # get_history 端到端返回），不加 schema 字段避免 DB 安全阀。验收标准 2 端到端。
-            _meta = getattr(dsr, 'metadata', None)
+            _meta = getattr(dsr, "metadata", None)
             _reason = _meta.get("reason", "") if isinstance(_meta, dict) else ""
             if _reason:
                 service.record_complete(
@@ -667,8 +660,8 @@ def _record_sync_result(service, record_uuid: str, result, started_at: float):
                     records_added=dsr.records_added,
                     records_updated=dsr.records_updated,
                     records_failed=dsr.records_failed,
-                    sync_strategy=getattr(dsr, 'sync_strategy', ''),
-                    error_message=getattr(result, 'message', '') or f"已是最新 ({_reason})",
+                    sync_strategy=getattr(dsr, "sync_strategy", ""),
+                    error_message=getattr(result, "message", "") or f"已是最新 ({_reason})",
                 )
                 return
             # #5893: success 仅当无错误且有产出（processed>0）或幂等跳过（skipped>0）；
@@ -684,13 +677,13 @@ def _record_sync_result(service, record_uuid: str, result, started_at: float):
                 records_added=dsr.records_added,
                 records_updated=dsr.records_updated,
                 records_failed=dsr.records_failed,
-                sync_strategy=getattr(dsr, 'sync_strategy', ''),
+                sync_strategy=getattr(dsr, "sync_strategy", ""),
             )
         else:
             # #5893: 成功但无 records_processed 统计，无法判断产出，报 partial
             service.record_complete(uuid=record_uuid, status="partial", duration_ms=duration_ms)
-    elif hasattr(result, 'is_success') and not result.is_success():
-        service.record_fail(uuid=record_uuid, error_message=getattr(result, 'message', 'Unknown error'))
+    elif hasattr(result, "is_success") and not result.is_success():
+        service.record_fail(uuid=record_uuid, error_message=getattr(result, "message", "Unknown error"))
     else:
         # #5893: result 无 is_success 方法，无法判断成败，报 partial
         service.record_complete(uuid=record_uuid, status="partial", duration_ms=duration_ms)
@@ -742,7 +735,7 @@ async def sync_data(request: DataUpdateRequest):
                     raise HTTPException(
                         status_code=400,
                         detail="No stockinfo records to sync; run stockinfo sync first "
-                               "(POST /api/v1/data/sync {\"type\":\"stockinfo\"})",
+                        '(POST /api/v1/data/sync {"type":"stockinfo"})',
                     )
             if not codes:
                 raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for bars update")
@@ -762,8 +755,14 @@ async def sync_data(request: DataUpdateRequest):
                         sync_svc.record_fail(uuid=rec.data["uuid"], error_message=str(e))
 
             return ok(
-                data={"type": "bars", "codes": codes, "total": len(codes), "failed": failed, "success_count": len(codes) - failed},
-                message=f"Bars update completed for {len(codes)} codes" + (f" ({failed} failed)" if failed else "")
+                data={
+                    "type": "bars",
+                    "codes": codes,
+                    "total": len(codes),
+                    "failed": failed,
+                    "success_count": len(codes) - failed,
+                },
+                message=f"Bars update completed for {len(codes)} codes" + (f" ({failed} failed)" if failed else ""),
             )
 
         elif request.type == "ticks":
@@ -789,8 +788,14 @@ async def sync_data(request: DataUpdateRequest):
                         sync_svc.record_fail(uuid=rec.data["uuid"], error_message=str(e))
 
             return ok(
-                data={"type": "ticks", "codes": codes, "total": len(codes), "failed": failed, "success_count": len(codes) - failed},
-                message=f"Ticks update completed for {len(codes)} codes" + (f" ({failed} failed)" if failed else "")
+                data={
+                    "type": "ticks",
+                    "codes": codes,
+                    "total": len(codes),
+                    "failed": failed,
+                    "success_count": len(codes) - failed,
+                },
+                message=f"Ticks update completed for {len(codes)} codes" + (f" ({failed} failed)" if failed else ""),
             )
 
         elif request.type in ("adjustfactor", "adjustfactors"):
@@ -798,7 +803,9 @@ async def sync_data(request: DataUpdateRequest):
             sync_type = "adjustfactor"
             codes = request.codes or []
             if not codes:
-                raise HTTPException(status_code=400, detail="codes (list of stock codes) is required for adjust factors update")
+                raise HTTPException(
+                    status_code=400, detail="codes (list of stock codes) is required for adjust factors update"
+                )
 
             adjustfactor_service = get_adjustfactor_service()
             # 批量同步复权因子，整体记录
@@ -830,7 +837,7 @@ async def sync_data(request: DataUpdateRequest):
 
             return ok(
                 data={"type": "adjustfactor", "codes": codes},
-                message=f"Adjust factors update completed for {len(codes)} codes"
+                message=f"Adjust factors update completed for {len(codes)} codes",
             )
 
         else:
@@ -879,37 +886,14 @@ async def get_data_sources():
     try:
         # 返回可用的数据源及其状态
         sources = [
-            {
-                "name": "Tushare",
-                "enabled": True,
-                "description": "中国金融数据接口",
-                "status": "active"
-            },
-            {
-                "name": "Yahoo",
-                "enabled": True,
-                "description": "Yahoo Finance数据",
-                "status": "active"
-            },
-            {
-                "name": "BaoStock",
-                "enabled": True,
-                "description": "免费证券数据平台",
-                "status": "active"
-            },
-            {
-                "name": "TDX",
-                "enabled": True,
-                "description": "通达信数据",
-                "status": "active"
-            }
+            {"name": "Tushare", "enabled": True, "description": "中国金融数据接口", "status": "active"},
+            {"name": "Yahoo", "enabled": True, "description": "Yahoo Finance数据", "status": "active"},
+            {"name": "BaoStock", "enabled": True, "description": "免费证券数据平台", "status": "active"},
+            {"name": "TDX", "enabled": True, "description": "通达信数据", "status": "active"},
         ]
 
         return ok(data=sources)
 
     except Exception as e:
         logger.error(f"Error getting data sources: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail="Failed to get data sources"
-        )
+        raise HTTPException(status_code=500, detail="Failed to get data sources")

--- a/api/api/data.py
+++ b/api/api/data.py
@@ -12,6 +12,7 @@ import time as _time
 from ginkgo.data.containers import container
 from ginkgo.enums import MARKET_TYPES, FREQUENCY_TYPES, ADJUSTMENT_TYPES
 from core.logging import logger
+from core.pagination import DEFAULT_MAX_PAGE_SIZE
 from core.response import ok, paginated
 
 router = APIRouter()
@@ -244,7 +245,7 @@ async def get_tick_data_summary(stockinfo_service, tick_service, sample_size: in
 async def get_stockinfo(
     search: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=50, ge=1, le=500),
+    page_size: int = Query(default=50, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
     limit: Optional[int] = None
 ):
     """获取股票信息列表（分页，搜索下推到DB层）
@@ -355,7 +356,7 @@ async def get_bars(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=100, ge=1, le=500),
+    page_size: int = Query(default=100, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
     order: Optional[str] = None,  # #5652: asc|desc，默认降序（最新在前）
 ):
     """获取K线数据列表（分页）"""
@@ -455,7 +456,7 @@ async def get_ticks(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=100, ge=1, le=500),
+    page_size: int = Query(default=100, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
     limit: Optional[int] = None  # #5621: 显式约束返回条数，未传沿用 page_size
 ):
     """获取Tick数据列表（分页）
@@ -549,7 +550,7 @@ async def get_adjust_factors(
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=100, ge=1, le=500)
+    page_size: int = Query(default=100, ge=1, le=DEFAULT_MAX_PAGE_SIZE)
 ):
     """获取复权因子列表（分页）"""
     try:
@@ -849,7 +850,7 @@ async def sync_data(request: DataUpdateRequest):
 async def get_sync_history(
     sync_type: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=20, ge=1, le=500),
+    page_size: int = Query(default=20, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
 ):
     """获取同步历史记录"""
     try:

--- a/api/api/file.py
+++ b/api/api/file.py
@@ -13,6 +13,7 @@ from typing import Optional
 from ginkgo.data.containers import container
 from ginkgo.enums import FILE_TYPES
 from core.logging import logger
+from core.pagination import DEFAULT_MAX_PAGE_SIZE
 from core.response import ok, paginated
 
 router = APIRouter()
@@ -50,7 +51,7 @@ def _file_to_dict(file_record):
 async def list_files(
     query: str = "",
     page: int = Query(1, ge=1),
-    size: int = Query(100, ge=1, le=500),
+    size: int = Query(100, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
     type: Optional[int] = None,
 ):
     """获取文件列表（flat 适配路由，薄委托 FileService.list_components）

--- a/api/api/file.py
+++ b/api/api/file.py
@@ -6,6 +6,7 @@ FileService 能力完整，但只通过 /components（组件视角）、
 /node-graphs/{uuid}/files（portfolio 绑定视角）暴露。本 router 提供面向
 "全局文件管理"语义的 flat 适配端点，薄委托 FileService 既有方法，不改 service 核心。
 """
+
 from fastapi import APIRouter, HTTPException, Query, status
 from pydantic import BaseModel
 from typing import Optional

--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -21,6 +21,7 @@ from schemas.node_graph import (
     ValidationErrorItem,
 )
 from core.logging import logger
+from core.pagination import DEFAULT_MAX_PAGE_SIZE
 from core.response import ok
 
 # 添加 Ginkgo 源码路径
@@ -51,7 +52,7 @@ def get_file_service():
 async def list_node_graphs(
     portfolio_uuid: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=20, ge=1, le=500),
+    page_size: int = Query(default=20, ge=1, le=DEFAULT_MAX_PAGE_SIZE),
 ):
     """
     获取节点图列表

--- a/api/api/node_graph.py
+++ b/api/api/node_graph.py
@@ -34,6 +34,7 @@ router = APIRouter()
 def get_portfolio_mapping_service():
     """获取 PortfolioMappingService 实例"""
     from ginkgo.data.containers import container
+
     return container.portfolio_mapping_service()
 
 
@@ -43,10 +44,12 @@ from ._file_type import _resolve_file_type, _validate_file_id  # noqa: F401 — 
 def get_file_service():
     """获取 FileService 实例"""
     from ginkgo.data.containers import container
+
     return container.file_service()
 
 
 # ==================== CRUD 操作 ====================
+
 
 @router.get("")
 async def list_node_graphs(
@@ -64,27 +67,30 @@ async def list_node_graphs(
         if portfolio_uuid:
             result = service.get_portfolio_graph(portfolio_uuid)
             if result.is_success():
-                return ok(data={
-                    "items": [result.data],
-                    "total": 1,
-                })
+                return ok(
+                    data={
+                        "items": [result.data],
+                        "total": 1,
+                    }
+                )
             else:
-                return ok(data={
-                    "items": [],
-                    "total": 0,
-                })
+                return ok(
+                    data={
+                        "items": [],
+                        "total": 0,
+                    }
+                )
 
         # TODO: 实现分页查询所有图
-        return ok(data={
-            "items": [],
-            "total": 0,
-        })
+        return ok(
+            data={
+                "items": [],
+                "total": 0,
+            }
+        )
     except Exception as e:
         logger.error(f"Error listing node graphs: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error listing node graphs"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error listing node graphs")
 
 
 @router.get("/{graph_uuid}")
@@ -101,35 +107,31 @@ async def get_node_graph(
         result = service.get_portfolio_graph(graph_uuid)
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Node graph {graph_uuid} not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Node graph {graph_uuid} not found")
 
         graph_data = result.data.get("graph_data", {})
         metadata = result.data.get("metadata", {})
 
-        return ok(data={
-            "uuid": graph_uuid,
-            "portfolio_uuid": graph_uuid,
-            "name": metadata.get("name", ""),
-            "description": "",
-            "graph_data": graph_data,
-            "mode": "BACKTEST",
-            "version": 1,
-            "is_template": False,
-            "tags": [],
-            "created_at": datetime.now().isoformat(),
-            "updated_at": datetime.now().isoformat(),
-        })
+        return ok(
+            data={
+                "uuid": graph_uuid,
+                "portfolio_uuid": graph_uuid,
+                "name": metadata.get("name", ""),
+                "description": "",
+                "graph_data": graph_data,
+                "mode": "BACKTEST",
+                "version": 1,
+                "is_template": False,
+                "tags": [],
+                "created_at": datetime.now().isoformat(),
+                "updated_at": datetime.now().isoformat(),
+            }
+        )
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting node graph {graph_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error getting node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error getting node graph")
 
 
 @router.post("", status_code=status.HTTP_201_CREATED)
@@ -154,31 +156,29 @@ async def create_node_graph(
 
         if not result.is_success():
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.error or "Failed to create node graph"
+                status_code=status.HTTP_400_BAD_REQUEST, detail=result.error or "Failed to create node graph"
             )
 
-        return ok(data={
-            "uuid": portfolio_uuid,
-            "portfolio_uuid": portfolio_uuid,
-            "name": data.name,
-            "description": data.description,
-            "graph_data": data.graph_data,
-            "user_uuid": "",  # TODO: 从JWT token获取
-            "version": 1,
-            "is_template": data.is_template or False,
-            "is_public": data.is_public or False,
-            "created_at": datetime.now().isoformat(),
-            "updated_at": datetime.now().isoformat(),
-        })
+        return ok(
+            data={
+                "uuid": portfolio_uuid,
+                "portfolio_uuid": portfolio_uuid,
+                "name": data.name,
+                "description": data.description,
+                "graph_data": data.graph_data,
+                "user_uuid": "",  # TODO: 从JWT token获取
+                "version": 1,
+                "is_template": data.is_template or False,
+                "is_public": data.is_public or False,
+                "created_at": datetime.now().isoformat(),
+                "updated_at": datetime.now().isoformat(),
+            }
+        )
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error creating node graph: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error creating node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error creating node graph")
 
 
 @router.put("/{graph_uuid}")
@@ -201,8 +201,7 @@ async def update_node_graph(
 
         if not result.is_success():
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.error or "Failed to update node graph"
+                status_code=status.HTTP_400_BAD_REQUEST, detail=result.error or "Failed to update node graph"
             )
 
         # 返回更新后的数据
@@ -211,10 +210,7 @@ async def update_node_graph(
         raise
     except Exception as e:
         logger.error(f"Error updating node graph {graph_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error updating node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error updating node graph")
 
 
 @router.delete("/{graph_uuid}", status_code=status.HTTP_204_NO_CONTENT)
@@ -230,17 +226,13 @@ async def delete_node_graph(
         result = service.delete_graph(graph_uuid)
         if not result.is_success():
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.error or "Failed to delete node graph"
+                status_code=status.HTTP_400_BAD_REQUEST, detail=result.error or "Failed to delete node graph"
             )
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error deleting node graph {graph_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error deleting node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error deleting node graph")
 
 
 @router.post("/{graph_uuid}/duplicate")
@@ -256,21 +248,18 @@ async def duplicate_node_graph(
         result = service.duplicate_graph(graph_uuid, name=name)
         if not result.is_success():
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.error or "Failed to duplicate node graph"
+                status_code=status.HTTP_400_BAD_REQUEST, detail=result.error or "Failed to duplicate node graph"
             )
         return ok(data=result.data, message="Graph duplicated successfully")
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error duplicating node graph {graph_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error duplicating node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error duplicating node graph")
 
 
 # ==================== 验证和编译 ====================
+
 
 @router.post("/{graph_uuid}/validate")
 async def validate_node_graph(
@@ -286,40 +275,31 @@ async def validate_node_graph(
 
         # 基本验证
         if not data.nodes:
-            errors.append(ValidationErrorItem(
-                field="nodes",
-                message="图必须包含至少一个节点",
-                severity="error"
-            ))
+            errors.append(ValidationErrorItem(field="nodes", message="图必须包含至少一个节点", severity="error"))
 
         # 验证节点配置
         for i, node in enumerate(data.nodes):
-            node_id = node.id if hasattr(node, 'id') else node.get('id', '')
-            node_type = node.type if hasattr(node, 'type') else node.get('type', '')
-            node_data = node.data if hasattr(node, 'data') else node.get('data', {})
+            node_id = node.id if hasattr(node, "id") else node.get("id", "")
+            node_type = node.type if hasattr(node, "type") else node.get("type", "")
+            node_data = node.data if hasattr(node, "data") else node.get("data", {})
 
             # 检查文件ID
-            file_id = node_data.get('file_id') if isinstance(node_data, dict) else None
+            file_id = node_data.get("file_id") if isinstance(node_data, dict) else None
             if not file_id:
-                errors.append(ValidationErrorItem(
-                    field=f"nodes[{i}].file_id",
-                    message=f"节点 {node_id} 缺少 file_id",
-                    severity="error",
-                    node_id=node_id
-                ))
+                errors.append(
+                    ValidationErrorItem(
+                        field=f"nodes[{i}].file_id",
+                        message=f"节点 {node_id} 缺少 file_id",
+                        severity="error",
+                        node_id=node_id,
+                    )
+                )
 
-        result = ValidationResult(
-            is_valid=len(errors) == 0,
-            errors=errors,
-            warnings=warnings
-        )
+        result = ValidationResult(is_valid=len(errors) == 0, errors=errors, warnings=warnings)
         return ok(data=result.dict())
     except Exception as e:
         logger.error(f"Error validating node graph {graph_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error validating node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error validating node graph")
 
 
 @router.post("/{graph_uuid}/compile")
@@ -348,17 +328,14 @@ async def compile_node_graph(
                     "commission_rate": 0.0003,
                     "slippage_rate": 0.0,
                     "broker_attitude": 2,
-                }
+                },
             ),
-            warnings=[]
+            warnings=[],
         )
         return ok(data=result.dict())
     except Exception as e:
         logger.error(f"Error compiling node graph {graph_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error compiling node graph"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error compiling node graph")
 
 
 @router.post("/from-backtest/{backtest_uuid}")
@@ -375,15 +352,11 @@ async def create_from_backtest(
         bt_service = container.backtest_task_service()
         bt_result = bt_service.get_by_id(backtest_uuid)
         if not bt_result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Backtest {backtest_uuid} not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Backtest {backtest_uuid} not found")
         portfolio_id = getattr(bt_result.data, "portfolio_id", "") or ""
         if not portfolio_id:
             raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Backtest {backtest_uuid} has no portfolio_id"
+                status_code=status.HTTP_404_NOT_FOUND, detail=f"Backtest {backtest_uuid} has no portfolio_id"
             )
 
         mapping_service = get_portfolio_mapping_service()
@@ -391,26 +364,26 @@ async def create_from_backtest(
         if not graph_result.is_success():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Node graph for backtest {backtest_uuid} (portfolio {portfolio_id}) not found"
+                detail=f"Node graph for backtest {backtest_uuid} (portfolio {portfolio_id}) not found",
             )
 
-        return ok(data={
-            "backtest_uuid": backtest_uuid,
-            "portfolio_uuid": portfolio_id,
-            "graph_data": graph_result.data.get("graph_data", {}),
-            "metadata": graph_result.data.get("metadata", {}),
-        })
+        return ok(
+            data={
+                "backtest_uuid": backtest_uuid,
+                "portfolio_uuid": portfolio_id,
+                "graph_data": graph_result.data.get("graph_data", {}),
+                "metadata": graph_result.data.get("metadata", {}),
+            }
+        )
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error creating from backtest {backtest_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error creating from backtest"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error creating from backtest")
 
 
 # ==================== Portfolio 扩展接口 ====================
+
 
 @router.get("/{portfolio_uuid}/mappings")
 async def get_portfolio_mappings(
@@ -423,29 +396,24 @@ async def get_portfolio_mappings(
     try:
         service = get_portfolio_mapping_service()
 
-        result = service.get_portfolio_mappings(
-            portfolio_uuid=portfolio_uuid,
-            include_params=include_params
-        )
+        result = service.get_portfolio_mappings(portfolio_uuid=portfolio_uuid, include_params=include_params)
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Portfolio {portfolio_uuid} not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Portfolio {portfolio_uuid} not found")
 
-        return ok(data={
-            "portfolio_uuid": portfolio_uuid,
-            "mappings": result.data,
-            "total": len(result.data),
-        })
+        return ok(
+            data={
+                "portfolio_uuid": portfolio_uuid,
+                "mappings": result.data,
+                "total": len(result.data),
+            }
+        )
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting portfolio mappings {portfolio_uuid}: {str(e)}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error getting portfolio mappings"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error getting portfolio mappings"
         )
 
 
@@ -467,24 +435,20 @@ async def get_portfolio_files(portfolio_uuid: str):
         )
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Portfolio {portfolio_uuid} not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Portfolio {portfolio_uuid} not found")
 
-        return ok(data={
-            "portfolio_uuid": portfolio_uuid,
-            "files": result.data,
-            "total": len(result.data),
-        })
+        return ok(
+            data={
+                "portfolio_uuid": portfolio_uuid,
+                "files": result.data,
+                "total": len(result.data),
+            }
+        )
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error getting portfolio files {portfolio_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error getting portfolio files"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error getting portfolio files")
 
 
 @router.post("/{portfolio_uuid}/files")
@@ -524,28 +488,22 @@ async def add_file_to_portfolio(
         )
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.error or "Failed to add file"
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result.error or "Failed to add file")
 
-        return ok(data={
-            "file_id": file_id,
-        }, message="File added successfully")
+        return ok(
+            data={
+                "file_id": file_id,
+            },
+            message="File added successfully",
+        )
     except HTTPException:
         raise
     except ValueError as e:
         # #5645: 入参校验失败（空 file_id / 无效 file_type）→ 400 而非 500
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=str(e)
-        )
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     except Exception as e:
         logger.error(f"Error adding file to portfolio {portfolio_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error adding file"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error adding file")
 
 
 @router.delete("/{portfolio_uuid}/files/{file_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -565,15 +523,9 @@ async def remove_file_from_portfolio(
         )
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=result.error or "Failed to remove file"
-            )
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=result.error or "Failed to remove file")
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error removing file from portfolio {portfolio_uuid}: {str(e)}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Error removing file"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error removing file")

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -33,16 +33,16 @@ router = APIRouter()
 # #5469: SSRF 防护——webhook test 服务端直发用户可控 URL，须拦内网/云元数据。
 # 显式网络表（版本无关，精确对齐 AC：10/172.16-31/192.168/127/169.254 + IPv6 等价段）。
 _BLOCKED_NETWORKS = (
-    ipaddress.ip_network("127.0.0.0/8"),       # IPv4 loopback
-    ipaddress.ip_network("10.0.0.0/8"),        # RFC1918 私有
-    ipaddress.ip_network("172.16.0.0/12"),     # RFC1918 私有（172.16-31）
-    ipaddress.ip_network("192.168.0.0/16"),    # RFC1918 私有
-    ipaddress.ip_network("169.254.0.0/16"),    # link-local（含云元数据 169.254.169.254）
-    ipaddress.ip_network("0.0.0.0/8"),         # unspecified / current-network
-    ipaddress.ip_network("::1/128"),           # IPv6 loopback
-    ipaddress.ip_network("fc00::/7"),          # IPv6 unique-local
-    ipaddress.ip_network("fe80::/10"),         # IPv6 link-local
-    ipaddress.ip_network("::/128"),            # IPv6 unspecified
+    ipaddress.ip_network("127.0.0.0/8"),  # IPv4 loopback
+    ipaddress.ip_network("10.0.0.0/8"),  # RFC1918 私有
+    ipaddress.ip_network("172.16.0.0/12"),  # RFC1918 私有（172.16-31）
+    ipaddress.ip_network("192.168.0.0/16"),  # RFC1918 私有
+    ipaddress.ip_network("169.254.0.0/16"),  # link-local（含云元数据 169.254.169.254）
+    ipaddress.ip_network("0.0.0.0/8"),  # unspecified / current-network
+    ipaddress.ip_network("::1/128"),  # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),  # IPv6 unique-local
+    ipaddress.ip_network("fe80::/10"),  # IPv6 link-local
+    ipaddress.ip_network("::/128"),  # IPv6 unspecified
 )
 
 
@@ -123,7 +123,7 @@ def get_api_key_service():
 
 def hash_password(password: str) -> str:
     """对密码进行哈希"""
-    return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")
 
 
 def _resolve_is_admin(user_uuid) -> bool:
@@ -189,8 +189,10 @@ def _require_contact_ownership(req: Request, contact_uuid: str) -> None:
 
 # ==================== 用户管理 ====================
 
+
 class UserSummary(BaseModel):
     """用户摘要"""
+
     uuid: str
     username: str
     display_name: str
@@ -202,6 +204,7 @@ class UserSummary(BaseModel):
 
 class UserCreate(BaseModel):
     """创建用户请求"""
+
     username: str
     password: str
     display_name: str
@@ -212,6 +215,7 @@ class UserCreate(BaseModel):
 
 class UserUpdate(BaseModel):
     """更新用户请求"""
+
     # #5458: email 不属于用户档案，由 contacts API 管理；拒绝多余字段
     model_config = ConfigDict(extra="forbid")
 
@@ -221,11 +225,7 @@ class UserUpdate(BaseModel):
 
 
 @router.get("/users")
-async def list_users(
-    req: Request,
-    status: Optional[str] = None,
-    search: Optional[str] = None
-):
+async def list_users(req: Request, status: Optional[str] = None, search: Optional[str] = None):
     """获取用户列表"""
     _require_admin(req)  # #5467
     try:
@@ -241,10 +241,7 @@ async def list_users(
         # 通过 Service 查询用户
         result = user_service.list_users(**filters)
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to list users"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list users")
 
         # list_users 返回 {"users": [...], "count": N}
         raw_data = result.data
@@ -258,7 +255,12 @@ async def list_users(
         # 搜索过滤
         if search:
             search_lower = search.lower()
-            users = [u for u in users if search_lower in u.get("username", "").lower() or (u.get("display_name") and search_lower in u.get("display_name", "").lower())]
+            users = [
+                u
+                for u in users
+                if search_lower in u.get("username", "").lower()
+                or (u.get("display_name") and search_lower in u.get("display_name", "").lower())
+            ]
 
         result_list = []
         for user in users:
@@ -269,15 +271,17 @@ async def list_users(
             is_admin = user.get("is_admin", False)
             is_active = user.get("is_active", True)
 
-            result_list.append({
-                "uuid": user.get("uuid", ""),
-                "username": username,
-                "display_name": user.get("display_name") or username,
-                "email": user.get("email", ""),
-                "roles": ["admin"] if is_admin else [],
-                "status": "active" if is_active else "disabled",
-                "created_at": user.get("created_at") or datetime.utcnow().isoformat() + "Z"
-            })
+            result_list.append(
+                {
+                    "uuid": user.get("uuid", ""),
+                    "username": username,
+                    "display_name": user.get("display_name") or username,
+                    "email": user.get("email", ""),
+                    "roles": ["admin"] if is_admin else [],
+                    "status": "active" if is_active else "disabled",
+                    "created_at": user.get("created_at") or datetime.utcnow().isoformat() + "Z",
+                }
+            )
 
         return ok(data=result_list)
 
@@ -285,10 +289,7 @@ async def list_users(
         raise
     except Exception as e:
         logger.error(f"Error listing users: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list users"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list users")
 
 
 @router.post("/users", status_code=201)
@@ -302,10 +303,7 @@ async def create_user(req: Request, data: UserCreate):
         existing_result = user_service.list_users(username=data.username, is_del=False)
         existing_users = existing_result.data.get("users", []) if existing_result.success else []
         if existing_users:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Username already exists"
-            )
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Username already exists")
 
         # 哈希密码
         password_hash = hash_password(data.password)
@@ -321,10 +319,7 @@ async def create_user(req: Request, data: UserCreate):
             password_hash=password_hash,
         )
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create user"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user")
 
         created_user_data = result.data
 
@@ -345,24 +340,23 @@ async def create_user(req: Request, data: UserCreate):
 
         logger.info(f"User created: {data.username} (uuid={created_user_data['uuid']})")
 
-        return ok(data={
-            "uuid": created_user_data["uuid"],
-            "username": data.username,
-            "display_name": data.display_name,
-            "email": data.email,
-            "roles": data.roles,
-            "status": data.status,
-            "created_at": created_user_data.get("created_at") or datetime.utcnow().isoformat() + "Z"
-        })
+        return ok(
+            data={
+                "uuid": created_user_data["uuid"],
+                "username": data.username,
+                "display_name": data.display_name,
+                "email": data.email,
+                "roles": data.roles,
+                "status": data.status,
+                "created_at": created_user_data.get("created_at") or datetime.utcnow().isoformat() + "Z",
+            }
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error creating user: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to create user"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user")
 
 
 @router.get("/users/{uuid}")
@@ -427,7 +421,7 @@ async def update_user(req: Request, uuid: str, data: UserUpdate):
             updates["display_name"] = data.display_name
 
         if data.status is not None:
-            updates["is_active"] = (data.status == "active")
+            updates["is_active"] = data.status == "active"
 
         # 凭据相关更新
         if data.roles is not None:
@@ -437,14 +431,8 @@ async def update_user(req: Request, uuid: str, data: UserUpdate):
             result = user_service.update_user(uuid, **updates)
             if not result.success:
                 if "not found" in result.error.lower():
-                    raise HTTPException(
-                        status_code=status.HTTP_404_NOT_FOUND,
-                        detail="User not found"
-                    )
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Failed to update user"
-                )
+                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
 
         # #6070: 仅当 status 或 roles 实际发生变更时撤销旧 token
         # （与 delete_user/reset_user_password/change_password 一致；改 display_name/email 不触发）
@@ -455,6 +443,7 @@ async def update_user(req: Request, uuid: str, data: UserUpdate):
             revoke = True
         if revoke:
             from middleware.auth import token_blacklist
+
             token_blacklist.revoke_user(uuid)
 
         logger.info(f"User updated: {uuid}")
@@ -465,10 +454,7 @@ async def update_user(req: Request, uuid: str, data: UserUpdate):
         raise
     except Exception as e:
         logger.error(f"Error updating user: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update user"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user")
 
 
 @router.post("/users/{uuid}/reset-password")
@@ -502,19 +488,14 @@ async def reset_user_password(uuid: str, data: ResetPasswordRequest, req: Reques
         result = user_service.reset_password(uuid, new_password_hash)
         if not result.success:
             if "not found" in result.error.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="User credential not found"
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to update password"
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User credential not found")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update password")
 
         logger.info(f"Password reset for user: {uuid} by: {caller_uuid}")
 
         # 撤销该用户所有旧 token（防止被重置密码的账户旧 session 仍可用）
         from middleware.auth import token_blacklist
+
         token_blacklist.revoke_user(uuid)
 
         # #5770: 响应不包含明文密码
@@ -524,10 +505,7 @@ async def reset_user_password(uuid: str, data: ResetPasswordRequest, req: Reques
         raise
     except Exception as e:
         logger.error(f"Error resetting password: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to reset password"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to reset password")
 
 
 @router.delete("/users/{uuid}")
@@ -539,15 +517,13 @@ async def delete_user(req: Request, uuid: str):
 
         result = user_service.delete_user(uuid)
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="User not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
         logger.info(f"User deleted: {uuid}")
 
         # 撤销该用户所有 token（防止已删除账户的旧 session 仍可用）
         from middleware.auth import token_blacklist
+
         token_blacklist.revoke_user(uuid)
 
         return ok(message=f"User {uuid} deleted")
@@ -556,16 +532,15 @@ async def delete_user(req: Request, uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error deleting user: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to delete user"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete user")
 
 
 # ==================== 用户联系方式管理 ====================
 
+
 class UserContactSummary(BaseModel):
     """用户联系方式摘要"""
+
     uuid: str
     user_id: str
     contact_type: str  # email, webhook
@@ -577,6 +552,7 @@ class UserContactSummary(BaseModel):
 
 class UserContactCreate(BaseModel):
     """创建联系方式请求"""
+
     contact_type: str  # email, webhook
     address: str
     is_primary: bool = False
@@ -584,6 +560,7 @@ class UserContactCreate(BaseModel):
 
 class UserContactUpdate(BaseModel):
     """更新联系方式请求"""
+
     contact_type: Optional[str] = None
     address: Optional[str] = None
     is_primary: Optional[bool] = None
@@ -592,6 +569,7 @@ class UserContactUpdate(BaseModel):
 
 class UserContactTest(BaseModel):
     """测试联系方式请求"""
+
     address: str
     subject: str = "Ginkgo Test Notification"
     content: str = "This is a test notification from Ginkgo."
@@ -606,33 +584,31 @@ async def list_user_contacts(user_uuid: str):
         # 验证用户存在
         user_result = user_service.get_user(user_uuid)
         if not user_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="User not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
         # 获取联系方式
         contacts_result = user_service.get_user_contacts(user_uuid)
         if not contacts_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to list contacts"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list contacts")
 
         contacts_data = contacts_result.data
         contacts = contacts_data.get("contacts", []) if isinstance(contacts_data, dict) else contacts_data
 
         result = []
         for contact in contacts:
-            result.append({
-                "uuid": contact.get("uuid", ""),
-                "user_id": contact.get("user_id", ""),
-                "contact_type": contact.get("contact_type", "EMAIL").lower(),
-                "address": contact.get("address", ""),
-                "is_primary": contact.get("is_primary", False),
-                "is_active": contact.get("is_active", True),
-                "created_at": contact.get("created_at") or contact.get("create_at") or datetime.utcnow().isoformat() + "Z"
-            })
+            result.append(
+                {
+                    "uuid": contact.get("uuid", ""),
+                    "user_id": contact.get("user_id", ""),
+                    "contact_type": contact.get("contact_type", "EMAIL").lower(),
+                    "address": contact.get("address", ""),
+                    "is_primary": contact.get("is_primary", False),
+                    "is_active": contact.get("is_active", True),
+                    "created_at": contact.get("created_at")
+                    or contact.get("create_at")
+                    or datetime.utcnow().isoformat() + "Z",
+                }
+            )
 
         return ok(data=result)
 
@@ -640,10 +616,7 @@ async def list_user_contacts(user_uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error listing contacts: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list contacts"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list contacts")
 
 
 @router.post("/users/{user_uuid}/contacts", status_code=201)
@@ -655,16 +628,10 @@ async def create_user_contact(user_uuid: str, data: UserContactCreate):
         # 验证用户存在
         user_result = user_service.get_user(user_uuid)
         if not user_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="User not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
         # 验证联系方式类型
-        type_map = {
-            "email": CONTACT_TYPES.EMAIL,
-            "webhook": CONTACT_TYPES.WEBHOOK
-        }
+        type_map = {"email": CONTACT_TYPES.EMAIL, "webhook": CONTACT_TYPES.WEBHOOK}
         contact_type_enum = type_map.get(data.contact_type.lower(), CONTACT_TYPES.EMAIL)
 
         # 通过 Service 创建联系方式
@@ -675,31 +642,27 @@ async def create_user_contact(user_uuid: str, data: UserContactCreate):
             is_primary=data.is_primary,
         )
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create contact"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create contact")
 
         logger.info(f"Contact created for user: {user_uuid}")
 
-        return ok(data={
-            "uuid": result.data.get("uuid", "") if isinstance(result.data, dict) else "",
-            "user_id": user_uuid,
-            "contact_type": data.contact_type,
-            "address": data.address,
-            "is_primary": data.is_primary,
-            "is_active": True,
-            "created_at": datetime.utcnow().isoformat() + "Z"
-        })
+        return ok(
+            data={
+                "uuid": result.data.get("uuid", "") if isinstance(result.data, dict) else "",
+                "user_id": user_uuid,
+                "contact_type": data.contact_type,
+                "address": data.address,
+                "is_primary": data.is_primary,
+                "is_active": True,
+                "created_at": datetime.utcnow().isoformat() + "Z",
+            }
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error creating contact: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to create contact"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create contact")
 
 
 @router.put("/users/contacts/{contact_uuid}")
@@ -714,10 +677,7 @@ async def update_user_contact(contact_uuid: str, data: UserContactUpdate, req: R
         updates = {}
 
         if data.contact_type is not None:
-            type_map = {
-                "email": CONTACT_TYPES.EMAIL,
-                "webhook": CONTACT_TYPES.WEBHOOK
-            }
+            type_map = {"email": CONTACT_TYPES.EMAIL, "webhook": CONTACT_TYPES.WEBHOOK}
             updates["contact_type"] = type_map.get(data.contact_type.lower(), CONTACT_TYPES.EMAIL).value
 
         if data.address is not None:
@@ -733,13 +693,9 @@ async def update_user_contact(contact_uuid: str, data: UserContactUpdate, req: R
             result = user_service.update_contact(contact_uuid, **updates)
             if not result.success:
                 if "not found" in result.error.lower():
-                    raise HTTPException(
-                        status_code=status.HTTP_404_NOT_FOUND,
-                        detail="Contact not found"
-                    )
+                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
                 raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Failed to update contact"
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update contact"
                 )
 
         logger.info(f"Contact updated: {contact_uuid}")
@@ -750,10 +706,7 @@ async def update_user_contact(contact_uuid: str, data: UserContactUpdate, req: R
         raise
     except Exception as e:
         logger.error(f"Error updating contact: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update contact"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update contact")
 
 
 @router.delete("/users/contacts/{contact_uuid}")
@@ -764,10 +717,7 @@ async def delete_user_contact(contact_uuid: str):
 
         result = user_service.delete_contact(contact_uuid)
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Contact not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
 
         logger.info(f"Contact deleted: {contact_uuid}")
 
@@ -777,10 +727,7 @@ async def delete_user_contact(contact_uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error deleting contact: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to delete contact"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete contact")
 
 
 @router.post("/users/contacts/{contact_uuid}/test")
@@ -792,10 +739,7 @@ async def test_user_contact(contact_uuid: str, data: UserContactTest):
         # 获取联系方式
         contact_result = user_service.get_contact(contact_uuid)
         if not contact_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Contact not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
 
         contact = contact_result.data
         contact_type = contact.get_contact_type_enum()
@@ -803,48 +747,34 @@ async def test_user_contact(contact_uuid: str, data: UserContactTest):
         # 根据联系方式类型发送测试通知
         if contact_type == CONTACT_TYPES.EMAIL:
             # #5595: 邮件发送未实现——诚实返 501，不假装发送成功
-            raise HTTPException(
-                status_code=status.HTTP_501_NOT_IMPLEMENTED,
-                detail="Email sending is not implemented"
-            )
+            raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Email sending is not implemented")
         elif contact_type == CONTACT_TYPES.WEBHOOK:
             # Webhook 已实现（下方 requests.post 实发），原 TODO 注释为过期残留（#5595）
             # #5469: 发送前校验目标 URL 防 SSRF（拦内网/云元数据/scheme），不安全抛 400。
             _assert_safe_webhook_url(data.address)
             import requests
+
             try:
                 response = requests.post(
-                    data.address,
-                    json={
-                        "subject": data.subject,
-                        "content": data.content,
-                        "test": True
-                    },
-                    timeout=10
+                    data.address, json={"subject": data.subject, "content": data.content, "test": True}, timeout=10
                 )
-                return ok(data={
-                    "detail": f"Status code: {response.status_code}"
-                }, message=f"Test webhook sent to {data.address}")
+                return ok(
+                    data={"detail": f"Status code: {response.status_code}"},
+                    message=f"Test webhook sent to {data.address}",
+                )
             except Exception as e:
                 logger.error(f"Webhook test failed: {e}")
-                raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Webhook test failed"
-                )
+                raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Webhook test failed")
         else:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Unsupported contact type: {contact_type}"
+                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unsupported contact type: {contact_type}"
             )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error testing contact: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to test contact"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to test contact")
 
 
 @router.post("/users/contacts/{contact_uuid}/set-primary")
@@ -856,10 +786,7 @@ async def set_primary_contact(contact_uuid: str):
         # 获取联系方式
         contact_result = user_service.get_contact(contact_uuid)
         if not contact_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Contact not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Contact not found")
 
         contact = contact_result.data
 
@@ -883,16 +810,15 @@ async def set_primary_contact(contact_uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error setting primary contact: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to set primary contact"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to set primary contact")
 
 
 # ==================== 用户组管理 ====================
 
+
 class UserGroupSummary(BaseModel):
     """用户组摘要"""
+
     uuid: str
     name: str
     description: Optional[str]
@@ -902,6 +828,7 @@ class UserGroupSummary(BaseModel):
 
 class UserGroupCreate(BaseModel):
     """创建用户组请求"""
+
     name: str
     description: Optional[str] = None
     permissions: List[str] = []
@@ -909,6 +836,7 @@ class UserGroupCreate(BaseModel):
 
 class UserGroupUpdate(BaseModel):
     """更新用户组请求"""
+
     name: Optional[str] = None
     description: Optional[str] = None
     permissions: Optional[List[str]] = None
@@ -922,10 +850,7 @@ async def list_user_groups():
 
         result = group_service.list_groups()
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to list user groups"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list user groups")
 
         raw_groups = result.data
         # user 版 list_groups 返 dict {"groups":[...],"count":N}；#5625 mock 仍返 list。
@@ -939,13 +864,15 @@ async def list_user_groups():
         group_list = []
         for group_data in raw_groups:
             group_uuid = group_data["uuid"]
-            group_list.append({
-                "uuid": group_uuid,
-                "name": group_data["name"],
-                "description": group_data.get("description", ""),
-                "user_count": member_counts.get(group_uuid, 0),
-                "permissions": []
-            })
+            group_list.append(
+                {
+                    "uuid": group_uuid,
+                    "name": group_data["name"],
+                    "description": group_data.get("description", ""),
+                    "user_count": member_counts.get(group_uuid, 0),
+                    "permissions": [],
+                }
+            )
 
         return ok(data=group_list)
 
@@ -953,10 +880,7 @@ async def list_user_groups():
         raise
     except Exception as e:
         logger.error(f"Error listing user groups: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list user groups"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list user groups")
 
 
 @router.post("/user-groups", status_code=201)
@@ -969,43 +893,38 @@ async def create_user_group(data: UserGroupCreate):
         existing_result = group_service.list_groups()
         if existing_result.success:
             existing_payload = existing_result.data or {}
-            existing_groups = existing_payload.get("groups", []) if isinstance(existing_payload, dict) else (existing_payload or [])
+            existing_groups = (
+                existing_payload.get("groups", []) if isinstance(existing_payload, dict) else (existing_payload or [])
+            )
             for g in existing_groups:
                 if g["name"] == data.name:
-                    raise HTTPException(
-                        status_code=status.HTTP_409_CONFLICT,
-                        detail="Group name already exists"
-                    )
+                    raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Group name already exists")
 
         result = group_service.create_group(
             name=data.name,
             description=data.description or "",
         )
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create user group"
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user group")
 
         group_data = result.data
         logger.info(f"User group created: {data.name} (uuid={group_data['uuid']})")
 
-        return ok(data={
-            "uuid": group_data["uuid"],
-            "name": data.name,
-            "description": data.description or "",
-            "user_count": 0,
-            "permissions": data.permissions
-        })
+        return ok(
+            data={
+                "uuid": group_data["uuid"],
+                "name": data.name,
+                "description": data.description or "",
+                "user_count": 0,
+                "permissions": data.permissions,
+            }
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error creating user group: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to create user group"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create user group")
 
 
 @router.put("/user-groups/{uuid}")
@@ -1023,15 +942,11 @@ async def update_user_group(uuid: str, data: UserGroupUpdate):
                 existing_data = existing_result.data
                 # user 版 list_groups 返 dict（取 "groups"）；#5625 mock 返 list（直用）
                 existing_groups = (
-                    existing_data.get("groups", []) if isinstance(existing_data, dict)
-                    else (existing_data or [])
+                    existing_data.get("groups", []) if isinstance(existing_data, dict) else (existing_data or [])
                 )
                 for g in existing_groups:
                     if g["name"] == data.name and g["uuid"] != uuid:
-                        raise HTTPException(
-                            status_code=status.HTTP_409_CONFLICT,
-                            detail="Group name already exists"
-                        )
+                        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Group name already exists")
             updates["name"] = data.name
 
         if data.description is not None:
@@ -1041,13 +956,9 @@ async def update_user_group(uuid: str, data: UserGroupUpdate):
             result = group_service.update_group(uuid, **updates)
             if not result.success:
                 if "not found" in result.error.lower():
-                    raise HTTPException(
-                        status_code=status.HTTP_404_NOT_FOUND,
-                        detail="User group not found"
-                    )
+                    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User group not found")
                 raise HTTPException(
-                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                    detail="Failed to update user group"
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user group"
                 )
 
         logger.info(f"User group updated: {uuid}")
@@ -1058,10 +969,7 @@ async def update_user_group(uuid: str, data: UserGroupUpdate):
         raise
     except Exception as e:
         logger.error(f"Error updating user group: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update user group"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update user group")
 
 
 @router.delete("/user-groups/{uuid}")
@@ -1073,14 +981,8 @@ async def delete_user_group(uuid: str):
         result = group_service.delete_group(uuid)
         if not result.success:
             if "not found" in result.error.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="User group not found"
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to delete user group"
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User group not found")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete user group")
 
         logger.info(f"User group deleted: {uuid}")
 
@@ -1090,16 +992,15 @@ async def delete_user_group(uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error deleting user group: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to delete user group"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete user group")
 
 
 # ==================== 用户组成员管理 ====================
 
+
 class GroupMemberSummary(BaseModel):
     """组成员摘要"""
+
     uuid: str
     user_uuid: str
     username: str
@@ -1117,17 +1018,13 @@ async def list_group_members(group_uuid: str):
         # 检查用户组是否存在
         group_result = group_service.get_group(group_uuid)
         if not group_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="User group not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User group not found")
 
         # 获取组成员映射
         members_result = group_service.list_members(group_uuid)
         if not members_result.success:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to list group members"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list group members"
             )
 
         members = members_result.data
@@ -1138,13 +1035,15 @@ async def list_group_members(group_uuid: str):
             user_result = user_service.get_user(user_uuid)
             if user_result.success:
                 user = user_result.data
-                result.append({
-                    "uuid": member_data.get("group_uuid", ""),
-                    "user_uuid": user["uuid"],
-                    "username": user["username"],
-                    "display_name": user.get("display_name") or user["username"],
-                    "email": user.get("email", "")
-                })
+                result.append(
+                    {
+                        "uuid": member_data.get("group_uuid", ""),
+                        "user_uuid": user["uuid"],
+                        "username": user["username"],
+                        "display_name": user.get("display_name") or user["username"],
+                        "email": user.get("email", ""),
+                    }
+                )
 
         return ok(data=result)
 
@@ -1152,10 +1051,7 @@ async def list_group_members(group_uuid: str):
         raise
     except Exception as e:
         logger.error(f"Error listing group members: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list group members"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list group members")
 
 
 @router.post("/user-groups/{group_uuid}/members", status_code=201)
@@ -1170,28 +1066,16 @@ async def add_group_member(group_uuid: str, data: AddGroupMemberRequest):
         # 检查用户是否存在
         user_result = user_service.get_user(user_uuid)
         if not user_result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="User not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
         # 添加成员到用户组
         result = group_service.add_member(user_uuid, group_uuid)
         if not result.success:
             if "already" in result.error.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_409_CONFLICT,
-                    detail="User is already in this group"
-                )
+                raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="User is already in this group")
             if "not found" in result.error.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="User group not found"
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to add user to group"
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User group not found")
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to add user to group")
 
         mapping_data = result.data
         logger.info(f"User {user_uuid} added to group {group_uuid}")
@@ -1202,10 +1086,7 @@ async def add_group_member(group_uuid: str, data: AddGroupMemberRequest):
         raise
     except Exception as e:
         logger.error(f"Error adding group member: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to add user to group"
-        )
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to add user to group")
 
 
 @router.delete("/user-groups/{group_uuid}/members/{user_uuid}")
@@ -1217,13 +1098,9 @@ async def remove_group_member(group_uuid: str, user_uuid: str):
         result = group_service.remove_member(user_uuid, group_uuid)
         if not result.success:
             if "not found" in result.error.lower() or "not a member" in result.error.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="User is not in this group"
-                )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User is not in this group")
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to remove user from group"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to remove user from group"
             )
 
         logger.info(f"User {user_uuid} removed from group {group_uuid}")
@@ -1235,15 +1112,16 @@ async def remove_group_member(group_uuid: str, user_uuid: str):
     except Exception as e:
         logger.error(f"Error removing group member: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to remove user from group"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to remove user from group"
         )
 
 
 # ==================== 通知管理 ====================
 
+
 class NotificationTemplateSummary(BaseModel):
     """通知模板摘要"""
+
     uuid: str
     name: str
     type: str  # email, discord, system
@@ -1254,6 +1132,7 @@ class NotificationTemplateSummary(BaseModel):
 
 class NotificationHistoryItem(BaseModel):
     """通知历史记录"""
+
     uuid: str
     type: str
     subject: str
@@ -1265,6 +1144,7 @@ class NotificationHistoryItem(BaseModel):
 
 class NotificationTemplateCreate(BaseModel):
     """创建通知模板请求"""
+
     name: str
     type: str  # email, discord, system
     subject: str
@@ -1274,6 +1154,7 @@ class NotificationTemplateCreate(BaseModel):
 
 class NotificationTemplateUpdate(BaseModel):
     """更新通知模板请求"""
+
     name: Optional[str] = None
     type: Optional[str] = None
     subject: Optional[str] = None
@@ -1295,8 +1176,7 @@ async def list_notification_templates():
         result = notification_service.list_templates(is_del=False)
         if not result.success:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to list notification templates"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list notification templates"
             )
 
         templates = result.data
@@ -1307,14 +1187,16 @@ async def list_notification_templates():
             template_type = tpl.get_template_type_enum()
             type_str = template_type.name.lower() if template_type else "text"
 
-            result_list.append({
-                "uuid": tpl.uuid,
-                "name": tpl.template_name,
-                "type": type_str,
-                "subject": tpl.subject or "",
-                "enabled": tpl.is_active,
-                "updated_at": tpl.update_at.isoformat() if tpl.update_at else datetime.utcnow().isoformat() + "Z"
-            })
+            result_list.append(
+                {
+                    "uuid": tpl.uuid,
+                    "name": tpl.template_name,
+                    "type": type_str,
+                    "subject": tpl.subject or "",
+                    "enabled": tpl.is_active,
+                    "updated_at": tpl.update_at.isoformat() if tpl.update_at else datetime.utcnow().isoformat() + "Z",
+                }
+            )
 
         return ok(data=result_list)
 
@@ -1323,8 +1205,7 @@ async def list_notification_templates():
     except Exception as e:
         logger.error(f"Error listing notification templates: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list notification templates"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list notification templates"
         )
 
 
@@ -1338,15 +1219,12 @@ async def create_notification_template(data: NotificationTemplateCreate):
         notification_service = get_notification_service()
 
         # 映射类型字符串到枚举
-        type_map = {
-            "email": TEMPLATE_TYPES.TEXT,
-            "discord": TEMPLATE_TYPES.MARKDOWN,
-            "system": TEMPLATE_TYPES.TEXT
-        }
+        type_map = {"email": TEMPLATE_TYPES.TEXT, "discord": TEMPLATE_TYPES.MARKDOWN, "system": TEMPLATE_TYPES.TEXT}
         template_type = type_map.get(data.type.lower(), TEMPLATE_TYPES.TEXT)
 
         # 生成 template_id
         import uuid
+
         template_id = f"tpl_{uuid.uuid4().hex[:8]}"
 
         template = MNotificationTemplate(
@@ -1355,35 +1233,35 @@ async def create_notification_template(data: NotificationTemplateCreate):
             template_type=template_type.value,
             subject=data.subject,
             content=data.content,
-            is_active=data.enabled
+            is_active=data.enabled,
         )
 
         result = notification_service.create_template(template)
         if not result.success:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to create notification template"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create notification template"
             )
 
         created_uuid = result.data.get("uuid") if isinstance(result.data, dict) else result.data
         logger.info(f"Notification template created: {data.name}")
 
-        return ok(data={
-            "uuid": created_uuid,
-            "name": data.name,
-            "type": data.type,
-            "subject": data.subject,
-            "enabled": data.enabled,
-            "updated_at": datetime.utcnow().isoformat() + "Z"
-        })
+        return ok(
+            data={
+                "uuid": created_uuid,
+                "name": data.name,
+                "type": data.type,
+                "subject": data.subject,
+                "enabled": data.enabled,
+                "updated_at": datetime.utcnow().isoformat() + "Z",
+            }
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error creating notification template: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to create notification template"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create notification template"
         )
 
 
@@ -1397,10 +1275,7 @@ async def update_notification_template(uuid: str, data: NotificationTemplateUpda
 
         # 检查模板是否存在
         if not notification_service.template_exists(uuid):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Notification template not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification template not found")
 
         # 构建更新数据
         update_dict = {}
@@ -1408,11 +1283,7 @@ async def update_notification_template(uuid: str, data: NotificationTemplateUpda
             update_dict["template_name"] = data.name
 
         if data.type is not None:
-            type_map = {
-                "email": TEMPLATE_TYPES.TEXT,
-                "discord": TEMPLATE_TYPES.MARKDOWN,
-                "system": TEMPLATE_TYPES.TEXT
-            }
+            type_map = {"email": TEMPLATE_TYPES.TEXT, "discord": TEMPLATE_TYPES.MARKDOWN, "system": TEMPLATE_TYPES.TEXT}
             template_type = type_map.get(data.type.lower(), TEMPLATE_TYPES.TEXT)
             update_dict["template_type"] = template_type.value
 
@@ -1437,8 +1308,7 @@ async def update_notification_template(uuid: str, data: NotificationTemplateUpda
     except Exception as e:
         logger.error(f"Error updating notification template: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update notification template"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update notification template"
         )
 
 
@@ -1450,10 +1320,7 @@ async def delete_notification_template(uuid: str):
 
         result = notification_service.delete_template(uuid)
         if not result.success:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Notification template not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification template not found")
 
         logger.info(f"Notification template deleted: {uuid}")
 
@@ -1464,8 +1331,7 @@ async def delete_notification_template(uuid: str):
     except Exception as e:
         logger.error(f"Error deleting notification template: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to delete notification template"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete notification template"
         )
 
 
@@ -1476,15 +1342,11 @@ async def test_notification_template(uuid: str):
         notification_service = get_notification_service()
 
         if not notification_service.template_exists(uuid):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Notification template not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification template not found")
 
         # #5595: 真实测试发送未实现——诚实返 501，不假装发送成功
         raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail="Notification template test send is not implemented"
+            status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="Notification template test send is not implemented"
         )
 
     except HTTPException:
@@ -1492,8 +1354,7 @@ async def test_notification_template(uuid: str):
     except Exception as e:
         logger.error(f"Error testing notification template: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to test notification template"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to test notification template"
         )
 
 
@@ -1504,10 +1365,7 @@ async def toggle_notification_template(uuid: str, enabled: bool):
         notification_service = get_notification_service()
 
         if not notification_service.template_exists(uuid):
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="Notification template not found"
-            )
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Notification template not found")
 
         notification_service.update_template(uuid, is_active=enabled)
 
@@ -1520,16 +1378,13 @@ async def toggle_notification_template(uuid: str, enabled: bool):
     except Exception as e:
         logger.error(f"Error toggling notification template: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to toggle notification template"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to toggle notification template"
         )
 
 
 @router.get("/notifications/history")
 async def list_notification_history(
-    type: Optional[str] = None,
-    page: int = 1,
-    page_size: int = Query(default=20, ge=1, le=DEFAULT_MAX_PAGE_SIZE)
+    type: Optional[str] = None, page: int = 1, page_size: int = Query(default=20, ge=1, le=DEFAULT_MAX_PAGE_SIZE)
 ):
     """获取通知历史"""
     try:
@@ -1545,15 +1400,11 @@ async def list_notification_history(
             filters["channels"] = type
 
         result = notification_service.list_records(
-            filters=filters,
-            limit=page_size,
-            offset=offset,
-            sort=[("create_at", -1)]
+            filters=filters, limit=page_size, offset=offset, sort=[("create_at", -1)]
         )
         if not result.success:
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to list notification history"
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list notification history"
             )
 
         records = result.data
@@ -1561,21 +1412,26 @@ async def list_notification_history(
         for record in records:
             # 获取状态
             from ginkgo.enums import NOTIFICATION_STATUS_TYPES
+
             status_enum = NOTIFICATION_STATUS_TYPES.from_int(record.status)
             status_str = "success" if status_enum == NOTIFICATION_STATUS_TYPES.SENT else "failed"
 
             # 从 channels 中获取类型
             channel = record.channels[0] if record.channels else "system"
 
-            result_list.append({
-                "uuid": record.uuid,
-                "type": channel,
-                "subject": record.message_id,
-                "recipient": ", ".join(record.channels),
-                "status": status_str,
-                "created_at": record.create_at.isoformat() if record.create_at else datetime.utcnow().isoformat() + "Z",
-                "error": getattr(record, 'error_message', None)
-            })
+            result_list.append(
+                {
+                    "uuid": record.uuid,
+                    "type": channel,
+                    "subject": record.message_id,
+                    "recipient": ", ".join(record.channels),
+                    "status": status_str,
+                    "created_at": (
+                        record.create_at.isoformat() if record.create_at else datetime.utcnow().isoformat() + "Z"
+                    ),
+                    "error": getattr(record, "error_message", None),
+                }
+            )
 
         return ok(data=result_list)
 
@@ -1584,15 +1440,16 @@ async def list_notification_history(
     except Exception as e:
         logger.error(f"Error listing notification history: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list notification history"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list notification history"
         )
 
 
 # ==================== 通知接收人管理 ====================
 
+
 class UserInfo(BaseModel):
     """用户信息"""
+
     uuid: str
     username: str
     display_name: Optional[str] = None
@@ -1600,12 +1457,14 @@ class UserInfo(BaseModel):
 
 class UserGroupInfo(BaseModel):
     """用户组信息"""
+
     uuid: str
     name: str
 
 
 class NotificationRecipientSummary(BaseModel):
     """通知接收人摘要"""
+
     uuid: str
     name: str
     recipient_type: str  # USER, USER_GROUP
@@ -1620,6 +1479,7 @@ class NotificationRecipientSummary(BaseModel):
 
 class NotificationRecipientCreate(BaseModel):
     """创建通知接收人请求"""
+
     name: str
     recipient_type: str  # USER, USER_GROUP
     user_id: Optional[str] = None
@@ -1630,6 +1490,7 @@ class NotificationRecipientCreate(BaseModel):
 
 class NotificationRecipientUpdate(BaseModel):
     """更新通知接收人请求"""
+
     name: Optional[str] = None
     recipient_type: Optional[str] = None
     user_id: Optional[str] = None
@@ -1646,10 +1507,7 @@ async def list_notification_recipients():
         result = service.list_all()
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.message
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result.message)
 
         return ok(data=result.data["recipients"])
 
@@ -1658,8 +1516,7 @@ async def list_notification_recipients():
     except Exception as e:
         logger.error(f"Error listing notification recipients: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to list notification recipients"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list notification recipients"
         )
 
 
@@ -1675,35 +1532,34 @@ async def create_notification_recipient(data: NotificationRecipientCreate):
             user_id=data.user_id,
             user_group_id=data.user_group_id,
             is_default=data.is_default,
-            description=data.description
+            description=data.description,
         )
 
         if not result.is_success():
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.message
-            )
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result.message)
 
         recipient_data = result.data
-        return ok(data={
-            "uuid": recipient_data["uuid"],
-            "name": recipient_data["name"],
-            "recipient_type": recipient_data["recipient_type"].lower(),
-            "user_id": recipient_data["user_id"],
-            "user_group_id": recipient_data["user_group_id"],
-            "description": recipient_data["description"],
-            "is_default": recipient_data["is_default"],
-            "created_at": datetime.utcnow().isoformat() + "Z"
-        })
+        return ok(
+            data={
+                "uuid": recipient_data["uuid"],
+                "name": recipient_data["name"],
+                "recipient_type": recipient_data["recipient_type"].lower(),
+                "user_id": recipient_data["user_id"],
+                "user_group_id": recipient_data["user_group_id"],
+                "description": recipient_data["description"],
+                "is_default": recipient_data["is_default"],
+                "created_at": datetime.utcnow().isoformat() + "Z",
+            }
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         import traceback
+
         logger.error(f"Error creating notification recipient: {e}\nTraceback: {traceback.format_exc()}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to create notification recipient"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create notification recipient"
         )
 
 
@@ -1720,20 +1576,14 @@ async def update_notification_recipient(uuid: str, data: NotificationRecipientUp
             user_id=data.user_id,
             user_group_id=data.user_group_id,
             is_default=data.is_default,
-            description=data.description
+            description=data.description,
         )
 
         if not result.is_success():
             # Check if it's a "not found" error
             if "not found" in result.message.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=result.message
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.message
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result.message)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result.message)
 
         return ok(message="Notification recipient updated successfully")
 
@@ -1742,8 +1592,7 @@ async def update_notification_recipient(uuid: str, data: NotificationRecipientUp
     except Exception as e:
         logger.error(f"Error updating notification recipient {uuid}: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update notification recipient"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update notification recipient"
         )
 
 
@@ -1758,14 +1607,8 @@ async def delete_notification_recipient(uuid: str):
         if not result.is_success():
             # Check if it's a "not found" error
             if "not found" in result.message.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=result.message
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.message
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result.message)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result.message)
 
         return ok(message="Notification recipient deleted successfully")
 
@@ -1774,8 +1617,7 @@ async def delete_notification_recipient(uuid: str):
     except Exception as e:
         logger.error(f"Error deleting notification recipient {uuid}: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to delete notification recipient"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete notification recipient"
         )
 
 
@@ -1790,14 +1632,8 @@ async def toggle_notification_recipient(uuid: str):
         if not result.is_success():
             # Check if it's a "not found" error
             if "not found" in result.message.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=result.message
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=result.message
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=result.message)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=result.message)
 
         return ok(data={"is_default": result.data["is_default"]}, message="Notification recipient toggled successfully")
 
@@ -1806,8 +1642,7 @@ async def toggle_notification_recipient(uuid: str):
     except Exception as e:
         logger.error(f"Error updating notification recipient {uuid}: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to update notification recipient"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update notification recipient"
         )
 
 
@@ -1823,14 +1658,8 @@ async def test_notification_recipient(uuid: str):
         if not contacts_result.is_success():
             # Check if it's a "not found" error
             if "not found" in contacts_result.message.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail=contacts_result.message
-                )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=contacts_result.message
-            )
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=contacts_result.message)
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=contacts_result.message)
 
         contacts_data = contacts_result.data
         contacts = contacts_data.get("contacts", [])
@@ -1838,8 +1667,7 @@ async def test_notification_recipient(uuid: str):
 
         if contact_count == 0:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Recipient has no valid contact addresses"
+                status_code=status.HTTP_400_BAD_REQUEST, detail="Recipient has no valid contact addresses"
             )
 
         recipient_name = contacts_data.get("recipient_name", "Unknown")
@@ -1847,7 +1675,8 @@ async def test_notification_recipient(uuid: str):
 
         # 准备测试消息内容
         from datetime import datetime
-        test_time = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+
+        test_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         test_content = f"🧪 测试通知 - 接收人: {recipient_name} ({recipient_type}) | 发送时间: {test_time}"
 
         # 发送测试通知到每个联系方式
@@ -1865,21 +1694,20 @@ async def test_notification_recipient(uuid: str):
                     # #5469: 发送前校验目标 URL 防 SSRF（address 来自 DB contact，用户自设仍可控）。
                     _assert_safe_webhook_url(address)
                     import requests
+
                     payload = {
                         "content": test_content.replace("\n", " ").replace("\r", ""),
-                        "embeds": [{
-                            "title": "🧪 测试通知",
-                            "description": f"接收人: **{recipient_name}**\n类型: **{recipient_type}**",
-                            "color": 3447003,  # 蓝色
-                            "timestamp": datetime.now().isoformat()
-                        }]
+                        "embeds": [
+                            {
+                                "title": "🧪 测试通知",
+                                "description": f"接收人: **{recipient_name}**\n类型: **{recipient_type}**",
+                                "color": 3447003,  # 蓝色
+                                "timestamp": datetime.now().isoformat(),
+                            }
+                        ],
                     }
 
-                    response = requests.post(
-                        address,
-                        json=payload,
-                        timeout=10
-                    )
+                    response = requests.post(address, json=payload, timeout=10)
 
                     if response.status_code in [200, 204]:
                         success_count += 1
@@ -1920,28 +1748,32 @@ async def test_notification_recipient(uuid: str):
 
         logger.info(f"Test notification completed for recipient {uuid}: {success_count} success, {failed_count} failed")
 
-        return ok(data={
-            "details": results,
-            "recipient_name": recipient_name,
-            "contact_count": contact_count,
-            "success_count": success_count,
-            "failed_count": failed_count
-        }, message=f"测试通知已发送: {success_count} 成功, {failed_count} 失败")
+        return ok(
+            data={
+                "details": results,
+                "recipient_name": recipient_name,
+                "contact_count": contact_count,
+                "success_count": success_count,
+                "failed_count": failed_count,
+            },
+            message=f"测试通知已发送: {success_count} 成功, {failed_count} 失败",
+        )
 
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Error testing notification recipient {uuid}: {e}")
         raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to test notification recipient"
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to test notification recipient"
         )
 
 
 # ==================== API接口设置 ====================
 
+
 class CreateApiKeyRequest(BaseModel):
     """#5459: 创建 API 密钥请求（对齐前端 apiKey.ts CreateApiKeyRequest）。"""
+
     model_config = ConfigDict(extra="ignore")  # 忽略未知字段（#5474 同类校验理念）
     name: str = Field(..., min_length=1, description="密钥名称")
     permissions: Optional[List[str]] = Field(None, description="权限列表 read/trade/admin")
@@ -1952,6 +1784,7 @@ class CreateApiKeyRequest(BaseModel):
 
 class UpdateApiKeyRequest(BaseModel):
     """#5459: 更新 API 密钥请求（对齐前端 apiKey.ts UpdateApiKeyRequest，字段全可选）。"""
+
     model_config = ConfigDict(extra="ignore")
     name: Optional[str] = Field(None, min_length=1, description="密钥名称")
     permissions: Optional[List[str]] = Field(None, description="权限列表 read/trade/admin")
@@ -1962,6 +1795,7 @@ class UpdateApiKeyRequest(BaseModel):
 
 class APIKeySummary(BaseModel):
     """API密钥摘要"""
+
     key_id: str
     name: str
     masked_key: str
@@ -1972,6 +1806,7 @@ class APIKeySummary(BaseModel):
 
 class APIStats(BaseModel):
     """API统计"""
+
     today_calls: int
     month_calls: int
     success_rate: float

--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -16,6 +16,7 @@ from ginkgo.data.models import MUserCredential, MUser
 from ginkgo.enums import CONTACT_TYPES, CONTACT_METHOD_STATUS_TYPES
 from ginkgo.data.services.notification_service import NotificationService
 from core.logging import logger
+from core.pagination import DEFAULT_MAX_PAGE_SIZE
 from core.response import ok
 from core.exceptions import BusinessError
 from middleware.api_stats import collector as api_stats_collector
@@ -1528,7 +1529,7 @@ async def toggle_notification_template(uuid: str, enabled: bool):
 async def list_notification_history(
     type: Optional[str] = None,
     page: int = 1,
-    page_size: int = Query(default=20, ge=1, le=500)
+    page_size: int = Query(default=20, ge=1, le=DEFAULT_MAX_PAGE_SIZE)
 ):
     """获取通知历史"""
     try:

--- a/api/core/pagination.py
+++ b/api/core/pagination.py
@@ -1,0 +1,3 @@
+"""Shared pagination bounds for API route parameters."""
+
+DEFAULT_MAX_PAGE_SIZE = 500

--- a/tests/unit/test_api_page_size_bounds.py
+++ b/tests/unit/test_api_page_size_bounds.py
@@ -1,8 +1,9 @@
-"""#5566 AC1: 7 端点 page_size 加 Query(ge=1, le=500) 上限约束。
+"""#5566: API page_size 上限约束集中到默认配置。
 
 防 `?page_size=999999` 无界查询直达 DB LIMIT N 致内存膨胀。
 用 AST 源码级断言（零 import，绕过 api 层命名空间/容器启动问题）。
 """
+
 import ast
 from pathlib import Path
 
@@ -38,8 +39,12 @@ def _page_size_default(rel: str, fn_name: str):
     raise AssertionError(f"{fn_name} not found in {rel}")
 
 
+def _is_default_max_page_size(node) -> bool:
+    return isinstance(node, ast.Name) and node.id == "DEFAULT_MAX_PAGE_SIZE"
+
+
 def _is_bounded_query(node) -> bool:
-    """page_size 默认须是 Query(...) 调用且 keywords 含 le=500, ge=1。"""
+    """page_size 默认须是 Query(...) 调用且 keywords 含 le=DEFAULT_MAX_PAGE_SIZE, ge=1。"""
     if not isinstance(node, ast.Call):
         return False
     f = node.func
@@ -48,11 +53,39 @@ def _is_bounded_query(node) -> bool:
         return False
     le = ge = None
     for kw in node.keywords:
-        if kw.arg == "le" and isinstance(kw.value, ast.Constant):
-            le = kw.value.value
+        if kw.arg == "le":
+            le = kw.value
         if kw.arg == "ge" and isinstance(kw.value, ast.Constant):
             ge = kw.value.value
-    return le == 500 and ge == 1
+    return _is_default_max_page_size(le) and ge == 1
+
+
+def test_default_max_page_size_config_exists():
+    tree = ast.parse((REPO / "api/core/pagination.py").read_text())
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "DEFAULT_MAX_PAGE_SIZE":
+                    assert isinstance(node.value, ast.Constant)
+                    assert node.value.value == 500
+                    return
+    raise AssertionError("api/core/pagination.py must define DEFAULT_MAX_PAGE_SIZE = 500")
+
+
+def test_api_routes_do_not_hardcode_default_max_page_size():
+    offenders = []
+    for path in sorted((REPO / "api/api").glob("*.py")):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func_name = node.func.id if isinstance(node.func, ast.Name) else None
+            if func_name != "Query":
+                continue
+            for kw in node.keywords:
+                if kw.arg == "le" and isinstance(kw.value, ast.Constant) and kw.value.value == 500:
+                    offenders.append(f"{path.relative_to(REPO)}:{node.lineno}")
+    assert offenders == []
 
 
 @pytest.mark.parametrize("rel,fn_name", CASES)
@@ -60,6 +93,5 @@ def test_page_size_bounded(rel, fn_name):
     default = _page_size_default(rel, fn_name)
     assert default is not None, f"{fn_name}: page_size has no default value"
     assert _is_bounded_query(default), (
-        f"{fn_name}: page_size must be Query(default=…, ge=1, le=500), "
-        f"got {ast.dump(default)}"
+        f"{fn_name}: page_size must be Query(default=…, ge=1, le=DEFAULT_MAX_PAGE_SIZE), " f"got {ast.dump(default)}"
     )


### PR DESCRIPTION
## Summary

Completes the remaining #5566 AC3 follow-up from PR #6366:

- Adds `api/core/pagination.py` with `DEFAULT_MAX_PAGE_SIZE = 500`.
- Replaces the 7 #5566 route bounds with `le=DEFAULT_MAX_PAGE_SIZE`.
- Also replaces the remaining API route `le=500` bounds in `file.py` and `backtest.py`, so the default max is no longer hard-coded across routes.
- Extends the AST guard to verify the config exists and route `Query(le=500)` is not reintroduced.

Behavior is unchanged: the max remains 500.

## Test plan

- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/test_api_page_size_bounds.py -q -o "addopts=" --no-header --tb=short` — 9 passed
- `/home/kaoru/.ginkgo/.venv/bin/black --check api/core/pagination.py api/api/data.py api/api/settings.py api/api/node_graph.py api/api/file.py api/api/backtest.py tests/unit/test_api_page_size_bounds.py`
- `git diff --check`
- changed-file coverage check
- `py_compile` over `src api`
- startup smoke: 36 passed
- API import smoke with test `SECRET_KEY`: passed

Closes #5566
