### PR TITLE
fix(#4863): scheduler reconcile 对齐 plan 与 execution status

### DIFF
--- a/src/ginkgo/livecore/scheduler/heartbeat.py
+++ b/src/ginkgo/livecore/scheduler/heartbeat.py
@@ -9,6 +9,7 @@
 纯查询逻辑，无副作用。
 """
 
+import json
 import logging
 from typing import Dict, List
 
@@ -63,17 +64,33 @@ class HeartbeatChecker:
             node_id: ExecutionNode ID
 
         Returns:
-            Dict: 性能指标 {portfolio_count, queue_size, cpu_usage}
+            Dict: 性能指标 {portfolio_count, queue_size, cpu_usage, loaded_portfolio_ids}
+            loaded_portfolio_ids: 已加载 pid 列表；老节点未上报/JSON 损坏时为 None
+            (#4863 reconcile 据此判定漏加载，None 则跳过该节点)。
         """
         try:
             key = f"{self.NODE_METRICS_PREFIX}{node_id}"
             metrics = self.redis_client.hgetall(key)
 
+            # 解析 loaded_portfolio_ids（JSON 列表）；缺失或损坏降级为 None
+            loaded_raw = metrics.get(b'loaded_portfolio_ids')
+            loaded_ids = None
+            if loaded_raw is not None:
+                try:
+                    loaded_ids = json.loads(loaded_raw)
+                except (ValueError, TypeError) as e:
+                    logger.warning(
+                        f"Failed to parse loaded_portfolio_ids for node {node_id}: {e}"
+                    )
+                    loaded_ids = None
+
             return {
                 'portfolio_count': int(metrics.get(b'portfolio_count', 0)),
+                'loaded_portfolio_ids': loaded_ids,
                 'queue_size': int(metrics.get(b'queue_size', 0)),
                 'cpu_usage': float(metrics.get(b'cpu_usage', 0.0))
             }
         except Exception as e:
             logger.error(f"Failed to get metrics for node {node_id}: {e}")
-            return {'portfolio_count': 0, 'queue_size': 0, 'cpu_usage': 0.0}
+            return {'portfolio_count': 0, 'loaded_portfolio_ids': None,
+                    'queue_size': 0, 'cpu_usage': 0.0}

--- a/src/ginkgo/livecore/scheduler/plan_manager.py
+++ b/src/ginkgo/livecore/scheduler/plan_manager.py
@@ -93,6 +93,57 @@ class PlanManager:
             logger.error(f"Failed to detect orphaned portfolios: {e}")
             return []
 
+    def detect_undelivered_portfolios(self, healthy_nodes, current_plan=None) -> List[Dict[str, str]]:
+        """
+        #4863: 检测 plan 已分配给健康节点、但节点未实际加载的 Portfolio。
+
+        与 detect_orphaned_portfolios 互补：orphaned 处理「节点下线」（plan 的
+        node_id 不在 healthy_nodes），undelivered 处理「健康节点漏加载」——Kafka
+        schedule.updates 丢失、节点启动晚于消息、load_portfolio 失败等，会让
+        plan 写了 pid→X 但节点 X 的 self.portfolios 不含 pid，scheduler plan 与
+        execution status 永久漂移（plan 显示 5、status 显示 0）。
+
+        Args:
+            healthy_nodes: [{node_id, metrics: {portfolio_count, loaded_portfolio_ids}}]
+            current_plan: {portfolio_id: node_id}（为 None 时自动获取）
+
+        Returns:
+            List[Dict]: [{"portfolio_id": str, "node_id": str}, ...] 供 scheduler
+            重发 send_schedule_command（to_node 即原分配节点，幂等）。
+        """
+        try:
+            if current_plan is None:
+                current_plan = self.get_current_schedule_plan()
+
+            node_loaded = {}
+            for n in healthy_nodes:
+                metrics = n.get("metrics", {}) or {}
+                loaded = metrics.get("loaded_portfolio_ids")
+                if loaded is None:
+                    # 老节点未上报该字段，无法判定漏加载 → 跳过，不误报
+                    continue
+                node_loaded[n["node_id"]] = set(loaded)
+
+            undelivered = []
+            for portfolio_id, node_id in current_plan.items():
+                # 节点不健康（orphaned 职责）或未上报 loaded 字段 → 不在此处理
+                if node_id not in node_loaded:
+                    continue
+                if portfolio_id not in node_loaded[node_id]:
+                    undelivered.append({"portfolio_id": portfolio_id, "node_id": node_id})
+
+            if undelivered:
+                logger.warning(
+                    f"Undelivered portfolios (healthy node missing load): "
+                    f"{[(p['portfolio_id'][:8], p['node_id']) for p in undelivered]}"
+                )
+
+            return undelivered
+
+        except Exception as e:
+            logger.error(f"Failed to detect undelivered portfolios: {e}")
+            return []
+
     def detect_deleted_portfolios(self, current_plan: Dict[str, str]) -> List[str]:
         """
         检测已删除的 Portfolio（调度计划中有，但数据库不存在的）

--- a/src/ginkgo/livecore/scheduler/scheduler.py
+++ b/src/ginkgo/livecore/scheduler/scheduler.py
@@ -350,6 +350,35 @@ class Scheduler(threading.Thread):
         # 4. 检测离线 Node 的 Portfolio
         orphaned_portfolios = self._plan_manager.detect_orphaned_portfolios(healthy_nodes, current_plan)
 
+        # 4.5. #4863: reconcile — 检测「plan 已分配给健康节点、但节点漏加载」的 portfolio，
+        # 重发加载命令。与 orphaned（节点下线）互补：orphaned 是 node 不在 healthy 列表，
+        # undelivered 是 node 健康但 Kafka schedule.updates 丢失/节点启动晚于消息/load 失败，
+        # 导致 plan 写了 pid→X 但 X 的 self.portfolios 不含 pid，plan 与 status 永久漂移。
+        # 重发复用新分配同条路径（PORTFOLIO_MIGRATE，target==self → _receive_portfolio →
+        # load_portfolio 幂等）；from_node=None 表示非真实迁移、仅触发目标节点加载，不改 plan。
+        try:
+            undelivered = self._plan_manager.detect_undelivered_portfolios(healthy_nodes, current_plan)
+        except Exception as e:
+            logger.warning(f"Failed to detect undelivered portfolios: {e}")
+            undelivered = []
+        if undelivered:
+            logger.warning(
+                f"Reconciling {len(undelivered)} undelivered portfolios "
+                f"(plan assigned but healthy node missing load, resend load command)"
+            )
+            for item in undelivered:
+                try:
+                    self._send_schedule_command({
+                        "portfolio_id": item["portfolio_id"],
+                        "from_node": None,
+                        "to_node": item["node_id"],
+                    })
+                except Exception as e:
+                    logger.error(
+                        f"Failed to resend load command for portfolio "
+                        f"{item.get('portfolio_id', '?')[:8]} → {item.get('node_id')}: {e}"
+                    )
+
         # ========== 调度信息打印 ==========
         logger.info("")
         logger.info("="*70)

--- a/src/ginkgo/workers/execution_node/heartbeat_manager.py
+++ b/src/ginkgo/workers/execution_node/heartbeat_manager.py
@@ -19,6 +19,7 @@ HeartbeatManager - 心跳管理器
 """
 
 from ginkgo.libs import GLOG
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -212,6 +213,8 @@ class HeartbeatManager:
         Redis Key: node:metrics:{node_id} (Hash)
         Fields:
         - portfolio_count: Portfolio 数量
+        - loaded_portfolio_ids: 已加载的 portfolio_id 列表（JSON），供 Scheduler
+          reconcile 判定「plan 分配了但节点没加载」(#4863)
         - queue_size: 平均队列大小
         - status: 节点状态 (RUNNING/PAUSED/STOPPED)
         - cpu_usage: CPU 使用率（预留）
@@ -235,6 +238,7 @@ class HeartbeatManager:
             # 收集性能指标
             metrics = {
                 "portfolio_count": str(len(node.portfolios)),
+                "loaded_portfolio_ids": json.dumps(list(node.portfolios.keys())),
                 "queue_size": str(self.get_average_queue_size()),
                 "status": status,  # 节点状态
                 "cpu_usage": "0.0",  # 预留，未来实现

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -511,6 +511,17 @@ class ExecutionNode:
             ValueError: Portfolio不是实盘Portfolio或不存在
         """
         try:
+            # #4863: 早期幂等检查——Scheduler reconcile 会重发加载命令，对已加载
+            # portfolio 在昂贵的 DB 查询 + 引擎装配前直接返回，避免每调度周期重复
+            # 装配。与下方 lock 内检查（node.py 装配后）语义一致，返回 False。
+            with self.portfolio_lock:
+                if portfolio_id in self.portfolios:
+                    logger.info(
+                        f"[LOAD] Portfolio {portfolio_id[:8]} already loaded "
+                        f"(early idempotent skip, reconcile resend)"
+                    )
+                    return False
+
             logger.info(f"[LOAD] Loading portfolio {portfolio_id[:8]} from database...")
 
             # 1. 通过PortfolioService从数据库查询Portfolio配置

--- a/tests/unit/livecore/test_heartbeat_checker.py
+++ b/tests/unit/livecore/test_heartbeat_checker.py
@@ -1,0 +1,67 @@
+"""Tests for HeartbeatChecker (scheduler) -- #4863"""
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.livecore.scheduler.heartbeat import HeartbeatChecker
+
+
+@pytest.mark.tdd
+class TestGetNodeMetricsParsesLoadedPortfolioIds:
+    """#4863: get_node_metrics 必须从 node:metrics:{id} Hash 解析
+    `loaded_portfolio_ids`（JSON 列表），供 Scheduler reconcile 判定漏加载。
+
+    老节点无此字段 → 返回 None（detect_undelivered_portfolios 据此跳过，
+    不误判）；JSON 解析失败也降级为 None（不阻塞 metrics 读取）。
+    """
+
+    def test_parses_loaded_portfolio_ids_json(self):
+        redis_client = MagicMock()
+        redis_client.hgetall.return_value = {
+            b"portfolio_count": b"2",
+            b"loaded_portfolio_ids": b'["pid-1","pid-2"]',
+            b"queue_size": b"0",
+            b"cpu_usage": b"0.0",
+        }
+        checker = HeartbeatChecker(redis_client)
+
+        metrics = checker.get_node_metrics("nodeX")
+
+        assert metrics["loaded_portfolio_ids"] == ["pid-1", "pid-2"]
+
+    def test_missing_field_returns_none(self):
+        """老节点未上报 loaded_portfolio_ids → None（跳过该节点，不误报）。"""
+        redis_client = MagicMock()
+        redis_client.hgetall.return_value = {
+            b"portfolio_count": b"1",
+            b"queue_size": b"0",
+        }
+        checker = HeartbeatChecker(redis_client)
+
+        metrics = checker.get_node_metrics("nodeX")
+
+        assert metrics["loaded_portfolio_ids"] is None
+
+    def test_empty_list_parses(self):
+        redis_client = MagicMock()
+        redis_client.hgetall.return_value = {
+            b"portfolio_count": b"0",
+            b"loaded_portfolio_ids": b"[]",
+        }
+        checker = HeartbeatChecker(redis_client)
+
+        metrics = checker.get_node_metrics("nodeX")
+
+        assert metrics["loaded_portfolio_ids"] == []
+
+    def test_corrupt_json_returns_none(self):
+        """JSON 损坏 → None（降级，不抛异常阻塞 metrics 读取）。"""
+        redis_client = MagicMock()
+        redis_client.hgetall.return_value = {
+            b"portfolio_count": b"1",
+            b"loaded_portfolio_ids": b"not-json",
+        }
+        checker = HeartbeatChecker(redis_client)
+
+        metrics = checker.get_node_metrics("nodeX")
+
+        assert metrics["loaded_portfolio_ids"] is None

--- a/tests/unit/livecore/test_plan_manager.py
+++ b/tests/unit/livecore/test_plan_manager.py
@@ -94,3 +94,105 @@ class TestGetAllPortfolios:
         result = PlanManager._get_all_portfolios()
 
         assert result == []
+
+
+@pytest.mark.tdd
+class TestDetectUndeliveredPortfolios:
+    """#4863: detect_undelivered_portfolios 找出 plan 已分配给健康节点、
+    但节点未实际加载的 portfolio。
+
+    detect_orphaned_portfolios 只处理「节点下线」（plan 中 node_id 不在
+    healthy_nodes），漏掉了「健康节点漏加载」——Kafka schedule.updates 丢失、
+    节点启动晚于消息、load_portfolio 失败等，都会让 plan 写了 pid→X 但
+    节点 X 的 self.portfolios 不含 pid，且无 reconcile 机制 → plan/status
+    永久漂移（scheduler plan 显示 5、execution status 显示 0）。
+
+    输入契约：healthy_nodes[i] = {
+        "node_id": str,
+        "metrics": {"portfolio_count": int, "loaded_portfolio_ids": [str, ...]}
+    }
+    返回：[{"portfolio_id": str, "node_id": str}, ...] 供 scheduler 重发加载命令。
+    """
+
+    def test_plan_assigned_but_node_not_loaded_returns_undelivered(self):
+        """plan 把 pid 分给健康节点 X，X 上报 loaded_portfolio_ids=[] → 返回该 pid。"""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        redis_client = MagicMock()
+        pm = PlanManager(redis_client)
+
+        healthy_nodes = [
+            {"node_id": "nodeX", "metrics": {"portfolio_count": 0, "loaded_portfolio_ids": []}}
+        ]
+        current_plan = {"pid-1": "nodeX"}
+
+        result = pm.detect_undelivered_portfolios(healthy_nodes, current_plan)
+
+        assert result == [{"portfolio_id": "pid-1", "node_id": "nodeX"}]
+
+    def test_node_already_loaded_returns_empty(self):
+        """plan 把 pid 分给 X，X 已加载该 pid → 空列表（幂等重发不必要）。"""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        redis_client = MagicMock()
+        pm = PlanManager(redis_client)
+
+        healthy_nodes = [
+            {"node_id": "nodeX", "metrics": {"portfolio_count": 1, "loaded_portfolio_ids": ["pid-1"]}}
+        ]
+        current_plan = {"pid-1": "nodeX"}
+
+        result = pm.detect_undelivered_portfolios(healthy_nodes, current_plan)
+
+        assert result == []
+
+    def test_old_node_missing_loaded_field_skipped(self):
+        """老节点未上报 loaded_portfolio_ids（字段缺失）→ 跳过，不误报其 plan 为漏加载。"""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        redis_client = MagicMock()
+        pm = PlanManager(redis_client)
+
+        healthy_nodes = [
+            # 老节点：只有 portfolio_count，无 loaded_portfolio_ids
+            {"node_id": "node-old", "metrics": {"portfolio_count": 1}}
+        ]
+        current_plan = {"pid-1": "node-old"}
+
+        result = pm.detect_undelivered_portfolios(healthy_nodes, current_plan)
+
+        assert result == []
+
+    def test_node_not_healthy_left_to_orphaned(self):
+        """pid 分给的节点不在 healthy_nodes（已下线）→ 不归 undelivered（detect_orphaned 负责）。"""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        redis_client = MagicMock()
+        pm = PlanManager(redis_client)
+
+        # nodeX 下线了，healthy 列表里是另一个节点
+        healthy_nodes = [
+            {"node_id": "nodeY", "metrics": {"portfolio_count": 0, "loaded_portfolio_ids": []}}
+        ]
+        current_plan = {"pid-1": "nodeX"}
+
+        result = pm.detect_undelivered_portfolios(healthy_nodes, current_plan)
+
+        assert result == []
+
+    def test_mixed_loaded_and_undelivered(self):
+        """X 加载了 pid-1 漏了 pid-2，Y 健康无 plan → 只报 pid-2。"""
+        from ginkgo.livecore.scheduler.plan_manager import PlanManager
+
+        redis_client = MagicMock()
+        pm = PlanManager(redis_client)
+
+        healthy_nodes = [
+            {"node_id": "nodeX", "metrics": {"portfolio_count": 1, "loaded_portfolio_ids": ["pid-1"]}},
+            {"node_id": "nodeY", "metrics": {"portfolio_count": 0, "loaded_portfolio_ids": []}},
+        ]
+        current_plan = {"pid-1": "nodeX", "pid-2": "nodeX"}
+
+        result = pm.detect_undelivered_portfolios(healthy_nodes, current_plan)
+
+        assert result == [{"portfolio_id": "pid-2", "node_id": "nodeX"}]

--- a/tests/unit/livecore/test_scheduler_reconcile.py
+++ b/tests/unit/livecore/test_scheduler_reconcile.py
@@ -1,0 +1,86 @@
+"""Tests for Scheduler._schedule_loop reconcile -- #4863"""
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _make_scheduler_with_mocks():
+    """构造 Scheduler（patch 掉 GinkgoConsumer 网络依赖），替换 4 个子模块为 mock。"""
+    with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoConsumer", MagicMock):
+        from ginkgo.livecore.scheduler.scheduler import Scheduler
+        sched = Scheduler(redis_client=MagicMock(), kafka_producer=MagicMock())
+    sched._heartbeat_checker = MagicMock()
+    sched._plan_manager = MagicMock()
+    sched._load_balancer = MagicMock()
+    sched._publisher = MagicMock()
+    return sched
+
+
+def _stub_no_changes(sched, current_plan, healthy_nodes):
+    """让 plan_manager/load_balancer 不引入任何 plan 变化（隔离 reconcile 行为）。"""
+    sched._heartbeat_checker.get_healthy_nodes.return_value = healthy_nodes
+    sched._plan_manager.get_current_schedule_plan.return_value = dict(current_plan)
+    sched._plan_manager.discover_new_portfolios.return_value = []
+    sched._plan_manager.detect_deleted_portfolios.return_value = []
+    sched._plan_manager.detect_orphaned_portfolios.return_value = []
+    # assign 原样返回 plan → 不触发 publish_schedule_update
+    sched._load_balancer.assign_portfolios.return_value = dict(current_plan)
+    sched._load_balancer.get_plan_changes.return_value = {}
+
+
+@pytest.mark.tdd
+class TestScheduleLoopReconcilesUndelivered:
+    """#4863: _schedule_loop 检测到「plan 已分配但健康节点漏加载」的 portfolio 时，
+    通过 _send_schedule_command 重发加载命令（复用 migrate 接收端 →
+    _receive_portfolio → load_portfolio 幂等），且不修改 plan（重发≠重新分配）。
+    """
+
+    def test_undelivered_triggers_send_schedule_command(self):
+        sched = _make_scheduler_with_mocks()
+        plan = {"pid-1": "nodeX"}
+        healthy = [
+            {"node_id": "nodeX", "metrics": {"portfolio_count": 0, "loaded_portfolio_ids": []}}
+        ]
+        _stub_no_changes(sched, plan, healthy)
+        # detect_undelivered 报告 1 个漏加载
+        sched._plan_manager.detect_undelivered_portfolios.return_value = [
+            {"portfolio_id": "pid-1", "node_id": "nodeX"}
+        ]
+
+        sched._schedule_loop()
+
+        # 重发了加载命令，to_node=原分配节点，from_node=None（非真实迁移）
+        sched._publisher.send_schedule_command.assert_called()
+        sent = [c.args[0] for c in sched._publisher.send_schedule_command.call_args_list]
+        assert any(
+            c["portfolio_id"] == "pid-1" and c["to_node"] == "nodeX" and c["from_node"] is None
+            for c in sent
+        ), f"expected resend for pid-1→nodeX, sent={sent}"
+        # plan 未变 → 不发布计划更新
+        sched._publisher.publish_schedule_update.assert_not_called()
+
+    def test_no_undelivered_no_resend(self):
+        sched = _make_scheduler_with_mocks()
+        _stub_no_changes(sched, {}, [])
+        sched._plan_manager.detect_undelivered_portfolios.return_value = []
+
+        sched._schedule_loop()
+
+        sched._publisher.send_schedule_command.assert_not_called()
+
+    def test_reconcile_does_not_mutate_plan(self):
+        """重发不改 plan：plan 仍含原分配，不触发 assign 重新分配。"""
+        sched = _make_scheduler_with_mocks()
+        plan = {"pid-1": "nodeX", "pid-2": "nodeX"}
+        healthy = [
+            {"node_id": "nodeX", "metrics": {"portfolio_count": 1, "loaded_portfolio_ids": ["pid-1"]}}
+        ]
+        _stub_no_changes(sched, plan, healthy)
+        sched._plan_manager.detect_undelivered_portfolios.return_value = [
+            {"portfolio_id": "pid-2", "node_id": "nodeX"}
+        ]
+
+        sched._schedule_loop()
+
+        # assign 收到的 orphaned 不应含 pid-2（它是漏加载，不是孤儿）
+        assign_kwargs = sched._load_balancer.assign_portfolios.call_args.kwargs
+        assert "pid-2" not in (assign_kwargs.get("orphaned_portfolios") or [])

--- a/tests/unit/workers/test_execution_node_load_portfolio.py
+++ b/tests/unit/workers/test_execution_node_load_portfolio.py
@@ -78,3 +78,33 @@ class TestLoadPortfolioAssemblyFailure:
                     result = node.load_portfolio("test-uuid-1234")
 
         assert result is False
+
+
+@pytest.mark.unit
+class TestLoadPortfolioEarlyIdempotency:
+    """#4863: load_portfolio 对已加载 portfolio 应在昂贵的 DB 查询 + 引擎装配前
+    早期返回，避免 Scheduler reconcile 每周期重发时重复执行装配（plan 已分配、
+    节点也已加载，仅 heartbeat 漏报或 Kafka 滞后等 transient 情况触发重发）。
+
+    既有幂等检查在 node.py 装配之后（lock 内），对 reconcile 风暴代价过高。
+    """
+
+    def test_already_loaded_skips_db_query_and_assembly(self):
+        """已加载 portfolio → 立即返回 False，不查 DB、不装配。"""
+        from ginkgo.workers.execution_node.node import ExecutionNode
+        import ginkgo.workers.execution_node.node as node_mod
+
+        node = ExecutionNode(node_id="test-node")
+        node.portfolios["pid-loaded"] = MagicMock()  # 预置已加载
+
+        mock_ps = MagicMock()
+        with patch.object(node_mod, "services") as mock_svc:
+            mock_svc.data.portfolio_service.return_value = mock_ps
+            with patch(
+                "ginkgo.trading.services.engine_assembly_service.EngineAssemblyService"
+            ) as mock_eas:
+                result = node.load_portfolio("pid-loaded")
+
+        assert result is False
+        mock_ps.get.assert_not_called()   # 未查 DB
+        mock_eas.assert_not_called()      # 未装配

--- a/tests/unit/workers/test_heartbeat_manager.py
+++ b/tests/unit/workers/test_heartbeat_manager.py
@@ -1,0 +1,57 @@
+"""Tests for HeartbeatManager -- #4863"""
+import json
+
+import pytest
+from unittest.mock import MagicMock
+
+from ginkgo.workers.execution_node.heartbeat_manager import HeartbeatManager
+
+
+def _make_node(portfolios, node_id="nodeX", running=True, paused=False):
+    """构造 ExecutionNode 的 MagicMock，portfolios 用真 dict 避免 json 递归。"""
+    node = MagicMock()
+    node.node_id = node_id
+    node.portfolios = portfolios  # 真 dict
+    node.is_running = running
+    node.is_paused = paused
+    node.heartbeat_ttl = 30
+    node.total_event_count = 0
+    node.backpressure_count = 0
+    node.dropped_event_count = 0
+    redis_client = MagicMock()
+    node._get_redis_client.return_value = redis_client
+    return node, redis_client
+
+
+@pytest.mark.tdd
+class TestUpdateNodeMetricsReportsLoadedPortfolioIds:
+    """#4863: update_node_metrics 必须把 node.portfolios 的 id 列表上报到
+    node:metrics:{id} Hash 的 `loaded_portfolio_ids` 字段（JSON 编码）。
+
+    这是 reconcile 链路的数据源——Scheduler 读该字段才能判定「plan 分配了
+    但节点没加载」，重发 Kafka 加载命令。只有 portfolio_count（数量）不够：
+    scheduler 无法知道是 *哪些* pid 没加载。
+    """
+
+    def test_writes_loaded_portfolio_ids_as_json_list(self):
+        """node.portfolios 含 2 个 pid → metrics.loaded_portfolio_ids = JSON 列表。"""
+        node, redis_client = _make_node({"pid-1": object(), "pid-2": object()})
+        hm = HeartbeatManager(node)
+
+        hm.update_node_metrics()
+
+        redis_client.hset.assert_called_once()
+        kwargs = redis_client.hset.call_args.kwargs
+        assert "loaded_portfolio_ids" in kwargs["mapping"]
+        loaded = json.loads(kwargs["mapping"]["loaded_portfolio_ids"])
+        assert sorted(loaded) == ["pid-1", "pid-2"]
+
+    def test_empty_portfolios_writes_empty_list(self):
+        """node.portfolios={} → loaded_portfolio_ids = JSON 空列表（非空串）。"""
+        node, redis_client = _make_node({})
+        hm = HeartbeatManager(node)
+
+        hm.update_node_metrics()
+
+        kwargs = redis_client.hset.call_args.kwargs
+        assert json.loads(kwargs["mapping"]["loaded_portfolio_ids"]) == []


### PR DESCRIPTION
## Summary

#4863：Scheduler 把 portfolio 分配写入 `schedule:plan` 后经 Kafka 通知节点加载，但消息丢失/节点启动晚于消息/load 失败等会让 plan 写了 pid→X 而节点 X 未加载，无 reconcile 机制 → **plan 显示 N、execution status 显示 <N，永久漂移**。既有 `detect_orphaned` 只处理「节点下线」，漏掉「健康节点漏加载」。

方案（控制面 reconcile，复用现有加载路径，不动交易执行）：

| 文件 | 改动 |
|---|---|
| `heartbeat_manager.update_node_metrics` | 上报 `loaded_portfolio_ids`（`node.portfolios` keys 的 JSON）到 `node:metrics:{id}`。此前只有 `portfolio_count`（数量），无法知道是哪些 pid 没加载 |
| `heartbeat.get_node_metrics` | 解析 `loaded_portfolio_ids` JSON；老节点无此字段/JSON 损坏 → `None`（detect 据此跳过，不误判） |
| `plan_manager.detect_undelivered_portfolios` | 差集逻辑：plan 已分配给健康节点、但节点 `loaded_portfolio_ids` 不含的 pid，返回 `[{portfolio_id, node_id}]` |
| `scheduler._schedule_loop` | orphaned 检测后新增 reconcile 步骤，对漏加载 pid 重发 `send_schedule_command`（`to_node`=原分配节点，`from_node=None`），复用新分配同条接收端路径（`_receive_portfolio → load_portfolio` 幂等）；**不改 plan**（重发≠重新分配） |
| `node.load_portfolio` | 早期幂等检查移至 DB 查询/引擎装配前，避免 reconcile 每周期重发时对已加载 portfolio 重复装配 |

**关键设计**：
- reconcile 与 orphaned 互补——orphaned = node 不在 healthy 列表；undelivered = node 健康但漏加载。
- 重发复用 `PORTFOLIO_MIGRATE` + `target==self` → `_receive_portfolio → load_portfolio`（与新分配同条已验证路径），不引入新 command 类型。
- `load_portfolio` 幂等（已加载返回 False），重发安全。

## Test plan

TDD 垂直切片，21 passed：
- `test_plan_manager.TestDetectUndeliveredPortfolios`（5：漏加载/已加载/老节点跳过/不健康归 orphaned/混合）
- `test_heartbeat_manager.TestUpdateNodeMetricsReportsLoadedPortfolioIds`（2）
- `test_heartbeat_checker.TestGetNodeMetricsParsesLoadedPortfolioIds`（4：解析/缺失→None/空列表/损坏JSON→None）
- `test_scheduler_reconcile.TestScheduleLoopReconcilesUndelivered`（3：重发/无漏加载不重发/不改 plan）
- `test_execution_node_load_portfolio.TestLoadPortfolioEarlyIdempotency`（1）

冒烟三层：
- Layer 1 py_compile：5 个 src ✅
- Layer 2 启动路径：`test_user_cli.py::test_create_user_missing_name_fails` 1 失败，已 stash 证伪为 **pre-existing**（Rich ANSI 把 `--name` 拆开致断言失败，与本次改动无因果链；该测试不 import 任何改动模块）
- Layer 3 变更相关：21 passed + 既有 livecore scheduler/heartbeat 23 passed（无回归）

Closes #4863