### PR TITLE
fix: compute paper trading daily returns (#6048)

### DIFF
--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -121,10 +121,10 @@ def _get_stockinfo_service():
     return container.stockinfo_service()
 
 
-def _get_analyzer_record_crud():
-    """获取 AnalyzerRecordCRUD 实例（#6048: 查询上一日净资产）。"""
+def _get_analyzer_service():
+    """获取 AnalyzerService 实例（#6048: 查询上一日净资产，走 Service 分层非直访 CRUD）。"""
     from ginkgo.data.containers import container
-    return container.cruds.analyzer_record()
+    return container.analyzer_service()
 
 
 def _resolve_stock_names(codes: list) -> dict:
@@ -741,18 +741,22 @@ def _query_previous_net_asset(account_id: str, target_date: Optional[str] = None
         return None
 
     end_time = day_start - timedelta(microseconds=1)
-    crud = _get_analyzer_record_crud()
+    analyzer_service = _get_analyzer_service()
     for use_business_time in (True, False):
-        try:
-            records = crud.find_by_time_range(
-                portfolio_id=account_id,
-                end_time=end_time,
-                use_business_time=use_business_time,
-                analyzer_name="net_value",
+        result = analyzer_service.find_latest_before(
+            portfolio_id=account_id,
+            end_time=end_time,
+            analyzer_name="net_value",
+            use_business_time=use_business_time,
+        )
+        if not result.success:
+            # DB 故障：propagate 为 500（对齐 _query_positions, #5479 / 544c851c），
+            # 不吞为 None 让 today_pnl/daily_return 静默归 0。
+            raise HTTPException(
+                status_code=500,
+                detail=f"查询上一日净资产失败: {result.error}",
             )
-        except Exception:
-            continue
-        value = _record_value(records)
+        value = _record_value(result.data)
         if value is not None:
             return value
     return None

--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -7,7 +7,7 @@ Paper Trading 相关 API 路由
 from fastapi import APIRouter, HTTPException, status, Query, Request
 from pydantic import BaseModel, Field
 from typing import Optional, List
-from datetime import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 import sys
 from pathlib import Path
@@ -121,6 +121,12 @@ def _get_stockinfo_service():
     return container.stockinfo_service()
 
 
+def _get_analyzer_record_crud():
+    """获取 AnalyzerRecordCRUD 实例（#6048: 查询上一日净资产）。"""
+    from ginkgo.data.containers import container
+    return container.cruds.analyzer_record()
+
+
 def _resolve_stock_names(codes: list) -> dict:
     """批量查询股票名称，返回 {code: name}（#6048）。
 
@@ -210,6 +216,7 @@ async def list_paper_accounts():
             cash = float(getattr(p, 'cash', initial_capital) or initial_capital)
             position_value = _compute_position_value(_query_positions(p.uuid))
             total_asset = cash + position_value
+            today_pnl = _compute_today_pnl(total_asset, _query_previous_net_asset(p.uuid))
 
             accounts.append({
                 "uuid": p.uuid,
@@ -218,7 +225,7 @@ async def list_paper_accounts():
                 "available_cash": cash,
                 "position_value": position_value,
                 "total_asset": total_asset,
-                "today_pnl": 0,  # TODO(#6048): 需历史 position_record 按日对比（独立 slice）
+                "today_pnl": today_pnl,
                 "total_pnl": _compute_total_pnl(total_asset, initial_capital),
                 "status": _map_pt_status(p),
                 "created_at": _format_datetime(getattr(p, 'create_at', None)),
@@ -322,6 +329,7 @@ async def get_paper_account(account_id: str):
         positions = _query_positions(account_id)
         position_value = _compute_position_value(positions)
         total_asset = cash + position_value
+        today_pnl = _compute_today_pnl(total_asset, _query_previous_net_asset(account_id))
 
         # 查询活跃订单（pending 状态）
         orders = _query_orders(account_id, status_filter=["pending"])
@@ -334,7 +342,7 @@ async def get_paper_account(account_id: str):
                 "available_cash": cash,
                 "position_value": position_value,
                 "total_asset": total_asset,
-                "today_pnl": 0,  # TODO(#6048): 需历史 position_record 按日对比（独立 slice）
+                "today_pnl": today_pnl,
                 "total_pnl": _compute_total_pnl(total_asset, initial_capital),
                 "status": _map_pt_status(p),
                 "created_at": _format_datetime(getattr(p, 'create_at', None)),
@@ -556,14 +564,18 @@ async def get_paper_report(
         positions_result = result_service.get_current_positions(account_id, min_volume=1)
         positions = positions_result.data if positions_result.success else []
         positions_count = len(positions) if positions else 0
+        position_value = _compute_position_records_value(positions)
+        total_asset = cash + position_value
 
-        total_return = (cash / initial_capital - 1) * 100 if initial_capital > 0 else 0
+        total_return = _compute_return_rate(total_asset, initial_capital)
+        previous_net_asset = _query_previous_net_asset(account_id, target_date)
+        daily_return = _compute_daily_return(total_asset, previous_net_asset)
 
         return ok(
             data={
                 "date": target_date,
-                "total_return": round(total_return, 4),
-                "daily_return": 0,  # TODO: 需要前一日数据对比
+                "total_return": total_return,
+                "daily_return": daily_return,
                 "trades_count": trades_count,
                 "positions_count": positions_count,
             },
@@ -636,6 +648,20 @@ def _compute_position_value(positions: list) -> float:
         return 0.0
 
 
+def _compute_position_records_value(positions: list) -> float:
+    """从持仓记录对象计算总市值（price * volume）。"""
+    try:
+        return round(
+            sum(
+                float(getattr(p, "price", 0) or 0) * int(getattr(p, "volume", 0) or 0)
+                for p in (positions or [])
+            ),
+            2,
+        )
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _compute_total_pnl(total_asset: float, initial_capital: float) -> float:
     """计算总盈亏 = 当前净资产 − 初始资金（#6048）。
 
@@ -647,6 +673,89 @@ def _compute_total_pnl(total_asset: float, initial_capital: float) -> float:
         return round(float(total_asset) - float(initial_capital), 2)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _compute_return_rate(total_asset: float, initial_capital: float) -> float:
+    """计算累计收益率百分比。"""
+    try:
+        initial = float(initial_capital)
+        if initial <= 0:
+            return 0.0
+        return round((float(total_asset) / initial - 1) * 100, 4)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _compute_today_pnl(total_asset: float, previous_net_asset: Optional[float]) -> float:
+    """计算今日盈亏；缺少上一日净资产时降级为 0。"""
+    try:
+        if previous_net_asset is None or float(previous_net_asset) <= 0:
+            return 0.0
+        return round(float(total_asset) - float(previous_net_asset), 2)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _compute_daily_return(total_asset: float, previous_net_asset: Optional[float]) -> float:
+    """计算日收益率百分比；缺少上一日净资产时降级为 0。"""
+    try:
+        previous = float(previous_net_asset)
+        if previous <= 0:
+            return 0.0
+        return round((float(total_asset) / previous - 1) * 100, 4)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _target_day_start(target_date: Optional[str] = None) -> Optional[datetime]:
+    """返回目标日期 00:00；非法日期返回 None。"""
+    if target_date:
+        try:
+            return datetime.strptime(str(target_date), "%Y-%m-%d")
+        except (TypeError, ValueError):
+            return None
+    now = datetime.now()
+    return datetime(now.year, now.month, now.day)
+
+
+def _record_value(records) -> Optional[float]:
+    """提取查询结果第一条 analyzer value。"""
+    items = records if isinstance(records, list) else getattr(records, "data", [])
+    if not items:
+        return None
+    try:
+        value = float(getattr(items[0], "value", 0) or 0)
+        return value if value > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _query_previous_net_asset(account_id: str, target_date: Optional[str] = None) -> Optional[float]:
+    """查询目标日前最近一条 net_value 分析器记录。
+
+    NetValue analyzer 记录的是组合总资产（worth），不是归一化净值；因此可直接作为
+    ``today_pnl`` / ``daily_return`` 的上一期净资产基准。没有记录时返回 None。
+    """
+    day_start = _target_day_start(target_date)
+    if day_start is None:
+        return None
+
+    end_time = day_start - timedelta(microseconds=1)
+    crud = _get_analyzer_record_crud()
+    for use_business_time in (True, False):
+        try:
+            records = crud.find_by_time_range(
+                portfolio_id=account_id,
+                end_time=end_time,
+                use_business_time=use_business_time,
+                analyzer_name="net_value",
+            )
+        except Exception:
+            continue
+        value = _record_value(records)
+        if value is not None:
+            return value
+    return None
 
 
 def _expand_status_enums(status_filter: Optional[List[str]]) -> list:

--- a/api/api/trading.py
+++ b/api/api/trading.py
@@ -584,6 +584,11 @@ async def get_paper_report(
 
     except NotFoundError:
         raise
+    except HTTPException:
+        # 透传 helper 的 HTTPException(500)，避免被下方 except Exception 吞成 BusinessError(400)。
+        # HTTPException 继承 Exception，须显式前置 except，否则 AC1 生产路径返 400 非 500
+        # （544c851c/#5479 立规：DB 故障 loud，对齐 _query_positions / get_paper_account）。
+        raise
     except Exception as e:
         logger.error(f"Error getting paper report {account_id}: {str(e)}")
         raise BusinessError(f"Error getting paper report: {str(e)}")

--- a/src/ginkgo/data/services/analyzer_service.py
+++ b/src/ginkgo/data/services/analyzer_service.py
@@ -164,6 +164,32 @@ class AnalyzerService(BaseService):
             GLOG.ERROR(f"按 portfolio 查询失败: {e}")
             return ServiceResult.error(f"按 portfolio 查询失败: {e}")
 
+    def find_latest_before(
+        self,
+        portfolio_id: str,
+        end_time: Any,
+        analyzer_name: Optional[str] = None,
+        use_business_time: bool = True,
+    ) -> ServiceResult:
+        """查询 ``end_time`` 之前最近的 analyzer 记录（按时间倒序，records[0] 为最近）。
+
+        #6048: 封装 ``crud.find_by_time_range``，供 API 层查询上一日净资产基准，
+        避免 API 层直访 CRUD 违反分层（API → Service → CRUD）。
+        """
+        try:
+            records = self._crud_repo.find_by_time_range(
+                portfolio_id=portfolio_id,
+                start_time=None,
+                end_time=end_time,
+                use_business_time=use_business_time,
+                analyzer_name=analyzer_name,
+            )
+            GLOG.INFO(f"按时间范围查询成功: portfolio_id={portfolio_id}, count={len(records) if records else 0}")
+            return ServiceResult.success(records)
+        except Exception as e:
+            GLOG.ERROR(f"按时间范围查询失败: {e}")
+            return ServiceResult.error(f"按时间范围查询失败: {e}")
+
     def get_records(
         self,
         portfolio_id: Optional[str] = None,

--- a/tests/api/test_trading_daily_return.py
+++ b/tests/api/test_trading_daily_return.py
@@ -143,6 +143,38 @@ def test_query_previous_net_asset_returns_value_and_falls_back_to_timestamp(api_
     assert kwargs_f["use_business_time"] is False
 
 
+def test_get_paper_report_propagates_helper_http_exception(api_modules):
+    """端点层须透传 _query_previous_net_asset 的 HTTPException(500)。
+
+    DB 故障时 helper 已 loud raise HTTPException(500)（见
+    test_query_previous_net_asset_raises_on_db_failure）；但 ``get_paper_report``
+    的 ``except Exception`` 会把 HTTPException 吞成 BusinessError(400)（HTTPException
+    继承 Exception，FastAPI 按 MRO 先于 HTTPException handler 匹配 except Exception），
+    违反本 PR AC + 544c851c/#5479 立规。须 ``except HTTPException: raise`` 前置透传，
+    对齐 list_paper_accounts / get_paper_account。
+    """
+    from api.trading import get_paper_report
+    from fastapi import HTTPException
+
+    portfolio = SimpleNamespace(uuid="acc-1", initial_capital=100000, cash=95000)
+    result_service = MagicMock()
+    result_service.get_orders_by_portfolio_date.return_value = ServiceResult.success([])
+    result_service.get_current_positions.return_value = ServiceResult.success([])
+
+    with (
+        patch("api.trading._require_portfolio", return_value=[portfolio]),
+        patch("api.trading._get_result_service", return_value=result_service),
+        patch(
+            "api.trading._query_previous_net_asset",
+            side_effect=HTTPException(status_code=500, detail="查询上一日净资产失败: DB down"),
+        ),
+    ):
+        with pytest.raises(HTTPException) as exc:
+            run_async(get_paper_report("acc-1", date="2026-07-05"))
+
+    assert exc.value.status_code == 500
+
+
 def test_query_previous_net_asset_none_when_no_history(api_modules):
     """两次查询都空（无历史记录）→ 返回 None（合法，新账户未跑过）。"""
     from api.trading import _query_previous_net_asset

--- a/tests/api/test_trading_daily_return.py
+++ b/tests/api/test_trading_daily_return.py
@@ -1,0 +1,103 @@
+# Issue #6048: trading API today_pnl / daily_return use real net asset deltas.
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(autouse=True)
+def _ensure_debug():
+    GCONF.set_debug(True)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def test_get_paper_report_total_and_daily_return_use_net_assets(api_modules):
+    """日报收益率应基于现金+持仓市值；日收益基于上一条净值记录。"""
+    from api.trading import get_paper_report
+    from ginkgo.enums import ORDERSTATUS_TYPES
+
+    portfolio = SimpleNamespace(uuid="acc-1", initial_capital=100000, cash=95000)
+    positions = [
+        SimpleNamespace(code="000001", price=10, volume=600, status=None),
+        SimpleNamespace(code="600000", price=20, volume=200, status=None),
+    ]
+    orders = [SimpleNamespace(status=ORDERSTATUS_TYPES.FILLED)]
+
+    result_service = MagicMock()
+    result_service.get_orders_by_portfolio_date.return_value = ServiceResult.success(orders)
+    result_service.get_current_positions.return_value = ServiceResult.success(positions)
+
+    with (
+        patch("api.trading._require_portfolio", return_value=[portfolio]),
+        patch("api.trading._get_result_service", return_value=result_service),
+        patch("api.trading._query_previous_net_asset", return_value=102000.0),
+    ):
+        result = run_async(get_paper_report("acc-1", date="2026-07-05"))
+
+    data = result["data"]
+    assert data["total_return"] == 5.0
+    assert data["daily_return"] == 2.9412
+    assert data["trades_count"] == 1
+    assert data["positions_count"] == 2
+
+
+def test_get_paper_account_today_pnl_uses_previous_net_asset(api_modules):
+    """账户详情 today_pnl = 当前净资产 - 上一条净值记录。"""
+    from api.trading import get_paper_account
+
+    portfolio = SimpleNamespace(
+        uuid="acc-1",
+        name="paper",
+        initial_capital=100000,
+        cash=95000,
+        create_at=None,
+    )
+    positions = [{"code": "000001", "market_value": 10000.0}]
+
+    with (
+        patch("api.trading._require_portfolio", return_value=[portfolio]),
+        patch("api.trading._query_positions", return_value=positions),
+        patch("api.trading._query_orders", return_value=[]),
+        patch("api.trading._query_previous_net_asset", return_value=102000.0),
+    ):
+        result = run_async(get_paper_account("acc-1"))
+
+    data = result["data"]
+    assert data["total_asset"] == 105000.0
+    assert data["today_pnl"] == 3000.0
+
+
+def test_list_paper_accounts_today_pnl_uses_each_account_previous_net_asset(api_modules):
+    """账户列表每个账户独立计算 today_pnl。"""
+    from api.trading import list_paper_accounts
+
+    p1 = SimpleNamespace(uuid="acc-1", name="a", initial_capital=100000, cash=95000, create_at=None)
+    p2 = SimpleNamespace(uuid="acc-2", name="b", initial_capital=200000, cash=180000, create_at=None)
+
+    portfolio_service = MagicMock()
+    portfolio_service.get.return_value = ServiceResult.success([p1, p2])
+
+    positions_map = {
+        "acc-1": [{"market_value": 10000.0}],
+        "acc-2": [{"market_value": 15000.0}],
+    }
+    previous_map = {"acc-1": 102000.0, "acc-2": 190000.0}
+
+    with (
+        patch("api.trading._get_portfolio_service", return_value=portfolio_service),
+        patch("api.trading._query_positions", side_effect=lambda aid: positions_map[aid]),
+        patch("api.trading._query_previous_net_asset", side_effect=lambda aid: previous_map[aid]),
+    ):
+        result = run_async(list_paper_accounts())
+
+    accounts = result["data"]
+    assert accounts[0]["today_pnl"] == 3000.0
+    assert accounts[1]["today_pnl"] == 5000.0

--- a/tests/api/test_trading_daily_return.py
+++ b/tests/api/test_trading_daily_return.py
@@ -101,3 +101,57 @@ def test_list_paper_accounts_today_pnl_uses_each_account_previous_net_asset(api_
     accounts = result["data"]
     assert accounts[0]["today_pnl"] == 3000.0
     assert accounts[1]["today_pnl"] == 5000.0
+
+
+def test_query_previous_net_asset_raises_on_db_failure(api_modules):
+    """AnalyzerService DB 故障（ServiceResult.error）必须 loud raise HTTPException 500，
+    不得静默归 None 让 today_pnl/daily_return 归 0（对齐 _query_positions, #5479 / 544c851c）。"""
+    from api.trading import _query_previous_net_asset
+    from fastapi import HTTPException
+
+    analyzer_service = MagicMock()
+    analyzer_service.find_latest_before.return_value = ServiceResult.error("DB connection lost")
+
+    with patch("api.trading._get_analyzer_service", return_value=analyzer_service):
+        with pytest.raises(HTTPException) as exc:
+            _query_previous_net_asset("acc-1")
+
+    assert exc.value.status_code == 500
+    # DB 故障必须立即 raise，不得降级试 use_business_time=False
+    assert analyzer_service.find_latest_before.call_count == 1
+
+
+def test_query_previous_net_asset_returns_value_and_falls_back_to_timestamp(api_modules):
+    """success + business_time 查空 → 降级 timestamp 查到 → 返回 value。"""
+    from api.trading import _query_previous_net_asset
+
+    record = SimpleNamespace(value=102000.0)
+    analyzer_service = MagicMock()
+    analyzer_service.find_latest_before.side_effect = [
+        ServiceResult.success([]),  # use_business_time=True 空
+        ServiceResult.success([record]),  # use_business_time=False 命中
+    ]
+
+    with patch("api.trading._get_analyzer_service", return_value=analyzer_service):
+        value = _query_previous_net_asset("acc-1", target_date="2026-07-05")
+
+    assert value == 102000.0
+    assert analyzer_service.find_latest_before.call_count == 2
+    _, kwargs_t = analyzer_service.find_latest_before.call_args_list[0]
+    _, kwargs_f = analyzer_service.find_latest_before.call_args_list[1]
+    assert kwargs_t["use_business_time"] is True
+    assert kwargs_f["use_business_time"] is False
+
+
+def test_query_previous_net_asset_none_when_no_history(api_modules):
+    """两次查询都空（无历史记录）→ 返回 None（合法，新账户未跑过）。"""
+    from api.trading import _query_previous_net_asset
+
+    analyzer_service = MagicMock()
+    analyzer_service.find_latest_before.return_value = ServiceResult.success([])
+
+    with patch("api.trading._get_analyzer_service", return_value=analyzer_service):
+        value = _query_previous_net_asset("acc-1", target_date="2026-07-05")
+
+    assert value is None
+    assert analyzer_service.find_latest_before.call_count == 2

--- a/tests/unit/services/smoke/test_analyzer_service_smoke.py
+++ b/tests/unit/services/smoke/test_analyzer_service_smoke.py
@@ -1,9 +1,11 @@
 """Smoke test for AnalyzerService -- #3823"""
+
 import pytest
 from unittest.mock import MagicMock, patch
 
 try:
     from ginkgo.data.services.analyzer_service import AnalyzerService
+
     HAS_MODULE = True
 except ImportError:
     HAS_MODULE = False
@@ -49,3 +51,37 @@ class TestAnalyzerServiceSmoke:
         result = svc.get_latest_by_portfolio(portfolio_id="p1")
         assert result is not None
         mock_crud.find.assert_called_once()
+
+    def test_find_latest_before_forwards_to_crud_and_wraps_result(self):
+        """#6048: find_latest_before 封装 crud.find_by_time_range，转发参数并包装为 ServiceResult.success。"""
+        from datetime import datetime
+
+        svc, mock_crud = self._make_svc()
+        record = MagicMock(value=102000.0)
+        mock_crud.find_by_time_range.return_value = [record]
+
+        end = datetime(2026, 7, 5)
+        result = svc.find_latest_before(
+            portfolio_id="acc-1",
+            end_time=end,
+            analyzer_name="net_value",
+            use_business_time=True,
+        )
+
+        assert result.success is True
+        assert result.data == [record]
+        mock_crud.find_by_time_range.assert_called_once_with(
+            portfolio_id="acc-1",
+            start_time=None,
+            end_time=end,
+            use_business_time=True,
+            analyzer_name="net_value",
+        )
+
+    def test_find_latest_before_wraps_exception_as_error(self):
+        """#6048: crud 抛异常 → ServiceResult.error（API 层据 success=False raise 500，loud）。"""
+        svc, mock_crud = self._make_svc()
+        mock_crud.find_by_time_range.side_effect = RuntimeError("DB down")
+
+        result = svc.find_latest_before(portfolio_id="acc-1", end_time=None)
+        assert result.success is False


### PR DESCRIPTION
## Summary
- Compute paper account `today_pnl` from current net assets minus the latest prior `net_value` analyzer record.
- Compute daily report `total_return` from cash + current position market value, not cash alone.
- Compute daily report `daily_return` from the same current net asset against the prior net asset, falling back to 0 when no history exists.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/api/test_trading_daily_return.py tests/api/test_trading_position_value.py tests/api/test_trading_total_pnl.py tests/api/test_trading_stock_name.py tests/api/test_trading_helpers.py tests/api/test_paper_trading_status.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `PY=/home/kaoru/.ginkgo/.venv/bin/python; find src api -name "*.py" -not -path "*/__pycache__/*" -print0 | ... py_compile`
- `git diff --check` / `git diff --cached --check`
- `/home/kaoru/.ginkgo/.venv/bin/python -m black --check tests/api/test_trading_daily_return.py --line-length 120`

Closes #6048