### PR TITLE
fix(client): GinkgoJSONEncoder isinstance 白名单防 MagicMock 无限递归 OOM

### DIFF
--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -220,9 +220,10 @@ class GinkgoJSONEncoder(json.JSONEncoder):
     - datetime/date → ISO8601（``T`` 分隔，非空格）
     - Decimal → str（金融精度，float 会丢；与 ADR-005 序列化对称同精神）
     - UUID → 带横线（用户面向，与库内 hex 存储 ``arch_uuid_storage_no_dashes`` 分层）
-    - pydantic BaseModel → ``model_dump(mode="json")``（duck-typing，避免顶部
-      import pydantic 拖慢 CLI 启动，呼应 ``arch_module_level_validator_import_crash``）
-    - SQLAlchemy Model → 列字典
+    - pydantic BaseModel → ``model_dump(mode="json")``（isinstance 判定 + 延迟 import，
+      防 MagicMock duck-trap 无限递归；呼应 ``arch_module_level_validator_import_crash``）
+    - SQLAlchemy DeclarativeBase → 列字典（isinstance 判定，非 ``hasattr(__table__)``）
+    - 未识别类型 → ``raise TypeError``（响亮失败，json 标准契约；非 ``super().default()`` 兜底）
     - DataFrame → ``to_dict('records')``（每行一对象，jq 友好）
     """
 
@@ -238,13 +239,22 @@ class GinkgoJSONEncoder(json.JSONEncoder):
             return str(obj)
         if isinstance(obj, pd.DataFrame):
             return obj.to_dict("records")
-        # pydantic v2 BaseModel（duck-typing on model_dump）
-        if hasattr(obj, "model_dump"):
-            return obj.model_dump(mode="json")
-        # SQLAlchemy ORM Model
-        if hasattr(obj, "__table__"):
-            return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
-        return super().default(obj)
+        # pydantic v2 BaseModel —— isinstance 替代 hasattr，防 MagicMock duck-trap 无限递归
+        try:
+            from pydantic import BaseModel
+            if isinstance(obj, BaseModel):
+                return obj.model_dump(mode="json")
+        except ImportError:
+            pass
+        # SQLAlchemy ORM Model —— isinstance(DeclarativeBase) 替代 hasattr(__table__)
+        try:
+            from sqlalchemy.orm import DeclarativeBase
+            if isinstance(obj, DeclarativeBase):
+                return {c.name: getattr(obj, c.name) for c in obj.__table__.columns}
+        except ImportError:
+            pass
+        # 未识别类型：显式 TypeError（json 标准契约，响亮失败而非无限递归 OOM）
+        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def safe_confirm(

--- a/tests/unit/client/test_cli_utils.py
+++ b/tests/unit/client/test_cli_utils.py
@@ -306,14 +306,28 @@ class TestGinkgoJSONEncoder:
         assert out == {"x": 1, "y": "abc"}
 
     def test_sqlalchemy_model_columns_dict(self):
-        col1 = SimpleNamespace(name="id")
-        col2 = SimpleNamespace(name="name")
-        tbl = SimpleNamespace(columns=[col1, col2])
-        record = SimpleNamespace(__table__=tbl)
-        record.id = 42
-        record.name = "foo"
+        # 真实 DeclarativeBase（isinstance 判定，非 SimpleNamespace duck-typing）
+        from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+        class Base(DeclarativeBase):
+            pass
+
+        class Record(Base):
+            __tablename__ = "record_cli_utils_test"
+            id: Mapped[int] = mapped_column(primary_key=True)
+            name: Mapped[str] = mapped_column()
+
+        record = Record(id=42, name="foo")
         out = json.loads(json.dumps(record, cls=cli_utils.GinkgoJSONEncoder))
         assert out == {"id": 42, "name": "foo"}
+
+    def test_magicmock_raises_typeerror_not_infinite_recursion(self):
+        """防回归（OOM 根因）：MagicMock 对任意属性 hasattr 恒 True，
+        旧 ``hasattr(obj, "model_dump")`` duck-typing 触发 C 层无限递归 ~1GB/s → OOM。
+        isinstance 白名单后须抛 TypeError（响亮失败），绝不递归。"""
+        m = MagicMock()
+        with pytest.raises(TypeError):
+            json.dumps(m, cls=cli_utils.GinkgoJSONEncoder)
 
     def test_unknown_type_falls_back_to_default(self):
         # 未覆盖类型应让父类 default 抛 TypeError


### PR DESCRIPTION
## 根因

`GinkgoJSONEncoder.default()` 用 `hasattr(obj, "model_dump")` / `hasattr(obj, "__table__")` duck-typing。**MagicMock 对任意属性 `hasattr` 恒 True** → `model_dump()` 返回子 MagicMock → encoder 递归自身 → **C 层无限递归 ~1GB/s → global OOM**（93GB 机亦爆；递归在 C 层不走 Python 栈深，直接内存爆炸而非 RecursionError）。

master 休眠隐患：`cli_utils.py:242/245` 仍是 `hasattr`，只缺一个 MagicMock 测试点燃。本 PR 提前消除。

## 修复

- pydantic: `hasattr(obj, "model_dump")` → `isinstance(obj, BaseModel)`
- SQLAlchemy: `hasattr(obj, "__table__")` → `isinstance(obj, DeclarativeBase)`
- 未识别类型: `super().default(obj)` → 显式 `raise TypeError`（json 标准契约，响亮失败）

## 来源

cherry-pick 自 #6652 的 6db1fdc1（同 commit，2 文件 40 行）。独立提出让 master 早日消除隐患，不阻塞 #6652 review；#6652 合并时该改动语义一致，git 会自动合并无冲突。

## 验证

- `TestGinkgoJSONEncoder` 9 passed（master worktree 实跑，0.27s）
- 新增 `test_magicmock_raises_typeerror_not_infinite_recursion` 防回归（一行式哨兵：`json.dumps(MagicMock())` 应抛 TypeError）
- `test_sqlalchemy_model_columns_dict` 改用真 `DeclarativeBase`（接近生产，非 SimpleNamespace 替身）
- cherry-pick 到 master CLEAN apply（auto-merge 无冲突）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
