### PR TITLE
refactor(expression): 统一算子异常/窗口提取/注册冲突检测 (#6479 AC1/2/4/6)

### DIFF
--- a/src/ginkgo/features/engines/expression/operators/basic.py
+++ b/src/ginkgo/features/engines/expression/operators/basic.py
@@ -23,123 +23,79 @@ from ginkgo.libs import GLOG
 @register_operator("Pow", "Power function", min_args=2, max_args=2)
 def pow_operator(data: pd.DataFrame, base: pd.Series, exponent: pd.Series) -> pd.Series:
     """幂运算"""
-    try:
-        with np.errstate(over='ignore', invalid='ignore'):
-            result = np.power(base, exponent)
-            return pd.Series(result, index=base.index).replace([np.inf, -np.inf], np.nan)
-    except Exception as e:
-        GLOG.ERROR(f"Pow operator failed: {e}")
-        return pd.Series([np.nan] * len(base), index=base.index)
+    with np.errstate(over='ignore', invalid='ignore'):
+        result = np.power(base, exponent)
+        return pd.Series(result, index=base.index).replace([np.inf, -np.inf], np.nan)
 
 
 @register_operator("Sqrt", "Square root", min_args=1, max_args=1)
 def sqrt_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """平方根"""
-    try:
-        with np.errstate(invalid='ignore'):
-            result = np.sqrt(series)
-            return pd.Series(result, index=series.index)
-    except Exception as e:
-        GLOG.ERROR(f"Sqrt operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    with np.errstate(invalid='ignore'):
+        result = np.sqrt(series)
+        return pd.Series(result, index=series.index)
 
 
 @register_operator("Exp", "Exponential function", min_args=1, max_args=1)
 def exp_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """指数函数"""
-    try:
-        with np.errstate(over='ignore'):
-            result = np.exp(series)
-            return pd.Series(result, index=series.index).replace([np.inf, -np.inf], np.nan)
-    except Exception as e:
-        GLOG.ERROR(f"Exp operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    with np.errstate(over='ignore'):
+        result = np.exp(series)
+        return pd.Series(result, index=series.index).replace([np.inf, -np.inf], np.nan)
 
 
 @register_operator("Round", "Round to decimal places", min_args=1, max_args=2)
 def round_operator(data: pd.DataFrame, series: pd.Series, decimals: pd.Series = None) -> pd.Series:
     """四舍五入"""
-    try:
-        decimal_places = 0
-        if decimals is not None and len(decimals) > 0:
-            decimal_places = int(decimals.iloc[0])
-        
-        return series.round(decimal_places)
-    except Exception as e:
-        GLOG.ERROR(f"Round operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    decimal_places = 0
+    if decimals is not None and len(decimals) > 0:
+        decimal_places = int(decimals.iloc[0])
+    
+    return series.round(decimal_places)
 
 
 @register_operator("Floor", "Floor function", min_args=1, max_args=1)
 def floor_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """向下取整"""
-    try:
-        return series.apply(np.floor)
-    except Exception as e:
-        GLOG.ERROR(f"Floor operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.apply(np.floor)
 
 
 @register_operator("Ceil", "Ceiling function", min_args=1, max_args=1)
 def ceil_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """向上取整"""
-    try:
-        return series.apply(np.ceil)
-    except Exception as e:
-        GLOG.ERROR(f"Ceil operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.apply(np.ceil)
 
 
 @register_operator("Sign", "Sign function", min_args=1, max_args=1)
 def sign_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """符号函数"""
-    try:
-        return series.apply(np.sign)
-    except Exception as e:
-        GLOG.ERROR(f"Sign operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.apply(np.sign)
 
 
 @register_operator("Add", "Addition", min_args=2, max_args=2)
 def add_operator(data: pd.DataFrame, left: pd.Series, right: pd.Series) -> pd.Series:
     """加法运算"""
-    try:
-        return left + right
-    except Exception as e:
-        GLOG.ERROR(f"Add operator failed: {e}")
-        return pd.Series([np.nan] * len(left), index=left.index)
+    return left + right
 
 
 @register_operator("Subtract", "Subtraction", min_args=2, max_args=2)
 def subtract_operator(data: pd.DataFrame, left: pd.Series, right: pd.Series) -> pd.Series:
     """减法运算"""
-    try:
-        return left - right
-    except Exception as e:
-        GLOG.ERROR(f"Subtract operator failed: {e}")
-        return pd.Series([np.nan] * len(left), index=left.index)
+    return left - right
 
 
 @register_operator("Multiply", "Multiplication", min_args=2, max_args=2)
 def multiply_operator(data: pd.DataFrame, left: pd.Series, right: pd.Series) -> pd.Series:
     """乘法运算"""
-    try:
-        return left * right
-    except Exception as e:
-        GLOG.ERROR(f"Multiply operator failed: {e}")
-        return pd.Series([np.nan] * len(left), index=left.index)
+    return left * right
 
 
 @register_operator("Divide", "Division", min_args=2, max_args=2)
 def divide_operator(data: pd.DataFrame, left: pd.Series, right: pd.Series) -> pd.Series:
     """除法运算"""
-    try:
-        with np.errstate(divide='ignore', invalid='ignore'):
-            result = left / right
-            return result.replace([np.inf, -np.inf], np.nan)
-    except Exception as e:
-        GLOG.ERROR(f"Divide operator failed: {e}")
-        return pd.Series([np.nan] * len(left), index=left.index)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        result = left / right
+        return result.replace([np.inf, -np.inf], np.nan)
 
 
 @register_operator("If", "Conditional if-then-else", min_args=3, max_args=3)
@@ -155,18 +111,14 @@ def if_operator(data: pd.DataFrame, condition: pd.Series, true_value: pd.Series,
     Returns:
         pd.Series: 根据条件选择的值序列
     """
-    try:
-        # 将条件转换为布尔值
-        bool_condition = condition.fillna(False).astype(bool)
-        
-        # 使用pandas的where方法进行条件选择
-        result = true_value.where(bool_condition, false_value)
-        
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"If operator failed: {e}")
-        return pd.Series([np.nan] * len(condition), index=condition.index)
+    # 将条件转换为布尔值
+    bool_condition = condition.fillna(False).astype(bool)
+    
+    # 使用pandas的where方法进行条件选择
+    result = true_value.where(bool_condition, false_value)
+    
+    return result
+    
 
 
 @register_operator("SignedPower", "Signed power function", min_args=2, max_args=2)
@@ -181,20 +133,16 @@ def signed_power_operator(data: pd.DataFrame, base: pd.Series, exponent: pd.Seri
     Returns:
         pd.Series: 带符号的幂运算结果
     """
-    try:
-        with np.errstate(over='ignore', invalid='ignore'):
-            # 获取底数的符号
-            signs = np.sign(base)
-            
-            # 对绝对值进行幂运算
-            abs_base = np.abs(base)
-            abs_result = np.power(abs_base, exponent)
-            
-            # 应用原始符号
-            result = signs * abs_result
-            
-            return pd.Series(result, index=base.index).replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"SignedPower operator failed: {e}")
-        return pd.Series([np.nan] * len(base), index=base.index)
+    with np.errstate(over='ignore', invalid='ignore'):
+        # 获取底数的符号
+        signs = np.sign(base)
+        
+        # 对绝对值进行幂运算
+        abs_base = np.abs(base)
+        abs_result = np.power(abs_base, exponent)
+        
+        # 应用原始符号
+        result = signs * abs_result
+        
+        return pd.Series(result, index=base.index).replace([np.inf, -np.inf], np.nan)
+        

--- a/src/ginkgo/features/engines/expression/operators/statistical.py
+++ b/src/ginkgo/features/engines/expression/operators/statistical.py
@@ -15,242 +15,149 @@ Statistical Operators - 统计函数操作符
 
 import pandas as pd
 import numpy as np
-from ginkgo.features.engines.expression.registry import register_operator
+from ginkgo.features.engines.expression.registry import register_operator, _extract_window, _extract_periods
 from ginkgo.libs import GLOG
 
 
 @register_operator("Variance", "Rolling variance", min_args=2, max_args=2)
 def variance_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动方差"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).var()
-    except Exception as e:
-        GLOG.ERROR(f"Variance operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).var()
 
 
 @register_operator("Skew", "Rolling skewness", min_args=2, max_args=2)
 def skew_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动偏度"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=3).skew()
-    except Exception as e:
-        GLOG.ERROR(f"Skew operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=3).skew()
 
 
 @register_operator("Kurt", "Rolling kurtosis", min_args=2, max_args=2)
 def kurt_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动峰度"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=4).kurt()
-    except Exception as e:
-        GLOG.ERROR(f"Kurt operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=4).kurt()
 
 
 @register_operator("Median", "Rolling median", min_args=2, max_args=2)
 def median_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动中位数"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).median()
-    except Exception as e:
-        GLOG.ERROR(f"Median operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).median()
 
 
 @register_operator("Count", "Rolling count of non-null values", min_args=2, max_args=2)
 def count_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动非空值计数"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size).count()
-    except Exception as e:
-        GLOG.ERROR(f"Count operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size).count()
 
 
 @register_operator("Zscore", "Rolling z-score", min_args=2, max_args=2)
 def zscore_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动Z分数标准化"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
+    window_size = _extract_window(window)
+    
+    rolling_mean = series.rolling(window=window_size, min_periods=1).mean()
+    rolling_std = series.rolling(window=window_size, min_periods=1).std()
+    
+    # 避免除零
+    with np.errstate(divide='ignore', invalid='ignore'):
+        zscore = (series - rolling_mean) / rolling_std
+        return zscore.replace([np.inf, -np.inf], np.nan)
         
-        rolling_mean = series.rolling(window=window_size, min_periods=1).mean()
-        rolling_std = series.rolling(window=window_size, min_periods=1).std()
-        
-        # 避免除零
-        with np.errstate(divide='ignore', invalid='ignore'):
-            zscore = (series - rolling_mean) / rolling_std
-            return zscore.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"Zscore operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
 
 
 @register_operator("Percentile", "Rolling percentile", min_args=3, max_args=3)
 def percentile_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series, percentile: pd.Series) -> pd.Series:
     """滚动百分位数"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        pct = float(percentile.iloc[0]) if len(percentile) > 0 else 50
-        
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        if not 0 <= pct <= 100:
-            raise ValueError(f"Percentile must be between 0 and 100, got {pct}")
-        
-        return series.rolling(window=window_size, min_periods=1).quantile(pct / 100.0)
-    except Exception as e:
-        GLOG.ERROR(f"Percentile operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    pct = float(percentile.iloc[0]) if len(percentile) > 0 else 50
+
+    if not 0 <= pct <= 100:
+        raise ValueError(f"Percentile must be between 0 and 100, got {pct}")
+
+    return series.rolling(window=window_size, min_periods=1).quantile(pct / 100.0)
 
 
 @register_operator("Corr", "Rolling correlation", min_args=3, max_args=3)
 def corr_operator(data: pd.DataFrame, series1: pd.Series, series2: pd.Series, window: pd.Series) -> pd.Series:
     """滚动相关系数"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series1.rolling(window=window_size, min_periods=2).corr(series2)
-    except Exception as e:
-        GLOG.ERROR(f"Corr operator failed: {e}")
-        return pd.Series([np.nan] * len(series1), index=series1.index)
+    window_size = _extract_window(window)
+    
+    return series1.rolling(window=window_size, min_periods=2).corr(series2)
 
 
 @register_operator("Cov", "Rolling covariance", min_args=3, max_args=3)
 def cov_operator(data: pd.DataFrame, series1: pd.Series, series2: pd.Series, window: pd.Series) -> pd.Series:
     """滚动协方差"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series1.rolling(window=window_size, min_periods=2).cov(series2)
-    except Exception as e:
-        GLOG.ERROR(f"Cov operator failed: {e}")
-        return pd.Series([np.nan] * len(series1), index=series1.index)
+    window_size = _extract_window(window)
+    
+    return series1.rolling(window=window_size, min_periods=2).cov(series2)
 
 
 @register_operator("AutoCorr", "Rolling autocorrelation", min_args=3, max_args=3)
 def autocorr_operator(data: pd.DataFrame, series: pd.Series, lag: pd.Series, window: pd.Series) -> pd.Series:
     """滚动自相关"""
-    try:
-        lag_periods = int(lag.iloc[0]) if len(lag) > 0 else 1
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        if lag_periods < 0:
-            raise ValueError(f"Lag must be non-negative, got {lag_periods}")
-        
-        lagged_series = series.shift(lag_periods)
-        return series.rolling(window=window_size, min_periods=2).corr(lagged_series)
-    except Exception as e:
-        GLOG.ERROR(f"AutoCorr operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    lag_periods = _extract_periods(lag, allow_negative=False)
+    window_size = _extract_window(window)
+
+    lagged_series = series.shift(lag_periods)
+    return series.rolling(window=window_size, min_periods=2).corr(lagged_series)
 
 
 @register_operator("Rank", "Rolling rank calculation", min_args=2, max_args=2)
 def rank_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动排名计算"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        # 计算滚动排名（百分位）
-        result = series.rolling(window=window_size).rank(pct=True)
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"Rank operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    # 计算滚动排名（百分位）
+    result = series.rolling(window=window_size).rank(pct=True)
+    return result
+    
 
 
 @register_operator("QTLU", "Upper quantile (75th percentile)", min_args=2, max_args=2)
 def qtlu_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """上分位数（75%分位数）"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size).quantile(0.75)
-        
-    except Exception as e:
-        GLOG.ERROR(f"QTLU operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size).quantile(0.75)
+    
 
 
 @register_operator("QTLD", "Lower quantile (25th percentile)", min_args=2, max_args=2)
 def qtld_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """下分位数（25%分位数）"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size).quantile(0.25)
-        
-    except Exception as e:
-        GLOG.ERROR(f"QTLD operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size).quantile(0.25)
+    
 
 
 @register_operator("IMAX", "Index of maximum value", min_args=2, max_args=2)
 def imax_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """最大值位置索引"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        # 计算滚动窗口内最大值的位置索引
-        result = series.rolling(window=window_size).apply(lambda x: len(x) - 1 - np.argmax(x.values) if len(x) > 0 and not np.isnan(x.values).all() else np.nan)
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"IMAX operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    # 计算滚动窗口内最大值的位置索引
+    result = series.rolling(window=window_size).apply(lambda x: len(x) - 1 - np.argmax(x.values) if len(x) > 0 and not np.isnan(x.values).all() else np.nan)
+    return result
+    
 
 
 @register_operator("IMIN", "Index of minimum value", min_args=2, max_args=2)
 def imin_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """最小值位置索引"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        # 计算滚动窗口内最小值的位置索引
-        result = series.rolling(window=window_size).apply(lambda x: len(x) - 1 - np.argmin(x.values) if len(x) > 0 and not np.isnan(x.values).all() else np.nan)
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"IMIN operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    # 计算滚动窗口内最小值的位置索引
+    result = series.rolling(window=window_size).apply(lambda x: len(x) - 1 - np.argmin(x.values) if len(x) > 0 and not np.isnan(x.values).all() else np.nan)
+    return result
+    

--- a/src/ginkgo/features/engines/expression/operators/technical.py
+++ b/src/ginkgo/features/engines/expression/operators/technical.py
@@ -10,43 +10,40 @@
 """
 Technical Operators - 技术指标操作符
 
-提供常用技术指标的操作符实现，这些是对现有indicators模块的封装。
+提供常用技术指标(RSI/MACD/布林带/ATR 等)的操作符实现,均为基于 pandas/numpy 的内联计算,
+不依赖外部 indicators 模块。
 """
 
 import pandas as pd
 import numpy as np
-from ginkgo.features.engines.expression.registry import register_operator
+from ginkgo.features.engines.expression.registry import register_operator, _extract_window, _extract_periods
 from ginkgo.libs import GLOG
 
 
 @register_operator("RSI", "Relative Strength Index", min_args=2, max_args=2)
 def rsi_operator(data: pd.DataFrame, close_series: pd.Series, period: pd.Series) -> pd.Series:
     """RSI相对强弱指数"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 14
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
+    period_value = int(period.iloc[0]) if len(period) > 0 else 14
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 计算价格变化
+    delta = close_series.diff()
+    
+    # 分离上涨和下跌
+    gain = delta.where(delta > 0, 0)
+    loss = -delta.where(delta < 0, 0)
+    
+    # 计算平均收益和损失
+    avg_gain = gain.rolling(window=period_value, min_periods=1).mean()
+    avg_loss = loss.rolling(window=period_value, min_periods=1).mean()
+    
+    # 计算RSI
+    with np.errstate(divide='ignore', invalid='ignore'):
+        rs = avg_gain / avg_loss
+        rsi = 100 - (100 / (1 + rs))
+        return rsi.replace([np.inf, -np.inf], np.nan)
         
-        # 计算价格变化
-        delta = close_series.diff()
-        
-        # 分离上涨和下跌
-        gain = delta.where(delta > 0, 0)
-        loss = -delta.where(delta < 0, 0)
-        
-        # 计算平均收益和损失
-        avg_gain = gain.rolling(window=period_value, min_periods=1).mean()
-        avg_loss = loss.rolling(window=period_value, min_periods=1).mean()
-        
-        # 计算RSI
-        with np.errstate(divide='ignore', invalid='ignore'):
-            rs = avg_gain / avg_loss
-            rsi = 100 - (100 / (1 + rs))
-            return rsi.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"RSI operator failed: {e}")
-        return pd.Series([np.nan] * len(close_series), index=close_series.index)
 
 
 @register_operator("MACD", "Moving Average Convergence Divergence", min_args=1, max_args=4)
@@ -54,401 +51,349 @@ def macd_operator(data: pd.DataFrame, close_series: pd.Series,
                  fast_period: pd.Series = None, slow_period: pd.Series = None, 
                  signal_period: pd.Series = None) -> pd.Series:
     """MACD指标"""
-    try:
-        fast = int(fast_period.iloc[0]) if fast_period is not None and len(fast_period) > 0 else 12
-        slow = int(slow_period.iloc[0]) if slow_period is not None and len(slow_period) > 0 else 26
-        signal = int(signal_period.iloc[0]) if signal_period is not None and len(signal_period) > 0 else 9
-        
-        if fast <= 0 or slow <= 0 or signal <= 0:
-            raise ValueError("All periods must be positive")
-        
-        # 计算EMA
-        ema_fast = close_series.ewm(span=fast).mean()
-        ema_slow = close_series.ewm(span=slow).mean()
-        
-        # MACD线
-        macd_line = ema_fast - ema_slow
-        
-        # 信号线
-        signal_line = macd_line.ewm(span=signal).mean()
-        
-        # 返回MACD线（可以扩展为返回多个值）
-        return macd_line
-        
-    except Exception as e:
-        GLOG.ERROR(f"MACD operator failed: {e}")
-        return pd.Series([np.nan] * len(close_series), index=close_series.index)
+    fast = int(fast_period.iloc[0]) if fast_period is not None and len(fast_period) > 0 else 12
+    slow = int(slow_period.iloc[0]) if slow_period is not None and len(slow_period) > 0 else 26
+    signal = int(signal_period.iloc[0]) if signal_period is not None and len(signal_period) > 0 else 9
+    
+    if fast <= 0 or slow <= 0 or signal <= 0:
+        raise ValueError("All periods must be positive")
+    
+    # 计算EMA
+    ema_fast = close_series.ewm(span=fast).mean()
+    ema_slow = close_series.ewm(span=slow).mean()
+    
+    # MACD线
+    macd_line = ema_fast - ema_slow
+    
+    # 信号线
+    signal_line = macd_line.ewm(span=signal).mean()
+    
+    # 返回MACD线（可以扩展为返回多个值）
+    return macd_line
+    
 
 
 @register_operator("BB_upper", "Bollinger Bands Upper", min_args=2, max_args=3)
 def bb_upper_operator(data: pd.DataFrame, close_series: pd.Series, period: pd.Series, 
                      std_dev: pd.Series = None) -> pd.Series:
     """布林带上轨"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 20
-        std_multiplier = float(std_dev.iloc[0]) if std_dev is not None and len(std_dev) > 0 else 2.0
-        
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
-        
-        # 计算移动平均和标准差
-        sma = close_series.rolling(window=period_value, min_periods=1).mean()
-        std = close_series.rolling(window=period_value, min_periods=1).std()
-        
-        # 上轨
-        upper_band = sma + (std * std_multiplier)
-        return upper_band
-        
-    except Exception as e:
-        GLOG.ERROR(f"BB_upper operator failed: {e}")
-        return pd.Series([np.nan] * len(close_series), index=close_series.index)
+    period_value = int(period.iloc[0]) if len(period) > 0 else 20
+    std_multiplier = float(std_dev.iloc[0]) if std_dev is not None and len(std_dev) > 0 else 2.0
+    
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 计算移动平均和标准差
+    sma = close_series.rolling(window=period_value, min_periods=1).mean()
+    std = close_series.rolling(window=period_value, min_periods=1).std()
+    
+    # 上轨
+    upper_band = sma + (std * std_multiplier)
+    return upper_band
+    
 
 
 @register_operator("BB_lower", "Bollinger Bands Lower", min_args=2, max_args=3)
 def bb_lower_operator(data: pd.DataFrame, close_series: pd.Series, period: pd.Series, 
                      std_dev: pd.Series = None) -> pd.Series:
     """布林带下轨"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 20
-        std_multiplier = float(std_dev.iloc[0]) if std_dev is not None and len(std_dev) > 0 else 2.0
-        
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
-        
-        # 计算移动平均和标准差
-        sma = close_series.rolling(window=period_value, min_periods=1).mean()
-        std = close_series.rolling(window=period_value, min_periods=1).std()
-        
-        # 下轨
-        lower_band = sma - (std * std_multiplier)
-        return lower_band
-        
-    except Exception as e:
-        GLOG.ERROR(f"BB_lower operator failed: {e}")
-        return pd.Series([np.nan] * len(close_series), index=close_series.index)
+    period_value = int(period.iloc[0]) if len(period) > 0 else 20
+    std_multiplier = float(std_dev.iloc[0]) if std_dev is not None and len(std_dev) > 0 else 2.0
+    
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 计算移动平均和标准差
+    sma = close_series.rolling(window=period_value, min_periods=1).mean()
+    std = close_series.rolling(window=period_value, min_periods=1).std()
+    
+    # 下轨
+    lower_band = sma - (std * std_multiplier)
+    return lower_band
+    
 
 
 @register_operator("ATR", "Average True Range", min_args=4, max_args=4)
 def atr_operator(data: pd.DataFrame, high_series: pd.Series, low_series: pd.Series, 
                 close_series: pd.Series, period: pd.Series) -> pd.Series:
     """平均真实范围"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 14
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
-        
-        # 前一日收盘价
-        prev_close = close_series.shift(1)
-        
-        # 计算真实范围的三个候选值
-        tr1 = high_series - low_series
-        tr2 = (high_series - prev_close).abs()
-        tr3 = (low_series - prev_close).abs()
-        
-        # 真实范围是三者的最大值
-        true_range = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
-        
-        # ATR是真实范围的移动平均
-        atr = true_range.rolling(window=period_value, min_periods=1).mean()
-        return atr
-        
-    except Exception as e:
-        GLOG.ERROR(f"ATR operator failed: {e}")
-        return pd.Series([np.nan] * len(high_series), index=high_series.index)
+    period_value = int(period.iloc[0]) if len(period) > 0 else 14
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 前一日收盘价
+    prev_close = close_series.shift(1)
+    
+    # 计算真实范围的三个候选值
+    tr1 = high_series - low_series
+    tr2 = (high_series - prev_close).abs()
+    tr3 = (low_series - prev_close).abs()
+    
+    # 真实范围是三者的最大值
+    true_range = pd.concat([tr1, tr2, tr3], axis=1).max(axis=1)
+    
+    # ATR是真实范围的移动平均
+    atr = true_range.rolling(window=period_value, min_periods=1).mean()
+    return atr
+    
 
 
 @register_operator("Stoch", "Stochastic Oscillator", min_args=4, max_args=4)
 def stoch_operator(data: pd.DataFrame, high_series: pd.Series, low_series: pd.Series, 
                   close_series: pd.Series, period: pd.Series) -> pd.Series:
     """随机振荡器%K"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 14
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
+    period_value = int(period.iloc[0]) if len(period) > 0 else 14
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 计算n期内的最高价和最低价
+    lowest_low = low_series.rolling(window=period_value, min_periods=1).min()
+    highest_high = high_series.rolling(window=period_value, min_periods=1).max()
+    
+    # 计算%K
+    with np.errstate(divide='ignore', invalid='ignore'):
+        k_percent = 100 * (close_series - lowest_low) / (highest_high - lowest_low)
+        return k_percent.replace([np.inf, -np.inf], np.nan)
         
-        # 计算n期内的最高价和最低价
-        lowest_low = low_series.rolling(window=period_value, min_periods=1).min()
-        highest_high = high_series.rolling(window=period_value, min_periods=1).max()
-        
-        # 计算%K
-        with np.errstate(divide='ignore', invalid='ignore'):
-            k_percent = 100 * (close_series - lowest_low) / (highest_high - lowest_low)
-            return k_percent.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"Stoch operator failed: {e}")
-        return pd.Series([np.nan] * len(high_series), index=high_series.index)
 
 
 @register_operator("Williams_R", "Williams %R", min_args=4, max_args=4)
 def williams_r_operator(data: pd.DataFrame, high_series: pd.Series, low_series: pd.Series, 
                        close_series: pd.Series, period: pd.Series) -> pd.Series:
     """威廉指标%R"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 14
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
+    period_value = int(period.iloc[0]) if len(period) > 0 else 14
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 计算n期内的最高价和最低价
+    highest_high = high_series.rolling(window=period_value, min_periods=1).max()
+    lowest_low = low_series.rolling(window=period_value, min_periods=1).min()
+    
+    # 计算Williams %R
+    with np.errstate(divide='ignore', invalid='ignore'):
+        williams_r = -100 * (highest_high - close_series) / (highest_high - lowest_low)
+        return williams_r.replace([np.inf, -np.inf], np.nan)
         
-        # 计算n期内的最高价和最低价
-        highest_high = high_series.rolling(window=period_value, min_periods=1).max()
-        lowest_low = low_series.rolling(window=period_value, min_periods=1).min()
-        
-        # 计算Williams %R
-        with np.errstate(divide='ignore', invalid='ignore'):
-            williams_r = -100 * (highest_high - close_series) / (highest_high - lowest_low)
-            return williams_r.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"Williams_R operator failed: {e}")
-        return pd.Series([np.nan] * len(high_series), index=high_series.index)
 
 
 @register_operator("CCI", "Commodity Channel Index", min_args=4, max_args=4)
 def cci_operator(data: pd.DataFrame, high_series: pd.Series, low_series: pd.Series, 
                 close_series: pd.Series, period: pd.Series) -> pd.Series:
     """商品路径指标"""
-    try:
-        period_value = int(period.iloc[0]) if len(period) > 0 else 20
-        if period_value <= 0:
-            raise ValueError(f"Period must be positive, got {period_value}")
+    period_value = int(period.iloc[0]) if len(period) > 0 else 20
+    if period_value <= 0:
+        raise ValueError(f"Period must be positive, got {period_value}")
+    
+    # 典型价格
+    typical_price = (high_series + low_series + close_series) / 3
+    
+    # 移动平均
+    sma_tp = typical_price.rolling(window=period_value, min_periods=1).mean()
+    
+    # 平均偏差
+    mean_deviation = (typical_price - sma_tp).abs().rolling(window=period_value, min_periods=1).mean()
+    
+    # CCI计算
+    with np.errstate(divide='ignore', invalid='ignore'):
+        cci = (typical_price - sma_tp) / (0.015 * mean_deviation)
+        return cci.replace([np.inf, -np.inf], np.nan)
         
-        # 典型价格
-        typical_price = (high_series + low_series + close_series) / 3
-        
-        # 移动平均
-        sma_tp = typical_price.rolling(window=period_value, min_periods=1).mean()
-        
-        # 平均偏差
-        mean_deviation = (typical_price - sma_tp).abs().rolling(window=period_value, min_periods=1).mean()
-        
-        # CCI计算
-        with np.errstate(divide='ignore', invalid='ignore'):
-            cci = (typical_price - sma_tp) / (0.015 * mean_deviation)
-            return cci.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"CCI operator failed: {e}")
-        return pd.Series([np.nan] * len(high_series), index=high_series.index)
 
 
 @register_operator("PinBar", "Pin Bar Pattern Detection", min_args=5, max_args=5)
 def pinbar_operator(data: pd.DataFrame, open_series: pd.Series, high_series: pd.Series,
                    low_series: pd.Series, close_series: pd.Series, direction: pd.Series) -> pd.Series:
     """PinBar形态检测"""
-    try:
-        dir_value = int(direction.iloc[0]) if len(direction) > 0 else 0
+    dir_value = int(direction.iloc[0]) if len(direction) > 0 else 0
+    
+    result = []
+    for i in range(len(open_series)):
+        open_price = open_series.iloc[i]
+        high_price = high_series.iloc[i]
+        low_price = low_series.iloc[i]
+        close_price = close_series.iloc[i]
         
-        result = []
-        for i in range(len(open_series)):
-            open_price = open_series.iloc[i]
-            high_price = high_series.iloc[i]
-            low_price = low_series.iloc[i]
-            close_price = close_series.iloc[i]
-            
-            if pd.isna(open_price) or pd.isna(high_price) or pd.isna(low_price) or pd.isna(close_price):
-                result.append(0)
-                continue
-            
-            if open_price == 0:
-                result.append(0)
-                continue
-                
-            # 计算影线长度
-            up_shadow = high_price - max(open_price, close_price)
-            down_shadow = min(open_price, close_price) - low_price
-            body_size = abs(close_price - open_price)
-            total_range = high_price - low_price
-            
-            # 实体变化幅度检查
-            chg_pct = body_size / open_price
-            if chg_pct > 0.03:  # 实体过大
-                result.append(0)
-                continue
-            
-            if total_range == 0:
-                result.append(0)
-                continue
-                
-            # 影线比例检查
-            if down_shadow == 0:
-                result.append(0)
-                continue
-                
-            shadow_ratio = up_shadow / down_shadow if down_shadow != 0 else float('inf')
-            if 0.6 < shadow_ratio < 1.4:  # 上下影线接近
-                result.append(0)
-                continue
-            
-            # 主要影线检查
-            main_shadow = max(up_shadow, down_shadow)
-            if main_shadow > total_range * 2 / 3:
-                if dir_value == 1:  # 只检测看涨PinBar
-                    result.append(1 if down_shadow > up_shadow else 0)
-                elif dir_value == -1:  # 只检测看跌PinBar
-                    result.append(-1 if up_shadow > down_shadow else 0)
-                else:  # 检测任意PinBar
-                    result.append(1 if down_shadow > up_shadow else (-1 if up_shadow > down_shadow else 0))
-            else:
-                result.append(0)
+        if pd.isna(open_price) or pd.isna(high_price) or pd.isna(low_price) or pd.isna(close_price):
+            result.append(0)
+            continue
         
-        return pd.Series(result, index=open_series.index)
+        if open_price == 0:
+            result.append(0)
+            continue
+            
+        # 计算影线长度
+        up_shadow = high_price - max(open_price, close_price)
+        down_shadow = min(open_price, close_price) - low_price
+        body_size = abs(close_price - open_price)
+        total_range = high_price - low_price
         
-    except Exception as e:
-        GLOG.ERROR(f"PinBar operator failed: {e}")
-        return pd.Series([0] * len(open_series), index=open_series.index)
+        # 实体变化幅度检查
+        chg_pct = body_size / open_price
+        if chg_pct > 0.03:  # 实体过大
+            result.append(0)
+            continue
+        
+        if total_range == 0:
+            result.append(0)
+            continue
+            
+        # 影线比例检查
+        if down_shadow == 0:
+            result.append(0)
+            continue
+            
+        shadow_ratio = up_shadow / down_shadow if down_shadow != 0 else float('inf')
+        if 0.6 < shadow_ratio < 1.4:  # 上下影线接近
+            result.append(0)
+            continue
+        
+        # 主要影线检查
+        main_shadow = max(up_shadow, down_shadow)
+        if main_shadow > total_range * 2 / 3:
+            if dir_value == 1:  # 只检测看涨PinBar
+                result.append(1 if down_shadow > up_shadow else 0)
+            elif dir_value == -1:  # 只检测看跌PinBar
+                result.append(-1 if up_shadow > down_shadow else 0)
+            else:  # 检测任意PinBar
+                result.append(1 if down_shadow > up_shadow else (-1 if up_shadow > down_shadow else 0))
+        else:
+            result.append(0)
+    
+    return pd.Series(result, index=open_series.index)
+    
 
 
 @register_operator("Gap", "Gap Pattern Detection", min_args=5, max_args=5)
 def gap_operator(data: pd.DataFrame, open_series: pd.Series, high_series: pd.Series,
                 low_series: pd.Series, close_series: pd.Series, direction: pd.Series) -> pd.Series:
     """跳空形态检测"""
-    try:
-        dir_value = int(direction.iloc[0]) if len(direction) > 0 else 0
-        filter_ratio = 0.5  # 过滤比例
+    dir_value = int(direction.iloc[0]) if len(direction) > 0 else 0
+    filter_ratio = 0.5  # 过滤比例
+    
+    result = []
+    for i in range(len(open_series)):
+        if i == 0:
+            result.append(0)
+            continue
+            
+        # 当前K线数据
+        curr_open = open_series.iloc[i]
+        curr_high = high_series.iloc[i]
+        curr_low = low_series.iloc[i]
+        curr_close = close_series.iloc[i]
         
-        result = []
-        for i in range(len(open_series)):
-            if i == 0:
-                result.append(0)
-                continue
-                
-            # 当前K线数据
-            curr_open = open_series.iloc[i]
-            curr_high = high_series.iloc[i]
-            curr_low = low_series.iloc[i]
-            curr_close = close_series.iloc[i]
-            
-            # 前一根K线数据
-            prev_high = high_series.iloc[i-1]
-            prev_low = low_series.iloc[i-1]
-            
-            if any(pd.isna(x) for x in [curr_open, curr_high, curr_low, curr_close, prev_high, prev_low]):
-                result.append(0)
-                continue
-            
-            # 计算前一根K线的范围
-            prev_range = prev_high - prev_low
-            if prev_range <= 0:
-                result.append(0)
-                continue
-            
-            # 当前K线的实体范围
-            curr_top = max(curr_open, curr_close)
-            curr_bottom = min(curr_open, curr_close)
-            
-            # 检测跳空
-            if curr_bottom > prev_high:  # 向上跳空
-                gap = curr_bottom - prev_high
-                gap_value = gap if gap > prev_range * filter_ratio else 0
-                if dir_value == 1:  # 只检测向上跳空
-                    result.append(gap_value)
-                elif dir_value == -1:  # 只检测向下跳空
-                    result.append(0)
-                else:  # 检测任意跳空
-                    result.append(gap_value)
-            elif curr_top < prev_low:  # 向下跳空
-                gap = curr_top - prev_low  # 负值
-                gap_value = gap if abs(gap) > prev_range * filter_ratio else 0
-                if dir_value == -1:  # 只检测向下跳空
-                    result.append(gap_value)
-                elif dir_value == 1:  # 只检测向上跳空
-                    result.append(0)
-                else:  # 检测任意跳空
-                    result.append(gap_value)
-            else:
-                result.append(0)
+        # 前一根K线数据
+        prev_high = high_series.iloc[i-1]
+        prev_low = low_series.iloc[i-1]
         
-        return pd.Series(result, index=open_series.index)
+        if any(pd.isna(x) for x in [curr_open, curr_high, curr_low, curr_close, prev_high, prev_low]):
+            result.append(0)
+            continue
         
-    except Exception as e:
-        GLOG.ERROR(f"Gap operator failed: {e}")
-        return pd.Series([0] * len(open_series), index=open_series.index)
+        # 计算前一根K线的范围
+        prev_range = prev_high - prev_low
+        if prev_range <= 0:
+            result.append(0)
+            continue
+        
+        # 当前K线的实体范围
+        curr_top = max(curr_open, curr_close)
+        curr_bottom = min(curr_open, curr_close)
+        
+        # 检测跳空
+        if curr_bottom > prev_high:  # 向上跳空
+            gap = curr_bottom - prev_high
+            gap_value = gap if gap > prev_range * filter_ratio else 0
+            if dir_value == 1:  # 只检测向上跳空
+                result.append(gap_value)
+            elif dir_value == -1:  # 只检测向下跳空
+                result.append(0)
+            else:  # 检测任意跳空
+                result.append(gap_value)
+        elif curr_top < prev_low:  # 向下跳空
+            gap = curr_top - prev_low  # 负值
+            gap_value = gap if abs(gap) > prev_range * filter_ratio else 0
+            if dir_value == -1:  # 只检测向下跳空
+                result.append(gap_value)
+            elif dir_value == 1:  # 只检测向上跳空
+                result.append(0)
+            else:  # 检测任意跳空
+                result.append(gap_value)
+        else:
+            result.append(0)
+    
+    return pd.Series(result, index=open_series.index)
+    
 
 
 @register_operator("InflectionPoint", "Inflection Point Detection", min_args=2, max_args=2)
 def inflection_point_operator(data: pd.DataFrame, close_series: pd.Series, window: pd.Series) -> pd.Series:
     """拐点检测"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 4
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
+    window_size = _extract_window(window), 4
+    
+    result = []
+    for i in range(len(close_series)):
+        if i < window_size or i >= len(close_series) - window_size:
+            result.append(0)
+            continue
         
-        result = []
-        for i in range(len(close_series)):
-            if i < window_size or i >= len(close_series) - window_size:
-                result.append(0)
-                continue
-            
-            # 获取窗口内的价格数据
-            window_prices = close_series.iloc[i-window_size:i+window_size+1].values
-            center_idx = window_size
-            center_price = window_prices[center_idx]
-            
-            if pd.isna(center_price):
-                result.append(0)
-                continue
-            
-            # 检查是否为局部极值
-            is_peak = all(center_price >= price or pd.isna(price) 
-                         for j, price in enumerate(window_prices) if j != center_idx)
-            is_valley = all(center_price <= price or pd.isna(price) 
-                           for j, price in enumerate(window_prices) if j != center_idx)
-            
-            if is_peak and not is_valley:
-                result.append(1)  # 峰值
-            elif is_valley and not is_peak:
-                result.append(-1)  # 谷值
-            else:
-                result.append(0)  # 非拐点
+        # 获取窗口内的价格数据
+        window_prices = close_series.iloc[i-window_size:i+window_size+1].values
+        center_idx = window_size
+        center_price = window_prices[center_idx]
         
-        return pd.Series(result, index=close_series.index)
+        if pd.isna(center_price):
+            result.append(0)
+            continue
         
-    except Exception as e:
-        GLOG.ERROR(f"InflectionPoint operator failed: {e}")
-        return pd.Series([0] * len(close_series), index=close_series.index)
+        # 检查是否为局部极值
+        is_peak = all(center_price >= price or pd.isna(price) 
+                     for j, price in enumerate(window_prices) if j != center_idx)
+        is_valley = all(center_price <= price or pd.isna(price) 
+                       for j, price in enumerate(window_prices) if j != center_idx)
+        
+        if is_peak and not is_valley:
+            result.append(1)  # 峰值
+        elif is_valley and not is_peak:
+            result.append(-1)  # 谷值
+        else:
+            result.append(0)  # 非拐点
+    
+    return pd.Series(result, index=close_series.index)
+    
 
 
 @register_operator("GoldenSection", "Golden Section Levels", min_args=3, max_args=3)
 def golden_section_operator(data: pd.DataFrame, high_series: pd.Series, low_series: pd.Series, 
                            ratio: pd.Series) -> pd.Series:
     """黄金分割位计算"""
-    try:
-        ratio_value = float(ratio.iloc[0]) if len(ratio) > 0 else 0.618
-        if not 0 < ratio_value < 1:
-            raise ValueError(f"Ratio must be between 0 and 1, got {ratio_value}")
-        
-        # 计算20期高低点
-        rolling_high = high_series.rolling(window=20, min_periods=1).max()
-        rolling_low = low_series.rolling(window=20, min_periods=1).min()
-        
-        # 计算黄金分割位
-        golden_level = rolling_low + (rolling_high - rolling_low) * ratio_value
-        
-        return golden_level
-        
-    except Exception as e:
-        GLOG.ERROR(f"GoldenSection operator failed: {e}")
-        return pd.Series([np.nan] * len(high_series), index=high_series.index)
+    ratio_value = float(ratio.iloc[0]) if len(ratio) > 0 else 0.618
+    if not 0 < ratio_value < 1:
+        raise ValueError(f"Ratio must be between 0 and 1, got {ratio_value}")
+    
+    # 计算20期高低点
+    rolling_high = high_series.rolling(window=20, min_periods=1).max()
+    rolling_low = low_series.rolling(window=20, min_periods=1).min()
+    
+    # 计算黄金分割位
+    golden_level = rolling_low + (rolling_high - rolling_low) * ratio_value
+    
+    return golden_level
+    
 
 
 @register_operator("RSV", "Raw Stochastic Value", min_args=4, max_args=4)
 def rsv_operator(data: pd.DataFrame, high_series: pd.Series, low_series: pd.Series, 
                 close_series: pd.Series, window: pd.Series) -> pd.Series:
     """RSV未成熟随机值"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 9
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
+    window_size = _extract_window(window), 9
+    
+    # 计算n期内的最高价和最低价
+    lowest_low = low_series.rolling(window=window_size, min_periods=1).min()
+    highest_high = high_series.rolling(window=window_size, min_periods=1).max()
+    
+    # 计算RSV = (收盘价-最低价)/(最高价-最低价) * 100
+    with np.errstate(divide='ignore', invalid='ignore'):
+        rsv = 100 * (close_series - lowest_low) / (highest_high - lowest_low)
+        return rsv.replace([np.inf, -np.inf], np.nan)
         
-        # 计算n期内的最高价和最低价
-        lowest_low = low_series.rolling(window=window_size, min_periods=1).min()
-        highest_high = high_series.rolling(window=window_size, min_periods=1).max()
-        
-        # 计算RSV = (收盘价-最低价)/(最高价-最低价) * 100
-        with np.errstate(divide='ignore', invalid='ignore'):
-            rsv = 100 * (close_series - lowest_low) / (highest_high - lowest_low)
-            return rsv.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"RSV operator failed: {e}")
-        return pd.Series([np.nan] * len(high_series), index=high_series.index)

--- a/src/ginkgo/features/engines/expression/operators/temporal.py
+++ b/src/ginkgo/features/engines/expression/operators/temporal.py
@@ -15,242 +15,179 @@ Temporal Operators - 时序操作符
 
 import pandas as pd
 import numpy as np
-from ginkgo.features.engines.expression.registry import register_operator
+from ginkgo.features.engines.expression.registry import register_operator, _extract_window, _extract_periods
 from ginkgo.libs import GLOG
 
 
 @register_operator("Returns", "Calculate returns", min_args=1, max_args=2)
 def returns_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series = None) -> pd.Series:
     """收益率计算"""
-    try:
-        shift_periods = 1
-        if periods is not None and len(periods) > 0:
-            shift_periods = int(periods.iloc[0])
+    shift_periods = 1
+    if periods is not None and len(periods) > 0:
+        shift_periods = int(periods.iloc[0])
+    
+    if shift_periods <= 0:
+        raise ValueError(f"Periods must be positive, got {shift_periods}")
+    
+    prev_values = series.shift(shift_periods)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        returns = (series - prev_values) / prev_values
+        return returns.replace([np.inf, -np.inf], np.nan)
         
-        if shift_periods <= 0:
-            raise ValueError(f"Periods must be positive, got {shift_periods}")
-        
-        prev_values = series.shift(shift_periods)
-        with np.errstate(divide='ignore', invalid='ignore'):
-            returns = (series - prev_values) / prev_values
-            return returns.replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"Returns operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
 
 
 @register_operator("LogReturns", "Calculate log returns", min_args=1, max_args=2)
 def log_returns_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series = None) -> pd.Series:
     """对数收益率计算"""
-    try:
-        shift_periods = 1
-        if periods is not None and len(periods) > 0:
-            shift_periods = int(periods.iloc[0])
+    shift_periods = 1
+    if periods is not None and len(periods) > 0:
+        shift_periods = int(periods.iloc[0])
+    
+    if shift_periods <= 0:
+        raise ValueError(f"Periods must be positive, got {shift_periods}")
+    
+    prev_values = series.shift(shift_periods)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        log_returns = np.log(series / prev_values)
+        return pd.Series(log_returns, index=series.index).replace([np.inf, -np.inf], np.nan)
         
-        if shift_periods <= 0:
-            raise ValueError(f"Periods must be positive, got {shift_periods}")
-        
-        prev_values = series.shift(shift_periods)
-        with np.errstate(divide='ignore', invalid='ignore'):
-            log_returns = np.log(series / prev_values)
-            return pd.Series(log_returns, index=series.index).replace([np.inf, -np.inf], np.nan)
-            
-    except Exception as e:
-        GLOG.ERROR(f"LogReturns operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
 
 
 @register_operator("Pct_change", "Percentage change", min_args=1, max_args=2)
 def pct_change_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series = None) -> pd.Series:
     """百分比变化"""
-    try:
-        shift_periods = 1
-        if periods is not None and len(periods) > 0:
-            shift_periods = int(periods.iloc[0])
-        
-        return series.pct_change(periods=shift_periods)
-    except Exception as e:
-        GLOG.ERROR(f"Pct_change operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    shift_periods = 1
+    if periods is not None and len(periods) > 0:
+        shift_periods = int(periods.iloc[0])
+    
+    return series.pct_change(periods=shift_periods)
 
 
 @register_operator("CumSum", "Cumulative sum", min_args=1, max_args=1)
 def cumsum_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """累积求和"""
-    try:
-        return series.cumsum()
-    except Exception as e:
-        GLOG.ERROR(f"CumSum operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.cumsum()
 
 
 @register_operator("WMA", "Weighted Moving Average", min_args=2, max_args=2)
 def wma_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """加权移动平均"""
-    try:
-        window_size = int(window.iloc[0])
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        # 生成线性权重：最新数据权重最大
-        weights = np.arange(1, window_size + 1)
-        weights = weights / weights.sum()  # 标准化权重
-        
-        result = []
-        for i in range(len(series)):
-            if i < window_size - 1:
-                # 数据不足，返回NaN
-                result.append(np.nan)
-            else:
-                # 获取窗口数据
-                window_data = series.iloc[i - window_size + 1:i + 1].values
-                # 计算加权平均
-                wma_value = np.sum(window_data * weights)
-                result.append(wma_value)
-        
-        return pd.Series(result, index=series.index)
-        
-    except Exception as e:
-        GLOG.ERROR(f"WMA operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = int(window.iloc[0])
+    if window_size <= 0:
+        raise ValueError(f"Window size must be positive, got {window_size}")
+    
+    # 生成线性权重：最新数据权重最大
+    weights = np.arange(1, window_size + 1)
+    weights = weights / weights.sum()  # 标准化权重
+    
+    result = []
+    for i in range(len(series)):
+        if i < window_size - 1:
+            # 数据不足，返回NaN
+            result.append(np.nan)
+        else:
+            # 获取窗口数据
+            window_data = series.iloc[i - window_size + 1:i + 1].values
+            # 计算加权平均
+            wma_value = np.sum(window_data * weights)
+            result.append(wma_value)
+    
+    return pd.Series(result, index=series.index)
+    
 
 
 @register_operator("CumProd", "Cumulative product", min_args=1, max_args=1)
 def cumprod_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """累积乘积"""
-    try:
-        return series.cumprod()
-    except Exception as e:
-        GLOG.ERROR(f"CumProd operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.cumprod()
 
 
 @register_operator("CumMax", "Cumulative maximum", min_args=1, max_args=1)
 def cummax_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """累积最大值"""
-    try:
-        return series.cummax()
-    except Exception as e:
-        GLOG.ERROR(f"CumMax operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.cummax()
 
 
 @register_operator("CumMin", "Cumulative minimum", min_args=1, max_args=1)
 def cummin_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """累积最小值"""
-    try:
-        return series.cummin()
-    except Exception as e:
-        GLOG.ERROR(f"CumMin operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.cummin()
 
 
 @register_operator("Expanding_mean", "Expanding mean", min_args=1, max_args=1)
 def expanding_mean_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """扩展窗口均值"""
-    try:
-        return series.expanding(min_periods=1).mean()
-    except Exception as e:
-        GLOG.ERROR(f"Expanding_mean operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.expanding(min_periods=1).mean()
 
 
 @register_operator("Expanding_std", "Expanding standard deviation", min_args=1, max_args=1)
 def expanding_std_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """扩展窗口标准差"""
-    try:
-        return series.expanding(min_periods=2).std()
-    except Exception as e:
-        GLOG.ERROR(f"Expanding_std operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.expanding(min_periods=2).std()
 
 
 @register_operator("EWM", "Exponentially weighted moving average", min_args=2, max_args=2)
 def ewm_operator(data: pd.DataFrame, series: pd.Series, span: pd.Series) -> pd.Series:
     """指数加权移动平均"""
-    try:
-        span_value = float(span.iloc[0]) if len(span) > 0 else 20
-        if span_value <= 0:
-            raise ValueError(f"Span must be positive, got {span_value}")
-        
-        return series.ewm(span=span_value, adjust=False).mean()
-    except Exception as e:
-        GLOG.ERROR(f"EWM operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    span_value = float(span.iloc[0]) if len(span) > 0 else 20
+    if span_value <= 0:
+        raise ValueError(f"Span must be positive, got {span_value}")
+    
+    return series.ewm(span=span_value, adjust=False).mean()
 
 
 @register_operator("EWMSTD", "Exponentially weighted moving standard deviation", min_args=2, max_args=2)
 def ewmstd_operator(data: pd.DataFrame, series: pd.Series, span: pd.Series) -> pd.Series:
     """指数加权移动标准差"""
-    try:
-        span_value = float(span.iloc[0]) if len(span) > 0 else 20
-        if span_value <= 0:
-            raise ValueError(f"Span must be positive, got {span_value}")
-        
-        return series.ewm(span=span_value, adjust=False).std()
-    except Exception as e:
-        GLOG.ERROR(f"EWMSTD operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    span_value = float(span.iloc[0]) if len(span) > 0 else 20
+    if span_value <= 0:
+        raise ValueError(f"Span must be positive, got {span_value}")
+    
+    return series.ewm(span=span_value, adjust=False).std()
 
 
 @register_operator("Shift_fill", "Shift with fill value", min_args=2, max_args=3)
 def shift_fill_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series, fill_value: pd.Series = None) -> pd.Series:
     """带填充值的时间偏移"""
-    try:
-        shift_periods = int(periods.iloc[0]) if len(periods) > 0 else 1
-        fill_val = 0
-        if fill_value is not None and len(fill_value) > 0:
-            fill_val = float(fill_value.iloc[0])
-        
-        return series.shift(shift_periods, fill_value=fill_val)
-    except Exception as e:
-        GLOG.ERROR(f"Shift_fill operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    shift_periods = _extract_periods(periods)
+    fill_val = 0
+    if fill_value is not None and len(fill_value) > 0:
+        fill_val = float(fill_value.iloc[0])
+    
+    return series.shift(shift_periods, fill_value=fill_val)
 
 
 @register_operator("Rolling_apply", "Rolling custom function", min_args=3, max_args=3)
 def rolling_apply_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series, func_name: pd.Series) -> pd.Series:
     """滚动自定义函数应用"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        function_name = str(func_name.iloc[0]) if len(func_name) > 0 else "mean"
-        
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        # 支持的函数映射
-        func_mapping = {
-            "mean": lambda x: x.mean(),
-            "std": lambda x: x.std(),
-            "var": lambda x: x.var(),
-            "min": lambda x: x.min(),
-            "max": lambda x: x.max(),
-            "median": lambda x: x.median(),
-            "sum": lambda x: x.sum(),
-            "prod": lambda x: x.prod(),
-            "first": lambda x: x.iloc[0] if len(x) > 0 else np.nan,
-            "last": lambda x: x.iloc[-1] if len(x) > 0 else np.nan,
-        }
-        
-        if function_name not in func_mapping:
-            raise ValueError(f"Unsupported function: {function_name}")
-        
-        return series.rolling(window=window_size, min_periods=1).apply(func_mapping[function_name])
-    except Exception as e:
-        GLOG.ERROR(f"Rolling_apply operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    function_name = str(func_name.iloc[0]) if len(func_name) > 0 else "mean"
+
+    # 支持的函数映射
+    func_mapping = {
+        "mean": lambda x: x.mean(),
+        "std": lambda x: x.std(),
+        "var": lambda x: x.var(),
+        "min": lambda x: x.min(),
+        "max": lambda x: x.max(),
+        "median": lambda x: x.median(),
+        "sum": lambda x: x.sum(),
+        "prod": lambda x: x.prod(),
+        "first": lambda x: x.iloc[0] if len(x) > 0 else np.nan,
+        "last": lambda x: x.iloc[-1] if len(x) > 0 else np.nan,
+    }
+    
+    if function_name not in func_mapping:
+        raise ValueError(f"Unsupported function: {function_name}")
+    
+    return series.rolling(window=window_size, min_periods=1).apply(func_mapping[function_name])
 
 
 @register_operator("Delay", "Delay series (alias for Shift)", min_args=2, max_args=2)
 def delay_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series) -> pd.Series:
     """数据延迟（Shift的别名）"""
-    try:
-        delay_periods = int(periods.iloc[0]) if len(periods) > 0 else 1
-        return series.shift(delay_periods)
-    except Exception as e:
-        GLOG.ERROR(f"Delay operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    delay_periods = _extract_periods(periods)
+    return series.shift(delay_periods)
 
 
 @register_operator("Ts_Rank", "Time series rank", min_args=2, max_args=2)
@@ -265,26 +202,20 @@ def ts_rank_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -
     Returns:
         pd.Series: 在窗口内的排名 (0-1之间，1为最大值)
     """
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        def rolling_rank(x):
-            """计算窗口内的排名"""
-            if len(x) == 0:
-                return np.nan
-            # 使用rank方法，method='min'处理重复值
-            ranks = x.rank(method='min')
-            # 标准化到0-1之间
-            return (ranks.iloc[-1] - 1) / (len(x) - 1) if len(x) > 1 else 0.5
-        
-        result = series.rolling(window=window_size, min_periods=1).apply(rolling_rank)
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"Ts_Rank operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    def rolling_rank(x):
+        """计算窗口内的排名"""
+        if len(x) == 0:
+            return np.nan
+        # 使用rank方法，method='min'处理重复值
+        ranks = x.rank(method='min')
+        # 标准化到0-1之间
+        return (ranks.iloc[-1] - 1) / (len(x) - 1) if len(x) > 1 else 0.5
+    
+    result = series.rolling(window=window_size, min_periods=1).apply(rolling_rank)
+    return result
+    
 
 
 @register_operator("Ts_ArgMax", "Time series argmax", min_args=2, max_args=2)
@@ -299,23 +230,17 @@ def ts_argmax_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series)
     Returns:
         pd.Series: 最大值在窗口内的位置 (0为最早，window-1为最新)
     """
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        def rolling_argmax(x):
-            """计算窗口内最大值的索引"""
-            if len(x) == 0:
-                return np.nan
-            return x.argmax()
-        
-        result = series.rolling(window=window_size, min_periods=1).apply(rolling_argmax)
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"Ts_ArgMax operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    def rolling_argmax(x):
+        """计算窗口内最大值的索引"""
+        if len(x) == 0:
+            return np.nan
+        return x.argmax()
+    
+    result = series.rolling(window=window_size, min_periods=1).apply(rolling_argmax)
+    return result
+    
 
 
 @register_operator("Ts_ArgMin", "Time series argmin", min_args=2, max_args=2)
@@ -330,62 +255,38 @@ def ts_argmin_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series)
     Returns:
         pd.Series: 最小值在窗口内的位置 (0为最早，window-1为最新)
     """
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        def rolling_argmin(x):
-            """计算窗口内最小值的索引"""
-            if len(x) == 0:
-                return np.nan
-            return x.argmin()
-        
-        result = series.rolling(window=window_size, min_periods=1).apply(rolling_argmin)
-        return result
-        
-    except Exception as e:
-        GLOG.ERROR(f"Ts_ArgMin operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    def rolling_argmin(x):
+        """计算窗口内最小值的索引"""
+        if len(x) == 0:
+            return np.nan
+        return x.argmin()
+    
+    result = series.rolling(window=window_size, min_periods=1).apply(rolling_argmin)
+    return result
+    
 
 
 @register_operator("Ts_Max", "Time series rolling maximum", min_args=2, max_args=2)
 def ts_max_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """时序滚动最大值"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).max()
-    except Exception as e:
-        GLOG.ERROR(f"Ts_Max operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).max()
 
 
 @register_operator("Ts_Min", "Time series rolling minimum", min_args=2, max_args=2)
 def ts_min_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """时序滚动最小值"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).min()
-    except Exception as e:
-        GLOG.ERROR(f"Ts_Min operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).min()
 
 
 @register_operator("Ts_Mean", "Time series rolling mean", min_args=2, max_args=2)
 def ts_mean_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """时序滚动平均值"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).mean()
-    except Exception as e:
-        GLOG.ERROR(f"Ts_Mean operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).mean()

--- a/src/ginkgo/features/engines/expression/registry.py
+++ b/src/ginkgo/features/engines/expression/registry.py
@@ -29,18 +29,30 @@ class OperatorRegistry:
     _operator_metadata: Dict[str, Dict[str, Any]] = {}
     
     @classmethod
-    def register(cls, name: str, function: Callable, description: str = "", 
+    def register(cls, name: str, function: Callable, description: str = "",
                  min_args: int = 0, max_args: int = None):
         """
         注册操作符函数
-        
+
         Args:
             name: 函数名称
             function: 函数实现
             description: 函数描述
             min_args: 最少参数数量
             max_args: 最多参数数量
+
+        Raises:
+            ValueError: 同名操作符已注册时抛出。调用方须先 unregister() 或换名,
+                避免静默覆盖(历史 bug:截面 Rank 被滚动 Rank 静默覆盖成死代码,#6479)。
         """
+        if name in cls._operators:
+            existing = cls._operators[name]
+            raise ValueError(
+                f"Operator '{name}' is already registered by "
+                f"{existing.__module__}.{existing.__name__}; cannot register "
+                f"duplicate from {function.__module__}.{function.__name__}. "
+                f"Call unregister() first or use a distinct name."
+            )
         cls._operators[name] = function
         cls._operator_metadata[name] = {
             "description": description,
@@ -153,6 +165,37 @@ def register_operator(name: str, description: str = "", min_args: int = 0, max_a
 
 
 # ============================================================================
+# 操作符参数提取工具(供内置算子与 operators/* 共用,#6479 AC2)
+# 放在 registry(叶子模块)以避免 operators/__init__ 急切加载造成的循环 import。
+# ============================================================================
+def _extract_window(series: pd.Series, default: int = 20) -> int:
+    """从窗口参数 Series 提取整数:取首元素,空则用 default,<=0 抛 ValueError。
+
+    替换原模板::
+
+        window_size = int(window.iloc[0]) if len(window) > 0 else N
+        if window_size <= 0:
+            raise ValueError(f"Window size must be positive, got {window_size}")
+    """
+    window_size = int(series.iloc[0]) if len(series) > 0 else default
+    if window_size <= 0:
+        raise ValueError(f"Window size must be positive, got {window_size}")
+    return window_size
+
+
+def _extract_periods(series: pd.Series, default: int = 1, *, allow_negative: bool = True) -> int:
+    """从周期/滞后参数 Series 提取整数:取首元素,空则用 default。
+
+    - ``allow_negative=True``(默认):Ref/Delta/Shift_fill/Delay,允许负偏移。
+    - ``allow_negative=False``:AutoCorr lag,要求非负,<0 抛 ValueError。
+    """
+    periods = int(series.iloc[0]) if len(series) > 0 else default
+    if not allow_negative and periods < 0:
+        raise ValueError(f"Lag must be non-negative, got {periods}")
+    return periods
+
+
+# ============================================================================
 # 内置操作符定义
 # ============================================================================
 
@@ -165,143 +208,81 @@ def mean_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> p
         series: 输入序列
         window: 窗口大小序列
     """
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).mean()
-    except Exception as e:
-        GLOG.ERROR(f"Mean operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).mean()
 
 
 @register_operator("Std", "Standard deviation", min_args=2, max_args=2)
 def std_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """标准差"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).std()
-    except Exception as e:
-        GLOG.ERROR(f"Std operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).std()
 
 
 @register_operator("Max", "Rolling maximum", min_args=2, max_args=2)
 def max_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动最大值"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).max()
-    except Exception as e:
-        GLOG.ERROR(f"Max operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).max()
 
 
 @register_operator("Min", "Rolling minimum", min_args=2, max_args=2)
 def min_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动最小值"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).min()
-    except Exception as e:
-        GLOG.ERROR(f"Min operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).min()
 
 
 @register_operator("Ref", "Time reference/lag", min_args=2, max_args=2)
 def ref_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series) -> pd.Series:
     """时间偏移/滞后"""
-    try:
-        shift_periods = int(periods.iloc[0]) if len(periods) > 0 else 1
-        return series.shift(shift_periods)
-    except Exception as e:
-        GLOG.ERROR(f"Ref operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    shift_periods = _extract_periods(periods)
+    return series.shift(shift_periods)
 
 
 @register_operator("Delta", "Difference", min_args=2, max_args=2)
 def delta_operator(data: pd.DataFrame, series: pd.Series, periods: pd.Series) -> pd.Series:
     """差分"""
-    try:
-        diff_periods = int(periods.iloc[0]) if len(periods) > 0 else 1
-        return series.diff(diff_periods)
-    except Exception as e:
-        GLOG.ERROR(f"Delta operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    diff_periods = _extract_periods(periods)
+    return series.diff(diff_periods)
 
 
 @register_operator("Sum", "Rolling sum", min_args=2, max_args=2)
 def sum_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series) -> pd.Series:
     """滚动求和"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        
-        return series.rolling(window=window_size, min_periods=1).sum()
-    except Exception as e:
-        GLOG.ERROR(f"Sum operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
-
-
-@register_operator("Rank", "Cross-sectional rank", min_args=1, max_args=1)
-def rank_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
-    """截面排名"""
-    try:
-        return series.rank(method='min', na_option='keep')
-    except Exception as e:
-        GLOG.ERROR(f"Rank operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    
+    return series.rolling(window=window_size, min_periods=1).sum()
 
 
 @register_operator("Quantile", "Rolling quantile", min_args=3, max_args=3)
 def quantile_operator(data: pd.DataFrame, series: pd.Series, window: pd.Series, q: pd.Series) -> pd.Series:
     """滚动分位数"""
-    try:
-        window_size = int(window.iloc[0]) if len(window) > 0 else 20
-        quantile = float(q.iloc[0]) if len(q) > 0 else 0.5
-        
-        if window_size <= 0:
-            raise ValueError(f"Window size must be positive, got {window_size}")
-        if not 0 <= quantile <= 1:
-            raise ValueError(f"Quantile must be between 0 and 1, got {quantile}")
-        
-        return series.rolling(window=window_size, min_periods=1).quantile(quantile)
-    except Exception as e:
-        GLOG.ERROR(f"Quantile operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    window_size = _extract_window(window)
+    quantile = float(q.iloc[0]) if len(q) > 0 else 0.5
+
+    if not 0 <= quantile <= 1:
+        raise ValueError(f"Quantile must be between 0 and 1, got {quantile}")
+
+    return series.rolling(window=window_size, min_periods=1).quantile(quantile)
 
 
 @register_operator("Abs", "Absolute value", min_args=1, max_args=1)
 def abs_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """绝对值"""
-    try:
-        return series.abs()
-    except Exception as e:
-        GLOG.ERROR(f"Abs operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    return series.abs()
 
 
 @register_operator("Log", "Natural logarithm", min_args=1, max_args=1)
 def log_operator(data: pd.DataFrame, series: pd.Series) -> pd.Series:
     """自然对数"""
-    try:
-        with np.errstate(divide='ignore', invalid='ignore'):
-            result = np.log(series)
-            return result.replace([np.inf, -np.inf], np.nan)
-    except Exception as e:
-        GLOG.ERROR(f"Log operator failed: {e}")
-        return pd.Series([np.nan] * len(series), index=series.index)
+    with np.errstate(divide='ignore', invalid='ignore'):
+        result = np.log(series)
+        return result.replace([np.inf, -np.inf], np.nan)
 
 
 # 技术指标相关操作符会在indicators模块中定义和注册

--- a/tests/unit/features/test_operator_registry.py
+++ b/tests/unit/features/test_operator_registry.py
@@ -9,6 +9,12 @@ try:
 except ImportError:
     HAS_REGISTRY = False
 
+if HAS_REGISTRY:
+    # 触发 operators 包加载,注册全部算子。
+    # Rank/Mean 等住 operators 包(statistical),非 registry.py 内建;
+    # 不触发则 test_has_builtin_operators 看不到 Rank。
+    import ginkgo.features.engines.expression.operators  # noqa: F401
+
 
 @pytest.fixture
 def sample_df():
@@ -49,6 +55,30 @@ class TestOperatorRegistry:
 
     def test_validate_function_call(self):
         assert OperatorRegistry.validate_function_call('Mean', 2) is True
+
+    def test_duplicate_registration_raises(self):
+        """同名重注册必须 raise,禁止静默覆盖(#6479 回归)。"""
+        def op_a(data, x):
+            return x
+
+        def op_b(data, x):
+            return x * 2
+
+        name = "test_dup_op_xyz_6479"
+        OperatorRegistry.register(name, op_a, description="first")
+        try:
+            with pytest.raises(ValueError, match="already registered"):
+                OperatorRegistry.register(name, op_b, description="second")
+        finally:
+            OperatorRegistry.unregister(name)
+
+    def test_rank_is_rolling_two_arg(self):
+        """Rank 是滚动排名(2参, statistical),非被覆盖删除的截面版(#6479 回归)。"""
+        assert OperatorRegistry.is_registered('Rank')
+        info = OperatorRegistry.get_operator_info('Rank')
+        assert info['min_args'] == 2
+        assert info['max_args'] == 2
+        assert OperatorRegistry._operators['Rank'].__module__.endswith('statistical')
 
 
 # Test operator modules actually load and register their functions


### PR DESCRIPTION
## 概述

针对 #6479(因子表达式引擎 operator 基类过浅)的 4/6 验收标准重构。单 PR,6 个表达式引擎测试文件保持绿色(265 passed)。

## 改动

### AC1: 移除算子内部冗余 try/except(74 处)
- 5 个文件(basic/statistical/technical/temporal + registry 内建)共 74 个算子内部的 `try/except → GLOG.ERROR + return NaN` 统一剥离。
- 异常现统一冒泡到 `OperatorRegistry.execute_function` 的外层兜底(保留)。
- **行为等价证明**:算子内层 fallback 返回 `NaN(len(series), series.index)`;外层返回 `NaN(len(data), data.index)`。因 `series` 恒由 `data` 列派生,`series.index == data.index`,两路径产出的 NaN 序列等价。
- ⚠️ **一处语义变化(已在 AC 范围内可接受)**:`PinBar`/`Gap`/`InflectionPoint` 原异常路径返回 `0` 序列,现统一为 `NaN`。快乐路径(循环内赋 0)不变。这三个是布尔型模式检测算子,异常→NaN 比 异常→0 更一致(NaN 表示"无法判定",0 会与真实信号"否"混淆)。

### AC2: 提取 `_extract_window` / `_extract_periods`(36 处)
- 31 处窗口提取(`int(window.iloc[0]) if len>0 else N` + `if <=0: raise`)→ `_extract_window(window[, N])`。
- 5 处周期/滞后提取 → `_extract_periods(periods[, allow_negative=...])`。
- helper 内联进 `registry.py`。**未放 `operators/_helpers.py` 的原因**:那会触发 `operators/__init__.py` 急切加载 → basic 回导 registry(半初始化)→ 循环 import。registry 是叶子模块(operators 本单向依赖它),放此处无环。
- **合理保留未动的 4 处**:
  - `WMA`(`temporal.py`):无 default 严格抽取(`int(window.iloc[0])`,空则崩),语义不同于模板,纳入 helper 会改变空窗行为。
  - `Returns`/`LogReturns`/`Pct_change`:条件式 `if periods is not None:` 可选提取,完全不同 idiom。

### AC4: 注册冲突检测 + 删死截面 Rank
- `OperatorRegistry.register` 同名重注册从静默覆盖改为 `raise ValueError`。
- **根因复盘(前提反转)**:issue 原描述"滚动 Rank 变死代码"方向反了——实测 `statistical.py` 的**滚动 Rank(2参)是活的**(`alpha_factors.py` RANK5/10/20/30 在用),`registry.py` 的**截面 Rank(1参)才是被覆盖致死的**。删除 registry 截面 Rank,保留 statistical 滚动 Rank。加载顺序:registry 主体先注册截面 Rank → `parser._import_operators()` 后 statistical 滚动 Rank 覆盖 → 后者赢。
- 新增 2 回归测试:`test_duplicate_registration_raises`、`test_rank_is_rolling_two_arg`。

### AC6: technical.py docstring 订正
- 原文称"对现有 indicators 模块的封装",实测无任何 indicators import/调用(算子均为内联 pandas/numpy)。改为如实描述。

## 显式跳过(AC3/AC5)
- **AC3(算术中缀除法语义统一)** / **AC5(eval/AST 解耦)**:未受保护的 `BinaryOpNode` 中缀除法(14 处)几乎全部集中在 `worldquant_alpha101`,而 Alpha101 **未投入使用**(详见代码注释 + 无调用方)。实际影响为 0,推迟到 Alpha101 真正启用时再做。

## 验证
- `pytest tests/unit/features/{test_expression_engine,test_operator_registry,test_expression_parser,test_ast_nodes,test_definitions,test_factor_engine}.py` → **265 passed**, 3 预存 warnings(与本 PR 无关)。
- 净 **-288 行**(653 增 / 941 删)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)