### PR TITLE
fix: require target for scheduler migrate

### DIFF
--- a/src/ginkgo/client/scheduler_cli.py
+++ b/src/ginkgo/client/scheduler_cli.py
@@ -398,7 +398,7 @@ def nodes():
 @app.command()
 def migrate(
     portfolio_id: str = typer.Argument(..., help="Portfolio ID to migrate"),
-    target_node: str = typer.Option(None, "--target", "-t", help="Target ExecutionNode ID (if not specified, Scheduler will choose)"),
+    target_node: str = typer.Option(..., "--target", "-t", help="Target ExecutionNode ID"),
     force: bool = typer.Option(False, "--force", "-f", help="Force migration without confirmation"),
 ):
     """
@@ -408,7 +408,7 @@ def migrate(
 
     Examples:
       ginkgo scheduler migrate portfolio_uuid --target node_1
-      ginkgo scheduler migrate portfolio_uuid --force
+      ginkgo scheduler migrate portfolio_uuid --target node_1 --force
     """
     try:
         from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
@@ -417,19 +417,12 @@ def migrate(
 
         console.print(f":information: Migrating portfolio [cyan]{portfolio_id[:8]}...[/cyan]")
 
-        # If no target specified, get recommendation from Scheduler
-        if not target_node:
-            console.print(":information: No target specified, Scheduler will choose optimal node")
-            # TODO: Implement load-based recommendation
-            console.print("[yellow]:warning: Auto-selection not implemented, please specify --target[/yellow]")
-            raise typer.Exit(1)
-
         # Create migration command using DTO
         migration_dto = ScheduleUpdateDTO(
             command=ScheduleUpdateDTO.Commands.PORTFOLIO_MIGRATE,
             portfolio_id=portfolio_id,
             target_node=target_node,
-            source="cli"
+            source="cli",
         )
 
         # Show migration plan
@@ -799,5 +792,3 @@ def resume():
     except Exception as e:
         console.print(f"[red]:x: Error resuming scheduler: {e}[/red]")
         raise typer.Exit(1)
-
-

--- a/tests/unit/client/test_scheduler_cli.py
+++ b/tests/unit/client/test_scheduler_cli.py
@@ -165,6 +165,25 @@ class TestSchedulePlanRead:
 
 
 # ===========================================================================
+# migrate 命令（#5056）
+# ===========================================================================
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestSchedulerMigrateTarget:
+    """#5056: 自动选节点未实现时，--target 应作为 CLI 必填项暴露。"""
+
+    def test_migrate_without_target_fails_at_cli_validation(self, cli_runner):
+        result = cli_runner.invoke(scheduler_cli.app, ["migrate", "portfolio-001", "--force"])
+
+        assert result.exit_code == 2
+        assert "--target" in result.output
+        assert "Auto-selection not implemented" not in result.output
+        assert "Error migrating portfolio" not in result.output
+
+
+# ===========================================================================
 # 输出转义（#6001）
 # ===========================================================================
 


### PR DESCRIPTION
## Summary
- make `ginkgo scheduler migrate --target` a required option while auto-selection is not implemented
- remove the runtime auto-selection stub that produced `Error migrating portfolio: 1`
- update migrate help example and add CLI validation coverage

Closes #5056

## Tests
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/client/test_scheduler_cli.py -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 398-423 src/ginkgo/client/scheduler_cli.py
- /home/kaoru/.ginkgo/.venv/bin/python -m black --check --line-ranges 164-182 tests/unit/client/test_scheduler_cli.py
- git diff --check
- /home/kaoru/.ginkgo/.venv/bin/python -m compileall -q src api
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short