### PR TITLE
test: align paper advance contract (#6109)

### DIFF
--- a/tests/integration/trading/engines/test_paper_mode.py
+++ b/tests/integration/trading/engines/test_paper_mode.py
@@ -45,14 +45,14 @@ class TestPaperModeInitialization:
         assert engine.mode == EXECUTION_MODE.PAPER
         assert engine.mode != EXECUTION_MODE.BACKTEST
 
-    def test_paper_mode_rejects_manual_time_advance(self):
-        """PAPER 模式不支持手动时间推进（advance_time_to 返回 False）"""
+    def test_paper_mode_allows_manual_time_advance(self):
+        """PAPER 模式支持手动时间推进（REPLAY 路径依赖 advance_time_to）"""
         engine = TimeControlledEventEngine(
             name="TestPaper",
             mode=EXECUTION_MODE.PAPER,
         )
         result = engine.advance_time_to(engine.now)
-        assert result is False
+        assert result is True
 
 
 class TestPaperLiveEquivalence:
@@ -83,9 +83,9 @@ class TestPaperLiveEquivalence:
         assert paper.get_time_info().time_mode == TIME_MODE.SYSTEM
         assert live.get_time_info().time_mode == TIME_MODE.SYSTEM
 
-    def test_both_reject_manual_time_advance(self):
-        """PAPER 和 LIVE 都不支持手动时间推进"""
+    def test_paper_allows_live_rejects_manual_time_advance(self):
+        """PAPER 支持 REPLAY 推进；LIVE 仍拒绝手动时间推进"""
         paper = self._create_engine(EXECUTION_MODE.PAPER)
         live = self._create_engine(EXECUTION_MODE.LIVE)
-        assert paper.advance_time_to(paper.now) is False
+        assert paper.advance_time_to(paper.now) is True
         assert live.advance_time_to(live.now) is False


### PR DESCRIPTION
## Summary
- update stale PAPER mode integration assertions to match the current contract: PAPER allows advance_time_to for REPLAY/manual advance
- keep LIVE rejecting manual advance
- align test names/docstrings with existing unit coverage and the paper worker replay path

## Test plan
- RED: /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/integration/trading/engines/test_paper_mode.py::TestPaperModeInitialization::test_paper_mode_rejects_manual_time_advance tests/integration/trading/engines/test_paper_mode.py::TestPaperLiveEquivalence::test_both_reject_manual_time_advance -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/integration/trading/engines/test_paper_mode.py -q -o "addopts=" --no-header --tb=short
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/trading/engines/test_component_advance_order.py -q -o "addopts=" --no-header --tb=short
- git diff --check origin/master...HEAD
- /home/kaoru/.ginkgo/.venv/bin/python py_compile over src and api
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short

Closes #6109