### PR TITLE
refactor(#6715): BaseBroker 双胞胎收敛 + trade_gateway isinstance 修

### DIFF
--- a/docs/entity-lifecycles-and-flows.md
+++ b/docs/entity-lifecycles-and-flows.md
@@ -129,7 +129,7 @@ IBroker (接口)
   └─ (其他交易所适配器)
 ```
 
-> 源码: `src/ginkgo/trading/bases/base_broker.py`, `src/ginkgo/trading/brokers/broker_manager.py`
+> 源码: `src/ginkgo/trading/brokers/base_broker.py`, `src/ginkgo/trading/brokers/broker_manager.py`
 
 ---
 

--- a/src/ginkgo/livecore/main.py
+++ b/src/ginkgo/livecore/main.py
@@ -376,7 +376,7 @@ class LiveCore:
         集成方式（Phase 4完成broker配置后启用）：
         ```python
         from ginkgo.livecore.trade_gateway_adapter import TradeGatewayAdapter
-        from ginkgo.trading.bases.base_broker import BaseBroker
+        from ginkgo.trading.brokers.base_broker import BaseBroker
 
         # 1. 从config或环境变量加载broker配置
         brokers = self._load_brokers()

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -41,7 +41,7 @@ from datetime import datetime
 import time
 
 from ginkgo.trading.gateway.trade_gateway import TradeGateway
-from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.brokers.base_broker import BaseBroker
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoConsumer, GinkgoProducer
 from ginkgo.enums import DIRECTION_TYPES, ORDER_TYPES
 from ginkgo.interfaces.kafka_topics import KafkaTopics

--- a/src/ginkgo/trading/bases/broker_cache_mixin.py
+++ b/src/ginkgo/trading/bases/broker_cache_mixin.py
@@ -1,18 +1,17 @@
-# Upstream: SimBroker/ManualBroker/LiveBroker (Broker子类继承)、Portfolio (使用Broker执行订单)
-# Downstream: TimeMixin (继承提供时间戳管理)、ContextMixin (继承提供上下文管理)、LoggableMixin (继承提供日志记录)
-# Role: BaseBroker经纪商基础抽象基类通过Mixin组装时间戳管理/上下文管理/日志记录等基础功能定义订单执行和成交处理的核心方法
-
-
-
-
-
+# Upstream: SimBroker/LiveBrokerBase (Broker子类继承, 行情/持仓缓存)、Portfolio (使用Broker执行订单)
+# Downstream: TimeMixin (继承提供时间戳管理)、ContextMixin (继承提供上下文管理)、Base (mro 末端兜底)
+# Role: BrokerCacheMixin 经纪商行情/持仓缓存 Mixin——窄 Mixin，仅含缓存方法。
+#   历史：原弱侧 BaseBroker（与 trading/brokers/base_broker.py 的强侧 BaseBroker 同名双胞胎）。
+#   ADR-022 原则6（命名空间唯一性）收敛：弱侧降级为 BrokerCacheMixin，强侧保留为唯一 BaseBroker 组合根。
 
 """
-BaseBroker基础类
+BrokerCacheMixin 经纪商行情/持仓缓存 Mixin
 
-通过Mixin组装，提供Broker的基础功能。
-组装TimeMixin、ContextMixin、LoggableMixin等基础功能。
-不包含OrderManagementMixin，因为不同类型的Broker有不同的订单管理需求。
+ADR-022 原则6 收敛后的窄 Mixin：仅含行情数据缓存、持仓缓存、异步结果回调方法。
+强侧 BaseBroker（trading/brokers/base_broker.py）保留订单/账户状态组合根职责，
+本 Mixin 不与之揉成上帝对象。
+
+历史：原 trading/bases/base_broker.py:BaseBroker（与强侧同名双胞胎）。
 """
 
 from typing import Optional, Dict, Any
@@ -25,11 +24,11 @@ from ginkgo.enums import DIRECTION_TYPES
 from ginkgo.libs import GLOG
 
 
-class BaseBroker(TimeMixin, ContextMixin, Base):
+class BrokerCacheMixin(TimeMixin, ContextMixin, Base):
     """
-    Broker基础类
+    Broker 行情/持仓缓存 Mixin
 
-    通过Mixin组装提供Broker的基础功能：
+    通过Mixin组装提供行情/持仓缓存能力：
     - TimeMixin: 时间管理和业务时间戳处理
     - ContextMixin: 引擎上下文管理
 
@@ -40,9 +39,9 @@ class BaseBroker(TimeMixin, ContextMixin, Base):
     - LiveBroker: SDK管理订单状态，不需要本地队列
     """
 
-    def __init__(self, name: str = "BaseBroker", *args, **kwargs):
+    def __init__(self, name: str = "BrokerCacheMixin", *args, **kwargs):
         """
-        初始化Broker基础功能
+        初始化缓存 Mixin
 
         Args:
             name: Broker名称

--- a/src/ginkgo/trading/brokers/live_broker_base.py
+++ b/src/ginkgo/trading/brokers/live_broker_base.py
@@ -1,5 +1,5 @@
 # Upstream: InfrastructureFactory, FuturesBroker, HKStockBroker, USStockBroker, OKXBroker
-# Downstream: BaseBroker, BrokerExecutionResult, Order, DIRECTION_TYPES, ATTITUDE_TYPES, to_decimal
+# Downstream: BrokerCacheMixin, BrokerExecutionResult, Order, DIRECTION_TYPES, ATTITUDE_TYPES, to_decimal
 # Role: 实盘交易Broker基类，提供API交易、异步执行和本地风控等通用功能
 
 
@@ -10,7 +10,7 @@
 """
 LiveBrokerBase - 实盘交易基础类
 
-基于新的BaseBroker和IBroker接口，提供实盘交易的通用功能。
+基于BrokerCacheMixin和IBroker接口，提供实盘交易的通用功能。
 不同市场的实盘Broker可以继承此类并实现特定的API调用逻辑。
 """
 
@@ -18,14 +18,14 @@ from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import Dict, List, Optional, Any
 
-from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.bases.broker_cache_mixin import BrokerCacheMixin
 from ginkgo.trading.interfaces.broker_interface import BrokerExecutionResult
 from ginkgo.entities import Order
 from ginkgo.enums import ORDERSTATUS_TYPES, DIRECTION_TYPES, ORDER_TYPES, ATTITUDE_TYPES
 from ginkgo.libs import to_decimal, Number, GLOG
 
 
-class LiveBrokerBase(BaseBroker, ABC):
+class LiveBrokerBase(BrokerCacheMixin, ABC):
     """
     实盘交易基础类
 

--- a/src/ginkgo/trading/brokers/sim_broker.py
+++ b/src/ginkgo/trading/brokers/sim_broker.py
@@ -1,6 +1,6 @@
 # Upstream: Backtest Engines (回测模拟撮合)、Portfolio Manager (订单执行)
-# Downstream: BaseBroker (继承提供Broker基础功能)、IBroker接口(实现submit_order_event/get_market_data等Broker接口)、ATTITUDE_TYPES (撮合态度枚举OPTIMISTIC/PESSIMISTIC/RANDOM)
-# Role: SimBroker回测模拟撮合Broker继承BaseBroker和实现IBroker接口，提供立即执行同步返回、模拟撮合、完整验证订单等功能
+# Downstream: BrokerCacheMixin (继承提供行情/持仓缓存)、IBroker接口(实现submit_order_event/get_market_data等Broker接口)、ATTITUDE_TYPES (撮合态度枚举OPTIMISTIC/PESSIMISTIC/RANDOM)
+# Role: SimBroker回测模拟撮合Broker继承BrokerCacheMixin和实现IBroker接口，提供立即执行同步返回、模拟撮合、完整验证订单等功能
 
 
 
@@ -22,25 +22,25 @@ from decimal import Decimal
 from typing import Dict, List, Optional, Any
 from scipy import stats
 
-from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.bases.broker_cache_mixin import BrokerCacheMixin
 from ginkgo.trading.interfaces.broker_interface import BrokerExecutionResult
 from ginkgo.entities import Order
 from ginkgo.enums import DIRECTION_TYPES, ORDER_TYPES, ATTITUDE_TYPES, ORDERSTATUS_TYPES
 from ginkgo.libs import to_decimal, Number, GLOG
 
 
-class SimBroker(BaseBroker):
+class SimBroker(BrokerCacheMixin):
     """
     回测模拟撮合Broker
 
-    基于新的BaseBroker和IBroker接口，提供回测专用的模拟撮合功能。
+    基于BrokerCacheMixin和IBroker接口，提供回测专用的模拟撮合功能。
     支持滑点、态度设置、手续费计算等回测功能。
 
     核心特点：
     - 立即执行：支持同步立即执行（回测模式）
     - 模拟撮合：基于随机价格和滑点模型
     - 完整验证：订单验证、资金检查、价格限制
-    - 内存管理：使用BaseBroker的市场数据缓存
+    - 内存管理：使用BrokerCacheMixin的市场数据缓存
     """
 
     def __init__(self, name: str = "SimBroker", random_seed=None, **config):

--- a/src/ginkgo/trading/brokers/sim_broker.py
+++ b/src/ginkgo/trading/brokers/sim_broker.py
@@ -10,7 +10,7 @@
 """
 SimBroker - 回测模拟撮合Broker
 
-基于新的BaseBroker和IBroker接口，提供统一的回测模拟撮合功能。
+基于BrokerCacheMixin和IBroker接口，提供统一的回测模拟撮合功能。
 支持滑点、态度设置、手续费计算等回测功能。
 """
 

--- a/src/ginkgo/trading/gateway/trade_gateway.py
+++ b/src/ginkgo/trading/gateway/trade_gateway.py
@@ -1,5 +1,5 @@
 # Upstream: BaseEngine, TimeControlledEventEngine, PaperTradingWorker
-# Downstream: bases.base_trade_gateway, trading.interfaces.broker_interface, trading.bases.base_broker, entities.Order, trading.enums, trading.events.order_lifecycle_events
+# Downstream: bases.base_trade_gateway, trading.interfaces.broker_interface, trading.brokers.base_broker (强侧唯一 BaseBroker), entities.Order, trading.enums, trading.events.order_lifecycle_events
 # Role: 统一交易网关实现，支持回测/模拟/实盘三种模式，自动路由订单到对应市场Broker，纯内存订单管理
 
 
@@ -25,7 +25,7 @@ import traceback
 from ginkgo.libs import GLOG
 from ginkgo.trading.bases.base_trade_gateway import BaseTradeGateway
 from ginkgo.trading.interfaces.broker_interface import BrokerExecutionResult
-from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.brokers.base_broker import BaseBroker
 from ginkgo.entities import Order
 from ginkgo.enums import EVENT_TYPES, ORDERSTATUS_TYPES, DIRECTION_TYPES
 from ginkgo.trading.events.order_lifecycle_events import (

--- a/tests/unit/core/test_mixin_chain_sink.py
+++ b/tests/unit/core/test_mixin_chain_sink.py
@@ -4,7 +4,7 @@ import pytest
 
 from ginkgo.trading.events.base_event import EventBase
 from ginkgo.trading.events.price_update import EventPriceUpdate
-from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.bases.broker_cache_mixin import BrokerCacheMixin
 from ginkgo.trading.bases.base_trade_gateway import BaseTradeGateway
 from ginkgo.entities.base import Base
 
@@ -17,8 +17,8 @@ class TestMixinChainSink:
         assert Base in EventBase.__mro__
 
     def test_base_broker_has_base_in_mro(self):
-        """BaseBroker 的 MRO 中应包含 Base"""
-        assert Base in BaseBroker.__mro__
+        """BrokerCacheMixin 的 MRO 中应包含 Base（#6715：原 BaseBroker 弱侧降级为 Mixin）"""
+        assert Base in BrokerCacheMixin.__mro__
 
     def test_base_trade_gateway_has_base_in_mro(self):
         """BaseTradeGateway 的 MRO 中应包含 Base"""
@@ -37,8 +37,8 @@ class TestMixinChainSink:
         assert e is not None
 
     def test_base_broker_with_unknown_kwargs(self):
-        """BaseBroker 传入未知 kwargs 不应 TypeError"""
-        b = BaseBroker(name="test", extra_param="value")
+        """BrokerCacheMixin 传入未知 kwargs 不应 TypeError（#6715：原 BaseBroker 弱侧）"""
+        b = BrokerCacheMixin(name="test", extra_param="value")
         assert b is not None
 
     def test_base_trade_gateway_with_unknown_kwargs(self):

--- a/tests/unit/trading/gateway/test_trade_gateway.py
+++ b/tests/unit/trading/gateway/test_trade_gateway.py
@@ -9,15 +9,15 @@ from unittest.mock import Mock, patch, MagicMock
 from datetime import datetime, timedelta
 
 from ginkgo.trading.gateway.trade_gateway import TradeGateway
-from ginkgo.trading.bases.base_broker import BaseBroker
+from ginkgo.trading.brokers.base_broker import BaseBroker
 from ginkgo.entities import Order
 from ginkgo.enums import ORDERSTATUS_TYPES, DIRECTION_TYPES, ORDER_TYPES, EVENT_TYPES
 
 
 class StubBroker(BaseBroker):
-    """测试用 Broker 桩，满足 isinstance 检查"""
+    """测试用 Broker 桩，满足 isinstance 检查（#6715：继承强侧 BaseBroker）"""
     def __init__(self, market: str = "SIM"):
-        super().__init__()
+        super().__init__({})
         self.market = market
         self._result_callback = None
         self._submit_calls = []

--- a/tests/unit/trading/gateway/test_trade_gateway_isinstance.py
+++ b/tests/unit/trading/gateway/test_trade_gateway_isinstance.py
@@ -1,0 +1,110 @@
+# #6715 回归门：trade_gateway.py:62 isinstance(brokers, BaseBroker) 历史静默错判
+# 修复前 trade_gateway import 弱侧 BaseBroker(trading/bases/base_broker)，
+# 导致强侧 BaseBroker 子类(AutoBroker/ManualBroker)实例走单 broker 入参分支时
+# isinstance 静默返回 False → ValueError 误拒。
+# 修复：trade_gateway import 唯一强侧 BaseBroker(trading/brokers/base_broker.py)。
+"""
+TDD 回归：强侧 BaseBroker 子类实例通过 TradeGateway 单 broker 入参分支。
+原 bug：isinstance import 弱侧 BaseBroker，强侧实例被静默误拒。
+"""
+import pytest
+
+
+class TestTradeGatewayIsinstanceStrongSide:
+    """#6715: 强侧 BaseBroker 子类必须通过 TradeGateway 单 broker 入参路径。"""
+
+    def test_manual_broker_passes_isinstance_strong_basebroker(self):
+        """ManualBroker 实例 isinstance(强侧 BaseBroker) 返回 True。"""
+        from ginkgo.trading.brokers.base_broker import BaseBroker
+        from ginkgo.trading.brokers.manual_broker import ManualBroker
+
+        broker = ManualBroker({})
+        assert isinstance(broker, BaseBroker), (
+            "ManualBroker 必须通过强侧 BaseBroker isinstance（trade_gateway 类型门）"
+        )
+
+    def test_autobroker_subclass_passes_isinstance_strong_basebroker(self):
+        """AutoBroker 具体子类实例 isinstance(强侧 BaseBroker) 返回 True。"""
+        from ginkgo.trading.brokers.base_broker import BaseBroker
+        from ginkgo.trading.brokers.auto_broker import AutoBroker
+
+        class _ConcreteAutoBroker(AutoBroker):
+            async def _submit_order_to_api(self, order):
+                return {}
+
+            async def _cancel_order_via_api(self, broker_order_id):
+                return {}
+
+            async def _query_order_from_api(self, broker_order_id):
+                return {}
+
+            def _parse_api_response_to_execution_result(self, api_response, order_id):
+                from ginkgo.trading.brokers.base_broker import (
+                    ExecutionResult, ExecutionStatus,
+                )
+                return ExecutionResult(
+                    order_id=order_id, status=ExecutionStatus.SUBMITTED,
+                )
+
+            async def _initialize_api_client(self):
+                return True
+
+        broker = _ConcreteAutoBroker({})
+        assert isinstance(broker, BaseBroker), (
+            "AutoBroker 子类必须通过强侧 BaseBroker isinstance（trade_gateway 类型门）"
+        )
+
+    def test_trade_gateway_isinstance_check_strong_basebroker(self):
+        """#6715 核心回归：trade_gateway.py:62 isinstance(brokers, BaseBroker) 必须用强侧 BaseBroker。
+
+        原 bug：trade_gateway import 弱侧 BaseBroker，导致强侧 ManualBroker/AutoBroker
+        实例走单 broker 入参分支时 isinstance 静默返回 False → ValueError 误拒。
+        本测试用 MonkeyPatch 验证 trade_gateway 模块内的 BaseBroker 就是强侧
+        （trading.brokers.base_broker.BaseBroker），并验证 ManualBroker 通过 isinstance。
+        """
+        import ginkgo.trading.gateway.trade_gateway as gw_mod
+        from ginkgo.trading.brokers.base_broker import BaseBroker as StrongBaseBroker
+        from ginkgo.trading.brokers.manual_broker import ManualBroker
+
+        # trade_gateway 内 import 的 BaseBroker 必须是强侧
+        assert gw_mod.BaseBroker is StrongBaseBroker, (
+            "trade_gateway 必须收敛到唯一强侧 BaseBroker（ADR-022 原则6）"
+        )
+
+        broker = ManualBroker({})
+        # 单 broker 入参路径 line 62 的 isinstance 必须通过
+        assert isinstance(broker, gw_mod.BaseBroker), (
+            "ManualBroker 必须通过 trade_gateway 的 isinstance 类型门"
+        )
+
+    def test_strong_basebroker_remains_unique(self):
+        """验收 #1：grep ^class BaseBroker src/ 唯一命中 trading/brokers/base_broker.py。
+
+        防止再次出现双胞胎（ADR-022 原则6 命名空间唯一性）。
+        """
+        import ginkgo.trading.brokers.base_broker as strong_mod
+        from ginkgo.trading.bases.broker_cache_mixin import BrokerCacheMixin
+
+        # 强侧 BaseBroker 必须仍是 IBroker 子类（组合根）
+        from ginkgo.trading.brokers.interfaces import IBroker
+        assert issubclass(strong_mod.BaseBroker, IBroker)
+
+        # 弱侧已降级为 BrokerCacheMixin，不再是 BaseBroker
+        assert not hasattr(BrokerCacheMixin, "__name__") or BrokerCacheMixin.__name__ != "BaseBroker"
+
+    def test_broker_cache_mixin_preserves_market_data_cache(self):
+        """验收 #4：BrokerCacheMixin 保留行情/持仓缓存方法（SimBroker 回测依赖）。"""
+        from ginkgo.trading.bases.broker_cache_mixin import BrokerCacheMixin
+
+        # 行情缓存 API
+        assert hasattr(BrokerCacheMixin, "set_market_data")
+        assert hasattr(BrokerCacheMixin, "get_market_data")
+        assert hasattr(BrokerCacheMixin, "get_all_market_data")
+        assert hasattr(BrokerCacheMixin, "clear_market_data")
+        assert hasattr(BrokerCacheMixin, "update_price_data")
+
+        # 持仓缓存 API
+        assert hasattr(BrokerCacheMixin, "update_position")
+        assert hasattr(BrokerCacheMixin, "get_position")
+        assert hasattr(BrokerCacheMixin, "get_all_positions")
+        assert hasattr(BrokerCacheMixin, "clear_positions")


### PR DESCRIPTION
## Summary

ADR-022 原则6（命名空间唯一性）落地：消除 `BaseBroker` 同名双胞胎。

### 弱侧降级（窄 Mixin）
- `src/ginkgo/trading/bases/base_broker.py` → `broker_cache_mixin.py`（git rename）
- `class BaseBroker` → `class BrokerCacheMixin`
- 职责单一：仅含行情数据缓存 / 持仓缓存 / 异步结果回调方法

### 5 处弱侧 import 收敛
| 文件 | 改动 |
|---|---|
| `sim_broker.py` | `BaseBroker` → `BrokerCacheMixin`（继承基） |
| `live_broker_base.py` | `BaseBroker` → `BrokerCacheMixin`（继承基） |
| `livecore/main.py:379` | 类型提示改用强侧 `BaseBroker` |
| `trade_gateway_adapter.py:44` | 类型提示改用强侧 `BaseBroker` |
| `trade_gateway.py:28` | **关键修复**：import 强侧 `BaseBroker(trading.brokers.base_broker)` |

### isinstance 静默错判修复
`trade_gateway.py:62 isinstance(brokers, BaseBroker)` 原导入弱侧，强侧 `AutoBroker`/`ManualBroker` 实例静默通不过 → `ValueError` 误拒。收敛后 import 唯一强侧 `BaseBroker`，强侧实例自动通过。

### 强侧保留
`trading/brokers/base_broker.py:106 BaseBroker(IBroker)` 为唯一组合根。

## ⚠️ 与 issue 字面规约的偏差（安全阀触发）

Issue 「继承基调整」段落写：`SimBroker`/`LiveBrokerBase` 继承基改为 `(BaseBroker, BrokerCacheMixin)`（双继承）。

**实跑验证发现此双继承会破坏 SimBroker 回测主力路径**：
- 强侧 `BaseBroker.set_market_data` 写入 `_current_prices`（Decimal 价格）
- 弱侧 `BrokerCacheMixin.get_market_data` 读 `_current_market_data`（原始 Bar 对象）
- MRO `(strong, weak)` 下 `set/get` 数据流断裂 → `_current_market_data` 永空
- SimBroker `validate_order` 因 `get_market_data(...) is None` 拒所有订单 → 回测 0 成交

命中 CLAUDE.md 实盘/回测逻辑安全阀：**立即停 + 报告**，降级为仅继承 `BrokerCacheMixin`（与原 `BaseBroker` 弱侧职责完全等价，缓存行为零变更）。原 bug（trade_gateway isinstance 静默错判）已通过 import 收敛修复，验收标准 #1-4 全部满足。

## Test plan

### 冒烟三层
- **L1 py_compile**（src api）: PASS
- **L2 smoke**（crud/containers/cli）: 仅 1 例 preexisting 失败（master 同款，rich markup ANSI 遮断断言，非本 PR 影响），其余 PASS
- **L3 broker 相关**（9 文件，含 5 新增回归）: **124 passed, 1 skipped**

### 验收 grep
```
$ grep -rn "^class BaseBroker" src/
src/ginkgo/trading/brokers/base_broker.py:106:class BaseBroker(IBroker):  # 唯一强侧组合根

$ grep -rn "^class BrokerCacheMixin" src/
src/ginkgo/trading/bases/broker_cache_mixin.py:27:class BrokerCacheMixin(TimeMixin, ContextMixin, Base):  # 唯一弱侧 Mixin
```

### e2e 双验证
- SimBroker 路径（回测主力）：行情/持仓缓存 roundtrip 通过，`_current_market_data` / `_current_positions` 行为不丢
- LiveBrokerBase 路径（实盘根）：MRO 含 `BrokerCacheMixin`，实盘 broker 继承链不丢缓存能力
- 强侧 `BaseBroker(IBroker)` 唯一组合根，`issubclass(BaseBroker, IBroker)` True

### 新增回归门
`tests/unit/trading/gateway/test_trade_gateway_isinstance.py`（5 cases）：
- `ManualBroker` 实例 `isinstance(强侧 BaseBroker)` 返 True
- `AutoBroker` 子类实例 `isinstance(强侧 BaseBroker)` 返 True
- `trade_gateway` 模块内 `BaseBroker` 就是强侧（防再次双胞胎）
- `BrokerCacheMixin` 保留全部缓存方法 API

Closes #6715
