### PR TITLE
refactor(#6714): ITimeProvider→TimeProvider

### DIFF
--- a/src/ginkgo/trading/context/engine_context.py
+++ b/src/ginkgo/trading/context/engine_context.py
@@ -20,7 +20,7 @@ from typing import Optional, TYPE_CHECKING
 from ginkgo.enums import SOURCE_TYPES
 
 if TYPE_CHECKING:
-    from ginkgo.trading.time.interfaces import ITimeProvider
+    from ginkgo.trading.time.interfaces import TimeProvider
 
 
 class EngineContext:
@@ -31,7 +31,7 @@ class EngineContext:
     - Store engine_id (read-only, updatable by Engine)
     - Store task_id (read-only, updatable by Engine)
     - Store source_type (marks BACKTEST / PAPER_REPLAY / PAPER_LIVE)
-    - Hold reference to ITimeProvider for dynamic business_timestamp
+    - Hold reference to TimeProvider for dynamic business_timestamp
     - Provide read-only property access
 
     Design:
@@ -50,7 +50,7 @@ class EngineContext:
         self._engine_id = engine_id
         self._task_id: Optional[str] = None
         self._source_type: int = SOURCE_TYPES.OTHER
-        self._time_provider: Optional["ITimeProvider"] = None
+        self._time_provider: Optional["TimeProvider"] = None
 
     @property
     def engine_id(self) -> str:
@@ -68,8 +68,8 @@ class EngineContext:
         return self._source_type
 
     @property
-    def time_provider(self) -> Optional["ITimeProvider"]:
-        """Read-only: Bound ITimeProvider instance"""
+    def time_provider(self) -> Optional["TimeProvider"]:
+        """Read-only: Bound TimeProvider instance"""
         return self._time_provider
 
     @property
@@ -106,12 +106,12 @@ class EngineContext:
         """
         self._source_type = source_type
 
-    def set_time_provider(self, provider: Optional["ITimeProvider"]) -> None:
+    def set_time_provider(self, provider: Optional["TimeProvider"]) -> None:
         """
-        Bind or unbind an ITimeProvider (only Engine should call this).
+        Bind or unbind a TimeProvider (only Engine should call this).
 
         Args:
-            provider: ITimeProvider instance, or None to unbind
+            provider: TimeProvider instance, or None to unbind
         """
         self._time_provider = provider
 

--- a/src/ginkgo/trading/engines/time_controlled_engine.py
+++ b/src/ginkgo/trading/engines/time_controlled_engine.py
@@ -30,7 +30,7 @@ import time
 
 from .event_engine import EventEngine
 from ..events.base_event import EventBase
-from ..time.interfaces import ITimeProvider, ITimeAwareComponent
+from ..time.interfaces import TimeProvider, ITimeAwareComponent
 from ..time.providers import LogicalTimeProvider, SystemTimeProvider
 from ..time.clock import set_global_time_provider, now as clock_now
 from ginkgo.enums import EVENT_TYPES, SOURCE_TYPES, EXECUTION_MODE, TIME_MODE, ENGINESTATUS_TYPES
@@ -103,7 +103,7 @@ class TimeControlledEventEngine(EventEngine, ITimeAwareComponent):
         # mode属性通过继承BaseEngine的mode属性获取
 
         # 时间提供者
-        self._time_provider: Optional[ITimeProvider] = None
+        self._time_provider: Optional[TimeProvider] = None
 
         # 并发控制（实盘模式）
         self._executor: Optional[ThreadPoolExecutor] = None
@@ -340,7 +340,7 @@ class TimeControlledEventEngine(EventEngine, ITimeAwareComponent):
 
     # === 时间感知组件接口实现 ===
 
-    def set_time_provider(self, time_provider: ITimeProvider) -> None:
+    def set_time_provider(self, time_provider: TimeProvider) -> None:
         """设置时间提供者（带模式校验）"""
         from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 
@@ -529,7 +529,7 @@ class TimeControlledEventEngine(EventEngine, ITimeAwareComponent):
 
     # === 扩展接口 ===
 
-    def get_time_controller(self) -> ITimeProvider:
+    def get_time_controller(self) -> TimeProvider:
         """获取时间控制器"""
         return self._time_provider
 

--- a/src/ginkgo/trading/feeders/backtest_feeder.py
+++ b/src/ginkgo/trading/feeders/backtest_feeder.py
@@ -32,7 +32,7 @@ from ginkgo.trading.feeders.interfaces import (
 from ginkgo.trading.events import EventPriceUpdate, EventBase
 from ginkgo.entities import Bar
 from ginkgo.entities.mixins import TimeMixin
-from ginkgo.trading.time.interfaces import ITimeProvider
+from ginkgo.trading.time.interfaces import TimeProvider
 from ginkgo.trading.time.providers import TimeBoundaryValidator
 from ginkgo.libs import datetime_normalize, cache_with_expiration, GLOG
 from ginkgo.enums import SOURCE_TYPES, EVENT_TYPES, ADJUSTMENT_TYPES
@@ -55,7 +55,7 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
         self.status = DataFeedStatus.IDLE
 
         # 时间控制组件（由Engine注入）
-        self.time_controller: Optional[ITimeProvider] = None
+        self.time_controller: Optional[TimeProvider] = None
         self.time_boundary_validator: Optional[TimeBoundaryValidator] = None
 
         # 数据缓存
@@ -115,7 +115,7 @@ class BacktestFeeder(FeederPublishMixin, SubscribableMixin, BaseFeeder, IBacktes
         """获取当前状态"""
         return self.status
 
-    def set_time_provider(self, time_controller: ITimeProvider) -> None:
+    def set_time_provider(self, time_controller: TimeProvider) -> None:
         """设置时间控制器"""
         # 调用父类TimeMixin的set_time_provider
         super().set_time_provider(time_controller)

--- a/src/ginkgo/trading/feeders/interfaces.py
+++ b/src/ginkgo/trading/feeders/interfaces.py
@@ -24,7 +24,7 @@ from datetime import datetime, date, timedelta
 from enum import Enum
 
 from ginkgo.trading.events import EventBase, EventPriceUpdate
-from ginkgo.trading.time.interfaces import ITimeProvider
+from ginkgo.trading.time.interfaces import TimeProvider
 from ginkgo.trading.time.providers import TimeBoundaryValidator
 
 
@@ -102,7 +102,7 @@ class IDataFeeder(ABC):
         pass
     
     @abstractmethod
-    def set_time_provider(self, time_provider: ITimeProvider) -> None:
+    def set_time_provider(self, time_provider: TimeProvider) -> None:
         """
         设置时间提供者
 

--- a/src/ginkgo/trading/feeders/live_feeder.py
+++ b/src/ginkgo/trading/feeders/live_feeder.py
@@ -32,7 +32,7 @@ from ginkgo.trading.feeders.interfaces import (
     ILiveDataFeeder, DataFeedStatus
 )
 from ginkgo.trading.events import EventBase, EventPriceUpdate
-from ginkgo.trading.time.interfaces import ITimeProvider
+from ginkgo.trading.time.interfaces import TimeProvider
 from ginkgo.entities.mixins import EngineBindableMixin
 from ginkgo.trading.feeders.mixins.feeder_publish_mixin import FeederPublishMixin
 from ginkgo.trading.time.providers import TimeBoundaryValidator
@@ -199,7 +199,7 @@ class LiveDataFeeder(EngineBindableMixin, FeederPublishMixin, ILiveDataFeeder):
         # 核心组件（懒加载）
         self.connection_manager: Optional[ConnectionManager] = None
         self.rate_limiter: Optional[RateLimiter] = None
-        self.time_controller: Optional[ITimeProvider] = None
+        self.time_controller: Optional[TimeProvider] = None
         self.time_boundary_validator: Optional[TimeBoundaryValidator] = None
 
         # 限流配置
@@ -320,7 +320,7 @@ class LiveDataFeeder(EngineBindableMixin, FeederPublishMixin, ILiveDataFeeder):
         """获取当前状态"""
         return self.status
     
-    def set_time_provider(self, time_controller: ITimeProvider) -> None:
+    def set_time_provider(self, time_controller: TimeProvider) -> None:
         """设置时间控制器"""
         self.time_controller = time_controller
         # 自动启用时间边界检查

--- a/src/ginkgo/trading/time/__init__.py
+++ b/src/ginkgo/trading/time/__init__.py
@@ -1,5 +1,5 @@
 # Upstream: BacktestEngine, LiveEngine, EventProcessor, all time-aware components
-# Downstream: ITimeProvider, ITimeAwareComponent, LogicalTimeProvider, SystemTimeProvider, TimeBoundaryValidator, TIME_MODE
+# Downstream: TimeProvider, ITimeAwareComponent, LogicalTimeProvider, SystemTimeProvider, TimeBoundaryValidator, TIME_MODE
 # Role: 时间管理模块包，导出时间提供者接口和逻辑/系统时钟实现
 
 
@@ -13,12 +13,12 @@
 提供统一的时间语义和时间控制接口，避免多时钟漂移问题。
 """
 
-from .interfaces import ITimeProvider, ITimeAwareComponent
+from .interfaces import TimeProvider, ITimeAwareComponent
 from .providers import LogicalTimeProvider, SystemTimeProvider, TimeBoundaryValidator
 from ginkgo.enums import TIME_MODE
 
 __all__ = [
-    'ITimeProvider',
+    'TimeProvider',
     'ITimeAwareComponent',
     'TIME_MODE',
     'LogicalTimeProvider',

--- a/src/ginkgo/trading/time/clock.py
+++ b/src/ginkgo/trading/time/clock.py
@@ -1,11 +1,11 @@
 # Upstream: 全项目 (通过clock.now()获取时间)
-# Downstream: ITimeProvider实现 (LogicalTimeProvider/SystemTimeProvider)
+# Downstream: TimeProvider实现 (LogicalTimeProvider/SystemTimeProvider)
 # Role: 全局时钟适配层，统一now()入口，支持provider注入和回退
 
 """
 Global Clock Adapter
 
-提供一个轻量全局时钟适配层，便于在尚未彻底注入 ITimeProvider 的代码中，
+提供一个轻量全局时钟适配层，便于在尚未彻底注入 TimeProvider 的代码中，
 统一通过 clock.now() 获取当前时间：
 - 若已设置全局 provider，则返回 provider.now()
 - 否则回退为系统 UTC 时间
@@ -18,17 +18,17 @@ from typing import Optional
 
 from ginkgo.libs import GLOG
 
-from .interfaces import ITimeProvider
+from .interfaces import TimeProvider
 
-_GLOBAL_TIME_PROVIDER: Optional[ITimeProvider] = None
+_GLOBAL_TIME_PROVIDER: Optional[TimeProvider] = None
 
 
-def set_global_time_provider(provider: ITimeProvider) -> None:
+def set_global_time_provider(provider: TimeProvider) -> None:
     global _GLOBAL_TIME_PROVIDER
     _GLOBAL_TIME_PROVIDER = provider
 
 
-def get_global_time_provider() -> Optional[ITimeProvider]:
+def get_global_time_provider() -> Optional[TimeProvider]:
     return _GLOBAL_TIME_PROVIDER
 
 

--- a/src/ginkgo/trading/time/interfaces.py
+++ b/src/ginkgo/trading/time/interfaces.py
@@ -1,5 +1,5 @@
 # Upstream: LogicalTimeProvider, SystemTimeProvider, TimeBoundaryValidator
-# Downstream: ITimeProvider, ITimeAwareComponent, TIME_MODE
+# Downstream: TimeProvider, ITimeAwareComponent, TIME_MODE
 # Role: 时间控制接口定义，提供时间提供者和时间感知组件的抽象接口
 
 
@@ -19,7 +19,7 @@ from typing import Optional, List, Callable
 from ginkgo.enums import TIME_MODE
 
 
-class ITimeProvider(ABC):
+class TimeProvider(ABC):
     """时间提供者接口
     
     系统中唯一的时间权威，所有时间获取必须通过此接口。
@@ -59,7 +59,7 @@ class ITimeAwareComponent(ABC):
     """
     
     @abstractmethod
-    def set_time_provider(self, time_provider: ITimeProvider) -> None:
+    def set_time_provider(self, time_provider: TimeProvider) -> None:
         """设置时间提供者"""
         pass
     

--- a/src/ginkgo/trading/time/providers.py
+++ b/src/ginkgo/trading/time/providers.py
@@ -1,6 +1,6 @@
 # Upstream: TimeControlledEventEngine, clock.py (全局provider)
-# Downstream: ITimeProvider接口, TimeBoundaryValidator
-# Role: ITimeProvider实现(逻辑时间/系统时间)及时间边界验证器
+# Downstream: TimeProvider接口, TimeBoundaryValidator
+# Role: TimeProvider实现(逻辑时间/系统时间)及时间边界验证器
 
 """
 时间提供者实现
@@ -12,11 +12,11 @@ import pytz
 from collections import OrderedDict
 from datetime import datetime, timezone
 from typing import Optional, Set
-from .interfaces import ITimeProvider, ITimeAwareComponent
+from .interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.enums import TIME_MODE
 
 
-class LogicalTimeProvider(ITimeProvider):
+class LogicalTimeProvider(TimeProvider):
     """逻辑时间提供者
     
     用于回测场景，提供可控的逻辑时间推进功能。
@@ -144,7 +144,7 @@ class LogicalTimeProvider(ITimeProvider):
             self._listeners.remove(listener)
 
 
-class SystemTimeProvider(ITimeProvider):
+class SystemTimeProvider(TimeProvider):
     """系统时间提供者
     
     用于实盘交易场景，提供基于系统时钟的实时时间。
@@ -241,7 +241,7 @@ class TimeBoundaryValidator:
     _shared_cache: dict = {}
     _default_cache_size: int = 50  # 每个run默认50个槽位
 
-    def __init__(self, time_provider: ITimeProvider, task_id: Optional[str] = None, cache_size: Optional[int] = None):
+    def __init__(self, time_provider: TimeProvider, task_id: Optional[str] = None, cache_size: Optional[int] = None):
         """初始化时间边界验证器
 
         Args:

--- a/tests/integration/trading/engines/test_engine_integration.py
+++ b/tests/integration/trading/engines/test_engine_integration.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance

--- a/tests/integration/trading/engines/test_engine_time_advance.py
+++ b/tests/integration/trading/engines/test_engine_time_advance.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance
@@ -1419,7 +1419,7 @@ class TestComponentTimeSync:
 
         # 验证引擎时间提供者
         assert getattr(engine, '_time_provider', None) is not None, "引擎应有时间提供者"
-        assert isinstance(engine._time_provider, ITimeProvider), "时间提供者应实现ITimeProvider接口"
+        assert isinstance(engine._time_provider, TimeProvider), "时间提供者应实现TimeProvider接口"
 
         # 验证时间提供者的基本方法
         assert callable(getattr(engine._time_provider, 'now', None)), "时间提供者应有now方法"

--- a/tests/unit/trading/engines/test_engine_construction.py
+++ b/tests/unit/trading/engines/test_engine_construction.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance
@@ -325,9 +325,9 @@ class TestTimeControlledEngineProperties:
         assert isinstance(paper_engine._time_provider, SystemTimeProvider), "PAPER_MANUAL模式应创建SystemTimeProvider"
         assert paper_engine._time_provider is not None, "时间提供者不应为空"
 
-        # 验证时间提供者实现了ITimeProvider接口
-        assert isinstance(backtest_engine._time_provider, ITimeProvider), "时间提供者应实现ITimeProvider接口"
-        assert isinstance(live_engine._time_provider, ITimeProvider), "时间提供者应实现ITimeProvider接口"
+        # 验证时间提供者实现了TimeProvider接口
+        assert isinstance(backtest_engine._time_provider, TimeProvider), "时间提供者应实现TimeProvider接口"
+        assert isinstance(live_engine._time_provider, TimeProvider), "时间提供者应实现TimeProvider接口"
 
     def test_engine_state_tracking(self):
         """测试引擎状态追踪能力"""
@@ -554,8 +554,8 @@ class TestTimeControllerDataSetting:
         # 验证时间提供者类型
         assert isinstance(backtest_engine._time_provider, LogicalTimeProvider), "回测模式应使用LogicalTimeProvider"
 
-        # 验证时间提供者实现了ITimeProvider接口
-        assert isinstance(backtest_engine._time_provider, ITimeProvider), "时间提供者应实现ITimeProvider接口"
+        # 验证时间提供者实现了TimeProvider接口
+        assert isinstance(backtest_engine._time_provider, TimeProvider), "时间提供者应实现TimeProvider接口"
 
         # 测试时间提供者的now方法
         initial_time = backtest_engine._time_provider.now()
@@ -585,8 +585,8 @@ class TestTimeControllerDataSetting:
         # 验证时间提供者类型
         assert isinstance(live_engine._time_provider, SystemTimeProvider), "实盘模式应使用SystemTimeProvider"
 
-        # 验证时间提供者实现了ITimeProvider接口
-        assert isinstance(live_engine._time_provider, ITimeProvider), "时间提供者应实现ITimeProvider接口"
+        # 验证时间提供者实现了TimeProvider接口
+        assert isinstance(live_engine._time_provider, TimeProvider), "时间提供者应实现TimeProvider接口"
 
         # 测试时间提供者的now方法
         current_time = live_engine._time_provider.now()
@@ -637,14 +637,14 @@ class TestTimeControllerDataSetting:
                     result = method()
                     # 验证返回的时间提供者
                     if result is not None:
-                        assert isinstance(result, ITimeProvider), "返回的应是ITimeProvider实例"
+                        assert isinstance(result, TimeProvider), "返回的应是TimeProvider实例"
                 print(f"全局时间提供者方法{method_name}测试成功")
             except Exception as e:
                 print(f"全局时间提供者方法{method_name}调用问题: {e}")
 
         # 验证引擎内部时间提供者
         assert getattr(engine, '_time_provider', None) is not None, "引擎应有内部时间提供者"
-        assert isinstance(engine._time_provider, ITimeProvider), "内部时间提供者应实现ITimeProvider接口"
+        assert isinstance(engine._time_provider, TimeProvider), "内部时间提供者应实现TimeProvider接口"
 
         print("全局时间提供者注册功能检查完成")
 

--- a/tests/unit/trading/engines/test_engine_event_handling.py
+++ b/tests/unit/trading/engines/test_engine_event_handling.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance

--- a/tests/unit/trading/engines/test_engine_mode_management.py
+++ b/tests/unit/trading/engines/test_engine_mode_management.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance
@@ -4100,9 +4100,9 @@ class TestEXECUTION_MODESwitch:
             assert actual_provider == expected_provider, \
                 f"模式{mode}应使用{expected_provider.__name__}，实际使用{actual_provider.__name__}"
 
-            # 验证时间提供者实现了ITimeProvider接口
-            assert isinstance(engine._time_provider, ITimeProvider), \
-                f"时间提供者应实现ITimeProvider接口"
+            # 验证时间提供者实现了TimeProvider接口
+            assert isinstance(engine._time_provider, TimeProvider), \
+                f"时间提供者应实现TimeProvider接口"
 
             # 测试时间提供者的基本方法
             assert callable(getattr(engine._time_provider, 'now', None)), "时间提供者应有now方法"

--- a/tests/unit/trading/engines/test_engine_time_controller.py
+++ b/tests/unit/trading/engines/test_engine_time_controller.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance

--- a/tests/unit/trading/engines/test_time_controlled_engine_basic.py
+++ b/tests/unit/trading/engines/test_time_controlled_engine_basic.py
@@ -24,7 +24,7 @@ from ginkgo.trading.engines.time_controlled_engine import (
 )
 from ginkgo.enums import EXECUTION_MODE, ENGINESTATUS_TYPES
 from ginkgo.trading.engines.event_engine import EventEngine
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.time_advance import EventTimeAdvance

--- a/tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py
+++ b/tests/unit/trading/engines/test_time_controlled_engine_stop_guard.py
@@ -61,7 +61,7 @@ def test_set_time_provider_defined_once():
     """set_time_provider() 只能定义一次（#5551 AC: remove duplicate definitions）。
 
     曾有两处定义：@161 静默吞版（无模式校验，try/except 吞异常 + 设 global）
-    被 @360 带校验版（BACKTEST/LIVE 模式 + ITimeProvider 注解）遮蔽为死代码，
+    被 @360 带校验版（BACKTEST/LIVE 模式 + TimeProvider 注解）遮蔽为死代码，
     与 stop() 同构。后定义覆盖前定义的命名空间绑定，前者从不被调用。
     """
     cls = _class_body("TimeControlledEventEngine")

--- a/tests/unit/trading/time/test_time_providers.py
+++ b/tests/unit/trading/time/test_time_providers.py
@@ -18,7 +18,7 @@ if _path not in sys.path:
 
 # 导入TimeProvider相关组件
 from ginkgo.trading.time.providers import LogicalTimeProvider, SystemTimeProvider, TimeBoundaryValidator, DSTHandler
-from ginkgo.trading.time.interfaces import ITimeProvider, ITimeAwareComponent
+from ginkgo.trading.time.interfaces import TimeProvider, ITimeAwareComponent
 from ginkgo.enums import TIME_MODE
 
 
@@ -816,9 +816,9 @@ class TestTimeProvidersIntegration:
         logical = LogicalTimeProvider(datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc))
         system = SystemTimeProvider()
 
-        # 验证都实现了ITimeProvider接口
-        assert isinstance(logical, ITimeProvider)
-        assert isinstance(system, ITimeProvider)
+        # 验证都实现了TimeProvider接口
+        assert isinstance(logical, TimeProvider)
+        assert isinstance(system, TimeProvider)
 
         # 验证都实现了核心接口方法
         for provider in [logical, system]:


### PR DESCRIPTION
## Summary

ADR-022 原则1「删 I* 前缀」。`ITimeProvider` 是 src/ 内最大改动面的 I* 抽象（35 引用 / 9 src 文件 + 多处 isinstance 测试），单独管控避免污染批量去前缀 issue。

## 变更

- `src/ginkgo/trading/time/interfaces.py:22` 定义 `ITimeProvider(ABC)` → `TimeProvider(ABC)`（保留 ABC；2 实现 `LogicalTimeProvider`/`SystemTimeProvider` 继承基同步）
- 同步 9 src 文件 35 引用点：type hint / import / 继承基 / 注释
  - trading/time/{interfaces,__init__,clock,providers}.py
  - trading/feeders/{interfaces,backtest_feeder,live_feeder}.py
  - trading/context/engine_context.py
  - trading/engines/time_controlled_engine.py
- 同步 9 测试文件（isinstance 断言 + import + 注释）

## 验收

- `grep -rn 'ITimeProvider' src/ tests/` 零命中 ✅
- `grep -rn '^class TimeProvider' src/` 唯一命中 `trading/time/interfaces.py:22` ✅
- 冒烟三层绿：
  - L1 py_compile（src + api）：exit 0 ✅
  - L2 containers + user_cli smoke：37 passed ✅
  - L3 4 受影响测试文件：133 passed, 14 skipped ✅

## Test plan

- [x] py_compile src/api 全绿
- [x] tests/unit/data/crud/test_user_crud_mock.py + tests/unit/features/test_containers.py + tests/unit/client/test_user_cli.py 全绿
- [x] tests/unit/trading/engines/test_engine_construction.py 全绿
- [x] tests/unit/trading/time/test_time_providers.py 全绿
- [x] tests/integration/trading/engines/test_engine_time_advance.py 全绿
- [x] tests/unit/trading/engines/test_engine_mode_management.py 全绿
- [x] 其余 5 个仅 import/注释变更的测试文件 `--collect-only` 通过（75 tests collected）

Note: `test_engine_time_advance.py` 实际位于 `tests/integration/` 而非 issue body 所写的 `tests/unit/`。

Closes #6714