### PR TITLE
docs: 精简 README 为入门定位(介绍+安装+使用)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,223 +1,27 @@
 # Ginkgo
 
-Modern Python Quantitative Trading Library
-
-Ginkgo is a quantitative trading framework featuring event-driven backtesting, multi-database support, complete risk management, and a Web UI for strategy management.
+Modern Python Quantitative Trading Library — event-driven backtesting, multi-database support, complete risk control, and a Web UI for strategy management.
 
 ## Features
 
-- **Event-Driven Backtesting**: `PriceUpdate -> Strategy -> Signal -> Portfolio -> Order -> Fill`
-- **Multi-Database Support**: ClickHouse (time-series), MySQL (relational), MongoDB (documents), Redis (cache)
-- **Multiple Data Sources**: Tushare, Yahoo Finance, AKShare, BaoStock, TDX
-- **Complete Risk Control**: Position management, stop-loss/profit, real-time monitoring
-- **Web UI**: Vue 3 + shadcn-vue + Tailwind CSS dashboard for backtest/portfolio/component management
-- **Live Trading**: OKX broker integration with heartbeat monitoring and crash recovery (⚠️ CLI end-to-end status — see [e2e audit](docs/e2e-cli-flow-audit.md))
-- **CLI Interface**: Typer-based CLI with Rich formatting
+- **Event-Driven Backtesting**: `PriceUpdate → Strategy → Signal → Portfolio → Order → Fill`
+- **Multi-Database**: ClickHouse (time-series), MySQL (relational), MongoDB (documents), Redis (cache)
+- **Multiple Data Sources**: Tushare, AKShare, Yahoo Finance, BaoStock, TDX
+- **Complete Risk Control**: position sizing, stop-loss / take-profit, real-time monitoring
+- **Web UI**: Vue 3 + shadcn-vue dashboard for portfolio / backtest / component management
+- **Live Trading**: OKX integration with heartbeat monitoring (⚠️ end-to-end pending — see [e2e audit](docs/e2e-cli-flow-audit.md))
+- **CLI**: Typer + Rich
 
-> **CLI pipeline status (2026-06-28 verified)**: Build ✅ · Backtest ⚠️ (data traps, no pre-check) · Paper trading ⚠️ (core fix #6164 landed, end-to-end pending re-test) · Live ⚠️ (integration ready, end-to-end pending). Details: [docs/e2e-cli-flow-audit.md](docs/e2e-cli-flow-audit.md).
+> Architecture diagrams, component inventory, design rules, dev reference → [docs/claude-dev-reference.md](docs/claude-dev-reference.md) · [ADRs](docs/adrs/README.md)
 
-## Architecture
-
-### System Overview
-
-```mermaid
-graph TB
-    subgraph "🖥️ Application Layer"
-        CLI["<b>CLI</b><br/>Typer + Rich<br/><i>35 command groups</i>"]
-        API["<b>REST API</b><br/>FastAPI<br/><i>16 routers</i>"]
-        WEB["<b>Web UI</b><br/>Vue 3 + shadcn-vue<br/><i>17 views</i>"]
-    end
-
-    subgraph "⚙️ Worker Layer"
-        BW["<b>Backtest Worker</b><br/>Kafka consumer"]
-        EN["<b>Execution Node</b><br/>Live order routing"]
-    end
-
-    subgraph "🧠 Service Hub (Dependency Injection)"
-        SH["ServiceHub<br/><i>11 module containers</i>"]
-        SH --- M1["data"] & M2["trading"] & M3["core"]
-        SH --- M4["features"] & M5["quant_ml"] & M6["research"]
-        SH --- M7["validation"] & M8["notifier"] & M9["optimization"]
-        SH --- M10["comparison"] & M11["logging"]
-    end
-
-    subgraph "📊 Trading Engine"
-        EE["EventEngine<br/><i>事件队列 + 线程分发</i>"] --> TCE["TimeControlledEngine<br/><i>回测/实盘统一</i>"]
-        EE --> FDR["Data Feeders (7)"]
-        EE --> PTF["Portfolio<br/><i>中央编排器</i>"]
-        PTF --> STR["Strategy (11)"]
-        PTF --> RSK["Risk (17)"]
-        PTF --> SIZ["Sizer (3)"]
-        PTF --> SEL2["Selector (4)"]
-    end
-
-    subgraph "🔀 Gateway & Brokers"
-        GW["TradeGateway<br/><i>多市场路由</i>"]
-        GW --- B1["AShare (T+1)"] & B2["HK Stock"]
-        GW --- B3["US Stock"] & B4["Futures"]
-        GW --- B5["OKX Crypto"] & B6["Sim"]
-        GW --- B7["Auto"] & B8["Manual"]
-    end
-
-    subgraph "🗄️ Data Layer"
-        DRV["Drivers"]
-        DRV --- CH["ClickHouse<br/><i>时序数据</i>"]
-        DRV --- MY["MySQL<br/><i>关系数据</i>"]
-        DRV --- MO["MongoDB<br/><i>文档数据</i>"]
-        DRV --- RD["Redis<br/><i>缓存</i>"]
-        DRV --- KF["Kafka<br/><i>消息队列</i>"]
-        SRC["Data Sources"]
-        SRC --- S1["Tushare"] & S2["AKShare"]
-        SRC --- S3["Yahoo"] & S4["BaoStock"] & S5["TDX"]
-    end
-
-    CLI & API & WEB --> SH
-    BW & EN --> SH
-    SH --> EE & DRV & SRC
-    EE --> PTF
-    PTF --> GW
-
-    style SH fill:#4A90D9,color:#fff
-    style EE fill:#E8A838,color:#fff
-    style PTF fill:#D94A7A,color:#fff
-    style GW fill:#7A4AD9,color:#fff
-    style DRV fill:#50B87E,color:#fff
-```
-
-### Trading Pipeline — Event Flow
-
-```mermaid
-sequenceDiagram
-    participant F as Feeder
-    participant E as EventEngine
-    participant P as Portfolio
-    participant STR as Strategy
-    participant RSK as Risk
-    participant SIZ as Sizer
-    participant GW as TradeGateway
-    participant BRK as Broker
-
-    F->>E: ① EventPriceUpdate (Bar/Tick)
-    E->>P: dispatch → on_price_received()
-    P->>STR: ② strategy.cal(portfolio, event) → Signal[]
-    P->>RSK: ③ risk.generate_signals() → Signal[] (止损/止盈)
-    P->>E: put(EventSignalGeneration) per signal
-    Note over E: ④ T+1 延迟（当日信号延迟到下一时段）
-    E->>P: dispatch → on_signal()
-    P->>SIZ: ⑤ sizer.cal(signal) → Order
-    P->>RSK: ⑥ risk.cal(order) → adjusted Order (减量/拒绝)
-    Note over RSK: 双模风控：被动拦截 + 主动信号
-    P->>E: put(EventOrderAck)
-    E->>GW: ⑦ route to market broker
-    GW->>BRK: AShare / HK / US / Futures / OKX
-    BRK-->>E: EventOrderPartiallyFilled
-    E->>P: ⑧ update position, PnL, frozen funds
-```
-
-### Module Map
-
-```mermaid
-graph LR
-    subgraph "ginkgo"
-        direction TB
-
-        subgraph "trading/"
-            direction TB
-            engines["engines/<br/>BaseEngine → EventEngine → TimeControlled"]
-            events["events/<br/>PriceUpdate · Signal · Order<br/>TimeAdvance · Portfolio"]
-            bases["bases/<br/>Portfolio · Position · Order<br/>Strategy · Selector · Sizer · Risk"]
-            strat["strategies/ (13)"]
-            risk["risk_management/ (17)"]
-            sel["selectors/ (4)"]
-            sizer["sizers/ (3)"]
-            brk["brokers/ (8)"]
-            fdr["feeders/ (7)"]
-            analysis["analysis/<br/>analyzers (21) · reports · plots"]
-            evl["evaluation/<br/>pipeline · rules · visualization"]
-        end
-
-        subgraph "data/"
-            direction TB
-            drv["drivers/<br/>ClickHouse · MySQL<br/>MongoDB · Redis · Kafka"]
-            mdl["models/ (50)"]
-            crud["crud/ (49)"]
-            svc["services/ (31)"]
-            src["sources/ (5)"]
-            stm["streaming/<br/>cache · checkpoint · recovery"]
-        end
-
-        subgraph "core/"
-            direction TB
-            adapters["adapters/"]
-            factories["factories/"]
-            ifaces["interfaces/"]
-        end
-
-        subgraph "Supporting"
-            feat["features/<br/>definitions (16) · expression engine"]
-            ml["quant_ml/<br/>models · features · strategies"]
-            res["research/<br/>IC · factor · orthogonal · decay"]
-            val["validation/<br/>MonteCarlo · WalkForward · Sensitivity"]
-            live["livecore/<br/>scheduler · heartbeat"]
-            ntf["notifier/<br/>channels · workers"]
-        end
-    end
-```
-
-### Key Design Rules
-
-| Rule | Description |
-|------|-------------|
-| **单向数据流** | `Selector → Strategy → Sizer → Risk`，禁止反向调用 |
-| **三层分离** | `API → Service → CRUD`，API 禁止直接调 CRUD |
-| **事件驱动** | 引擎通过 Queue 分发事件，解耦数据与交易逻辑 |
-| **容器注入** | ServiceHub 懒加载 11 个 DI 容器，按需初始化 |
-| **引擎双模** | 仅分 `BACKTEST` / `LIVE`，共享 EventEngine 机制 |
-| **Portfolio 编排** | Portfolio 持有全部组件（策略/风控/Sizer/分析器），是交易核心 |
-| **双模风控** | 被动拦截 `cal(order)` + 主动信号 `generate_signals()` |
-| **T+1 延迟** | 当日信号延迟到下一时段才执行（A 股规则） |
-
-### Component Inventory
-
-| Category | Count | Examples |
-|----------|-------|---------|
-| **Strategies** | 11 | MA Crossover, Momentum, Mean Reversion, Dual Thrust, Scalping, ML Predictor |
-| **Risk Managers** | 17 | Position Ratio, Loss Limit, Profit Target, Max Drawdown, Volatility, Concentration, Time Based |
-| **Selectors** | 4 | Fixed, CN All, Momentum, Popularity |
-| **Sizers** | 3 | Fixed, ATR, Ratio |
-| **Brokers** | 8 | Sim, AShare, HK Stock, US Stock, Futures, OKX, Manual, Auto |
-| **Feeders** | 7 | Backtest, Live, OKX, OKX Data, Alpaca, EastMoney, Fushu |
-| **Analyzers** | 21 | Net Value, Max Drawdown, Sharpe, Calmar, Profit Factor, Annualized Returns |
-| **Data Sources** | 5 | Tushare, AKShare, Yahoo, BaoStock, TDX |
-| **DB Drivers** | 5 | ClickHouse, MySQL, MongoDB, Redis, Kafka |
-| **Factors** | 158+ | Alpha158, Barra, Fama-French, WorldQuant Alpha101 |
-
-### Service Access
-
-```python
-from ginkgo import services
-
-bar_crud = services.data.cruds.bar()
-stockinfo_service = services.data.services.stockinfo_service()
-engine = services.trading.engines.historic()
-```
-
-## Quick Start
-
-### Installation
+## Installation
 
 ```bash
 # uv (recommended)
 uv sync
 ```
 
-> **Note:** You need [uv](https://docs.astral.sh/uv/) installed. If you don't have it, run `curl -LsSf https://astral.sh/uv/install.sh | sh`.
-
-Docker containers (Kafka, Redis, MySQL, ClickHouse, MongoDB) start automatically.
-
-### Global CLI
-
-After installation, `ginkgo` is globally available:
+Requires [uv](https://docs.astral.sh/uv/). Docker containers (Kafka, Redis, MySQL, ClickHouse, MongoDB) start automatically. After install, `ginkgo` is globally available:
 
 ```bash
 ginkgo version
@@ -227,7 +31,7 @@ ginkgo debug on          # Required for database operations
 
 ### Configuration
 
-`~/.ginkgo/` is the single config home. It is initialized by `install.py` (`copy_config`) on first run and materialized on demand by `GCONF` (`generate_config_file`). Both resolve templates from the package's bundled `config/` dir (via `__file__`), so host / container / wheel installs land on the same layout; existing files are preserved on re-init (idempotent).
+`~/.ginkgo/` is the single config home, initialized by `install.py` (`copy_config`) and materialized on demand by `GCONF` (`generate_config_file`). Both resolve templates from the package's bundled `config/` dir (via `__file__`), so host / container / wheel installs land on the same layout.
 
 ```bash
 vi ~/.ginkgo/config.yml       # Main config
@@ -235,82 +39,40 @@ vi ~/.ginkgo/secure.yml       # Credentials (base64 encoded)
 vi ~/.ginkgo/task_timer.yml   # tasktimer worker schedule
 ```
 
-Force-overwrite stale config: `python install.py -updateconfig`. Docker workers mount the host `~/.ginkgo` read-only at `/root/.ginkgo` (`x-worker-common` volume), so containers read your real config, not a build-time template.
+Force-overwrite stale config: `python install.py -updateconfig`. Docker workers mount the host `~/.ginkgo` read-only at `/root/.ginkgo` (`x-worker-common` volume).
 
-## CLI Reference
-
-### Data Management
+## Usage
 
 ```bash
-ginkgo data init                           # Initialize database tables
-ginkgo data update --stockinfo             # Update stock information
-ginkgo data update day --code 000001.SZ    # Update daily bar data
-ginkgo data list stockinfo --page 50       # List stock info
-```
+# Data
+ginkgo data init
+ginkgo data update --stockinfo
+ginkgo data update day --code 000001.SZ
 
-### Portfolio & Components
-
-```bash
-ginkgo portfolio create --name "my_portfolio" --capital 1000000
-ginkgo portfolio list
-ginkgo portfolio get <uuid> --details
-
+# Portfolio & components
+ginkgo portfolio create --name "my" --capital 1000000
 ginkgo component list
-ginkgo component create --type strategy --name "my_strategy"
-ginkgo component show <uuid>
+ginkgo portfolio bind-component <pid> <file_id> --type strategy \
+  --param '0:MyStrategy' --param '1:14'        # index 0 = constructor name
 
-# Bind component with parameters
-ginkgo portfolio bind-component <portfolio_id> <file_id> --type strategy \
-  --param '0:"MyStrategy"' --param '1:0.3'
-```
+# Backtest
+ginkgo backtest create --portfolio <pid> --start 2025-01-01 --end 2026-01-01 --name "test"
+ginkgo backtest run <id>
+ginkgo backtest cat <id>
 
-### Backtesting
+# Deploy (paper / live) — ⚠️ end-to-end pending, see e2e audit
+ginkgo account create <user_id> --exchange okx --name "my_okx" --api-key <k> --api-secret <s>
+ginkgo deploy deploy <pid> --mode paper
+ginkgo deploy deploy <pid> --mode live --account <account_uuid>
 
-```bash
-ginkgo backtest create --portfolio <id> --start 2025-01-01 --end 2026-01-01 --name "test"
-ginkgo backtest run <backtest_id>
-ginkgo backtest cat <backtest_id>
-ginkgo backtest list
-```
-
-### Deployment (Paper / Live)
-
-> ⚠️ End-to-end status: see [e2e audit](docs/e2e-cli-flow-audit.md). Paper-trading core fix landed (#6164 deploy-clone completeness); full paper/live pipeline pending end-to-end re-test.
-
-```bash
-ginkgo deploy deploy <portfolio_id> --mode paper                # Paper trading deployment
-ginkgo deploy deploy <portfolio_id> --mode live --account <id>  # Live deployment (needs a live account)
-ginkgo deploy info <deployment_id>                              # Deployment details
-ginkgo deploy list                                              # List deployments
-```
-
-### Live Account Management
-
-> Added in #6284. Create an account first, then use its UUID with `deploy --mode live --account <id>`.
-
-```bash
-ginkgo account create <user_id> --exchange okx --name "my_okx" \
-  --api-key <key> --api-secret <secret> [--passphrase <pp>] [--environment testnet]
-ginkgo account list <user_id>
-ginkgo account get <account_uuid>
-```
-
-### Worker Management
-
-```bash
-ginkgo worker status
-ginkgo worker start --count 4
-ginkgo worker run --debug
-```
-
-### Development Servers
-
-```bash
-ginkgo serve api      # FastAPI server on :8000
+# Servers
+ginkgo serve api      # FastAPI on :8000
 ginkgo serve webui    # Vue dev server on :5173
 ```
 
-## Strategy Development
+Full CLI walkthrough (build → backtest → paper → live) → [docs/e2e-cli-flow-audit.md](docs/e2e-cli-flow-audit.md)
+
+### Write a Strategy
 
 ```python
 from ginkgo.trading.strategies.strategy_base import BaseStrategy
@@ -325,50 +87,9 @@ class MyStrategy(BaseStrategy):
         return []
 ```
 
-### Risk Management
+Risk managers, analyzers, selectors, sizers → [docs/claude-dev-reference.md](docs/claude-dev-reference.md)
 
-```python
-from ginkgo.trading.risk_management.position_ratio_risk import PositionRatioRisk
-from ginkgo.trading.risk_management.loss_limit_risk import LossLimitRisk
-from ginkgo.trading.risk_management.profit_target_risk import ProfitTargetRisk
-
-portfolio.add_risk_manager(PositionRatioRisk(max_position_ratio=0.2))
-portfolio.add_risk_manager(LossLimitRisk(loss_limit=10.0))
-portfolio.add_risk_manager(ProfitTargetRisk(profit_limit=20.0))
-```
-
-## Web UI
-
-Vue 3 + shadcn-vue + Tailwind CSS + ECharts + Lightweight Charts dashboard:
-
-```bash
-ginkgo serve webui    # http://localhost:5173
-```
-
-Features: portfolio management, backtest creation/monitoring, component editor (Monaco), factor research, real-time charts.
-
-## Live Trading
-
-> ⚠️ **Status**: OKX integration code is in place (classes below) and the CLI is wired (`ginkgo account` + `ginkgo deploy --mode live`, landed in #6284), but the end-to-end path (real account → order routing → fill) has not been re-verified since the 2026-06-22 audit. See [e2e audit](docs/e2e-cli-flow-audit.md).
-
-OKX exchange integration with:
-
-- **LiveEngine**: Unified lifecycle management
-- **OKXBroker**: Exchange adapter implementing IBroker interface
-- **BrokerManager**: Instance lifecycle (start/pause/resume/stop)
-- **HeartbeatMonitor**: Timeout detection and recovery
-
-```bash
-# Low-level engine lifecycle
-python -m ginkgo.livecore.main live-start   # Start live engine
-python -m ginkgo.livecore.main live-status  # Check status
-
-# High-level CLI pipeline: create account → deploy live
-ginkgo account create <user_id> --exchange okx --name "my_okx" --api-key <key> --api-secret <secret>
-ginkgo deploy deploy <portfolio_id> --mode live --account <account_uuid>
-```
-
-## System Requirements
+## Requirements
 
 - **Python**: 3.12.8+
 - **Databases**: ClickHouse, MySQL, MongoDB, Redis
@@ -377,25 +98,10 @@ ginkgo deploy deploy <portfolio_id> --mode live --account <account_uuid>
 
 ## Contributing
 
-1. Fork the repository
-2. Create feature branch: `git checkout -b {seq}-{type}/{description}`
-   - Branch format: `{incrementing-number}-{type}/{description}`
-   - Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`
-   - Example: `4128-feat/webui-navigation`
-3. Commit and push to branch
-4. Open Pull Request
-
-### Running Tests
-
-```bash
-# Full suite MUST use -n auto (process isolation via pytest-xdist)
-# Single-process accumulates 80GB+ RSS → OOM (Base.metadata + autouse fixtures never released, confirmed even on 96GB hosts)
-pytest tests/ -n auto --ignore=tests/integration
-
-# Single file/module — no -n auto needed
-pytest tests/unit/data/test_xxx.py -v
-```
+1. Branch: `{seq}-{type}/{description}` — types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`. Next seq: `git branch -r | grep -oP '\d+(?=-)' | sort -n | tail -1`
+2. Tests in `tests/` (no in-module `tests/` subdirs)
+3. Open a Pull Request
 
 ## License
 
-MIT License - see the LICENSE file for details.
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -227,10 +227,15 @@ ginkgo debug on          # Required for database operations
 
 ### Configuration
 
+`~/.ginkgo/` is the single config home. It is initialized by `install.py` (`copy_config`) on first run and materialized on demand by `GCONF` (`generate_config_file`). Both resolve templates from the package's bundled `config/` dir (via `__file__`), so host / container / wheel installs land on the same layout; existing files are preserved on re-init (idempotent).
+
 ```bash
-vi ~/.ginkgo/config.yaml   # Main config
-vi ~/.ginkgo/secure.yml    # Credentials (base64 encoded)
+vi ~/.ginkgo/config.yml       # Main config
+vi ~/.ginkgo/secure.yml       # Credentials (base64 encoded)
+vi ~/.ginkgo/task_timer.yml   # tasktimer worker schedule
 ```
+
+Force-overwrite stale config: `python install.py -updateconfig`. Docker workers mount the host `~/.ginkgo` read-only at `/root/.ginkgo` (`x-worker-common` volume), so containers read your real config, not a build-time template.
 
 ## CLI Reference
 


### PR DESCRIPTION
## 改动
README 从 **401 → 107 行**,定位回归"框架介绍 + 安装 + 使用"入口,深入内容指针到 docs。

### 删除(指针到 docs)
- 3 个 mermaid 大图(系统总览 / 事件流 / 模块映射)
- 组件清单表(158+ factors 等)、设计规则表
- Service Access 代码、详细 Web UI / Live Trading 段

### 保留
- Features(7 条)、Installation、Configuration、Usage 核心 CLI(data/portfolio/component/backtest/deploy/account/serve)、Strategy 示例、Requirements、Contributing(分支规范)、License

### 深入内容指针(4 个链接已验存活)
- 架构 / 组件 / 设计规则 / 开发参考 → `docs/claude-dev-reference.md`
- ADR → `docs/adrs/README.md`
- CLI 全链路 → `docs/e2e-cli-flow-audit.md`

## 配套 config 统一(#6640)
顺手修正 `config.yaml → config.yml`(与 install.py / GCONF / 包内文件一致),补 `~/.ginkgo` 初始化来源说明(install.py `copy_config` + GCONF `generate_config_file` 经 `__file__`)+ 容器 `x-worker-common` volume 挂载。

## ⚠️ 依赖
README `Configuration` 段描述的"install.py + GCONF `__file__` + 容器 volume 统一初始化"机制由 **#6640 (ginkgo-dir-config-unify)** 引入,该分支尚未合并 master。建议等 #6640 合并后再合并此 PR,或一并 review。

`deploy` 段保留 ⚠️ end-to-end pending 标注,口径以 `docs/e2e-cli-flow-audit.md` 为准,不超前于代码实际能力。

🤖 Generated with [Claude Code](https://claude.com/claude-code)