### PR TITLE
fix: compensate portfolio mapping update/remove failures (#5559)

### DIFF
--- a/src/ginkgo/data/services/portfolio_mapping_service.py
+++ b/src/ginkgo/data/services/portfolio_mapping_service.py
@@ -193,6 +193,11 @@ class PortfolioMappingService(BaseService):
             ServiceResult
         """
         try:
+            previous_doc = self._snapshot_graph_from_mongo(
+                portfolio_uuid=portfolio_uuid,
+                source="GRAPH_EDITOR"
+            )
+
             # 1. 提取图中的文件映射和参数
             file_mappings = self._extract_files_from_graph(graph_data)
             node_params = self._extract_params_from_graph(graph_data)
@@ -205,17 +210,24 @@ class PortfolioMappingService(BaseService):
                 source="GRAPH_EDITOR"
             )
 
-            # 3. 同步到 MySQL Mapping
-            self._sync_mappings_from_files(
-                portfolio_uuid=portfolio_uuid,
-                file_mappings=file_mappings
-            )
+            try:
+                # 3. 同步到 MySQL Mapping
+                self._sync_mappings_from_files(
+                    portfolio_uuid=portfolio_uuid,
+                    file_mappings=file_mappings
+                )
 
-            # 4. 同步到 MySQL MParam
-            self._sync_params_from_nodes(
-                portfolio_uuid=portfolio_uuid,
-                node_params=node_params
-            )
+                # 4. 同步到 MySQL MParam
+                self._sync_params_from_nodes(
+                    portfolio_uuid=portfolio_uuid,
+                    node_params=node_params
+                )
+            except Exception:
+                if previous_doc:
+                    self._restore_graph_in_mongo(previous_doc)
+                else:
+                    self._delete_graph_from_mongo(mongo_id)
+                raise
 
             GLOG.INFO(f"从图编辑器更新配置: {portfolio_uuid}")
 
@@ -349,18 +361,26 @@ class PortfolioMappingService(BaseService):
             mappings = self._mapping_crud.find(
                 filters={"portfolio_id": portfolio_uuid, "file_id": file_id}
             )
+            param_snapshots = {
+                mapping.uuid: list(self._param_service.find_by_mapping_id(mapping.uuid))
+                for mapping in mappings
+            }
 
-            # 2. 删除对应的参数
-            for mapping in mappings:
-                self._param_service.remove_by_mapping(mapping.uuid)
+            try:
+                # 2. 删除对应的参数
+                for mapping in mappings:
+                    self._param_service.remove_by_mapping(mapping.uuid)
 
-            # 3. 删除 MySQL Mapping
-            self._mapping_crud.delete_mapping(portfolio_uuid, file_id)
+                # 3. 删除 MySQL Mapping
+                self._mapping_crud.delete_mapping(portfolio_uuid, file_id)
 
-            GLOG.INFO(f"移除文件映射: {portfolio_uuid} -> {file_id}")
+                GLOG.INFO(f"移除文件映射: {portfolio_uuid} -> {file_id}")
 
-            # 4. 同步更新 MongoDB 图结构
-            self._sync_graph_from_mappings(portfolio_uuid)
+                # 4. 同步更新 MongoDB 图结构
+                self._sync_graph_from_mappings(portfolio_uuid)
+            except Exception:
+                self._restore_removed_file_mappings(mappings, param_snapshots)
+                raise
 
             return ServiceResult.success(data={"file_id": file_id})
 
@@ -757,6 +777,30 @@ class PortfolioMappingService(BaseService):
             GLOG.ERROR(f"补偿删除 MongoDB 图文档失败: {doc_id}, {e}")
             return False
 
+    def _snapshot_graph_from_mongo(
+        self,
+        portfolio_uuid: str,
+        source: str = "GRAPH_EDITOR",
+    ) -> Optional[Dict[str, Any]]:
+        """读取当前图文档快照，用于 update 失败补偿。"""
+        collection = self._mongo_driver.get_collection("portfolio_graph_data")
+        return collection.find_one({
+            "portfolio_uuid": portfolio_uuid,
+            "metadata.source": source
+        })
+
+    def _restore_graph_in_mongo(self, document: Dict[str, Any]) -> bool:
+        """恢复 MongoDB 图文档快照（补偿原语，#5559）。"""
+        try:
+            if not document or "_id" not in document:
+                return False
+            collection = self._mongo_driver.get_collection("portfolio_graph_data")
+            collection.replace_one({"_id": document["_id"]}, document, upsert=True)
+            return True
+        except Exception as e:
+            GLOG.ERROR(f"补偿恢复 MongoDB 图文档失败: {e}")
+            return False
+
     def _update_graph_in_mongo(
         self,
         portfolio_uuid: str,
@@ -857,6 +901,29 @@ class PortfolioMappingService(BaseService):
                 self._param_service.remove_by_mapping(existing_mapping.uuid)
 
         return mapping_uuids
+
+    def _restore_removed_file_mappings(self, mappings: list, param_snapshots: Dict[str, list]) -> None:
+        """恢复 remove_file 已删除的 MySQL mapping/params（补偿原语，#5559）。"""
+        for mapping in mappings or []:
+            try:
+                restored = MPortfolioFileMapping(
+                    portfolio_id=getattr(mapping, "portfolio_id", ""),
+                    file_id=getattr(mapping, "file_id", ""),
+                    name=getattr(mapping, "name", "ginkgo_bind"),
+                    type=getattr(mapping, "type", FILE_TYPES.OTHER),
+                    source=getattr(mapping, "source", SOURCE_TYPES.SIM),
+                )
+                restored_mapping = self._mapping_crud.add(restored)
+                restored_uuid = getattr(restored_mapping, "uuid", None) or getattr(mapping, "uuid", "")
+                for param in param_snapshots.get(getattr(mapping, "uuid", ""), []):
+                    self._param_service.add_param(
+                        mapping_id=restored_uuid,
+                        index=int(getattr(param, "index", 0)),
+                        value=getattr(param, "value", ""),
+                        source=getattr(param, "source", SOURCE_TYPES.SIM),
+                    )
+            except Exception as e:
+                GLOG.ERROR(f"补偿恢复文件映射失败: {getattr(mapping, 'uuid', '')}, {e}")
 
     def _sync_params_from_nodes(
         self,

--- a/tests/unit/data/services/test_portfolio_mapping_compensation.py
+++ b/tests/unit/data/services/test_portfolio_mapping_compensation.py
@@ -3,8 +3,9 @@
 create_from_graph_editor 先写 MongoDB 后 sync MySQL，下游失败时
 MongoDB 文档成孤儿。验证补偿事务：sync 失败 → 反向删 Mongo。
 
-update_from_graph_editor / remove_file 同类非原子问题留 follow-up（本 PR 聚焦 create）。
+后续切片补齐 update_from_graph_editor / remove_file 的反向补偿，避免更新/删除半成功。
 """
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ from unittest.mock import MagicMock, patch
 def _make_service():
     """实例化 service（4 个依赖均 MagicMock，无需 DB）"""
     from ginkgo.data.services.portfolio_mapping_service import PortfolioMappingService
+
     return PortfolioMappingService(
         mapping_crud=MagicMock(),
         param_service=MagicMock(),
@@ -58,14 +60,14 @@ class TestCreateCompensationOnSyncFailure:
     def test_deletes_mongo_when_mapping_sync_fails(self):
         """步骤4 sync Mapping 失败 → 补偿删 Mongo + 返 error"""
         svc = _make_service()
-        with patch.object(svc, "_save_graph_to_mongo", return_value="doc-123"), \
-             patch.object(svc, "_sync_mappings_from_files", side_effect=RuntimeError("mysql down")), \
-             patch.object(svc, "_extract_files_from_graph", return_value=[]), \
-             patch.object(svc, "_extract_params_from_graph", return_value=[]), \
-             patch.object(svc, "_delete_graph_from_mongo") as mock_delete:
-            result = svc.create_from_graph_editor(
-                portfolio_uuid="p1", graph_data={"nodes": []}, name="t"
-            )
+        with (
+            patch.object(svc, "_save_graph_to_mongo", return_value="doc-123"),
+            patch.object(svc, "_sync_mappings_from_files", side_effect=RuntimeError("mysql down")),
+            patch.object(svc, "_extract_files_from_graph", return_value=[]),
+            patch.object(svc, "_extract_params_from_graph", return_value=[]),
+            patch.object(svc, "_delete_graph_from_mongo") as mock_delete,
+        ):
+            result = svc.create_from_graph_editor(portfolio_uuid="p1", graph_data={"nodes": []}, name="t")
         # 补偿删 Mongo 被调（每次重试都删 doc-123）
         assert mock_delete.called
         assert all(call.args == ("doc-123",) for call in mock_delete.call_args_list)
@@ -75,15 +77,15 @@ class TestCreateCompensationOnSyncFailure:
     def test_deletes_mongo_when_param_sync_fails(self):
         """步骤5 sync MParam 失败（步骤4成功）→ 补偿删 Mongo"""
         svc = _make_service()
-        with patch.object(svc, "_save_graph_to_mongo", return_value="doc-456"), \
-             patch.object(svc, "_sync_mappings_from_files", return_value=MagicMock()), \
-             patch.object(svc, "_sync_params_from_nodes", side_effect=RuntimeError("param sync fail")), \
-             patch.object(svc, "_extract_files_from_graph", return_value=[]), \
-             patch.object(svc, "_extract_params_from_graph", return_value=[]), \
-             patch.object(svc, "_delete_graph_from_mongo") as mock_delete:
-            result = svc.create_from_graph_editor(
-                portfolio_uuid="p1", graph_data={"nodes": []}, name="t"
-            )
+        with (
+            patch.object(svc, "_save_graph_to_mongo", return_value="doc-456"),
+            patch.object(svc, "_sync_mappings_from_files", return_value=MagicMock()),
+            patch.object(svc, "_sync_params_from_nodes", side_effect=RuntimeError("param sync fail")),
+            patch.object(svc, "_extract_files_from_graph", return_value=[]),
+            patch.object(svc, "_extract_params_from_graph", return_value=[]),
+            patch.object(svc, "_delete_graph_from_mongo") as mock_delete,
+        ):
+            result = svc.create_from_graph_editor(portfolio_uuid="p1", graph_data={"nodes": []}, name="t")
         assert mock_delete.called
         assert all(call.args == ("doc-456",) for call in mock_delete.call_args_list)
         assert not result.is_success()
@@ -91,14 +93,72 @@ class TestCreateCompensationOnSyncFailure:
     def test_no_delete_on_success(self):
         """全部成功 → 不调补偿删（回归保护）"""
         svc = _make_service()
-        with patch.object(svc, "_save_graph_to_mongo", return_value="doc-ok"), \
-             patch.object(svc, "_sync_mappings_from_files", return_value=MagicMock()), \
-             patch.object(svc, "_sync_params_from_nodes", return_value=MagicMock()), \
-             patch.object(svc, "_extract_files_from_graph", return_value=[]), \
-             patch.object(svc, "_extract_params_from_graph", return_value=[]), \
-             patch.object(svc, "_delete_graph_from_mongo") as mock_delete:
-            result = svc.create_from_graph_editor(
-                portfolio_uuid="p1", graph_data={"nodes": []}, name="t"
-            )
+        with (
+            patch.object(svc, "_save_graph_to_mongo", return_value="doc-ok"),
+            patch.object(svc, "_sync_mappings_from_files", return_value=MagicMock()),
+            patch.object(svc, "_sync_params_from_nodes", return_value=MagicMock()),
+            patch.object(svc, "_extract_files_from_graph", return_value=[]),
+            patch.object(svc, "_extract_params_from_graph", return_value=[]),
+            patch.object(svc, "_delete_graph_from_mongo") as mock_delete,
+        ):
+            result = svc.create_from_graph_editor(portfolio_uuid="p1", graph_data={"nodes": []}, name="t")
         assert result.is_success()
         mock_delete.assert_not_called()
+
+
+class TestUpdateCompensationOnSyncFailure:
+    """Slice 3: update_from_graph_editor sync 失败时恢复旧 Mongo 图"""
+
+    def test_restores_previous_mongo_graph_when_mapping_sync_fails(self):
+        """更新 Mongo 后 sync Mapping 失败 → 恢复更新前的图文档"""
+        svc = _make_service()
+        previous_doc = {
+            "_id": "doc-prev",
+            "portfolio_uuid": "p1",
+            "name": "old graph",
+            "graph_data": {"nodes": [{"id": "old"}]},
+            "metadata": {"source": "GRAPH_EDITOR"},
+        }
+        with (
+            patch.object(svc, "_snapshot_graph_from_mongo", return_value=previous_doc),
+            patch.object(svc, "_update_graph_in_mongo", return_value="doc-prev"),
+            patch.object(svc, "_sync_mappings_from_files", side_effect=RuntimeError("mysql down")),
+            patch.object(svc, "_extract_files_from_graph", return_value=[]),
+            patch.object(svc, "_extract_params_from_graph", return_value=[]),
+            patch.object(svc, "_restore_graph_in_mongo") as mock_restore,
+        ):
+            result = svc.update_from_graph_editor(
+                portfolio_uuid="p1", graph_data={"nodes": [{"id": "new"}]}, name="new graph"
+            )
+
+        assert mock_restore.called
+        assert all(call.args == (previous_doc,) for call in mock_restore.call_args_list)
+        assert not result.is_success()
+
+
+class TestRemoveFileCompensationOnGraphFailure:
+    """Slice 4: remove_file graph sync 失败时恢复 MySQL mapping/params"""
+
+    def test_restores_deleted_mapping_and_params_when_graph_sync_fails(self):
+        """删除 mapping/params 后 sync graph 失败 → 恢复刚删除的 MySQL 数据"""
+        svc = _make_service()
+        mapping = MagicMock()
+        mapping.uuid = "mapping-1"
+        mapping.portfolio_id = "p1"
+        mapping.file_id = "file-1"
+        mapping.name = "strategy"
+        mapping.type = "STRATEGY"
+        mapping.source = "SIM"
+        param = MagicMock()
+        param.index = 0
+        param.value = "20"
+        param.source = "SIM"
+
+        svc._mapping_crud.find.return_value = [mapping]
+        svc._param_service.find_by_mapping_id.return_value = [param]
+        with patch.object(svc, "_sync_graph_from_mappings", side_effect=RuntimeError("mongo down")):
+            result = svc.remove_file(portfolio_uuid="p1", file_id="file-1")
+
+        assert svc._mapping_crud.add.called
+        assert svc._param_service.add_param.called
+        assert not result.is_success()


### PR DESCRIPTION
## Summary
- Restore the previous Mongo graph document when `update_from_graph_editor` updates Mongo but MySQL mapping/param sync fails.
- Snapshot removed mapping params before `remove_file`, and restore deleted mapping/params when graph sync fails after MySQL deletion.
- Extend the existing #5559 compensation tests from create-only coverage to update/remove failure paths.

## Test plan
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/services/test_portfolio_mapping_compensation.py tests/unit/services/test_portfolio_mapping_graph_read_priority.py tests/unit/services/test_portfolio_mapping_graph_lifecycle.py tests/unit/services/test_portfolio_mapping_service_deploy_sync.py tests/unit/services/smoke/test_portfolio_mapping_service_smoke.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `PY=/home/kaoru/.ginkgo/.venv/bin/python; find src api -name "*.py" -not -path "*/__pycache__/*" -print0 | ... py_compile`
- `/home/kaoru/.ginkgo/.venv/bin/python -m black --check tests/unit/data/services/test_portfolio_mapping_compensation.py --line-length 120`
- `git diff --check` / `git diff --cached --check`

Closes #5559