### PR TITLE
fix: DataManager.start() 无限递归致实盘数据管线静默失败 (#6695)

### DIFF
--- a/src/ginkgo/livecore/data_manager.py
+++ b/src/ginkgo/livecore/data_manager.py
@@ -233,80 +233,78 @@ class DataManager(threading.Thread):
 
         return None
 
+    def initialize(self) -> None:
+        """
+        同步初始化：构造 Kafka producer、启动所有 feeders、恢复订阅。
+
+        与 start() 解耦——start() 仅负责孵化后台线程（run()），
+        所有同步 setup 集中在此，可独立调用（#6695）。
+        启动失败（编程错误）原样抛出，不静默吞错。
+        """
+        GLOG.INFO("DataManager initializing...")
+
+        # 初始化 Kafka Producer
+        self._producer = GinkgoProducer()
+
+        # 启动所有 feeders
+        with self._feeder_lock:
+            for feeder_type, feeder in self._feeders.items():
+                if not feeder.initialize():
+                    GLOG.ERROR(f"Failed to initialize feeder {feeder_type}")
+                    continue
+
+                # 设置事件发布器
+                feeder.set_event_publisher(
+                    lambda event, ft=feeder_type: self._on_live_data_received(event, ft)
+                )
+
+                # 启动 feeder
+                if not feeder.start():
+                    GLOG.ERROR(f"Failed to start feeder {feeder_type}")
+                    continue
+
+                GLOG.INFO(f"Feeder {feeder_type} started")
+
+        # 恢复订阅（从数据库）
+        self.restore_subscriptions()
+
+        GLOG.INFO("DataManager initialized")
+
     def start(self) -> bool:
         """
-        启动 DataManager
+        启动 DataManager 后台线程（run()）。
 
-        Returns:
-            bool: 启动是否成功
+        须先调用 initialize() 完成同步 setup（producer/feeders/订阅恢复）。
+        本方法仅孵化线程，遵循 threading.Thread 契约（调用 super().start()）。
+        启动路径上的编程错误原样抛出，不静默吞错（#6695）。
         """
+        GLOG.INFO("DataManager starting...")
+
+        # 标记运行状态
+        self._running.set()
+
+        # 孵化后台线程执行 run()
+        super().start()
+
+        GLOG.INFO("DataManager started successfully")
+
+        # 发送启动通知（通知失败不影响主流程）
         try:
-            GLOG.INFO("DataManager starting...")
+            from ginkgo.notifier.core.notification_service import notify
+            notify(
+                "DataManager启动成功",
+                level="INFO",
+                module="DataManager",
+                details={
+                    "组件": "DataManager",
+                    "数据源": list(self._feeders.keys()),
+                    "启动时间": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+                },
+            )
+        except Exception as notify_error:
+            GLOG.WARNING(f"Failed to send start notification: {notify_error}")
 
-            # 初始化 Kafka Producer
-            self._producer = GinkgoProducer()
-
-            # 启动所有 feeders
-            with self._feeder_lock:
-                for feeder_type, feeder in self._feeders.items():
-                    if not feeder.initialize():
-                        GLOG.ERROR(f"Failed to initialize feeder {feeder_type}")
-                        continue
-
-                    # 设置事件发布器
-                    feeder.set_event_publisher(lambda event, ft=feeder_type: self._on_live_data_received(event, ft))
-
-                    # 启动 feeder
-                    if not feeder.start():
-                        GLOG.ERROR(f"Failed to start feeder {feeder_type}")
-                        continue
-
-                    GLOG.INFO(f"Feeder {feeder_type} started")
-
-            # 恢复订阅（从数据库）
-            self.restore_subscriptions()
-
-            # 启动主线程
-            self._running.set()
-            self.start()
-
-            GLOG.INFO("DataManager started successfully")
-
-            # 发送启动通知
-            try:
-                from ginkgo.notifier.core.notification_service import notify
-                notify(
-                    "DataManager启动成功",
-                    level="INFO",
-                    module="DataManager",
-                    details={
-                        "组件": "DataManager",
-                        "数据源": list(self._feeders.keys()),
-                        "启动时间": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
-                    },
-                )
-            except Exception as notify_error:
-                GLOG.WARNING(f"Failed to send start notification: {notify_error}")
-
-            return True
-
-        except Exception as e:
-            GLOG.ERROR(f"DataManager start failed: {e}")
-
-            # 发送失败通知
-            try:
-                from ginkgo.notifier.core.notification_service import notify
-                notify(
-                    f"DataManager启动失败: {e}",
-                    level="ERROR",
-                    module="DataManager",
-                    details={"组件": "DataManager", "错误信息": str(e)},
-                )
-            except Exception as e:
-                GLOG.WARNING(f"{e}")
-                pass
-
-            return False
+        return True
 
     def stop(self) -> bool:
         """

--- a/src/ginkgo/livecore/main.py
+++ b/src/ginkgo/livecore/main.py
@@ -336,6 +336,7 @@ class LiveCore:
         from ginkgo.livecore.data_manager import DataManager
 
         self.data_manager = DataManager()
+        self.data_manager.initialize()
         self.data_manager.start()
         self.threads.append(self.data_manager)
         ```
@@ -346,6 +347,7 @@ class LiveCore:
         from ginkgo.livecore.data_manager import DataManager
 
         self.data_manager = DataManager()
+        self.data_manager.initialize()
         self.data_manager.start()
         self.threads.append(self.data_manager)
         GLOG.INFO("DataManager started successfully")

--- a/tests/unit/livecore/test_data_manager.py
+++ b/tests/unit/livecore/test_data_manager.py
@@ -1,4 +1,6 @@
-"""Smoke tests for livecore.data_manager -- #3870"""
+"""Smoke + behavior tests for livecore.data_manager -- #3870, #6695"""
+import threading
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -27,3 +29,97 @@ class TestDataManager:
             assert isinstance(status, dict)
         except (AttributeError, TypeError):
             pass  # Expected if no Kafka configured
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="DataManager not available")
+class TestDataManagerStartContract:
+    """#6695: start() must honor threading.Thread contract (super().start()),
+    not self-recurse. Synchronous setup lives in initialize()."""
+
+    @staticmethod
+    def _make_dm_with_mock_feeder(mock_feeder):
+        """Build a DataManager whose feeder is a MagicMock, bypassing real
+        feeder construction (network/heavy deps)."""
+        def fake_init_feeder(self_dm, feeder_type, config=None):
+            self_dm._feeders[feeder_type] = mock_feeder
+            return True
+        with patch.object(DataManager, "_initialize_feeder", fake_init_feeder):
+            return DataManager(feeder_types=["eastmoney"])
+
+    def test_initialize_sets_up_producer_and_feeders_without_starting_thread(self):
+        """initialize() performs synchronous setup (producer, feeders,
+        restore_subscriptions) and does NOT launch the background thread."""
+        mock_feeder = MagicMock()
+        with patch("ginkgo.livecore.data_manager.GinkgoProducer") as MockProducer, \
+             patch.object(DataManager, "restore_subscriptions") as mock_restore:
+            dm = self._make_dm_with_mock_feeder(mock_feeder)
+            dm.initialize()
+
+            # producer constructed
+            assert MockProducer.called
+            # feeder initialized, wired, and started
+            mock_feeder.initialize.assert_called_once()
+            mock_feeder.set_event_publisher.assert_called_once()
+            mock_feeder.start.assert_called_once()
+            # subscriptions restored
+            mock_restore.assert_called_once()
+            # thread NOT launched yet
+            assert dm.is_alive() is False
+
+    def test_start_launches_thread_that_enters_run(self):
+        """start() must spawn the background thread via super().start() so
+        run() actually executes. Regression guard for the self.start()
+        recursion that previously swallowed RecursionError (#6695)."""
+        run_entered = threading.Event()
+        mock_feeder = MagicMock()
+        with patch("ginkgo.livecore.data_manager.GinkgoProducer"), \
+             patch.object(DataManager, "restore_subscriptions"), \
+             patch("ginkgo.notifier.core.notification_service.notify"):
+            dm = self._make_dm_with_mock_feeder(mock_feeder)
+            # Replace run() with a signal stub (avoids real Kafka consumers).
+            dm.run = lambda: run_entered.set()
+            dm.initialize()
+            dm.start()
+            try:
+                assert run_entered.wait(2.0), "run() was never entered"
+                assert dm.is_alive() is False or run_entered.is_set()
+            finally:
+                dm.join(timeout=2.0)
+
+    def test_start_does_not_swallow_programming_errors(self):
+        """A programming/runtime error on the startup path must propagate,
+        not be swallowed by a broad except Exception (#6695). The old code
+        masked RecursionError and returned False silently."""
+        mock_feeder = MagicMock()
+        with patch("ginkgo.livecore.data_manager.GinkgoProducer"), \
+             patch.object(DataManager, "restore_subscriptions"), \
+             patch("ginkgo.notifier.core.notification_service.notify"):
+            dm = self._make_dm_with_mock_feeder(mock_feeder)
+            dm.initialize()
+            # super().start() raising simulates a startup-path error.
+            with patch.object(threading.Thread, "start", side_effect=RuntimeError("boom")):
+                with pytest.raises(RuntimeError):
+                    dm.start()
+
+    def test_start_source_honors_thread_contract(self):
+        """Regression guard (source inspection): start() must delegate to
+        super().start() and must never self-recurse (#6695)."""
+        import inspect
+        src = inspect.getsource(DataManager.start)
+        assert "self.start()" not in src, "start() must not self-recurse"
+        assert "super().start()" in src, "start() must call super().start()"
+
+    def test_livecore_start_data_manager_calls_initialize_before_start(self):
+        """LiveCore._start_data_manager must call initialize() before start()
+        so synchronous setup runs before the thread launches (#6695)."""
+        import inspect
+        try:
+            from ginkgo.livecore.main import LiveCore
+        except Exception:
+            pytest.skip("LiveCore import unavailable in this env")
+        src = inspect.getsource(LiveCore._start_data_manager)
+        init_idx = src.find(".initialize()")
+        start_idx = src.find(".start()")
+        assert init_idx != -1, "_start_data_manager must call initialize()"
+        assert start_idx != -1, "_start_data_manager must call start()"
+        assert init_idx < start_idx, "initialize() must run before start()"


### PR DESCRIPTION
## Summary

`DataManager.start()` 无限自递归（调用 `self.start()` 而非 `super().start()`），触发 `RecursionError` 被外层宽 `except Exception` 静默吞掉，返回 `False`。结果：**实盘市场数据管线静默死亡，而进程保持存活**——最坏的可观测性故障（P0）。

根因：`DataManager(threading.Thread)` 违反 `threading.Thread` 契约。Thread 子类应重写 `run()`（线程体），`start()` 必须委托 `super().start()` 来孵化线程。原代码在 `start()` 内调 `self.start()` = 无限递归。

修复：
- **抽 `initialize()`**：同步初始化（构造 `GinkgoProducer`、启动所有 feeders、`restore_subscriptions`）独立成方法，可独立调用、可单独测试，不孵化线程。
- **重写 `start()`**：仅 `_running.set()` → `super().start()`（正确孵化执行 `run()` 的线程）→ 通知 → `return True`。
- **移除宽 `except Exception`**：启动路径的编程错误原样抛出（响亮失败），不再被吞为静默 `return False`。
- **`LiveCore._start_data_manager`**：先 `initialize()` 再 `start()`，保持原有装配语义。

## Test plan

三层冒烟关卡全绿（对齐 CI 标准）：
- **Layer 1 py_compile**：`src api` 全量编译通过（零依赖秒级检查）
- **Layer 2 启动路径 smoke**：`test_user_crud_mock` + `test_containers` 通过（`test_user_cli` 1 处失败为 pre-existing，主仓库复现同指纹，与本 issue 无关）
- **Layer 3 变更相关**：`tests/unit/livecore/` 全目录 **101 passed**（1 warning 为 heartbeat_monitor 后台线程既有工件，非本变更）

新增 5 个契约测试（`TestDataManagerStartContract`）：
1. `initialize()` 完成同步 setup 且不孵化线程
2. `start()` 经 `super().start()` 孵化线程并进入 `run()`
3. `start()` 不吞编程错误（`patch.object(threading.Thread, "start", side_effect=RuntimeError)` → 原样抛出）
4. 源码守卫：`inspect.getsource(DataManager.start)` 不含 `self.start()`、含 `super().start()`
5. `LiveCore._start_data_manager` 中 `initialize()` 在 `start()` 之前

Closes #6695