### PR TITLE
fix(logging): 回测日志灌入 glob 匹配全 UUID 文件名 + logs 命令去重复渲染

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -254,6 +254,18 @@ def run_task(
                         current_date=str(result.data.get("backtest_end_date", "")) if isinstance(result.data, dict) else "",
                     )
                     console.print(f":white_check_mark: Backtest completed: {task.uuid[:12]}")
+
+                    # 灌入日志到 ClickHouse（静默降级）—— 镜像非 bg 路径 (L279-288)，
+                    # 否则 --bg 回测日志不灌入、logging logs --task 恒空
+                    # （#5293 在 --bg 场景仍复现，#6564 review 曾标范围外）。
+                    try:
+                        from ginkgo.services.logging.log_ingester import LogIngester
+                        ingester = LogIngester()
+                        ingest_result = ingester.ingest_task_logs(task.uuid)
+                        if ingest_result.inserted > 0:
+                            console.print(f"   Logs ingested: {ingest_result.inserted} records")
+                    except Exception as e:
+                        GLOG.WARNING(f"{e}")
                 else:
                     _emit_backtest_failure(result)
 

--- a/src/ginkgo/client/logging_cli.py
+++ b/src/ginkgo/client/logging_cli.py
@@ -235,7 +235,6 @@ def view_logs(
         msg = str(entry.get("message", ""))[:60]
         style = LEVEL_STYLES.get(lvl, "")
         table.add_row(ts, f"[{style}]{lvl}[/{style}]" if style else lvl, evt, sym, msg)
-        table.add_row(ts, f"[{style}]{lvl}[/{style}]" if style else lvl, evt, sym, msg)
 
     console.print(table)
 

--- a/src/ginkgo/services/logging/log_ingester.py
+++ b/src/ginkgo/services/logging/log_ingester.py
@@ -238,7 +238,19 @@ class LogIngester:
         return result
 
     def ingest_task_logs(self, task_uuid: str) -> IngestResult:
-        """根据 task_uuid 前缀匹配 bt_<prefix>_*.log 文件并灌入"""
+        """根据 task_uuid 前缀匹配 bt_<prefix>*.log 文件并灌入 (#5293)。
+
+        文件命名有两个 producer，下划线落点不同：
+        - ``engine_assembly_service`` (CLI/orchestrator): ``bt_<32hex 全UUID>_<ts>``
+        - ``backtest_worker.task_processor``: ``bt_<8hex>_<ts>``
+
+        故 glob 用 ``bt_{task_uuid[:8]}*`` —— 不要求第 8 位后紧跟下划线，
+        让 ``*`` 同时吸收 ``_<ts>`` (短) 与 ``<剩余24hex>_<ts>`` (全)。
+        原版 ``bt_{task_uuid[:8]}_*`` 要求下划线在第 8 位后, 全 UUID 文件
+        下划线在第 32 位后 → 永不匹配 → 本地 CLI 回测日志不灌入 ClickHouse
+        → ``ginkgo logging logs --task <id>`` 恒空 (#5293)。
+        行级 task_id 来自日志内容而非文件名, 文件级前缀碰撞不影响查询正确性。
+        """
         log_dir = GCONF.LOGGING_PATH
         prefix = f"bt_{task_uuid[:8]}"
         result = IngestResult()
@@ -247,7 +259,7 @@ class LogIngester:
             GLOG.WARN(f"Log directory not found: {log_dir}")
             return result
 
-        for fname in sorted(Path(log_dir).glob(f"{prefix}_*.log")):
+        for fname in sorted(Path(log_dir).glob(f"{prefix}*.log")):
             file_result = self.ingest_file(str(fname))
             result.total_lines += file_result.total_lines
             result.inserted += file_result.inserted

--- a/tests/unit/client/test_backtest_cli.py
+++ b/tests/unit/client/test_backtest_cli.py
@@ -343,6 +343,72 @@ class TestBacktestRunTaskBgGuard:
         )
 
 
+class TestBacktestRunTaskBgIngest:
+    """#6704: --bg 成功分支必须镜像非 bg 路径调 ingest_task_logs。
+
+    否则 --bg 回测日志不灌入 ClickHouse、``logging logs --task`` 恒空
+    （#5293 在 --bg 场景仍复现；#6564 review 曾标范围外）。对称非 bg 路径 L279-288。
+    """
+
+    @patch("ginkgo.services.logging.log_ingester.LogIngester")
+    @patch("ginkgo.data.containers.container")
+    @patch("ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator")
+    def test_bg_success_ingests_task_logs(
+        self, mock_orch_cls, mock_container, mock_log_cls):
+        """--bg 成功后必须调 ingest_task_logs(task.uuid)，与非 bg 路径对称。"""
+        import time
+        from ginkgo.client.backtest_cli import app
+        from ginkgo.trading.services.backtest_orchestrator import OrchestratorResult
+
+        mock_ingester = MagicMock()
+        mock_ingester.ingest_task_logs.return_value = MagicMock(inserted=0)
+        mock_log_cls.return_value = mock_ingester
+
+        mock_service = MagicMock()
+        get_result = MagicMock()
+        get_result.is_success.return_value = True
+        task = MagicMock()
+        task.uuid = "task-bg-ingest-001"
+        task.portfolio_id = "port-bg"
+        task.config_snapshot = '{"start_date": "2024-01-01", "end_date": "2024-06-30"}'
+        get_result.data = task
+        mock_service.get_by_id.return_value = get_result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        mock_orch = MagicMock()
+        mock_orch.run_from_task.return_value = OrchestratorResult(success=True, data={})
+        mock_orch_cls.return_value = mock_orch
+
+        invoke_result = runner.invoke(app, ["run", "task-bg-ingest-001", "--bg"])
+
+        # 主线程立即返回 exit 0（bg 契约，daemon 线程后台跑）
+        assert invoke_result.exit_code == 0, (
+            f"--bg 主线程应 exit 0，实际 {invoke_result.exit_code}；"
+            f"exception={invoke_result.exception!r}"
+        )
+
+        # 轮询等待 bg 线程跑到 ingest（daemon 异步，最多等 2s）
+        deadline = time.monotonic() + 2.0
+        ingest_call = None
+        while time.monotonic() < deadline:
+            for c in mock_ingester.ingest_task_logs.call_args_list:
+                if c.args and c.args[0] == "task-bg-ingest-001":
+                    ingest_call = c
+                    break
+            if ingest_call is not None:
+                break
+            time.sleep(0.02)
+
+        # 守卫断言：--bg 成功必须调 ingest_task_logs（镜像非 bg L279-288）。
+        # 守卫缺失时 --bg 回测日志不灌入 → logging logs --task 恒空（#5293 --bg 场景）。
+        assert ingest_call is not None, (
+            "--bg 成功后必须调 ingest_task_logs(task.uuid) 灌入日志"
+            "（镜像非 bg 路径，#5293 --bg 场景）；"
+            "ingest_task_logs 未被调用 = --bg 回测日志恒不灌入。"
+            f" calls={mock_ingester.ingest_task_logs.call_args_list}"
+        )
+
+
 class TestBacktestRunTaskBanner:
     """#6449 review fix: 非 bg 模式补回 master 启动 banner（Period/Capital/Portfolio）。
 

--- a/tests/unit/client/test_logging_cli.py
+++ b/tests/unit/client/test_logging_cli.py
@@ -210,6 +210,54 @@ class TestViewErrors:
         assert call_kwargs["end_time"] is not None
 
 
+@pytest.mark.unit
+@pytest.mark.cli
+class TestViewLogsRendering:
+    """Tests for the 'logs' command row rendering (#5293).
+
+    回归: ``view_logs`` 曾对每条日志 ``table.add_row(...)`` 连续调用两次,
+    导致有日志时每行在表格里渲染两遍。本测试 mock ``Table.add_row`` 计数,
+    断言 N 条日志恰好 N 次 add_row。
+    """
+
+    def _make_log(self, ts: str, msg: str) -> dict:
+        return {"timestamp": ts, "level": "INFO", "event_type": "BACKTEST",
+                "symbol": "", "message": msg}
+
+    def test_logs_no_duplicate_rows(self, cli_runner):
+        mock_service = MagicMock()
+        mock_service.query_backtest_logs.return_value = [
+            self._make_log("2026-05-06 12:00:00", "first"),
+            self._make_log("2026-05-06 13:00:00", "second"),
+        ]
+
+        with patch("ginkgo.services.logging.containers.container") as mock_container, \
+             patch("ginkgo.client.logging_cli.Table") as mock_table_cls:
+            mock_container.log_service.return_value = mock_service
+            table_instance = mock_table_cls.return_value
+            result = cli_runner.invoke(logging_cli.app, ["logs", "--task", "abc"])
+
+        assert result.exit_code == 0
+        assert table_instance.add_row.call_count == 2, (
+            f"每条日志应渲染 1 行, 2 条日志期望 add_row 调用 2 次, "
+            f"实际 {table_instance.add_row.call_count} 次 —— #5293 add_row 重复回归"
+        )
+
+    def test_logs_empty_shows_no_logs_message(self, cli_runner):
+        mock_service = MagicMock()
+        mock_service.query_backtest_logs.return_value = []
+
+        with patch("ginkgo.services.logging.containers.container") as mock_container, \
+             patch("ginkgo.client.logging_cli.Table") as mock_table_cls:
+            mock_container.log_service.return_value = mock_service
+            table_instance = mock_table_cls.return_value
+            result = cli_runner.invoke(logging_cli.app, ["logs", "--task", "abc"])
+
+        assert result.exit_code == 0
+        assert "no logs found" in result.output.lower()
+        assert table_instance.add_row.call_count == 0
+
+
 # ============================================================================
 # 3. Validation / errors (5)
 # ============================================================================

--- a/tests/unit/services/test_log_ingester_glob.py
+++ b/tests/unit/services/test_log_ingester_glob.py
@@ -1,0 +1,81 @@
+"""Unit tests for LogIngester task_uuid → bt_*.log 文件匹配 (#5293).
+
+回归: ``ingest_task_logs`` 的 glob 曾要求 ``bt_{uuid[:8]}_*`` —— 第 8 位 hex 后紧跟
+下划线。但实际日志文件由 ``engine_assembly_service`` 以 **全 UUID** 命名
+(``bt_<32hex>_<ts>``)，下划线落在第 32 位后。glob 永不匹配 → 本地 CLI 回测日志
+不灌入 ClickHouse → ``ginkgo logging logs --task <id>`` 恒空。
+
+本测试构造全 UUID 命名的真实文件，验证 ``ingest_task_logs`` 能命中并灌入。
+"""
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.mark.unit
+class TestIngestTaskLogsGlob:
+    """ingest_task_logs 必须匹配全 UUID 命名的 bt_*.log 文件 (#5293)。"""
+
+    FULL_UUID = "fb965d187695463aada70ce163823b79"
+
+    def _write_backtest_log(self, path, task_id: str):
+        """写一行合法的 backtest-category JSON 日志 (带 task_id)。"""
+        line = {
+            "@timestamp": "2026-07-11 12:00:00",
+            "log": {"level": "INFO", "logger": "ginkgo"},
+            "message": "engine event",
+            "ginkgo": {"log_category": "backtest", "task_id": task_id},
+        }
+        path.write_text(json.dumps(line) + "\n", encoding="utf-8")
+
+    def test_matches_full_uuid_filename(self, tmp_path):
+        """全 UUID 文件名 ``bt_<32hex>_<ts>`` 必须被 ingest_task_logs 命中。"""
+        from ginkgo.services.logging.log_ingester import LogIngester
+
+        log_file = tmp_path / f"bt_{self.FULL_UUID}_20260711120000.log"
+        self._write_backtest_log(log_file, self.FULL_UUID)
+
+        ingester = LogIngester()
+        with patch("ginkgo.services.logging.log_ingester.GCONF") as mock_gconf, \
+             patch("ginkgo.data.drivers.add_all", return_value=(1, None)):
+            mock_gconf.LOGGING_PATH = str(tmp_path)
+            result = ingester.ingest_task_logs(self.FULL_UUID)
+
+        assert result.total_lines == 1, (
+            f"glob 未命中全 UUID 文件 (inserted={result.inserted}, "
+            f"total_lines={result.total_lines}) —— #5293 回归"
+        )
+        assert result.inserted == 1
+
+    def test_matches_short_prefix_filename(self, tmp_path):
+        """短前缀文件名 ``bt_<8hex>_<ts>`` (worker 路径) 仍应被命中。"""
+        from ginkgo.services.logging.log_ingester import LogIngester
+
+        log_file = tmp_path / f"bt_{self.FULL_UUID[:8]}_20260711120000.log"
+        self._write_backtest_log(log_file, self.FULL_UUID)
+
+        ingester = LogIngester()
+        with patch("ginkgo.services.logging.log_ingester.GCONF") as mock_gconf, \
+             patch("ginkgo.data.drivers.add_all", return_value=(1, None)):
+            mock_gconf.LOGGING_PATH = str(tmp_path)
+            result = ingester.ingest_task_logs(self.FULL_UUID)
+
+        assert result.total_lines == 1
+        assert result.inserted == 1
+
+    def test_does_not_match_unrelated_task(self, tmp_path):
+        """不同 task 的文件不应被误命中 (8-hex 前缀仍保证唯一性)。"""
+        from ginkgo.services.logging.log_ingester import LogIngester
+
+        other_uuid = "aaaaaaaabbbbccccddddeeeeffff0000"
+        log_file = tmp_path / f"bt_{other_uuid}_20260711120000.log"
+        self._write_backtest_log(log_file, other_uuid)
+
+        ingester = LogIngester()
+        with patch("ginkgo.services.logging.log_ingester.GCONF") as mock_gconf, \
+             patch("ginkgo.data.drivers.add_all", return_value=(0, None)):
+            mock_gconf.LOGGING_PATH = str(tmp_path)
+            result = ingester.ingest_task_logs(self.FULL_UUID)
+
+        assert result.total_lines == 0


### PR DESCRIPTION
## Summary

修复 `ginkgo logging logs --task <id>` 对已完成回测恒返回空结果 (#5293)。

## Root cause

本地 CLI 回测（`ginkgo backtest run`，无 Vector）依赖 `LogIngester.ingest_task_logs` 事后灌入 ClickHouse。该方法的文件名 glob 为：

```python
bt_{task_uuid[:8]}_*.log   # 要求第 8 位 hex 后紧跟下划线
```

但磁盘上日志文件实际由 `engine_assembly_service`（`src/ginkgo/trading/services/engine_assembly_service.py:376`）以**全 UUID** 命名：

```
bt_<32hex 全UUID>_<ts>.log   # 下划线落在第 32 位后
```

→ glob 永不匹配 → 本地 CLI 回测日志从不灌入 ClickHouse → `logging logs --task <id>` 恒空。

Docker 生产环境用 Vector 实时 tail（与文件名无关），故 32.9M 行存在但本地回测查询为空——这是「生产有数据、本地查询空」的根因。

## 决定性复现

```
ls ~/.ginkgo/logs/ | head        # 全是 bt_<32hex>_<ts> 长 UUID 文件
glob bt_fb965d18_*.log   → 0 匹配（旧 glob，下划线在第 8 位后）
glob bt_fb965d18*.log    → 1 匹配（新 glob）
```

## Changes

### 1. `src/ginkgo/services/logging/log_ingester.py`（根因修复）
- glob 从 `bt_{task_uuid[:8]}_*` 改为 `bt_{task_uuid[:8]}*`：`*` 同时吸收 `_<ts>`（短，worker 路径）与 `<24hex>_<ts>`（全，assembly service 路径）。
- 行级 `task_id` 来自日志 JSON 内容（非文件名），文件级 8-hex 前缀碰撞不影响查询正确性。
- 补 docstring 解释双 producer 命名差异。

### 2. `src/ginkgo/client/logging_cli.py`（次要 bug）
- `view_logs` 的 `table.add_row(...)` 误写两次 → 每条日志渲染两行。删除重复行。
- 此 bug 之前不可见是因为日志恒空（根因修复后才暴露），一并修掉。

### Tests

- `tests/unit/services/test_log_ingester_glob.py`（新增 81 行）：构造全 UUID / 短前缀 / 无关 task 三种文件名，验证 `ingest_task_logs` 命中正确。红→绿验证完成。
- `tests/unit/client/test_logging_cli.py`（+48 行）：`TestViewLogsRendering` mock `Table.add_row` 计数，断言 N 条日志恰好 N 次 add_row（旧实现 N 条 → 2N 次）。

## Test plan

- [x] `pytest tests/unit/services/test_log_ingester_glob.py` — 3 passed
- [x] `pytest tests/unit/client/test_logging_cli.py` — 19 passed（含新增 2）
- [x] Layer 1 py_compile 全过
- [x] Layer 2 启动路径 smoke（test_user_crud_mock / test_containers / test_user_cli）36 passed（1 失败为 master 原有 ANSI 耦合，已 stash 对照确认非回归）
- [ ] 端到端：`ginkgo backtest run <id>` 后 `ginkgo logging logs --task <id>` 返回非空（待本地回测复测）

## Notes

- 文件命名双 producer（assembly service 全 UUID vs worker 短 8-hex）是历史遗留；本 PR 在消费侧（ingester glob）兼容两种命名，不动 producer（避免影响 Vector 路径与既有文件）。
- 不涉及 Base 类修改、不涉及 DB schema。

Closes #5293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
