### PR TITLE
chore: add diff coverage gate (#6135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # diff coverage needs the PR base commit
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -98,3 +100,22 @@ jobs:
         run: |
           uv run python -m pytest tests/unit/client/test_user_cli.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: Diff coverage gate (#6135)
+        if: github.event_name == 'pull_request'
+        # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
+        # 不把当前全仓 6.85% smoke baseline 当作质量目标；无 src/api 改动时跳过。
+        run: |
+          uv run python -m pytest \
+            tests/unit/data/crud/test_user_crud_mock.py \
+            tests/unit/features/test_containers.py \
+            tests/unit/client/test_user_cli.py \
+            --cov=src/ginkgo \
+            --cov=api \
+            --cov-report=json:coverage.json \
+            --cov-report=term-missing:skip-covered \
+            -q -o "addopts=" --no-header --tb=short
+          uv run python scripts/check_diff_coverage.py \
+            --coverage-json coverage.json \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.sha }}" \
+            --threshold 80

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # diff coverage needs the PR base commit
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
@@ -65,6 +63,11 @@ jobs:
       TERM: dumb  # GITHUB_ACTIONS=true 致 typer/rich 强制 colorize，--name 被 ANSI 分隔使断言失败；TERM=dumb 禁 color（NO_COLOR 无效，rich 只认 TERM）
     steps:
       - uses: actions/checkout@v4
+        with:
+          # diff coverage gate (#6135) runs `git diff <pr base.sha> <head>`;
+          # the base commit is absent in a depth-1 clone → "unknown revision".
+          # Full history only needed in this job (the one that runs the gate).
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,5 +120,5 @@ jobs:
           uv run python scripts/check_diff_coverage.py \
             --coverage-json coverage.json \
             --base "${{ github.event.pull_request.base.sha }}" \
-            --head "${{ github.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
             --threshold 80

--- a/docs/coverage-baseline.md
+++ b/docs/coverage-baseline.md
@@ -85,3 +85,6 @@ Result: 36 passed.
   avoid maintaining two equivalent coverage configs.
 - This baseline is not a quality target. It is a reproducible starting point for
   module-level trend tracking and later diff-coverage gates.
+- PR diff coverage (#6135) uses an 80% threshold for executable changed lines
+  under `src/` and `api/`. The gate is intentionally scoped to changed lines so
+  the low smoke-suite baseline above does not block unrelated cleanup.

--- a/scripts/check_diff_coverage.py
+++ b/scripts/check_diff_coverage.py
@@ -65,6 +65,12 @@ def parse_unified_diff(diff_text: str) -> dict[str, set[int]]:
             current_line += 1
         elif line.startswith("-") and not line.startswith("---"):
             continue
+        elif line.startswith("\\"):
+            # git's "\ No newline at end of file" marker — metadata about the
+            # adjacent +/- line, not a file line. Skipping it (rather than the
+            # context branch's `current_line += 1`) prevents line-number drift
+            # for files without a trailing newline.
+            continue
         else:
             current_line += 1
 
@@ -91,15 +97,22 @@ def calculate_diff_coverage(changed_lines: dict[str, set[int]], coverage_json: d
 
     for path, lines in sorted(changed_lines.items()):
         data = coverage_files.get(path)
-        if data is None:
-            # File wasn't imported by the smoke subset → coverage unknown.
-            # Exempt it (diff_cover convention) instead of counting every
-            # changed line (incl. comments/blanks) as uncovered executable.
+        executed = set(data.get("executed_lines", [])) if data else set()
+        missing = set(data.get("missing_lines", [])) if data else set()
+
+        if data is None or not executed:
+            # No positive coverage signal for this file under the smoke subset:
+            #   - data is None: file absent from the report (never imported).
+            #   - executed empty: file present (e.g. coverage.py statically
+            #     scanned it under `--cov=src/...`) but no line was ever
+            #     executed, so the smoke subset gave no usable signal.
+            # Either way coverage is unknown, not "uncovered" — exempt it
+            # (diff_cover convention) and warn, instead of failing every
+            # changed line at 0%. A file the smoke subset DID execute keeps
+            # its full signal below (changed uncovered lines still gated).
             exempt[path] = sorted(lines)
             continue
 
-        executed = set(data.get("executed_lines", []))
-        missing = set(data.get("missing_lines", []))
         executable = lines & (executed | missing)
 
         for line_no in sorted(executable):

--- a/scripts/check_diff_coverage.py
+++ b/scripts/check_diff_coverage.py
@@ -24,6 +24,10 @@ class DiffCoverageResult(NamedTuple):
     covered: int
     total: int
     uncovered: dict[str, list[int]]
+    # Changed src/api files the smoke subset never measured. These are exempt
+    # (unknown coverage, not "uncovered") so a PR touching a file outside the
+    # 3-test subset isn't failed at 0% — see diff_cover convention.
+    exempt: dict[str, list[int]] = {}
 
     @property
     def percent(self) -> float:
@@ -83,16 +87,20 @@ def calculate_diff_coverage(changed_lines: dict[str, set[int]], coverage_json: d
     covered = 0
     total = 0
     uncovered: dict[str, list[int]] = {}
+    exempt: dict[str, list[int]] = {}
 
     for path, lines in sorted(changed_lines.items()):
         data = coverage_files.get(path)
         if data is None:
-            executable = lines
-            executed: set[int] = set()
-        else:
-            executed = set(data.get("executed_lines", []))
-            missing = set(data.get("missing_lines", []))
-            executable = lines & (executed | missing)
+            # File wasn't imported by the smoke subset → coverage unknown.
+            # Exempt it (diff_cover convention) instead of counting every
+            # changed line (incl. comments/blanks) as uncovered executable.
+            exempt[path] = sorted(lines)
+            continue
+
+        executed = set(data.get("executed_lines", []))
+        missing = set(data.get("missing_lines", []))
+        executable = lines & (executed | missing)
 
         for line_no in sorted(executable):
             total += 1
@@ -101,7 +109,7 @@ def calculate_diff_coverage(changed_lines: dict[str, set[int]], coverage_json: d
             else:
                 uncovered.setdefault(path, []).append(line_no)
 
-    return DiffCoverageResult(covered=covered, total=total, uncovered=uncovered)
+    return DiffCoverageResult(covered=covered, total=total, uncovered=uncovered, exempt=exempt)
 
 
 def _git_diff(base: str, head: str) -> str:
@@ -127,8 +135,19 @@ def main(argv: list[str] | None = None) -> int:
     changed_lines = parse_unified_diff(_git_diff(args.base, args.head))
     result = calculate_diff_coverage(changed_lines, coverage_json)
 
+    # Surface files the smoke subset never measured so the PR author knows their
+    # change wasn't gated (not silently passed, not falsely failed).
+    for path, lines in result.exempt.items():
+        print(
+            f"::warning file={path}::{len(lines)} changed line(s) not measured by the "
+            f"smoke subset — diff coverage gate does not cover this file"
+        )
+
     if result.total == 0:
-        print("Diff coverage: no changed executable src/api Python lines; gate skipped.")
+        if result.exempt:
+            print("Diff coverage: all changed src/api lines are in exempt (unmeasured) files; gate skipped.")
+        else:
+            print("Diff coverage: no changed executable src/api Python lines; gate skipped.")
         return 0
 
     print(

--- a/scripts/check_diff_coverage.py
+++ b/scripts/check_diff_coverage.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Small diff coverage gate for CI.
+
+The repo cannot run the full test suite in CI safely, so this checker consumes
+coverage from the existing smoke subset and gates only executable lines touched
+by the PR diff.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+from typing import NamedTuple
+
+
+SOURCE_PREFIXES = ("src/", "api/")
+HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+class DiffCoverageResult(NamedTuple):
+    covered: int
+    total: int
+    uncovered: dict[str, list[int]]
+
+    @property
+    def percent(self) -> float:
+        if self.total == 0:
+            return 100.0
+        return round((self.covered / self.total) * 100, 2)
+
+
+def parse_unified_diff(diff_text: str) -> dict[str, set[int]]:
+    changed: dict[str, set[int]] = {}
+    current_file: str | None = None
+    current_line: int | None = None
+
+    for line in diff_text.splitlines():
+        if line.startswith("+++ b/"):
+            path = line[len("+++ b/") :]
+            if path.endswith(".py") and path.startswith(SOURCE_PREFIXES):
+                current_file = path
+                changed.setdefault(path, set())
+            else:
+                current_file = None
+            current_line = None
+            continue
+
+        match = HUNK_RE.match(line)
+        if match:
+            current_line = int(match.group(1))
+            continue
+
+        if current_file is None or current_line is None:
+            continue
+
+        if line.startswith("+") and not line.startswith("+++"):
+            changed[current_file].add(current_line)
+            current_line += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        else:
+            current_line += 1
+
+    return {path: lines for path, lines in changed.items() if lines}
+
+
+def _coverage_file_map(coverage_json: dict) -> dict[str, dict]:
+    files = coverage_json.get("files", {})
+    by_norm = {}
+    for path, data in files.items():
+        normalized = path.replace("\\", "/")
+        if normalized.startswith("./"):
+            normalized = normalized[2:]
+        by_norm[normalized] = data
+    return by_norm
+
+
+def calculate_diff_coverage(changed_lines: dict[str, set[int]], coverage_json: dict) -> DiffCoverageResult:
+    coverage_files = _coverage_file_map(coverage_json)
+    covered = 0
+    total = 0
+    uncovered: dict[str, list[int]] = {}
+
+    for path, lines in sorted(changed_lines.items()):
+        data = coverage_files.get(path)
+        if data is None:
+            executable = lines
+            executed: set[int] = set()
+        else:
+            executed = set(data.get("executed_lines", []))
+            missing = set(data.get("missing_lines", []))
+            executable = lines & (executed | missing)
+
+        for line_no in sorted(executable):
+            total += 1
+            if line_no in executed:
+                covered += 1
+            else:
+                uncovered.setdefault(path, []).append(line_no)
+
+    return DiffCoverageResult(covered=covered, total=total, uncovered=uncovered)
+
+
+def _git_diff(base: str, head: str) -> str:
+    completed = subprocess.run(
+        ["git", "diff", "--unified=0", base, head, "--", "src", "api"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return completed.stdout
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Check diff coverage from coverage.py JSON output")
+    parser.add_argument("--coverage-json", default="coverage.json")
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--threshold", type=float, default=80.0)
+    args = parser.parse_args(argv)
+
+    coverage_path = Path(args.coverage_json)
+    coverage_json = json.loads(coverage_path.read_text(encoding="utf-8"))
+    changed_lines = parse_unified_diff(_git_diff(args.base, args.head))
+    result = calculate_diff_coverage(changed_lines, coverage_json)
+
+    if result.total == 0:
+        print("Diff coverage: no changed executable src/api Python lines; gate skipped.")
+        return 0
+
+    print(
+        f"Diff coverage: {result.covered}/{result.total} executable changed lines covered "
+        f"({result.percent:.2f}%), threshold {args.threshold:.2f}%"
+    )
+
+    if result.percent < args.threshold:
+        for path, lines in result.uncovered.items():
+            for line_no in lines:
+                print(f"::error file={path},line={line_no}::changed executable line is not covered")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_check_diff_coverage.py
+++ b/tests/unit/scripts/test_check_diff_coverage.py
@@ -67,3 +67,37 @@ def test_calculate_diff_coverage_reports_no_source_changes():
     assert result.total == 0
     assert result.covered == 0
     assert result.percent == 100.0
+
+
+def test_calculate_diff_coverage_exempts_files_absent_from_coverage_report():
+    """Files the smoke subset never imported are exempt, not 0%-covered.
+
+    Mirrors diff_cover: a file absent from the coverage report is "unknown
+    coverage", not "uncovered". Otherwise a PR touching any file outside the
+    3-test smoke subset fails at 0% even when it ships dedicated tests, and
+    comments/blank lines in the diff get counted as uncovered executable
+    lines — contradicting the module docstring.
+    """
+    module = _load_module()
+    changed = {
+        "src/ginkgo/foo.py": {11, 12, 13},  # measured below
+        "src/ginkgo/unmeasured.py": {5, 6, 7},  # absent from coverage.json
+    }
+    coverage = {
+        "files": {
+            "src/ginkgo/foo.py": {
+                "executed_lines": [11, 12],
+                "missing_lines": [13],
+            }
+        }
+    }
+
+    result = module.calculate_diff_coverage(changed, coverage)
+
+    # unmeasured.py must not pollute the totals or show up as uncovered.
+    assert result.total == 3
+    assert result.covered == 2
+    assert result.uncovered == {"src/ginkgo/foo.py": [13]}
+    assert "src/ginkgo/unmeasured.py" not in result.uncovered
+    # And it must be surfaced so CI can warn the author their file wasn't measured.
+    assert result.exempt == {"src/ginkgo/unmeasured.py": [5, 6, 7]}

--- a/tests/unit/scripts/test_check_diff_coverage.py
+++ b/tests/unit/scripts/test_check_diff_coverage.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    script = Path(__file__).resolve().parents[3] / "scripts" / "check_diff_coverage.py"
+    spec = importlib.util.spec_from_file_location("check_diff_coverage", script)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_parse_unified_diff_tracks_added_python_lines_under_src_and_api():
+    module = _load_module()
+    diff = """diff --git a/src/ginkgo/foo.py b/src/ginkgo/foo.py
+--- a/src/ginkgo/foo.py
++++ b/src/ginkgo/foo.py
+@@ -10,0 +11,3 @@
++covered()
++# comment
++missing()
+diff --git a/docs/readme.md b/docs/readme.md
+--- a/docs/readme.md
++++ b/docs/readme.md
+@@ -1,0 +2,1 @@
++ignored
+diff --git a/api/bar.py b/api/bar.py
+--- a/api/bar.py
++++ b/api/bar.py
+@@ -4,2 +4,2 @@
+-old()
++new()
+ context()
+"""
+
+    assert module.parse_unified_diff(diff) == {
+        "src/ginkgo/foo.py": {11, 12, 13},
+        "api/bar.py": {4},
+    }
+
+
+def test_calculate_diff_coverage_ignores_non_executable_lines():
+    module = _load_module()
+    changed = {"src/ginkgo/foo.py": {11, 12, 13}}
+    coverage = {
+        "files": {
+            "src/ginkgo/foo.py": {
+                "executed_lines": [11],
+                "missing_lines": [13],
+            }
+        }
+    }
+
+    result = module.calculate_diff_coverage(changed, coverage)
+
+    assert result.total == 2
+    assert result.covered == 1
+    assert result.uncovered == {"src/ginkgo/foo.py": [13]}
+    assert result.percent == 50.0
+
+
+def test_calculate_diff_coverage_reports_no_source_changes():
+    module = _load_module()
+
+    result = module.calculate_diff_coverage({}, {"files": {}})
+
+    assert result.total == 0
+    assert result.covered == 0
+    assert result.percent == 100.0

--- a/tests/unit/scripts/test_check_diff_coverage.py
+++ b/tests/unit/scripts/test_check_diff_coverage.py
@@ -101,3 +101,74 @@ def test_calculate_diff_coverage_exempts_files_absent_from_coverage_report():
     assert "src/ginkgo/unmeasured.py" not in result.uncovered
     # And it must be surfaced so CI can warn the author their file wasn't measured.
     assert result.exempt == {"src/ginkgo/unmeasured.py": [5, 6, 7]}
+
+
+def test_parse_unified_diff_skips_no_newline_marker_without_drift():
+    r"""git emits `\ No newline at end of file` after a +/- line that lacks a
+    trailing newline. The marker (line starting with `\`) is metadata about
+    the adjacent diff line, not a file line. Falling through to the context
+    branch (`current_line += 1`) drifts the tracked line number so real changed
+    lines land outside `executed | missing` and are silently dropped.
+
+    Real repro: many src/api files lack a trailing newline (90/804 at audit).
+    """
+    module = _load_module()
+    diff = (
+        "diff --git a/api/foo.py b/api/foo.py\n"
+        "--- a/api/foo.py\n"
+        "+++ b/api/foo.py\n"
+        "@@ -1 +1,2 @@\n"
+        "-old()\n"
+        "\\ No newline at end of file\n"
+        "+x()\n"
+        "+y()\n"
+        "\\ No newline at end of file\n"
+    )
+
+    assert module.parse_unified_diff(diff) == {"api/foo.py": {1, 2}}
+
+
+def test_calculate_diff_coverage_exempts_files_with_zero_executed_lines():
+    """Under `--cov=src/ginkgo --cov=api`, coverage.py statically scans the
+    whole source tree, so an unimported file appears in coverage.json with
+    executed_lines=[] and every statement in missing_lines (0% present, NOT
+    absent). The `data is None` exemption never fires for such files, so a PR
+    editing any existing executable line in api/main.py (e.g. executed=0,
+    missing=[...95 lines...]) fails at 0% < 80% — even though the smoke subset
+    never ran that file and gave no coverage signal.
+
+    Fix: a file with no executed lines has no positive coverage signal from
+    the smoke subset → exempt (with warning), same as an absent file. A file
+    the smoke subset DID execute (executed_lines non-empty) stays fully gated.
+    """
+    module = _load_module()
+    changed = {
+        # 0%-present unimported file (the api/main.py reproducer): must exempt.
+        "api/main.py": {11},
+        # Measured file the smoke subset exercised: changed uncovered line must
+        # still be gated (no false exemption).
+        "src/ginkgo/foo.py": {11, 13},
+    }
+    coverage = {
+        "files": {
+            "api/main.py": {
+                "executed_lines": [],
+                "missing_lines": [1, 2, 3, 11, 95],
+            },
+            "src/ginkgo/foo.py": {
+                "executed_lines": [11, 12],
+                "missing_lines": [13],
+            },
+        }
+    }
+
+    result = module.calculate_diff_coverage(changed, coverage)
+
+    # api/main.py exempt (no signal), not counted in totals or uncovered.
+    assert "api/main.py" not in result.uncovered
+    assert result.exempt == {"api/main.py": [11]}
+    # foo.py still gated on its real signal: 2 executable, 1 covered, 1 missing.
+    assert result.total == 2
+    assert result.covered == 1
+    assert result.uncovered == {"src/ginkgo/foo.py": [13]}
+    assert result.percent == 50.0

--- a/tests/unit/scripts/test_ci_workflow.py
+++ b/tests/unit/scripts/test_ci_workflow.py
@@ -1,0 +1,48 @@
+"""Structural guard for the CI diff-coverage gate wiring.
+
+The gate is a separate concern from the checker script: even a correct
+`check_diff_coverage.py` fails in CI if the workflow that runs it checks out
+a shallow clone. These tests pin the workflow shape so the gate stays runnable.
+"""
+
+from pathlib import Path
+
+import yaml
+
+
+def _ci_workflow():
+    ci_path = Path(__file__).resolve().parents[3] / ".github" / "workflows" / "ci.yml"
+    return yaml.safe_load(ci_path.read_text(encoding="utf-8"))
+
+
+def _job_running_gate(workflow):
+    for name, job in workflow.get("jobs", {}).items():
+        for step in job.get("steps", []):
+            if "Diff coverage gate" in (step.get("name") or ""):
+                return name, job
+    return None, None
+
+
+def test_diff_coverage_gate_job_checks_out_full_history():
+    """The gate runs `git diff <base.sha> <head>`, which needs the PR base
+    commit. A depth-1 checkout omits it, so `git diff` raises "unknown
+    revision" on every PR. The checkout in the job that runs the gate must
+    therefore set fetch-depth: 0 (full history).
+    """
+    workflow = _ci_workflow()
+    gate_job_name, gate_job = _job_running_gate(workflow)
+    assert gate_job is not None, "no step named 'Diff coverage gate' found in ci.yml"
+
+    checkouts = [
+        s
+        for s in gate_job.get("steps", [])
+        if isinstance(s.get("uses"), str) and s["uses"].startswith("actions/checkout")
+    ]
+    assert checkouts, f"'{gate_job_name}' job has no actions/checkout step"
+
+    depths = [c.get("with", {}).get("fetch-depth") for c in checkouts]
+    assert 0 in depths, (
+        f"'{gate_job_name}' job runs the diff coverage gate (git diff base head) but "
+        f"its checkout(s) have fetch-depth={depths}; the base commit is absent in a "
+        f"shallow clone, so the gate fails on every PR"
+    )

--- a/tests/unit/scripts/test_ci_workflow.py
+++ b/tests/unit/scripts/test_ci_workflow.py
@@ -5,6 +5,7 @@ The gate is a separate concern from the checker script: even a correct
 a shallow clone. These tests pin the workflow shape so the gate stays runnable.
 """
 
+import re
 from pathlib import Path
 
 import yaml
@@ -45,4 +46,36 @@ def test_diff_coverage_gate_job_checks_out_full_history():
         f"'{gate_job_name}' job runs the diff coverage gate (git diff base head) but "
         f"its checkout(s) have fetch-depth={depths}; the base commit is absent in a "
         f"shallow clone, so the gate fails on every PR"
+    )
+
+
+def test_diff_coverage_gate_uses_pr_head_sha_not_merge_commit():
+    """The gate diffs `<base.sha> <head>`. In a `pull_request` event,
+    `github.sha` is the auto-generated merge commit (`refs/pull/N/merge`), not
+    the PR head. When the PR base falls behind master, `git diff base
+    github.sha` pulls master's post-base commits into the diff as if they were
+    part of the PR — spurious warnings, or false failures if they touch a
+    smoke-measured file. The head must therefore be the PR's actual tip:
+    `github.event.pull_request.head.sha`.
+    """
+    workflow = _ci_workflow()
+    gate_job_name, gate_job = _job_running_gate(workflow)
+    assert gate_job is not None, "no step named 'Diff coverage gate' found in ci.yml"
+
+    gate_step = next(
+        s
+        for s in gate_job.get("steps", [])
+        if "Diff coverage gate" in (s.get("name") or "")
+    )
+    script = gate_step.get("run", "")
+
+    head_match = re.search(r'--head\s+"?\$\{\{\s*([^}]+?)\s*\}\}"?', script)
+    assert head_match, f"gate script has no --head argument:\n{script}"
+
+    head_expr = head_match.group(1).strip()
+    assert head_expr == "github.event.pull_request.head.sha", (
+        f"'{gate_job_name}' gate --head uses {{{{ {head_expr} }}}}; in pull_request "
+        f"events github.sha is the merge commit (refs/pull/N/merge), which pulls "
+        f"master's post-base commits into the diff and causes false failures. Use "
+        f"github.event.pull_request.head.sha (the PR's actual tip)."
     )


### PR DESCRIPTION
## Summary
- add a repo-local diff coverage checker for executable changed Python lines under src/ and api/
- wire PR CI to rerun the existing smoke subset with coverage JSON and enforce an 80% changed-line threshold
- record the threshold choice in docs/coverage-baseline.md based on the #6132 smoke baseline

## Test plan
- RED: /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/scripts/test_check_diff_coverage.py -q -o "addopts=" --no-header --tb=short (failed before script existed)
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/scripts/test_check_diff_coverage.py -q -o "addopts=" --no-header --tb=short
- local CI simulation: smoke subset with --cov=src/ginkgo --cov=api to /tmp/ginkgo-6135-coverage.json, then scripts/check_diff_coverage.py --base origin/master --head HEAD --threshold 80
- YAML parse check for .github/workflows/ci.yml
- git diff --check origin/master...HEAD
- /home/kaoru/.ginkgo/.venv/bin/python py_compile over src, api, scripts
- /home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short

Closes #6135