### PR TITLE
refactor: 退役 KafkaService 消费 worker 模型及连带死代码 (#6736)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,16 @@ jobs:
         run: |
           uv run python -m pytest tests/unit/data/services/test_list_count_smoke.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: kafka service retired contract smoke (#6736)
+        # #6736 退役 KafkaService 消费 worker 模型（删 _message_handlers/_consumer_threads
+        # 等本地状态）连带改动 3 个查询/健康方法的可执行行（get_topic_status 直返 crud、
+        # get_queue_metrics(None)→[]、health_check 删 consumer 字段+精简 healthy 判定）。
+        # 同目录 test_kafka_consumer_retired.py 只断言 hasattr（已删除），不调方法体 →
+        # 门禁红。本 smoke mock crud 调起 3 方法体补覆盖信号，并锁定退役后新契约。
+        # 独立 step 使 push→master 时也跑（gate 仅 PR 触发），同时纳入下方 gate 合集采集。
+        run: |
+          uv run python -m pytest tests/unit/data/services/test_kafka_service_retired_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: deployment_service list/count smoke (#5009 pagination)
         # DeploymentService.list_deployments(page=,page_size=)→find(order_by/desc) +
         # count_deployments→count 是本 PR 新增可执行行，被 containers import 链触达但
@@ -170,6 +180,7 @@ jobs:
             tests/unit/data/mappers/test_bar_mapper.py \
             tests/unit/data/services/test_page_size_passthrough_smoke.py \
             tests/unit/data/services/test_list_count_smoke.py \
+            tests/unit/data/services/test_kafka_service_retired_smoke.py \
             tests/unit/trading/services/test_deployment_list_smoke.py \
             tests/unit/client/test_deploy_cli_list_smoke.py \
             tests/unit/client/test_record_cli_list_smoke.py \

--- a/src/ginkgo/client/kafka_cli.py
+++ b/src/ginkgo/client/kafka_cli.py
@@ -126,33 +126,7 @@ def _check_queue_status():
         receive_stats = stats.get("receive_statistics", {})
         table.add_row("Total Messages Received", str(receive_stats.get("total_received", 0)), ":inbox_tray:")
         
-        # 显示订阅信息
-        active_subscriptions = stats.get("active_subscriptions", 0)
-        running_consumers = stats.get("running_consumers", 0)
-        table.add_row("Active Subscriptions", str(active_subscriptions), "[blue]📑[/blue]")
-        table.add_row("Running Consumers", str(running_consumers), "[blue]🏃[/blue]")
-        
         console.print(table)
-        
-        # 显示订阅详情
-        subscription_details = stats.get("subscription_details", [])
-        if subscription_details:
-            detail_table = Table(title="Subscription Details")
-            detail_table.add_column("Topic", style="cyan")
-            detail_table.add_column("Handler", style="blue")
-            detail_table.add_column("Consumer Status", style="green")
-            detail_table.add_column("Thread Name", style="yellow")
-            
-            for sub in subscription_details:
-                status = ":green_circle: Running" if sub.get("is_consuming", False) else ":red_circle: Stopped"
-                detail_table.add_row(
-                    sub.get("topic", "N/A"),
-                    ":white_check_mark: Registered" if sub.get("has_handler", False) else ":x: No Handler",
-                    status,
-                    sub.get("thread_name", "N/A")
-                )
-            
-            console.print(detail_table)
         
         # 执行健康检查
         health_result = kafka_service.health_check()
@@ -367,7 +341,6 @@ def _start_queue_monitor(duration: int, interval: int):
                 
                 kafka_table.add_row("Connection", ":white_check_mark: Connected" if kafka_conn.get("connected") else ":x: Disconnected")
                 kafka_table.add_row("Active Consumers", str(kafka_conn.get("active_consumers", 0)))
-                kafka_table.add_row("Subscriptions", str(stats.get("active_subscriptions", 0)))
                 kafka_table.add_row("Messages Sent", str(send_stats.get("total_sent", 0)))
                 kafka_table.add_row("Messages Received", str(receive_stats.get("total_received", 0)))
                 kafka_table.add_row("Failed Sends", str(send_stats.get("failed_sends", 0)))
@@ -395,31 +368,6 @@ def _start_queue_monitor(duration: int, interval: int):
                     
             except Exception as e:
                 worker_table.add_row("Status", f":x: Error: {str(e)[:40]}...")
-            
-            # 订阅详情表
-            subscription_table = Table(title="Active Subscriptions", expand=True)
-            subscription_table.add_column("Topic", style="cyan")
-            subscription_table.add_column("Status", style="green")
-            subscription_table.add_column("Thread", style="yellow")
-            
-            try:
-                stats_result = kafka_service.get_statistics()
-                stats = stats_result.data if stats_result.success else {}
-                subscription_details = stats.get("subscription_details", [])
-                
-                if subscription_details:
-                    for sub in subscription_details:
-                        status = ":green_circle: Running" if sub.get("is_consuming") else ":red_circle: Stopped"
-                        subscription_table.add_row(
-                            sub.get("topic", "N/A"),
-                            status,
-                            sub.get("thread_name", "N/A")
-                        )
-                else:
-                    subscription_table.add_row("No subscriptions", "N/A", "N/A")
-                    
-            except Exception as e:
-                subscription_table.add_row("Error", f"{str(e)[:30]}...", "N/A")
             
             # 创建布局
             layout = Layout()

--- a/src/ginkgo/client/kafka_cli.py
+++ b/src/ginkgo/client/kafka_cli.py
@@ -374,7 +374,6 @@ def _start_queue_monitor(duration: int, interval: int):
             layout.split_column(
                 Layout(kafka_table, name="kafka"),
                 Layout(worker_table, name="worker"),
-                Layout(subscription_table, name="subscriptions")
             )
             
             # 添加时间信息

--- a/src/ginkgo/data/crud/kafka_crud.py
+++ b/src/ginkgo/data/crud/kafka_crud.py
@@ -243,58 +243,6 @@ class KafkaCRUD:
             GLOG.ERROR(f"Failed to consume messages from topic {topic}: {e}")
             return messages
     
-    @time_logger
-    def consume_with_callback(self, topic: str, callback: Callable[[Dict[str, Any]], bool], 
-                             group_id: str = None, max_messages: int = None) -> int:
-        """
-        使用回调函数消费消息
-        
-        Args:
-            topic: 主题名称
-            callback: 消息处理回调函数，返回True表示处理成功
-            group_id: 消费者组ID
-            max_messages: 最大消息数量，None表示无限制
-            
-        Returns:
-            int: 成功处理的消息数量
-        """
-        processed_count = 0
-        
-        try:
-            consumer = self._get_or_create_consumer(topic, group_id)
-            if not consumer:
-                return 0
-                
-            for message in consumer.consumer:
-                try:
-                    message_data = {
-                        "topic": message.topic,
-                        "partition": message.partition,
-                        "offset": message.offset,
-                        "key": message.key.decode('utf-8') if message.key else None,
-                        "value": message.value,
-                        "timestamp": datetime.fromtimestamp(message.timestamp / 1000) if message.timestamp else None
-                    }
-
-                    # 调用回调函数处理消息
-                    if callback(message_data):
-                        processed_count += 1
-                        consumer.commit()  # 提交偏移量
-                        
-                    # 检查是否达到最大消息数量
-                    if max_messages and processed_count >= max_messages:
-                        break
-                        
-                except Exception as callback_error:
-                    GLOG.ERROR(f"Callback processing error: {callback_error}")
-                    
-            GLOG.DEBUG(f"Processed {processed_count} messages from topic: {topic}")
-            return processed_count
-            
-        except Exception as e:
-            GLOG.ERROR(f"Failed to consume with callback from topic {topic}: {e}")
-            return processed_count
-    
     def commit_offset(self, topic: str, group_id: str = None) -> bool:
         """
         手动提交消费偏移量

--- a/src/ginkgo/data/services/kafka_service.py
+++ b/src/ginkgo/data/services/kafka_service.py
@@ -46,11 +46,6 @@ class KafkaService(BaseService):
         # Keep kafka property for backward compatibility
         self.kafka = kafka_crud
 
-        # Message processing state tracking
-        self._message_handlers = {}  # {topic: handler_function}
-        self._consumer_threads = {}  # {topic: thread}
-        self._stop_events = {}      # {topic: threading.Event}
-
         # Message sending statistics
         self._send_stats = {
             "total_sent": 0,
@@ -256,249 +251,6 @@ class KafkaService(BaseService):
                 message=f"Error publishing message to {topic}: {str(e)}"
             )
     
-    def publish_batch_messages(self, topic: str, messages: List[Dict[str, Any]],
-                              add_metadata: bool = True) -> Dict[str, Any]:
-        """
-        批量发布消息
-        
-        Args:
-            topic: 主题名称
-            messages: 消息列表
-            add_metadata: 是否添加元数据
-            
-        Returns:
-            Dict: 发送结果统计
-        """
-        try:
-            self._log_operation_start("publish_batch_messages", topic=topic, count=len(messages))
-            
-            # 预处理消息
-            processed_messages = []
-            for msg in messages:
-                if add_metadata:
-                    if isinstance(msg, dict):
-                        enhanced_msg = msg.copy()
-                    else:
-                        enhanced_msg = {"content": msg}
-                    
-                    enhanced_msg.update({
-                        "message_id": str(uuid.uuid4()),
-                        "timestamp": datetime.now().isoformat(),
-                        "service": "KafkaService",
-                        "batch_id": str(uuid.uuid4())
-                    })
-                    processed_messages.append(enhanced_msg)
-                else:
-                    processed_messages.append(msg)
-            
-            # 批量发送
-            success_count = self._crud_repo.send_batch_messages(topic, processed_messages)
-            
-            # 更新统计信息
-            self._send_stats["total_sent"] += success_count
-            self._send_stats["failed_sends"] += len(messages) - success_count
-            self._send_stats["last_send_time"] = datetime.now()
-            
-            result = {
-                "topic": topic,
-                "total_messages": len(messages),
-                "successful_sends": success_count,
-                "failed_sends": len(messages) - success_count,
-                "success_rate": success_count / len(messages) if messages else 0
-            }
-            
-            self._log_operation_end("publish_batch_messages", success_count > 0)
-            return result
-            
-        except Exception as e:
-            self._logger.ERROR(f"Error in batch publish to {topic}: {e}")
-            return {
-                "topic": topic,
-                "total_messages": len(messages),
-                "successful_sends": 0,
-                "failed_sends": len(messages),
-                "success_rate": 0,
-                "error": str(e)
-            }
-    
-    # ==================== Message Subscription Service ====================
-
-    def subscribe_topic(self, topic: str, handler: Callable[[Dict[str, Any]], bool],
-                       group_id: str = None, auto_start: bool = True) -> bool:
-        """
-        Subscribe to topic and set message handler
-
-        Args:
-            topic: Topic name
-            handler: Message handler function, receives message dict, returns success status
-            group_id: Consumer group ID
-            auto_start: Whether to automatically start consumption
-
-        Returns:
-            bool: Whether subscription was successful
-        """
-        try:
-            self._log_operation_start("subscribe_topic", topic=topic, group_id=group_id)
-            
-            # 保存处理器
-            self._message_handlers[topic] = handler
-            
-            if auto_start:
-                return self.start_consuming(topic, group_id)
-            
-            self._logger.INFO(f"Subscribed to topic: {topic} (handler registered)")
-            return True
-            
-        except Exception as e:
-            self._logger.ERROR(f"Error subscribing to topic {topic}: {e}")
-            return False
-    
-    def start_consuming(self, topic: str, group_id: str = None, 
-                       max_messages: int = None) -> bool:
-        """
-        开始消费指定主题的消息
-        
-        Args:
-            topic: 主题名称
-            group_id: 消费者组ID
-            max_messages: 最大消息数量，None表示持续消费
-            
-        Returns:
-            bool: 启动是否成功
-        """
-        try:
-            self._log_operation_start("start_consuming", topic=topic, group_id=group_id)
-            
-            # 检查是否已有处理器
-            if topic not in self._message_handlers:
-                self._logger.ERROR(f"No handler registered for topic: {topic}")
-                return False
-            
-            # 停止现有的消费线程（如果有）
-            self.stop_consuming(topic)
-            
-            # 创建停止事件
-            stop_event = threading.Event()
-            self._stop_events[topic] = stop_event
-            
-            # 创建消费者线程
-            consumer_thread = threading.Thread(
-                target=self._consumer_worker,
-                args=(topic, group_id, max_messages, stop_event),
-                daemon=True,
-                name=f"kafka_consumer_{topic}"
-            )
-            
-            self._consumer_threads[topic] = consumer_thread
-            consumer_thread.start()
-            
-            self._logger.INFO(f"Started consuming topic: {topic}")
-            return True
-            
-        except Exception as e:
-            self._logger.ERROR(f"Error starting consumer for topic {topic}: {e}")
-            return False
-    
-    def stop_consuming(self, topic: str) -> ServiceResult:
-        """
-        停止消费指定主题
-
-        Args:
-            topic: 主题名称
-
-        Returns:
-            ServiceResult: 停止结果
-        """
-        try:
-            self._log_operation_start("stop_consuming", topic=topic)
-
-            # 设置停止信号
-            if topic in self._stop_events:
-                self._stop_events[topic].set()
-
-            # 等待线程结束
-            if topic in self._consumer_threads:
-                thread = self._consumer_threads[topic]
-                if thread.is_alive():
-                    thread.join(timeout=5.0)  # 最多等待5秒
-
-                del self._consumer_threads[topic]
-
-            # 清理停止事件
-            if topic in self._stop_events:
-                del self._stop_events[topic]
-
-            # 关闭对应的消费者
-            self._crud_repo.close_consumer(topic)
-
-            self._logger.INFO(f"Stopped consuming topic: {topic}")
-            return ServiceResult.success({"stopped": True}, f"Successfully stopped consuming topic: {topic}")
-
-        except Exception as e:
-            self._logger.ERROR(f"Error stopping consumer for topic {topic}: {e}")
-            return ServiceResult.error(f"Failed to stop consuming topic: {str(e)}")
-    
-    def _consumer_worker(self, topic: str, group_id: str, max_messages: int, 
-                        stop_event: threading.Event):
-        """
-        消费者工作线程
-        
-        Args:
-            topic: 主题名称
-            group_id: 消费者组ID
-            max_messages: 最大消息数量
-            stop_event: 停止事件
-        """
-        handler = self._message_handlers.get(topic)
-        if not handler:
-            self._logger.ERROR(f"No handler found for topic: {topic}")
-            return
-        
-        processed_count = 0
-        
-        try:
-            # 使用回调方式消费消息
-            def message_processor(message_data: Dict[str, Any]) -> bool:
-                nonlocal processed_count
-                
-                try:
-                    # 检查停止信号
-                    if stop_event.is_set():
-                        return False
-                    
-                    # 调用用户处理器
-                    success = handler(message_data)
-                    
-                    if success:
-                        processed_count += 1
-                        self._receive_stats["total_received"] += 1
-                        self._receive_stats["last_receive_time"] = datetime.now()
-                    
-                    # 检查最大消息数量
-                    if max_messages and processed_count >= max_messages:
-                        stop_event.set()
-                        return False
-                    
-                    return success
-                    
-                except Exception as e:
-                    self._logger.ERROR(f"Error in message handler for {topic}: {e}")
-                    return False
-            
-            # 开始消费
-            self._crud_repo.consume_with_callback(
-                topic=topic,
-                callback=message_processor,
-                group_id=group_id,
-                max_messages=max_messages
-            )
-            
-        except Exception as e:
-            self._logger.ERROR(f"Consumer worker error for topic {topic}: {e}")
-        
-        finally:
-            self._logger.DEBUG(f"Consumer worker for {topic} processed {processed_count} messages")
-    
     # ==================== Topic Management Service ====================
 
     def get_topic_status(self, topic: str) -> ServiceResult:
@@ -512,51 +264,13 @@ class KafkaService(BaseService):
             ServiceResult: Topic status information
         """
         try:
-            basic_info = self._crud_repo.get_topic_info(topic)
-
-            # 添加服务层的状态信息
-            status = basic_info.copy()
-            status.update({
-                "has_handler": topic in self._message_handlers,
-                "is_consuming": topic in self._consumer_threads and
-                               self._consumer_threads[topic].is_alive(),
-                "consumer_thread_name": self._consumer_threads[topic].name
-                                       if topic in self._consumer_threads else None
-            })
-
+            status = self._crud_repo.get_topic_info(topic)
             return ServiceResult.success(status, f"Retrieved status for topic: {topic}")
 
         except Exception as e:
             self._logger.ERROR(f"Error getting topic status for {topic}: {e}")
             return ServiceResult.error(f"Failed to get topic status: {str(e)}")
-    
-    def list_active_subscriptions(self) -> ServiceResult:
-        """
-        列出所有活跃的订阅
 
-        Returns:
-            ServiceResult: 订阅状态列表
-        """
-        try:
-            subscriptions = []
-
-            for topic in self._message_handlers.keys():
-                subscription_info = {
-                    "topic": topic,
-                    "has_handler": True,
-                    "is_consuming": topic in self._consumer_threads and
-                                   self._consumer_threads[topic].is_alive(),
-                    "thread_name": self._consumer_threads[topic].name
-                                  if topic in self._consumer_threads else None
-                }
-                subscriptions.append(subscription_info)
-
-            return ServiceResult.success(subscriptions, f"Listed {len(subscriptions)} active subscriptions")
-
-        except Exception as e:
-            self._logger.ERROR(f"Failed to list active subscriptions: {e}")
-            return ServiceResult.error(f"Failed to list active subscriptions: {str(e)}")
-    
     def list_consumer_groups(self) -> ServiceResult:
         """
         列出 broker 端所有 consumer groups
@@ -573,31 +287,6 @@ class KafkaService(BaseService):
             self._logger.ERROR(f"Failed to list consumer groups: {e}")
             return ServiceResult.error(f"Failed to list consumer groups: {str(e)}")
 
-    def unsubscribe_topic(self, topic: str) -> ServiceResult:
-        """
-        取消订阅主题
-
-        Args:
-            topic: 主题名称
-
-        Returns:
-            ServiceResult: 取消订阅结果
-        """
-        try:
-            # 停止消费
-            self.stop_consuming(topic)
-
-            # 移除处理器
-            if topic in self._message_handlers:
-                del self._message_handlers[topic]
-
-            self._logger.INFO(f"Unsubscribed from topic: {topic}")
-            return ServiceResult.success({"unsubscribed": True}, f"Successfully unsubscribed from topic: {topic}")
-
-        except Exception as e:
-            self._logger.ERROR(f"Error unsubscribing from topic {topic}: {e}")
-            return ServiceResult.error(f"Failed to unsubscribe from topic: {str(e)}")
-    
     # ==================== 队列监控和统计 ====================
     
     def get_statistics(self) -> ServiceResult:
@@ -610,18 +299,10 @@ class KafkaService(BaseService):
         try:
             kafka_status = self._crud_repo.get_kafka_status()
 
-            # 注意：list_active_subscriptions现在返回ServiceResult
-            subscriptions_result = self.list_active_subscriptions()
-            subscriptions_data = subscriptions_result.data if subscriptions_result.is_success() else []
-
             statistics = {
                 "kafka_connection": kafka_status,
                 "send_statistics": self._send_stats.copy(),
                 "receive_statistics": self._receive_stats.copy(),
-                "active_subscriptions": len(self._message_handlers),
-                "running_consumers": len([t for t in self._consumer_threads.values()
-                                        if t.is_alive()]),
-                "subscription_details": subscriptions_data
             }
 
             return ServiceResult.success(statistics, "Retrieved service statistics successfully")
@@ -629,7 +310,7 @@ class KafkaService(BaseService):
         except Exception as e:
             self._logger.ERROR(f"Failed to get statistics: {e}")
             return ServiceResult.error(f"Failed to get statistics: {str(e)}")
-    
+
     def get_unconsumed_count(self, topic: str, group_id: str = None) -> ServiceResult:
         """
         查询指定主题的未消费消息数量
@@ -795,14 +476,14 @@ class KafkaService(BaseService):
         获取队列指标
 
         Args:
-            topics: 主题列表，None表示所有订阅的主题
+            topics: 主题列表，None 表示空集（消费 worker 模型已退役，无本地订阅状态）
 
         Returns:
             ServiceResult: 队列指标
         """
         try:
             if topics is None:
-                topics = list(self._message_handlers.keys())
+                topics = []
 
             metrics = {
                 "timestamp": datetime.now().isoformat(),
@@ -831,33 +512,7 @@ class KafkaService(BaseService):
         except Exception as e:
             self._logger.ERROR(f"Failed to get queue metrics: {e}")
             return ServiceResult.error(f"Failed to get queue metrics: {str(e)}")
-    
-    def reset_statistics(self) -> ServiceResult:
-        """
-        重置统计信息
 
-        Returns:
-            ServiceResult: 重置结果
-        """
-        try:
-            self._send_stats = {
-                "total_sent": 0,
-                "failed_sends": 0,
-                "last_send_time": None
-            }
-
-            self._receive_stats = {
-                "total_received": 0,
-                "last_receive_time": None
-            }
-
-            self._logger.INFO("Statistics reset successfully")
-            return ServiceResult.success({"reset": True}, "Statistics reset successfully")
-
-        except Exception as e:
-            self._logger.ERROR(f"Error resetting statistics: {e}")
-            return ServiceResult.error(f"Failed to reset statistics: {str(e)}")
-    
     # ==================== 健康检查和系统管理 ====================
     
     def health_check(self) -> ServiceResult:
@@ -868,37 +523,15 @@ class KafkaService(BaseService):
             ServiceResult: 健康状态信息
         """
         try:
-            # 基础健康状态
-            base_health = {
-                "service": "KafkaService",
-                "status": "healthy",
-                "timestamp": time.time()
-            }
             kafka_status = self._crud_repo.get_kafka_status()
+            overall_healthy = kafka_status["connected"]
 
-            # 检查消费者线程健康状态
-            consumer_health = {}
-            for topic, thread in self._consumer_threads.items():
-                consumer_health[topic] = {
-                    "alive": thread.is_alive(),
-                    "name": thread.name
-                }
-
-            health_status = base_health.copy()
-            health_status.update({
+            health_status = {
+                "service": "KafkaService",
+                "status": "healthy" if overall_healthy else "unhealthy",
+                "timestamp": time.time(),
                 "kafka_connection": kafka_status["connected"],
-                "active_consumers": consumer_health,
-                "total_subscriptions": len(self._message_handlers),
-                "running_consumers": len([t for t in self._consumer_threads.values() if t.is_alive()])
-            })
-
-            # 判断整体健康状态
-            overall_healthy = (
-                kafka_status["connected"] and
-                len([t for t in self._consumer_threads.values() if not t.is_alive()]) == 0
-            )
-
-            health_status["status"] = "healthy" if overall_healthy else "unhealthy"
+            }
 
             status_message = "Kafka service is healthy" if overall_healthy else "Kafka service has issues"
             return ServiceResult.success(health_status, status_message)
@@ -906,35 +539,27 @@ class KafkaService(BaseService):
         except Exception as e:
             self._logger.ERROR(f"Health check failed: {e}")
             return ServiceResult.error(f"Health check failed: {str(e)}")
-    
+
     def shutdown(self) -> bool:
         """
         优雅关闭服务
-        
+
         Returns:
             bool: 关闭是否成功
         """
         try:
             self._logger.INFO("Shutting down KafkaService...")
-            
-            # 停止所有消费者
-            topics_to_stop = list(self._consumer_threads.keys())
-            for topic in topics_to_stop:
-                self.stop_consuming(topic)
-            
-            # 清理处理器
-            self._message_handlers.clear()
-            
-            # 关闭所有Kafka消费者连接
+
+            # 关闭所有 Kafka 消费者连接
             self._crud_repo.close_all_consumers()
-            
+
             self._logger.INFO("KafkaService shutdown completed")
             return True
-            
+
         except Exception as e:
             self._logger.ERROR(f"Error during service shutdown: {e}")
             return False
-    
+
     # ==================== Data Update Signal Sending ====================
 
     def send_stockinfo_update_signal(self) -> bool:
@@ -977,13 +602,6 @@ class KafkaService(BaseService):
             "code": code,
             "full": full,
             "force": force
-        })
-
-    def send_worker_kill_signal(self) -> bool:
-        """Send worker stop signal"""
-        return self.publish_message(KafkaTopics.DATA_UPDATE, {
-            "type": "kill",
-            "code": ""
         })
 
     def send_tick_all_signal(self, full: bool = False, force: bool = False) -> bool:

--- a/src/ginkgo/libs/core/threading.py
+++ b/src/ginkgo/libs/core/threading.py
@@ -569,31 +569,6 @@ if __name__ == "__main__":
         self.kill_thread(name)
         self.add_thread(name, target)
 
-    def get_proc_status(self, pid) -> str:
-        try:
-            # Handle cases where pid might be None, "None", or non-numeric
-            if pid is None or pid == "None" or not str(pid).isdigit():
-                return "NOT EXIST"
-            proc = psutil.Process(int(pid))
-            return proc.status().upper()
-        except Exception as e:
-            return "NOT EXIST"
-        finally:
-            pass
-
-    def kill_proc(self, pid: int) -> None:
-        try:
-            proc = psutil.Process(int(pid))
-            if proc.is_running():
-                control_logger.DEBUG(f"Kill PID: {pid}")
-                os.kill(int(pid), signal.SIGKILL)
-            console.print(f":leaf_fluttering_in_wind: Kill PID: {pid}")
-            time.sleep(0.4)
-        except Exception as e:
-            console.print(f":leaf_fluttering_in_wind: Kill PID Failed: {e}")
-        finally:
-            pass
-
     def clean_thread_pool(self, *args, **kwargs) -> None:
         cursor = 0
         while True:

--- a/tests/unit/client/test_kafka_cli_monitor.py
+++ b/tests/unit/client/test_kafka_cli_monitor.py
@@ -1,0 +1,71 @@
+"""
+#6736 review fix: `_start_queue_monitor` 的 `create_monitor_layout` 闭包曾引用
+已删除的 `subscription_table`（消费 worker 模型 #6736 退役后，Active Subscriptions
+面板语义失效，定义块被删但漏删 `layout.split_column` 内引用），致 `ginkgo kafka monitor`
+启动即 `NameError`，被外层 `except Exception` 吞成"安静失败"。
+
+回归保护：监控命令启动不进入 "Error starting queue monitor" 分支。
+"""
+import pytest
+
+
+class _FakeLive:
+    """rich.live.Live 的最小替身：context manager + update()，不真正渲染。"""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def update(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture
+def _monitor_env(monkeypatch):
+    """mock 掉监控命令的外部依赖，聚焦 create_monitor_layout 布局构造。"""
+    from unittest.mock import MagicMock
+
+    import ginkgo.data.containers as containers_mod
+    import ginkgo.libs.core.threading as gtm_mod
+    import rich.live as rich_live
+    import signal as signal_mod
+
+    fake_service = MagicMock()
+    fake_result = MagicMock()
+    fake_result.success = True
+    fake_result.data = {}
+    fake_service.get_statistics.return_value = fake_result
+
+    mock_container = MagicMock()
+    mock_container.kafka_service.return_value = fake_service
+    monkeypatch.setattr(containers_mod, "container", mock_container)
+
+    fake_gtm = MagicMock()
+    fake_gtm.get_worker_count.return_value = 0
+    fake_gtm.get_workers_status.return_value = {}
+    monkeypatch.setattr(gtm_mod, "GinkgoThreadManager", lambda: fake_gtm)
+
+    monkeypatch.setattr(rich_live, "Live", _FakeLive)
+    monkeypatch.setattr(signal_mod, "signal", lambda *a, **kw: None)
+
+
+class TestKafkaMonitorLayoutNoNameError:
+    """#6736 review fix：监控布局构造不应引用已删除的 subscription_table。"""
+
+    @pytest.mark.unit
+    def test_start_queue_monitor_does_not_enter_error_branch(
+        self, _monitor_env, capsys
+    ):
+        from ginkgo.client.kafka_cli import _start_queue_monitor
+
+        # duration=0：while 首次检查 elapsed >= duration 即退出，不阻塞。
+        _start_queue_monitor(duration=0, interval=1)
+
+        out = capsys.readouterr().out
+        assert "Error starting queue monitor" not in out
+        assert "subscription_table" not in out

--- a/tests/unit/data/services/test_kafka_consumer_retired.py
+++ b/tests/unit/data/services/test_kafka_consumer_retired.py
@@ -1,0 +1,113 @@
+"""
+#6736: KafkaService 消费 worker 模型（零活调用方，含阻塞迭代器 stop 语义 bug）退役。
+
+#6726 已删 threading main_control 远控消费链，#6727 已删 redis 进程 helper 与
+ginkgo status 残留输出。本 issue 收尾 KafkaService 自身的消费 worker 模型：
+subscribe_topic / start_consuming / stop_consuming / unsubscribe_topic / _consumer_worker
++ 状态字段 + 连带的散落执行类死方法（publish_batch_messages / reset_statistics /
+send_worker_kill_signal）+ KafkaCRUD.consume_with_callback（阻塞迭代器 bug 所在，
+唯一调用方是死的 _consumer_worker）。
+
+主力消费（DataWorker / paper_trading_worker / execution_node）绕过 KafkaService
+直接用 drivers 层 GinkgoConsumer.poll，本就不依赖这套消费模型——blast radius = 0。
+保留所有状态/查询接口（get_* / count / validate / check_integrity）与生产/信号路径。
+"""
+import pytest
+
+from ginkgo.data.services.kafka_service import KafkaService
+from ginkgo.data.crud.kafka_crud import KafkaCRUD
+from ginkgo.libs.core.threading import GinkgoThreadManager
+
+
+# ===========================================================================
+# KafkaService 消费 worker 模型退役
+# ===========================================================================
+
+class TestKafkaServiceConsumerWorkerRetired:
+    """消费 worker 模型零活调用方（#6726 删 threading 链后唯一外部入口已断），应移除。"""
+
+    @pytest.mark.unit
+    def test_subscription_methods_removed(self):
+        """subscribe_topic / start_consuming / stop_consuming / unsubscribe_topic 已移除。"""
+        assert not hasattr(KafkaService, "subscribe_topic")
+        assert not hasattr(KafkaService, "start_consuming")
+        assert not hasattr(KafkaService, "stop_consuming")
+        assert not hasattr(KafkaService, "unsubscribe_topic")
+
+    @pytest.mark.unit
+    def test_consumer_worker_removed(self):
+        """_consumer_worker（threading.Thread target，含阻塞迭代器调用）已移除。"""
+        assert not hasattr(KafkaService, "_consumer_worker")
+
+    @pytest.mark.unit
+    def test_list_active_subscriptions_removed(self):
+        """list_active_subscriptions 仅基于消费字段，消费模型删后成孤儿，应移除。"""
+        assert not hasattr(KafkaService, "list_active_subscriptions")
+
+    @pytest.mark.unit
+    def test_consumer_state_fields_not_initialized(self, kafka_service):
+        """__init__ 不再初始化 _message_handlers / _consumer_threads / _stop_events。"""
+        assert not hasattr(kafka_service, "_message_handlers")
+        assert not hasattr(kafka_service, "_consumer_threads")
+        assert not hasattr(kafka_service, "_stop_events")
+
+
+# ===========================================================================
+# KafkaService 散落执行类死方法退役
+# ===========================================================================
+
+class TestKafkaServiceDeadExecMethodsRetired:
+    """零调用方的执行类死方法（非状态/查询接口）应移除。"""
+
+    @pytest.mark.unit
+    def test_publish_batch_messages_removed(self):
+        """publish_batch_messages（批量发布执行类，零调用）已移除。"""
+        assert not hasattr(KafkaService, "publish_batch_messages")
+
+    @pytest.mark.unit
+    def test_reset_statistics_removed(self):
+        """reset_statistics（重置统计执行类，零调用）已移除。"""
+        assert not hasattr(KafkaService, "reset_statistics")
+
+    @pytest.mark.unit
+    def test_send_worker_kill_signal_removed(self):
+        """send_worker_kill_signal（双死：零调用 + DataWorker 无 type==kill 分支）已移除。"""
+        assert not hasattr(KafkaService, "send_worker_kill_signal")
+
+
+# ===========================================================================
+# KafkaCRUD consume_with_callback 退役
+# ===========================================================================
+
+class TestKafkaCRUDConsumeWithCallbackRetired:
+    """consume_with_callback（裸阻塞迭代器，唯一调用方是死的 _consumer_worker）。"""
+
+    @pytest.mark.unit
+    def test_consume_with_callback_removed(self):
+        assert not hasattr(KafkaCRUD, "consume_with_callback")
+
+
+# ===========================================================================
+# threading.py 孤儿清理（#6726 漏删）
+# ===========================================================================
+
+class TestThreadingOrphansRetired:
+    """#6726 删了 get_proc_status/kill_proc 的唯一调用方（main_status/watch_dog_status
+    property / kill_maincontrol / kill_watch_dog）却漏删本体，二者成孤儿，应移除。"""
+
+    @pytest.mark.unit
+    def test_get_proc_status_removed(self):
+        assert not hasattr(GinkgoThreadManager, "get_proc_status")
+
+    @pytest.mark.unit
+    def test_kill_proc_removed(self):
+        assert not hasattr(GinkgoThreadManager, "kill_proc")
+
+
+# ===========================================================================
+# fixtures
+# ===========================================================================
+
+@pytest.fixture
+def kafka_service():
+    return KafkaService()

--- a/tests/unit/data/services/test_kafka_service_retired_smoke.py
+++ b/tests/unit/data/services/test_kafka_service_retired_smoke.py
@@ -1,0 +1,81 @@
+"""#6736 KafkaService 消费 worker 退役后契约 smoke（#6685 diff coverage gate 采集）。
+
+退役删了 _message_handlers/_consumer_threads/_stop_events 等本地状态字段后，3 个
+查询/健康方法的**行为与返回契约发生变更**（非纯删），是本 PR 改动可执行行：
+- get_topic_status：不再 copy+update handler/consumer 字段，直返 crud.get_topic_info
+- get_queue_metrics(topics=None)：原 list(_message_handlers.keys()) → 现 []
+- health_check：healthy 判定去掉消费者线程维度；返回 dict 删了 active_consumers /
+  total_subscriptions / running_consumers 3 字段
+
+同目录 test_kafka_consumer_retired.py 只验证"已删除"（hasattr 断言），不调方法体 →
+diff coverage gate 红。本文件 mock crud（不连 Kafka）调起 3 方法体补覆盖信号，并锁定
+退役后的新契约，纳入 gate 合集采集。
+"""
+
+import os
+import sys
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.kafka_service import KafkaService
+
+
+@pytest.fixture
+def kafka_service():
+    with patch("ginkgo.libs.GLOG"):
+        return KafkaService(kafka_crud=MagicMock())
+
+
+@pytest.mark.unit
+def test_get_topic_status_returns_crud_info(kafka_service):
+    """get_topic_status 直返 crud.get_topic_info（退役后不再合成 handler/consumer 字段）。"""
+    kafka_service._crud_repo.get_topic_info.return_value = {
+        "topic": "ticks",
+        "partitions": 3,
+    }
+    result = kafka_service.get_topic_status("ticks")
+    assert result.success is True
+    assert result.data == {"topic": "ticks", "partitions": 3}
+    # 退役契约：返回 dict 不再含 handler/consumer 残留字段
+    assert "has_handler" not in result.data
+    assert "is_consuming" not in result.data
+
+
+@pytest.mark.unit
+def test_get_queue_metrics_none_topics_returns_empty(kafka_service):
+    """topics=None 现走空集分支（无本地订阅状态），metrics["topics"] 为 {}。"""
+    result = kafka_service.get_queue_metrics(None)
+    assert result.success is True
+    assert result.data["topics"] == {}
+    # 退役契约：topics 为空时不查 crud lag（get_message_count 不应被触达）
+    kafka_service._crud_repo.get_message_count.assert_not_called()
+
+
+@pytest.mark.unit
+def test_health_check_healthy_when_connected(kafka_service):
+    """健康判定仅看 kafka 连接；connected=True → healthy，字段契约精简。"""
+    kafka_service._crud_repo.get_kafka_status.return_value = {"connected": True}
+    result = kafka_service.health_check()
+    assert result.success is True
+    assert result.data["status"] == "healthy"
+    assert result.data["kafka_connection"] is True
+    assert result.data["service"] == "KafkaService"
+    # 退役契约：返回 dict 不再含消费者线程相关字段
+    assert "active_consumers" not in result.data
+    assert "total_subscriptions" not in result.data
+    assert "running_consumers" not in result.data
+
+
+@pytest.mark.unit
+def test_health_check_unhealthy_when_disconnected(kafka_service):
+    """connected=False → unhealthy（覆盖三元表达式 else 分支）。"""
+    kafka_service._crud_repo.get_kafka_status.return_value = {"connected": False}
+    result = kafka_service.health_check()
+    assert result.success is True
+    assert result.data["status"] == "unhealthy"
+    assert result.data["kafka_connection"] is False


### PR DESCRIPTION
## Summary

#6736 收尾 KafkaService 自身的消费 worker 模型退役（#6726 已删 threading main_control 远控消费链，#6727 已删 redis 进程 helper 与 status 残留输出）。

**消费 worker 模型零活调用方**：`#6726` 删除 threading 远控消费链后，`subscribe_topic` / `start_consuming` / `stop_consuming` / `unsubscribe_topic` / `_consumer_worker` 的唯一外部入口已断。主力消费（`DataWorker` / `paper_trading_worker` / `execution_node`）绕过 KafkaService，直接用 drivers 层 `GinkgoConsumer.poll`——本就不依赖这套消费模型，**blast radius = 0**。

**变更内容**：
| 文件 | 删除 |
|---|---|
| `kafka_service.py` | 消费 worker 5 方法 + `_message_handlers`/`_consumer_threads`/`_stop_events` 状态字段 + `list_active_subscriptions` + `publish_batch_messages`/`reset_statistics`/`send_worker_kill_signal`（零调用执行类死方法）+ `get_topic_status`/`get_statistics`/`get_queue_metrics`/`health_check`/`shutdown` 反向引用改造（保留状态/查询接口） |
| `kafka_crud.py` | `consume_with_callback`（裸阻塞迭代器 stop 语义 bug，唯一调用方是已删的 `_consumer_worker`） |
| `threading.py` | `get_proc_status` / `kill_proc`（#6726 删其唯一调用方却漏删本体，二者成孤儿） |
| `kafka_cli.py` | `status` / `monitor` 引用已删字段的显示行 |

**保留**：全部状态/查询接口（`get`/`count`/`validate`/`check_integrity`/`list_consumer_groups`/`get_unconsumed_count`/`get_consumer_group_lag`）、`_send_stats`/`_receive_stats` 统计报告、生产与信号路径。

遵循 [[feedback-deadcode-stateful-interface-keep]]：状态/查询接口即使零调用也保留，只删执行类死代码。

## Test plan

- [x] **Layer 1** py_compile 全量（src + api）通过
- [x] **Layer 2** 启动路径 smoke（`test_user_crud_mock` + `test_containers` + `test_user_cli`）37 passed
- [x] **Layer 3** 变更相关：
  - 新增 `test_kafka_consumer_retired.py`（TDD 红→绿，断言符号已移除）+ `test_kafka_service.py` = 43 passed
  - `test_kafka_cli` + `test_kafka_crud_mock` + threading + `test_main_control_status_retired`（#6727 回归）= 50 passed
- [x] 共 **130 passed, 0 failed**
- [x] grep 复核每个删除符号零外部调用方（仅内部互调，全在删除范围内）

Closes #6736