### PR TITLE
refactor: IBroker 分开设名为 Broker/SyncBroker (#6717)

### DIFF
--- a/src/ginkgo/trading/brokers/__init__.py
+++ b/src/ginkgo/trading/brokers/__init__.py
@@ -1,6 +1,6 @@
 # Upstream: EngineAssemblyService, InfrastructureFactory, PortfolioBase, SyncBrokerFacade
-# Downstream: IBroker, BaseBroker, BrokerType, OrderType, OrderSide, TradingOrder, Position
-# Role: 经纪商模块包，导出IBroker接口、数据类定义及BaseBroker基类
+# Downstream: Broker, BaseBroker, BrokerType, OrderType, OrderSide, TradingOrder, Position
+# Role: 经纪商模块包，导出Broker接口、数据类定义及BaseBroker基类
 
 
 
@@ -18,7 +18,7 @@
 """
 
 from .interfaces import (
-    IBroker,
+    Broker,
     BrokerType,
     OrderType,
     OrderSide,
@@ -39,7 +39,7 @@ from .base_broker import BaseBroker
 
 __all__ = [
     # 接口和枚举
-    'IBroker',
+    'Broker',
     'BrokerType',
     'OrderType',
     'OrderSide', 

--- a/src/ginkgo/trading/brokers/auto_broker.py
+++ b/src/ginkgo/trading/brokers/auto_broker.py
@@ -1,5 +1,5 @@
 # Upstream: Live Trading Engines (实盘自动API交易)、OKXBroker/AShareBroker等具体实现(继承获得API轮询能力)
-# Downstream: BaseBroker (继承提供Broker基础功能)、IBroker接口(实现Broker接口)、asyncio (异步轮询任务管理)
+# Downstream: BaseBroker (继承提供Broker基础功能)、Broker接口(实现Broker接口)、asyncio (异步轮询任务管理)
 # Role: AutoBroker自动API执行Broker基类用于实盘自动交易支持轮询状态
 
 

--- a/src/ginkgo/trading/brokers/base_broker.py
+++ b/src/ginkgo/trading/brokers/base_broker.py
@@ -1,6 +1,6 @@
 # Upstream: SimBroker/ManualBroker/AutoBroker等具体Broker实现(继承获得通用功能)
 # Downstream: asyncio(异步编程)、datetime/timedelta(时间管理)、clock_now(业务时间)、Decimal(精度计算)、dataclasses/Enum/typing(类型定义)、uuid(UUID生成)
-# Role: BaseBroker交易代理基类实现IBroker接口，提供订单生命周期管理/持仓计算/成交记录/账户统计
+# Role: BaseBroker交易代理基类实现Broker接口，提供订单生命周期管理/持仓计算/成交记录/账户统计
 
 
 
@@ -10,7 +10,7 @@
 """
 交易代理基类实现
 
-提供IBroker接口的基础实现，包括：
+提供Broker接口的基础实现，包括：
 - 统一的执行结果/状态类型
 - 订单生命周期管理
 - 持仓计算逻辑  
@@ -31,7 +31,7 @@ from uuid import uuid4
 
 from ginkgo.libs import GLOG
 from .interfaces import (
-    IBroker, BrokerType, OrderType, OrderSide, OrderStatus, PositionSide,
+    Broker, BrokerType, OrderType, OrderSide, OrderStatus, PositionSide,
     TradingOrder, BrokerPosition, BrokerTrade, AccountBalance, BrokerStats,
     ManualConfirmationRequired
 )
@@ -103,7 +103,7 @@ class ExecutionResult:
         }
 
 
-class BaseBroker(IBroker):
+class BaseBroker(Broker):
     """交易代理基类"""
     
     def __init__(self, config_or_type: Any, initial_cash: Decimal = Decimal('1000000')):

--- a/src/ginkgo/trading/brokers/interfaces.py
+++ b/src/ginkgo/trading/brokers/interfaces.py
@@ -1,6 +1,6 @@
 # Upstream: BaseBroker, FuturesBroker, HKStockBroker, USStockBroker, OKXBroker
-# Downstream: IBroker, BrokerType, OrderType, OrderSide, OrderStatus, TradingOrder, Position, Trade, GLOG, clock_now
-# Role: 交易代理接口定义，提供IBroker抽象接口及BrokerType/OrderType等数据类
+# Downstream: Broker, BrokerType, OrderType, OrderSide, OrderStatus, TradingOrder, Position, Trade, GLOG, clock_now
+# Role: 交易代理接口定义，提供Broker抽象接口及BrokerType/OrderType等数据类
 
 
 
@@ -278,7 +278,7 @@ class BrokerStats:
         return self.total_volume / self.total_trades
 
 
-class IBroker(ABC):
+class Broker(ABC):
     """交易代理接口"""
     
     def __init__(self, broker_type: BrokerType):

--- a/src/ginkgo/trading/brokers/live_broker_base.py
+++ b/src/ginkgo/trading/brokers/live_broker_base.py
@@ -10,7 +10,7 @@
 """
 LiveBrokerBase - 实盘交易基础类
 
-基于BrokerCacheMixin和IBroker接口，提供实盘交易的通用功能。
+基于BrokerCacheMixin和SyncBroker接口，提供实盘交易的通用功能。
 不同市场的实盘Broker可以继承此类并实现特定的API调用逻辑。
 """
 
@@ -111,7 +111,7 @@ class LiveBrokerBase(BrokerCacheMixin, ABC):
         """从交易所查询订单状态（由子类实现）"""
         pass
 
-    # ============= IBroker接口实现 =============
+    # ============= SyncBroker接口实现 =============
     def submit_order(self, order: Order) -> BrokerExecutionResult:
         """
         提交订单到实盘市场

--- a/src/ginkgo/trading/brokers/manual_broker.py
+++ b/src/ginkgo/trading/brokers/manual_broker.py
@@ -1,5 +1,5 @@
 # Upstream: Live Trading Engines (实盘人工确认)、CLI Commands (用户确认命令)
-# Downstream: BaseBroker (继承提供Broker基础功能)、IBroker接口(实现Broker接口)、通知系统(Telegram/Email/Console)
+# Downstream: BaseBroker (继承提供Broker基础功能)、Broker接口(实现Broker接口)、通知系统(Telegram/Email/Console)
 # Role: ManualBroker人工确认Broker专门用于实盘交易中需要人工确认的场景，订单提交后等待用户通过CLI确认
 
 

--- a/src/ginkgo/trading/brokers/okx_broker.py
+++ b/src/ginkgo/trading/brokers/okx_broker.py
@@ -1,4 +1,4 @@
-# Upstream: BrokerManager (生命周期管理)、IBroker (Broker接口)
+# Upstream: BrokerManager (生命周期管理)、SyncBroker (Broker接口)
 # Downstream: python-okx SDK (OKX API通信)、MBrokerInstance (状态跟踪)
 # Role: OKXBroker OKX交易所Broker实现处理订单提交/撤单/查询与OKX API通信
 
@@ -21,7 +21,7 @@ except ImportError:
     Trade = None
     OKXException = Exception
 
-from ginkgo.trading.interfaces.broker_interface import IBroker, BrokerExecutionResult
+from ginkgo.trading.interfaces.broker_interface import SyncBroker, BrokerExecutionResult
 from ginkgo.entities import Order
 from ginkgo.enums import ORDER_TYPES, ORDERSTATUS_TYPES, DIRECTION_TYPES
 from ginkgo.enums import ExchangeType, EnvironmentType
@@ -58,7 +58,7 @@ class RetryConfig:
         self.OKX_DOMAIN = GCONF.OKX_DOMAIN
 
 
-class OKXBroker(IBroker):
+class OKXBroker(SyncBroker):
     """
     OKX交易所Broker实现
 
@@ -656,7 +656,7 @@ class OKXBroker(IBroker):
         获取挂单信息
 
         Returns:
-            list: 挂单列表，格式符合 IBroker 接口定义
+            list: 挂单列表，格式符合 SyncBroker 接口定义
             [
                 {
                     "order_id": str,           # 订单ID (OKX ordId)

--- a/src/ginkgo/trading/brokers/sim_broker.py
+++ b/src/ginkgo/trading/brokers/sim_broker.py
@@ -1,6 +1,6 @@
 # Upstream: Backtest Engines (回测模拟撮合)、Portfolio Manager (订单执行)
-# Downstream: BrokerCacheMixin (继承提供行情/持仓缓存)、IBroker接口(实现submit_order_event/get_market_data等Broker接口)、ATTITUDE_TYPES (撮合态度枚举OPTIMISTIC/PESSIMISTIC/RANDOM)
-# Role: SimBroker回测模拟撮合Broker继承BrokerCacheMixin和实现IBroker接口，提供立即执行同步返回、模拟撮合、完整验证订单等功能
+# Downstream: BrokerCacheMixin (继承提供行情/持仓缓存)、SyncBroker接口(实现submit_order_event/get_market_data等Broker接口)、ATTITUDE_TYPES (撮合态度枚举OPTIMISTIC/PESSIMISTIC/RANDOM)
+# Role: SimBroker回测模拟撮合Broker继承BrokerCacheMixin和实现SyncBroker接口，提供立即执行同步返回、模拟撮合、完整验证订单等功能
 
 
 
@@ -10,7 +10,7 @@
 """
 SimBroker - 回测模拟撮合Broker
 
-基于BrokerCacheMixin和IBroker接口，提供统一的回测模拟撮合功能。
+基于BrokerCacheMixin和SyncBroker接口，提供统一的回测模拟撮合功能。
 支持滑点、态度设置、手续费计算等回测功能。
 """
 
@@ -33,7 +33,7 @@ class SimBroker(BrokerCacheMixin):
     """
     回测模拟撮合Broker
 
-    基于BrokerCacheMixin和IBroker接口，提供回测专用的模拟撮合功能。
+    基于BrokerCacheMixin和SyncBroker接口，提供回测专用的模拟撮合功能。
     支持滑点、态度设置、手续费计算等回测功能。
 
     核心特点：
@@ -82,7 +82,7 @@ class SimBroker(BrokerCacheMixin):
             return data.get(field, default)
         return default
 
-    # ============= IBroker接口实现 =============
+    # ============= SyncBroker接口实现 =============
     def submit_order_event(self, event) -> BrokerExecutionResult:
         """
         提交订单事件 - 同步立即执行（回测模式）

--- a/src/ginkgo/trading/interfaces/broker_interface.py
+++ b/src/ginkgo/trading/interfaces/broker_interface.py
@@ -1,6 +1,6 @@
-# Upstream: SimBroker/ManualBroker/AutoBroker/AShareBroker等Broker实现(实现IBroker接口)
+# Upstream: SimBroker/ManualBroker/AutoBroker/AShareBroker等Broker实现(实现SyncBroker接口)
 # Downstream: BaseEngine/BrokerRouter (通过接口调用Broker)、EVENT_TYPES/ORDERSTATUS_TYPES (事件类型和订单状态枚举)
-# Role: IBroker交易代理接口定义提交订单/取消订单/持仓/订单/成交/账户信息等方法
+# Role: SyncBroker交易代理接口定义提交订单/取消订单/持仓/订单/成交/账户信息等方法
 
 
 
@@ -125,7 +125,7 @@ class BrokerExecutionResult:
                 f"filled_volume={self.filled_volume})")
 
 
-class IBroker(ABC):
+class SyncBroker(ABC):
     """统一Broker接口"""
 
     @abstractmethod

--- a/tests/unit/trading/brokers/test_broker_rename.py
+++ b/tests/unit/trading/brokers/test_broker_rename.py
@@ -1,0 +1,37 @@
+"""IBroker 分开设名后的契约测试（tracer bullet）。
+
+ADR-022：async IBroker → Broker（实盘契约），sync IBroker → SyncBroker（回测/模拟契约）。
+本测试验证改名后：
+1. 新名 Broker/SyncBroker 可从权威位置 import
+2. 继承关系保持（BaseBroker→Broker, OKXBroker→SyncBroker）
+3. 两个契约为不同类（消歧成立）
+
+注：本 issue 只改名不修继承错配（OKXBroker 实盘继承 sync 契约是历史遗留，
+留 follow-up issue），此处仅断言「改名后继承关系与改名前一致」。
+"""
+from ginkgo.trading.brokers.interfaces import Broker as AsyncBrokerFromModule
+from ginkgo.trading.brokers import Broker as AsyncBrokerFromExport
+from ginkgo.trading.interfaces.broker_interface import SyncBroker
+from ginkgo.trading.brokers.base_broker import BaseBroker
+from ginkgo.trading.brokers.okx_broker import OKXBroker
+
+
+def test_async_ibroker_renamed_to_broker():
+    # async IBroker → Broker，权威定义在 brokers/interfaces.py
+    # export（brokers/__init__.py）指向同一对象
+    assert AsyncBrokerFromModule is AsyncBrokerFromExport
+
+
+def test_basebroker_inherits_async_broker():
+    # BaseBroker 仍是 async 契约（Broker）的子类（与改名前一致）
+    assert issubclass(BaseBroker, AsyncBrokerFromModule)
+
+
+def test_okx_broker_inherits_sync_broker():
+    # OKXBroker 仍是 sync 契约（SyncBroker）的子类（与改名前一致）
+    assert issubclass(OKXBroker, SyncBroker)
+
+
+def test_async_and_sync_broker_are_distinct():
+    # 分开设名的核心目的：两个契约为不同类，消除同名歧义
+    assert AsyncBrokerFromModule is not SyncBroker

--- a/tests/unit/trading/gateway/test_trade_gateway_isinstance.py
+++ b/tests/unit/trading/gateway/test_trade_gateway_isinstance.py
@@ -85,9 +85,9 @@ class TestTradeGatewayIsinstanceStrongSide:
         import ginkgo.trading.brokers.base_broker as strong_mod
         from ginkgo.trading.bases.broker_cache_mixin import BrokerCacheMixin
 
-        # 强侧 BaseBroker 必须仍是 IBroker 子类（组合根）
-        from ginkgo.trading.brokers.interfaces import IBroker
-        assert issubclass(strong_mod.BaseBroker, IBroker)
+        # 强侧 BaseBroker 必须仍是 Broker 子类（组合根）
+        from ginkgo.trading.brokers.interfaces import Broker
+        assert issubclass(strong_mod.BaseBroker, Broker)
 
         # 弱侧已降级为 BrokerCacheMixin，不再是 BaseBroker
         assert not hasattr(BrokerCacheMixin, "__name__") or BrokerCacheMixin.__name__ != "BaseBroker"


### PR DESCRIPTION
## Summary

Closes #6717

对应 issue #6717（refactor: IBroker async/sync 分开设名，高风险实盘）。

将 `IBroker` 双胞胎正式分开设名（ADR-022 命名空间唯一性）：
- **异步 `IBroker`**（`brokers/interfaces.py`）→ **`Broker`**（实盘 / 异步契约）
- **同步 `IBroker`**（`interfaces/broker_interface.py`）→ **`SyncBroker`**（回测 / 模拟契约）

更新所有 import / type hint / isinstance / 注释消费者（9 个 src 文件）。

## 验收（issue #6717 验收标准 1-4 达成）

| # | 标准 | 结果 |
|---|------|------|
| 1 | 异步 IBroker → `Broker` | ✅ |
| 2 | 同步 IBroker → `SyncBroker` | ✅ |
| 3 | 更新所有消费者 | ✅ |
| 4 | `grep IBroker src/` = 0 | ✅ |
| 5 | 继承链正确 | ⚠️ **未达成**（见下） |

4 项 grep 锚点全过：
- `grep ^class IBroker src/` = 0
- `grep ^class Broker src/` = 唯一 `brokers/interfaces.py:281`
- `grep ^class SyncBroker src/` = 唯一 `interfaces/broker_interface.py:128`
- `grep IBroker src/` = 0

## ⚠️ 验收标准 5 未达成 —— 诚实留债

机械改名过程发现继承拓扑存在 **双契约分裂**，本次只改名、不重构：

| Broker | 继承链 | submit 语义 |
|--------|--------|-------------|
| `OKXBroker`（实盘） | `SyncBroker`（同步） | 同步 `submit_order_event` + 异步 `submit_order` 双模 |
| `SimBroker`（回测） | `BrokerCacheMixin`（直接） | 同步 `submit_order_event` |
| `LiveBrokerBase`（实盘基类） | `BrokerCacheMixin`（直接） | 同步 `submit_order` |
| `AutoBroker`（实盘） | `BaseBroker` → 异步 `Broker` | `async submit_order` |
| `ManualBroker`（实盘） | `BaseBroker` → 异步 `Broker` | `async submit_order` |

**语义悖论**：实盘 broker（OKX / Live）走 **同步** 契约，而 AutoBroker / ManualBroker 走 **异步** 契约——同名 `Broker` 家族被劈成两套不互通的接口。

**更深债务**：`trade_gateway._handle_async_execution` 调用 `broker.submit_order(order)` 时 **从不 await**（对协程会崩），证明异步链是"声明层幻觉"，是半完成的 async 迁移；而 `SyncBrokerFacade` 又假设 `submit_order` 返回协程去 `self._run(...)`，与 gateway 矛盾。

## 处理决策

经与用户确认，**本次只做机械改名**（验收 1-4），以下留作后续 issue：
1. 继承拓扑统一（OKX / Sim / Live 与 Auto / Manual 收敛到同一契约）
2. async 迁移方向决策（gateway 的 await 缺失 / `SyncBrokerFacade` 的协程假设）
3. 建议对齐 #6697 史诗 与 ADR-022

## Test plan

- [x] tracer bullet：`tests/unit/trading/brokers/test_broker_rename.py` 4 passed（新名 import 链 + 继承 + 异步/同步 distinct）
- [x] 回归门：`tests/unit/trading/gateway/test_trade_gateway_isinstance.py` 5 passed
- [x] brokers 目录 123 passed（3 失败均为既有基线/flaky，与本改动无关：OKX SDK `timeout` 参数 ×2、sim_broker RANDOM 撮合 flaky ×1）
- [x] `py_compile` src + api 全通过
- [x] 启动路径 smoke 通过（`test_user_cli` 1 失败为 typer rich ANSI 渲染，物理隔离，既有）
