### PR TITLE
fix(#4984): skip weekend tick sync fetch

### DIFF
--- a/src/ginkgo/data/services/tick_service.py
+++ b/src/ginkgo/data/services/tick_service.py
@@ -91,6 +91,20 @@ class TickService(BaseService):
 
             GLOG.INFO(f"Syncing tick data for {code} on {normalized_date.date()}")
 
+            if normalized_date.weekday() >= 5:
+                sync_result = DataSyncResult.create_for_entity(
+                    entity_type="tick",
+                    entity_identifier=code,
+                    sync_range=(normalized_date, normalized_date),
+                    sync_strategy="single_date"
+                )
+                sync_result.add_warning("No tick data available from source")
+                duration = time.time() - start_time
+                sync_result.sync_duration = duration
+                return ServiceResult(success=True,
+                                   message=f"No tick data available for {code} on {normalized_date.date()}",
+                                   data=sync_result)
+
             # Check if data exists and fast_mode is enabled
             if fast_mode:
                 try:

--- a/tests/unit/data/services/test_tick_service_end_of_day.py
+++ b/tests/unit/data/services/test_tick_service_end_of_day.py
@@ -33,6 +33,24 @@ def _make_service(crud):
     )
 
 
+class TestTickSyncDateNonTradingDay:
+    """周末无 tick 数据时不应进入数据源 retry（#4984）。"""
+
+    @pytest.mark.unit
+    def test_weekend_date_returns_no_data_without_fetching_source(self):
+        crud = Mock()
+        service = _make_service(crud)
+        service._stockinfo_service.exists.return_value = True
+
+        result = service.sync_date("000001.SZ", "20260606")
+
+        assert result.success is True
+        assert "No tick data available" in result.message
+        assert result.data.records_skipped == 0
+        assert result.data.records_failed == 0
+        service._data_source.fetch_history_transaction_detail.assert_not_called()
+
+
 class TestTickEndDateCoversFullDay:
     """end_date 闭区间上界须覆盖整天盘中时段（#6000）。"""
 


### PR DESCRIPTION
## Summary
- Short-circuit `TickService.sync_date()` for weekend dates before entering the TDX fetch/retry path.
- Reuse the existing no-tick-data success result so `data sync tick --date 20260606` does not print retry tracebacks for a non-trading weekend.
- Add a pure mock unit test proving weekend sync does not call the data source.

Closes #4984

## Tests
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/services/test_tick_service_end_of_day.py::TestTickSyncDateNonTradingDay::test_weekend_date_returns_no_data_without_fetching_source -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/services/test_tick_service_end_of_day.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `py_compile` over `src api`
- `git diff --check`

## Notes
- `black --check src/ginkgo/data/services/tick_service.py tests/unit/data/services/test_tick_service_end_of_day.py` fails because Black would reformat large pre-existing sections of `tick_service.py`; left formatting churn out of this PR.
