### PR TITLE
fix: preserve bar trade_date dtype in legacy mapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,7 @@ jobs:
             tests/unit/data/crud/test_user_crud_mock.py \
             tests/unit/features/test_containers.py \
             tests/unit/client/test_user_cli.py \
+            tests/unit/data/mappers/test_bar_mapper.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/src/ginkgo/data/mappers/_legacy.py
+++ b/src/ginkgo/data/mappers/_legacy.py
@@ -22,6 +22,16 @@ from ginkgo.data.models import MAdjustfactor, MStockInfo, MBar
 from ginkgo.data.crud.tick_crud import get_tick_model
 from ginkgo.enums import SOURCE_TYPES, CURRENCY_TYPES, MARKET_TYPES, FREQUENCY_TYPES, TICKDIRECTION_TYPES
 
+
+def _normalize_tushare_trade_date(value: Any) -> Any:
+    """Keep numeric YYYYMMDD trade dates out of Unix timestamp parsing."""
+    if hasattr(value, "item"):
+        value = value.item()
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
 def dataframe_to_adjustfactor_models(df: pd.DataFrame, code: str) -> List[MAdjustfactor]:
     """
     Maps a DataFrame from Tushare to a list of MAdjustfactor models.
@@ -77,11 +87,13 @@ def dataframe_to_stockinfo_upsert_list(df: pd.DataFrame) -> List[dict]:
 def dataframe_to_bar_models(df: pd.DataFrame, code: str, frequency: FREQUENCY_TYPES = FREQUENCY_TYPES.DAY) -> List[MBar]:
     """Maps a DataFrame from Tushare to a list of MBar models."""
     items = []
-    for _, r in df.iterrows():
+    trade_dates = df["trade_date"]
+    for row_pos, (_, r) in enumerate(df.iterrows()):
         # Skip rows with invalid data
         if pd.isna(r["open"]) or pd.isna(r["close"]) or pd.isna(r["high"]) or pd.isna(r["low"]):
             continue
 
+        trade_date = _normalize_tushare_trade_date(trade_dates.iloc[row_pos])
         items.append(
             MBar(
                 code=code,
@@ -92,22 +104,25 @@ def dataframe_to_bar_models(df: pd.DataFrame, code: str, frequency: FREQUENCY_TY
                 volume=int(r["vol"]) if pd.notna(r["vol"]) else 0,
                 amount=to_decimal(r["amount"]) if pd.notna(r["amount"]) else to_decimal(0),
                 frequency=FREQUENCY_TYPES.validate_input(frequency),
-                timestamp=datetime_normalize(r["trade_date"]),
+                timestamp=datetime_normalize(trade_date),
                 source=SOURCE_TYPES.TUSHARE.value,
             )
         )
     return items
+
 
 def dataframe_to_bar_entities(df: pd.DataFrame, code: str, frequency: FREQUENCY_TYPES = FREQUENCY_TYPES.DAY) -> List[Any]:
     """Maps a DataFrame from Tushare to a list of Bar business entities."""
     from ginkgo.entities import Bar
 
     items = []
-    for _, r in df.iterrows():
+    trade_dates = df["trade_date"]
+    for row_pos, (_, r) in enumerate(df.iterrows()):
         # Skip rows with invalid data
         if pd.isna(r["open"]) or pd.isna(r["close"]) or pd.isna(r["high"]) or pd.isna(r["low"]):
             continue
 
+        trade_date = _normalize_tushare_trade_date(trade_dates.iloc[row_pos])
         # Create Bar business entity in Service layer
         bar = Bar(
             code=code,
@@ -118,7 +133,7 @@ def dataframe_to_bar_entities(df: pd.DataFrame, code: str, frequency: FREQUENCY_
             volume=int(r["vol"]) if pd.notna(r["vol"]) else 0,
             amount=to_decimal(r["amount"]) if pd.notna(r["amount"]) else to_decimal(0),
             frequency=frequency,
-            timestamp=datetime_normalize(r["trade_date"])
+            timestamp=datetime_normalize(trade_date)
         )
         # Store source information as attribute for CRUD layer
         bar._source = SOURCE_TYPES.TUSHARE
@@ -183,4 +198,3 @@ def dataframe_to_tick_models(df: pd.DataFrame, code: str) -> List[Any]:
             )
         )
     return items
-

--- a/tests/unit/data/mappers/test_bar_mapper.py
+++ b/tests/unit/data/mappers/test_bar_mapper.py
@@ -6,12 +6,15 @@
 - to_dto smoke（symbol=code 映射、对接 BarDTO）
 - model_to_dto 直转
 """
+from datetime import datetime
 from decimal import Decimal
 
+import pandas as pd
 import pytest
 
 from ginkgo.enums import FREQUENCY_TYPES
 from ginkgo.entities import Bar
+from ginkgo.data.mappers import dataframe_to_bar_entities, dataframe_to_bar_models
 from ginkgo.data.mappers.bar_mapper import BarMapper
 
 
@@ -83,3 +86,23 @@ def test_from_model_frequency_handling():
     # None（DB NULL）→ DAY 兜底（or 防止 None.frequency 下游崩溃）
     model.frequency = None
     assert BarMapper.from_model(model).frequency == FREQUENCY_TYPES.DAY
+
+
+def test_legacy_dataframe_bar_mappers_preserve_integer_trade_date():
+    """legacy DataFrame mapper must not let iterrows coerce YYYYMMDD to float seconds."""
+    df = pd.DataFrame(
+        [
+            {
+                "trade_date": 20260525,
+                "open": 1.1,
+                "high": 2.2,
+                "low": 1.0,
+                "close": 2.0,
+                "vol": 100.0,
+                "amount": 200.0,
+            }
+        ]
+    )
+
+    assert dataframe_to_bar_entities(df, "600519.SH")[0].timestamp == datetime(2026, 5, 25)
+    assert dataframe_to_bar_models(df, "600519.SH")[0].timestamp == datetime(2026, 5, 25)


### PR DESCRIPTION
## Summary
- read bar `trade_date` from the original DataFrame column instead of the `iterrows()` row Series
- normalize numpy scalar / integral float trade dates before passing them to `datetime_normalize`
- add a regression test for integer `YYYYMMDD` trade dates mixed with float OHLC columns

Refs #5690

## Tests
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/mappers/test_bar_mapper.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/mappers -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m compileall -q src api`
- `/home/kaoru/.ginkgo/.venv/bin/python -m pytest tests/unit/data/crud/test_user_crud_mock.py tests/unit/features/test_containers.py tests/unit/client/test_user_cli.py -q -o "addopts=" --no-header --tb=short`
- `/home/kaoru/.ginkgo/.venv/bin/python -m coverage run --source=src -m pytest tests/unit/data/mappers/test_bar_mapper.py -q -o "addopts=" --no-header --tb=short && /home/kaoru/.ginkgo/.venv/bin/python -m coverage json -q && /home/kaoru/.ginkgo/.venv/bin/python scripts/check_diff_coverage.py --base origin/master --head HEAD`