### PR TITLE
fix: discover TaskTimer heartbeat node for status

### DIFF
--- a/src/ginkgo/client/tasktimer_cli.py
+++ b/src/ginkgo/client/tasktimer_cli.py
@@ -59,6 +59,20 @@ def parse_heartbeat_value(value):
     }
 
 
+def _discover_alive_task_timers(redis_client):
+    """Return live TaskTimer heartbeat entries as (node_id, key, ttl)."""
+    from ginkgo.data.redis_schema import RedisKeyPattern, RedisKeyPrefix
+
+    alive = []
+    for key in redis_client.keys(RedisKeyPattern.TASK_TIMER_HEARTBEAT_ALL):
+        ttl = redis_client.ttl(key)
+        if ttl and ttl > 0:
+            prefix = f"{RedisKeyPrefix.TASK_TIMER_HEARTBEAT}:"
+            node_id = key[len(prefix) :] if str(key).startswith(prefix) else key.split(":")[-1]
+            alive.append((node_id, key, ttl))
+    return alive
+
+
 app = typer.Typer(help=":alarm_clock: TaskTimer - Scheduled Task Manager", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
 
@@ -205,6 +219,12 @@ def status(
         # Check heartbeat
         exists = redis_client.exists(heartbeat_key)
         ttl = redis_client.ttl(heartbeat_key)
+        discovered = []
+        if not (exists and ttl > 0):
+            discovered = _discover_alive_task_timers(redis_client)
+            if len(discovered) == 1:
+                node_id, heartbeat_key, ttl = discovered[0]
+                exists = True
 
         console.print(f":information: TaskTimer Status Check")
         console.print(f":information: Node ID: {node_id}\n")
@@ -222,6 +242,11 @@ def status(
             console.print(f"[dim]PID: {heartbeat_data['pid']}[/dim]")
             console.print(f"[dim]Jobs: {heartbeat_data['jobs_count']}[/dim]")
             console.print(f"[dim]Last Heartbeat: {heartbeat_data['timestamp']}[/dim]")
+        elif discovered:
+            console.print("[yellow]:warning: Multiple TaskTimer heartbeats found[/yellow]")
+            for candidate_node_id, _, candidate_ttl in discovered:
+                console.print(f"[dim]- {candidate_node_id} (TTL: {candidate_ttl}s)[/dim]")
+            console.print("[dim]Please run: ginkgo tasktimer status --node-id <node_id>[/dim]")
         else:
             console.print(f"[red]:x: TaskTimer is [bold]DEAD[/bold] or not running[/red]")
             console.print(f"[dim]Heartbeat key not found or expired[/dim]")

--- a/tests/unit/client/test_tasktimer_cli.py
+++ b/tests/unit/client/test_tasktimer_cli.py
@@ -129,6 +129,53 @@ class TestHeartbeatCommand:
 
 
 # ============================================================================
+# status 命令 — 默认 node_id 错配时发现实际 TaskTimer heartbeat（#4890）
+# ============================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestTaskTimerStatusCommand:
+    """status 不应因默认 node_id 与容器实际 node_id 不同而直接误报 DEAD。"""
+
+    def test_status_discovers_single_alive_tasktimer_when_default_key_missing(self, cli_runner):
+        fake_redis = MagicMock()
+        fake_redis.exists.return_value = 0
+        fake_redis.ttl.side_effect = [-2, 30]
+        fake_redis.keys.return_value = ["heartbeat:task_timer:tasktimer_host123"]
+        fake_redis.get.return_value = (
+            '{"timestamp": "2026-07-06T10:00:00Z", "host": "host123", "pid": 123, "jobs_count": 4}'
+        )
+
+        with patch("redis.Redis", return_value=fake_redis):
+            result = cli_runner.invoke(tasktimer_cli.app, ["status"])
+
+        assert result.exit_code == 0
+        assert "tasktimer_host123" in result.output
+        assert "ALIVE" in result.output
+        assert "DEAD" not in result.output
+
+    def test_status_lists_candidates_when_multiple_tasktimers_exist(self, cli_runner):
+        fake_redis = MagicMock()
+        fake_redis.exists.return_value = 0
+        fake_redis.ttl.side_effect = [-2, 30, 28]
+        fake_redis.keys.return_value = [
+            "heartbeat:task_timer:tasktimer_a",
+            "heartbeat:task_timer:tasktimer_b",
+        ]
+
+        with patch("redis.Redis", return_value=fake_redis):
+            result = cli_runner.invoke(tasktimer_cli.app, ["status"])
+
+        assert result.exit_code == 0
+        assert "Multiple TaskTimer heartbeats found" in result.output
+        assert "tasktimer_a" in result.output
+        assert "tasktimer_b" in result.output
+        assert "--node-id" in result.output
+        assert "DEAD" not in result.output
+
+
+# ============================================================================
 # init 链路拷贝 task_timer.yml — #4723
 #   ginkgo init → GCONF.generate_config_file 未安装 task_timer.yml，
 #   用户首次 tasktimer validate 即报 INVALID。修复：与 config.yml/secure.yml


### PR DESCRIPTION
## Summary
- discover live TaskTimer heartbeat keys when the default status node id is missing
- auto-use the single live TaskTimer node instead of reporting DEAD
- list candidate node ids when multiple TaskTimer heartbeats exist and ask for --node-id

Closes #4890

## Tests
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_tasktimer_cli.py -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_tasktimer_cli.py --cov=ginkgo.client.tasktimer_cli --cov-report=term-missing -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 59-73 --line-ranges 219-255 src/ginkgo/client/tasktimer_cli.py
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 128-181 tests/unit/client/test_tasktimer_cli.py
- git diff --check
- /home/kaoru/.ginkgo/.venv/bin/python -m compileall -q src api
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short