### PR TITLE
fix: add deploy undeploy command

### DIFF
--- a/src/ginkgo/client/deploy_cli.py
+++ b/src/ginkgo/client/deploy_cli.py
@@ -111,6 +111,37 @@ def info(
         raise typer.Exit(1)
 
 
+@app.command("undeploy")
+def undeploy(
+    deployment_id: Annotated[
+        str, typer.Argument(help="部署记录 ID 或 Portfolio ID（按部署 UUID / 源组合 / 目标组合 任一反查）")
+    ],
+):
+    """撤销部署并停止目标 Portfolio"""
+    try:
+        from ginkgo.trading.containers import trading_container
+
+        svc = trading_container.deployment_service()
+        result = svc.undeploy(deployment_id)
+
+        if result.success:
+            data = result.data or {}
+            console.print(f"[green]{result.message or '撤销部署成功'}[/green]")
+            if data.get("deployment_id"):
+                console.print(f"  Deployment ID: [cyan]{data['deployment_id']}[/cyan]")
+            if data.get("target_portfolio_id"):
+                console.print(f"  Target Portfolio: [cyan]{data['target_portfolio_id']}[/cyan]")
+        else:
+            console.print(f"[red]{result.error}[/red]")
+            raise typer.Exit(1)
+
+    except typer.Exit:
+        raise
+    except Exception as e:
+        console.print(f"[red]Error: {e}[/red]")
+        raise typer.Exit(1)
+
+
 @app.command("list")
 def list_deployments(
     portfolio_id: Annotated[Optional[str], typer.Option("--portfolio", "-p", help="按Portfolio ID筛选")] = None,

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -400,6 +400,63 @@ class DeploymentService(BaseService):
             GLOG.ERROR(f"Failed to find deployments by target: {e}")
             return ServiceResult.error(f"Failed to find deployments: {str(e)}")
 
+    def undeploy(self, deployment_id: str) -> ServiceResult:
+        """撤销部署：停止目标 Portfolio，并将部署记录标记为 STOPPED。"""
+        try:
+            if not deployment_id or not deployment_id.strip():
+                return ServiceResult(success=False, error="部署记录 ID 或 Portfolio ID 不能为空")
+
+            records = []
+            for finder in (
+                self._deployment_crud.get_by_uuid,
+                self._deployment_crud.get_by_source_portfolio,
+                self._deployment_crud.get_by_target_portfolio,
+            ):
+                found = finder(deployment_id) or []
+                records.extend(found)
+                if found:
+                    break
+
+            if not records:
+                return ServiceResult(success=False, error="未找到部署记录")
+
+            deployment = next(
+                (r for r in records if getattr(r, "status", None) == DEPLOYMENT_STATUS.DEPLOYED),
+                records[0],
+            )
+            if getattr(deployment, "status", None) == DEPLOYMENT_STATUS.STOPPED:
+                return ServiceResult(success=False, error="部署已停止")
+            if getattr(deployment, "status", None) != DEPLOYMENT_STATUS.DEPLOYED:
+                return ServiceResult(
+                    success=False,
+                    error=f"部署状态不允许撤销: {_status_name(getattr(deployment, 'status', None))}",
+                )
+
+            target_portfolio_id = getattr(deployment, "target_portfolio_id", "")
+            if not target_portfolio_id:
+                return ServiceResult(success=False, error="部署记录缺少目标 Portfolio")
+
+            stop_result = self._portfolio_service.stop(target_portfolio_id)
+            if not stop_result.success and "已停止" not in (stop_result.error or ""):
+                return ServiceResult(success=False, error=stop_result.error)
+
+            self._deployment_crud.modify(
+                filters={"uuid": deployment.uuid},
+                updates={"status": DEPLOYMENT_STATUS.STOPPED},
+            )
+
+            return ServiceResult(
+                success=True,
+                data={
+                    "deployment_id": deployment.uuid,
+                    "target_portfolio_id": target_portfolio_id,
+                },
+                message="撤销部署成功",
+            )
+        except Exception as e:
+            GLOG.ERROR(f"撤销部署失败: {e}")
+            return ServiceResult(success=False, error=f"撤销部署失败: {str(e)}")
+
     def _copy_params_raw(self, old_mapping_id: str, new_mapping_id: str) -> None:
         """原始值复制参数，不经过 json 序列化/反序列化"""
         from ginkgo.data.models import MParam

--- a/tests/unit/client/test_deploy_cli.py
+++ b/tests/unit/client/test_deploy_cli.py
@@ -23,7 +23,7 @@ def cli_runner():
 
 def _mock_svc():
     svc = MagicMock()
-    svc.get_deployment_info.return_value = ServiceResult(
+    deployment_info = ServiceResult(
         success=True,
         data={
             "source_task_id": "bt_task_123",
@@ -36,8 +36,17 @@ def _mock_svc():
             "create_at": "2026-06-22 10:00:00",
         },
     )
+    svc.get_deployment_info.return_value = deployment_info
+    svc.get_deployment_by_id.return_value = deployment_info
+    svc.find_by_source_portfolio.return_value = ServiceResult(success=True, data=[])
+    svc.find_by_target_portfolio.return_value = ServiceResult(success=True, data=[])
     svc.deploy.return_value = ServiceResult(
         success=True, data={"portfolio_id": "tgt_pid", "deployment_id": "d1"}
+    )
+    svc.undeploy.return_value = ServiceResult(
+        success=True,
+        data={"deployment_id": "d1", "target_portfolio_id": "tgt_pid"},
+        message="撤销部署成功",
     )
     return svc
 
@@ -77,3 +86,33 @@ class TestDeploySourceTaskPassthrough:
         svc.deploy.assert_called_once()
         _, kwargs = svc.deploy.call_args
         assert kwargs.get("source_task_id") == "bt_task_456"
+
+
+class TestDeployUndeployCommand:
+    """#4988: deploy undeploy 应撤销已部署组合。"""
+
+    def test_undeploy_calls_service(self, cli_runner):
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=_mock_svc(),
+        ) as factory:
+            result = cli_runner.invoke(deploy_cli.app, ["undeploy", "src_pid"])
+
+        assert result.exit_code == 0, result.output
+        svc = factory.return_value
+        svc.undeploy.assert_called_once_with("src_pid")
+        assert "撤销部署成功" in result.output
+        assert "tgt_pid" in result.output
+
+    def test_undeploy_failure_exits(self, cli_runner):
+        svc = _mock_svc()
+        svc.undeploy.return_value = ServiceResult(success=False, error="未找到部署记录")
+
+        with patch(
+            "ginkgo.trading.containers.trading_container.deployment_service",
+            return_value=svc,
+        ):
+            result = cli_runner.invoke(deploy_cli.app, ["undeploy", "missing_pid"])
+
+        assert result.exit_code == 1
+        assert "未找到部署记录" in result.output

--- a/tests/unit/trading/services/test_deployment_service.py
+++ b/tests/unit/trading/services/test_deployment_service.py
@@ -10,6 +10,7 @@ if _path not in sys.path:
 import pytest
 from unittest.mock import MagicMock
 from ginkgo.enums import PORTFOLIO_MODE_TYPES
+from ginkgo.enums import DEPLOYMENT_STATUS
 
 # #3626 已修: MDeployment() 实例化不再触发 MUserCredential mapper 错误, 全部测试可跑。
 # deploy→_deploy_core 路径现可经公共接口测(见 test_deploy_propagates_source_initial_capital)。
@@ -282,6 +283,65 @@ class TestDeploymentServiceErrorMessages:
         assert not result.error.startswith("部署失败:")
 
 
+class TestDeploymentServiceUndeploy:
+    """#4988: 支持撤销部署，释放已部署组合生命周期。"""
+
+    def test_undeploy_stops_target_portfolio_and_marks_deployment_stopped(self):
+        svc = _make_svc()
+        deployment = MagicMock()
+        deployment.uuid = "dep-1"
+        deployment.source_portfolio_id = "src-pid"
+        deployment.target_portfolio_id = "tgt-pid"
+        deployment.status = DEPLOYMENT_STATUS.DEPLOYED
+        svc._deployment_crud.get_by_uuid.return_value = []
+        svc._deployment_crud.get_by_source_portfolio.return_value = [deployment]
+        svc._portfolio_service.stop.return_value = MagicMock(success=True, data={"portfolio_id": "tgt-pid"})
+
+        result = svc.undeploy("src-pid")
+
+        assert result.success, result.error
+        svc._portfolio_service.stop.assert_called_once_with("tgt-pid")
+        svc._deployment_crud.modify.assert_called_once_with(
+            filters={"uuid": "dep-1"},
+            updates={"status": DEPLOYMENT_STATUS.STOPPED},
+        )
+        assert result.data["deployment_id"] == "dep-1"
+        assert result.data["target_portfolio_id"] == "tgt-pid"
+
+    def test_undeploy_stopped_deployment_does_not_send_stop_again(self):
+        svc = _make_svc()
+        deployment = MagicMock()
+        deployment.uuid = "dep-1"
+        deployment.target_portfolio_id = "tgt-pid"
+        deployment.status = DEPLOYMENT_STATUS.STOPPED
+        svc._deployment_crud.get_by_uuid.return_value = [deployment]
+
+        result = svc.undeploy("dep-1")
+
+        assert not result.success
+        assert "已停止" in result.error
+        svc._portfolio_service.stop.assert_not_called()
+        svc._deployment_crud.modify.assert_not_called()
+
+    def test_undeploy_marks_deployment_stopped_when_target_already_stopped(self):
+        """目标组合已由旧 unload 停止时，仍应释放 deployment 冻结状态。"""
+        svc = _make_svc()
+        deployment = MagicMock()
+        deployment.uuid = "dep-1"
+        deployment.target_portfolio_id = "tgt-pid"
+        deployment.status = DEPLOYMENT_STATUS.DEPLOYED
+        svc._deployment_crud.get_by_uuid.return_value = [deployment]
+        svc._portfolio_service.stop.return_value = MagicMock(success=False, error="组合已停止")
+
+        result = svc.undeploy("dep-1")
+
+        assert result.success, result.error
+        svc._deployment_crud.modify.assert_called_once_with(
+            filters={"uuid": "dep-1"},
+            updates={"status": DEPLOYMENT_STATUS.STOPPED},
+        )
+
+
 class TestDeploymentCloneKeepsAllBindings:
     """#6279: deploy 克隆必须保留全部组件绑定 (strategy/sizer 不被图同步删除)"""
 
@@ -436,4 +496,3 @@ class TestDeploymentServiceSourceTaskAutoFill:
         assert deployment_arg.source_task_id is None, (
             f"无 completed 回测时 source_task_id 应留空, 实际={deployment_arg.source_task_id!r}"
         )
-


### PR DESCRIPTION
## Summary
- add `ginkgo deploy undeploy <id>` for deployment UUID, source portfolio, or target portfolio lookup
- stop the deployed target portfolio through `PortfolioService.stop()`
- mark the deployment record as `STOPPED`, including already-stopped target portfolios so source portfolios are released

Closes #4988

## Tests
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_deploy_cli.py tests/unit/client/test_deploy_cli_info.py tests/unit/client/test_deploy_cli_list.py -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/trading/services/test_deployment_service.py tests/unit/trading/services/test_deployment_service_find.py tests/unit/trading/services/test_deployment_service_info_status.py tests/unit/trading/services/test_deployment_return_type_3882.py -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 114-143 src/ginkgo/client/deploy_cli.py
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 403-458 src/ginkgo/trading/services/deployment_service.py
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 26-42 --line-ranges 46-50 --line-ranges 91-118 tests/unit/client/test_deploy_cli.py
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 286-342 tests/unit/trading/services/test_deployment_service.py
- git diff --check
- /home/kaoru/.ginkgo/.venv/bin/python -m compileall -q src api
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short

## Notes
- Coverage command was attempted but pytest-cov collection hit an unrelated SciPy/numpy Python 3.14 import error (`_CopyMode.IF_NEEDED is neither True nor False`) while the same targeted tests pass without coverage.