### PR TITLE
refactor(gateway): 单实现 ABC 降级 + I* 前缀归一 (ADR-022) (#6116)

### DIFF
--- a/src/ginkgo/trading/gateway/__init__.py
+++ b/src/ginkgo/trading/gateway/__init__.py
@@ -19,11 +19,9 @@
 """
 
 from .interfaces import (
-    # 核心接口
-    IEventRoutingCenter,
-    ILoadBalancer,
-    ICircuitBreaker,
-    
+    # 负载均衡器纯契约（多实现 ABC，ADR-022 原则 1）
+    LoadBalancer,
+
     # 枚举类型
     RoutingStrategy,
     RoutingMode,
@@ -70,11 +68,9 @@ from .base_matchmaking import MatchMakingBase
 from .trade_gateway import TradeGateway
 
 __all__ = [
-    # 核心接口
-    'IEventRoutingCenter',
-    'ILoadBalancer', 
-    'ICircuitBreaker',
-    
+    # 负载均衡器纯契约
+    'LoadBalancer',
+
     # 枚举类型
     'RoutingStrategy',
     'RoutingMode',

--- a/src/ginkgo/trading/gateway/balancers.py
+++ b/src/ginkgo/trading/gateway/balancers.py
@@ -29,11 +29,11 @@ from ginkgo.trading.time.clock import now as clock_now
 from collections import defaultdict, deque
 
 from .interfaces import (
-    ILoadBalancer, RouteTarget, RoutingRule, RoutingStrategy
+    LoadBalancer, RouteTarget, RoutingRule, RoutingStrategy
 )
 
 
-class BaseLoadBalancer(ILoadBalancer):
+class BaseLoadBalancer(LoadBalancer):
     """负载均衡器基类"""
     
     def __init__(self):
@@ -419,7 +419,7 @@ class LoadBalancerFactory:
     }
     
     @classmethod
-    def create_balancer(cls, strategy: RoutingStrategy) -> ILoadBalancer:
+    def create_balancer(cls, strategy: RoutingStrategy) -> LoadBalancer:
         """创建负载均衡器"""
         balancer_class = cls._balancers.get(strategy)
         if not balancer_class:

--- a/src/ginkgo/trading/gateway/center.py
+++ b/src/ginkgo/trading/gateway/center.py
@@ -34,17 +34,17 @@ from uuid import uuid4
 from ginkgo.libs import GLOG
 from ginkgo.trading.time.clock import now as clock_now
 from .interfaces import (
-    IEventRoutingCenter, ILoadBalancer, ICircuitBreaker,
+    LoadBalancer,
     RouteTarget, RoutingRule, RoutingMetrics, RouteResult,
     HealthCheckResult, RoutingEvent, RoutingEventType,
     RoutingStrategy, RoutingMode, RouteStatus, EventPriority,
     CircuitBreakerState
 )
 from .balancers import LoadBalancerFactory
-from .circuit_breaker import get_circuit_breaker, CircuitBreakerConfig
+from .circuit_breaker import CircuitBreaker, CircuitBreakerConfig, get_circuit_breaker
 
 
-class EventRoutingCenter(IEventRoutingCenter):
+class EventRoutingCenter:
     """事件路由中心实现"""
     
     def __init__(self,
@@ -88,11 +88,11 @@ class EventRoutingCenter(IEventRoutingCenter):
         self._cache_lock = asyncio.Lock()
         
         # 负载均衡器
-        self._load_balancers: Dict[RoutingStrategy, ILoadBalancer] = {}
+        self._load_balancers: Dict[RoutingStrategy, LoadBalancer] = {}
         
         # 断路器配置
         self._circuit_breaker_config = CircuitBreakerConfig()
-        self._circuit_breakers: Dict[str, ICircuitBreaker] = {}
+        self._circuit_breakers: Dict[str, CircuitBreaker] = {}
         
         # 异步任务管理
         self._background_tasks: Set[asyncio.Task] = set()

--- a/src/ginkgo/trading/gateway/circuit_breaker.py
+++ b/src/ginkgo/trading/gateway/circuit_breaker.py
@@ -23,7 +23,7 @@ from typing import Dict, List, Optional, Callable
 from collections import deque
 from dataclasses import dataclass, field
 
-from .interfaces import ICircuitBreaker, CircuitBreakerState
+from .interfaces import CircuitBreakerState
 from ginkgo.trading.time.clock import now as clock_now
 
 
@@ -38,7 +38,7 @@ class CircuitBreakerConfig:
     min_calls_threshold: int = 10  # 最小调用数阈值
 
 
-class CircuitBreaker(ICircuitBreaker):
+class CircuitBreaker:
     """断路器实现"""
     
     def __init__(self, 

--- a/src/ginkgo/trading/gateway/interfaces.py
+++ b/src/ginkgo/trading/gateway/interfaces.py
@@ -10,11 +10,12 @@
 """
 事件路由中心接口定义
 
-提供统一的事件路由接口抽象，包括：
-- 路由中心接口(IEventRoutingCenter)
-- 路由数据结构(RouteTarget, RoutingRule, RoutingMetrics)  
-- 路由策略和负载均衡器接口
-- 断路器接口
+提供事件路由系统的数据结构、负载均衡器纯契约与断路器状态枚举：
+- 负载均衡器契约(LoadBalancer，多实现纯契约 ABC，ADR-022 原则 1)
+- 路由数据结构(RouteTarget, RoutingRule, RoutingMetrics)
+- 断路器状态枚举(CircuitBreakerState)
+路由中心(EventRoutingCenter)与断路器(CircuitBreaker)为单实现具体类，
+见 center.py / circuit_breaker.py（ADR-022 原则 2 单实现 ABC 降级）。
 """
 
 from abc import ABC, abstractmethod
@@ -213,101 +214,7 @@ class RoutingMetrics:
         return 100.0 - self.success_rate
 
 
-class IEventRoutingCenter(ABC):
-    """事件路由中心接口"""
-    
-    @abstractmethod
-    async def initialize(self) -> None:
-        """初始化路由中心"""
-        pass
-    
-    @abstractmethod
-    async def shutdown(self) -> None:
-        """关闭路由中心"""
-        pass
-    
-    @abstractmethod
-    async def register_target(self, target: RouteTarget) -> bool:
-        """注册路由目标"""
-        pass
-    
-    @abstractmethod
-    async def unregister_target(self, target_id: str) -> bool:
-        """注销路由目标"""
-        pass
-    
-    @abstractmethod
-    async def update_target(self, target_id: str, updates: Dict[str, Any]) -> bool:
-        """更新路由目标"""
-        pass
-    
-    @abstractmethod
-    async def get_target(self, target_id: str) -> Optional[RouteTarget]:
-        """获取路由目标"""
-        pass
-    
-    @abstractmethod
-    async def list_targets(self, status_filter: Optional[RouteStatus] = None) -> List[RouteTarget]:
-        """列出路由目标"""
-        pass
-    
-    @abstractmethod
-    async def add_routing_rule(self, rule: RoutingRule) -> bool:
-        """添加路由规则"""
-        pass
-    
-    @abstractmethod
-    async def remove_routing_rule(self, rule_id: str) -> bool:
-        """移除路由规则"""
-        pass
-    
-    @abstractmethod
-    async def update_routing_rule(self, rule_id: str, updates: Dict[str, Any]) -> bool:
-        """更新路由规则"""
-        pass
-    
-    @abstractmethod
-    async def get_routing_rule(self, rule_id: str) -> Optional[RoutingRule]:
-        """获取路由规则"""
-        pass
-    
-    @abstractmethod
-    async def list_routing_rules(self, enabled_only: bool = False) -> List[RoutingRule]:
-        """列出路由规则"""
-        pass
-    
-    @abstractmethod
-    async def route_event(self, event: Any) -> List[str]:
-        """路由事件"""
-        pass
-    
-    @abstractmethod
-    async def route_events(self, events: List[Any]) -> Dict[str, List[str]]:
-        """批量路由事件"""
-        pass
-    
-    @abstractmethod
-    async def get_routing_metrics(self) -> RoutingMetrics:
-        """获取路由指标"""
-        pass
-    
-    @abstractmethod
-    async def reset_metrics(self) -> None:
-        """重置指标"""
-        pass
-    
-    @abstractmethod
-    async def health_check(self) -> Dict[str, Any]:
-        """健康检查"""
-        pass
-    
-    @abstractmethod
-    async def reload_configuration(self, config: Dict[str, Any]) -> bool:
-        """重新加载配置"""
-        pass
-
-
-class ILoadBalancer(ABC):
+class LoadBalancer(ABC):
     """负载均衡器接口"""
     
     @abstractmethod
@@ -331,35 +238,6 @@ class CircuitBreakerState(Enum):
     CLOSED = "closed"
     OPEN = "open"  
     HALF_OPEN = "half_open"
-
-
-class ICircuitBreaker(ABC):
-    """断路器接口"""
-    
-    @abstractmethod
-    def is_open(self) -> bool:
-        """检查断路器是否开启"""
-        pass
-    
-    @abstractmethod
-    def record_success(self) -> None:
-        """记录成功"""
-        pass
-    
-    @abstractmethod
-    def record_failure(self) -> None:
-        """记录失败"""
-        pass
-    
-    @abstractmethod
-    def get_state(self) -> CircuitBreakerState:
-        """获取状态"""
-        pass
-    
-    @abstractmethod
-    def reset(self) -> None:
-        """重置断路器"""
-        pass
 
 
 @dataclass

--- a/tests/unit/trading/gateway/test_interface_naming_migration.py
+++ b/tests/unit/trading/gateway/test_interface_naming_migration.py
@@ -1,0 +1,88 @@
+"""
+gateway 抽象层命名迁移测试（ADR-022 原则 1 + 原则 2 / #6116）
+
+覆盖：
+- 原则 1：`I*` 前缀删除（IEventRoutingCenter/ICircuitBreaker/ILoadBalancer 退场）
+- 原则 2：单实现 ABC 降级为具体类（EventRoutingCenter/CircuitBreaker 不再是 ABC 派生）
+- 多实现纯契约保留为无前缀 ABC（LoadBalancer(ABC) 仍是 BaseLoadBalancer 的基类）
+- 行为不变：CircuitBreaker 熔断阈值逻辑未被改名破坏
+"""
+
+import importlib
+from abc import ABC
+
+import pytest
+
+import ginkgo.trading.gateway as gateway_pkg
+from ginkgo.trading.gateway import EventRoutingCenter, CircuitBreaker, LoadBalancer
+from ginkgo.trading.gateway.balancers import BaseLoadBalancer
+
+
+class TestIIprefixRemoved:
+    """原则 1：`I*` 前缀从公共 API 退场。"""
+
+    @pytest.mark.parametrize("removed_name", [
+        "IEventRoutingCenter",
+        "ICircuitBreaker",
+        "ILoadBalancer",
+    ])
+    def test_old_iprefix_names_gone_from_package(self, removed_name):
+        # 包级导出不再含 I* 前缀类
+        assert not hasattr(gateway_pkg, removed_name), (
+            f"{removed_name} 应已从 ginkgo.trading.gateway 退场（ADR-022 原则 1）"
+        )
+        # __all__ 同步清理
+        assert removed_name not in gateway_pkg.__all__
+
+    def test_interfaces_module_no_longer_defines_iprefix(self):
+        interfaces = importlib.import_module("ginkgo.trading.gateway.interfaces")
+        for removed in ("IEventRoutingCenter", "ICircuitBreaker", "ILoadBalancer"):
+            assert not hasattr(interfaces, removed), (
+                f"interfaces.{removed} 应已删除/改名"
+            )
+
+
+class TestSingleImplDowngradedToConcrete:
+    """原则 2：单实现 ABC 降级为具体类，不再经 ABC 契约派生。"""
+
+    def test_event_routing_center_is_concrete(self):
+        # 降级后不再继承 ABC（IEventRoutingCenter(ABC) 已删，EventRoutingCenter 独立）
+        assert ABC not in EventRoutingCenter.__mro__, (
+            "EventRoutingCenter 应为具体类，不再经 ABC 契约派生（ADR-022 原则 2）"
+        )
+
+    def test_circuit_breaker_is_concrete(self):
+        assert ABC not in CircuitBreaker.__mro__, (
+            "CircuitBreaker 应为具体类，不再经 ABC 契约派生（ADR-022 原则 2）"
+        )
+
+
+class TestMultiImplContractPreserved:
+    """多实现纯契约：LoadBalancer 去前缀但保留 ABC。"""
+
+    def test_loadbalancer_is_abstract_contract(self):
+        # 多实现族：保留为无前缀 ABC，仍含抽象方法
+        assert ABC in LoadBalancer.__mro__
+        assert getattr(LoadBalancer, "__abstractmethods__", set()), (
+            "LoadBalancer 应保留为纯契约 ABC（多实现族，ADR-022 原则 1）"
+        )
+
+    def test_base_loadbalancer_inherits_loadbalancer(self):
+        assert issubclass(BaseLoadBalancer, LoadBalancer)
+
+    def test_loadbalancer_factory_still_produces_balancers(self):
+        from ginkgo.trading.gateway.balancers import LoadBalancerFactory
+        from ginkgo.trading.gateway.interfaces import RoutingStrategy
+        balancer = LoadBalancerFactory.create_balancer(RoutingStrategy.ROUND_ROBIN)
+        assert isinstance(balancer, LoadBalancer)
+
+
+class TestCircuitBreakerBehaviorUnchanged:
+    """改名/降级未破坏 CircuitBreaker 熔断行为。"""
+
+    def test_opens_after_failure_threshold(self):
+        # 默认 failure_threshold=5；连续失败达阈值即开路
+        breaker = CircuitBreaker("test-target")
+        for _ in range(5):
+            breaker.record_failure()
+        assert breaker.is_open() is True


### PR DESCRIPTION
## Summary

按 [ADR-022](https://github.com/Kaoruha/GinkGO/blob/master/docs/adrs/ADR-022-abstract-layer-naming.md) 原则 1（删 `I*` 前缀）+ 原则 2（单实现 ABC 降级具体类），执行 #6116 的 gateway 抽象层收敛。

### 改动

| 类 | 原状 | 现状 | 依据 |
|---|---|---|---|
| `IEventRoutingCenter` | 单实现 ABC（19 方法） | 删除 → `EventRoutingCenter` 具体类 | 原则 2 + 原则 1 |
| `ICircuitBreaker` | 单实现 ABC（5 方法） | 删除 → `CircuitBreaker` 具体类 | 原则 2 + 原则 1 |
| `ILoadBalancer` | 多实现 ABC | 去前缀 → `LoadBalancer(ABC)`（保留） | 原则 1（多实现纯契约） |

- 全仓 import / `__all__` / 类型注解同步（src + api + client 的 `I*` 归零）
- `interfaces.py` 定义澄清：纯契约（`LoadBalancer`）+ 数据结构 + 枚举；单实现具体类归位 `center.py` / `circuit_breaker.py`
- 新增 `tests/unit/trading/gateway/test_interface_naming_migration.py`（88 行）守护命名契约 + 降级语义

## Test plan

- [x] **新测试 + gateway 既有测试**：55 passed（命名契约 + 行为不变，1.01s）
- [x] **Layer1 py_compile**：src + api 全量通过
- [x] **Layer2 启动路径 smoke**：`user_crud_mock` ✅、`containers` ✅、`user_cli` ✅
  - ⚠️ `test_create_user_missing_name_fails` 为 **pre-existing flaky**（rich/CliRunner 把 `--name` 渲染成 ANSI 片段致字面断言失败）；stash 回 master 基线对照**同样失败**，与本 PR 无关
- [x] **全仓 `I*` 归零**：`grep -rn "IEventRoutingCenter\|ICircuitBreaker\|ILoadBalancer" src/ api/ client/` = 0 命中
- [x] **降级语义实测**：`EventRoutingCenter.__mro__` 不含 ABC（原则 2）；`LoadBalancer.__mro__` 含 ABC（原则 1 多实现保留）

## Notes

- 决策依据 ADR-022 已由 #6705（docs）落地、#6689（决策 issue）CLOSED
- 本 PR 为 #6116 的**代码实施**（#6705 仅 ADR 文档，未动 gateway 代码；master 上三个 `I*` ABC 原样还在，问题此前未解决）

Closes #6116
