### PR TITLE
fix(#6741): PortfolioLive.on_order_partially_filled fill 应用加事务性（snapshot-restore + re-raise）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,17 @@ jobs:
             tests/unit/features/test_operator_registry.py \
             tests/unit/features/test_expression_engine.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: portfolio_live fill transactional smoke (#6741/#6742)
+        # portfolio_live.on_order_partially_filled 事务性重构（snapshot-restore 全回滚 +
+        # CRITICAL + re-raise）+ deal return False 转 raise（#6742 扩 scope）。整个方法体
+        # 被 gate 视为新增可执行行，但无 smoke 调其方法体 → diff coverage gate 红。
+        # PR 自带 10 测试（AC1-AC10：LONG/SHORT 异常回滚 + deal return False 回滚 +
+        # 正常路径 + worker 不崩）补覆盖信号。独立 step 使 push→master 时也跑，
+        # 同时纳入下方 gate 合集采集 coverage。
+        run: |
+          uv run python -m pytest \
+            tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
@@ -177,6 +188,7 @@ jobs:
             tests/unit/features/test_expression_registry.py \
             tests/unit/features/test_operator_registry.py \
             tests/unit/features/test_expression_engine.py \
+            tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -414,6 +414,18 @@ class PortfolioLive(PortfolioBase):
         order._transaction_volume = snapshot["order_transaction_volume"]
         order._transaction_price = snapshot["order_transaction_price"]
 
+    def clean_positions(self) -> None:
+        """移除已完全平仓的 position（``total_position <= 0``）。
+
+        SHORT 成交经 ``_sold`` 扣减 ``frozen_volume`` 后，若持仓被全部卖空
+        （``volume + frozen_volume + settlement_frozen_volume`` 均为 0），从
+        ``_positions`` 移除，避免空持仓残留污染快照与持久化。LONG 只增不减，
+        不会产生零持仓，不触发清理。#6741
+        """
+        emptied = [code for code, pos in self._positions.items() if pos.total_position <= 0]
+        for code in emptied:
+            del self._positions[code]
+
     def update_worth(self):
         pass
 

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -326,7 +326,9 @@ class PortfolioLive(PortfolioBase):
 
                 pos = self.get_position(code)
                 if pos is None:
-                    GLOG.ERROR(f"Partial SHORT fill but no position found for {code}")
+                    # SHORT 无持仓收到 fill = 业务异常；raise 进事务 except，回滚已执行的
+                    # add_cash/add_fee + CRITICAL + re-raise（修正原静默 ERROR 半应用资金，#6739 审计）
+                    raise ValueError(f"Partial SHORT fill but no position found for {code}")
                 else:
                     pos.deal(DIRECTION_TYPES.SHORT, price, qty)
                     self.clean_positions()

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -8,6 +8,7 @@
 
 
 import time
+import copy
 import datetime
 from enum import Enum
 from rich.console import Console
@@ -267,23 +268,25 @@ class PortfolioLive(PortfolioBase):
         # ORDER IDEMPOTENCY: Portfolio层只做幂等性检查，不负责持久化
         # TODO: 通过 Order.transaction_volume 判断是否重复处理
 
+        order = getattr(event, "order", None)
+        if order is None:
+            GLOG.ERROR("Partial fill event missing order payload")
+            return
+
+        qty = int(getattr(event, "filled_quantity", 0) or 0)
+        price = to_decimal(getattr(event, "fill_price", 0) or 0)
+        fee = to_decimal(getattr(event, "commission", 0) or 0)
+        if qty <= 0 or price <= 0:
+            GLOG.WARN(f"Partial fill ignored due to invalid qty/price: {qty}/{price}")
+            return
+
+        direction = getattr(order, "direction", None) or getattr(event, "direction", None)
+        code = event.code
+        fill_cost = price * qty + fee
+
+        # 事务边界：拍快照，fill 链任一步抛异常则全回滚 + CRITICAL + re-raise（#6741）
+        snapshot = self._snapshot_fill_state(order)
         try:
-            order = getattr(event, "order", None)
-            if order is None:
-                GLOG.ERROR("Partial fill event missing order payload")
-                return
-
-            qty = int(getattr(event, "filled_quantity", 0) or 0)
-            price = to_decimal(getattr(event, "fill_price", 0) or 0)
-            fee = to_decimal(getattr(event, "commission", 0) or 0)
-            if qty <= 0 or price <= 0:
-                GLOG.WARN(f"Partial fill ignored due to invalid qty/price: {qty}/{price}")
-                return
-
-            direction = getattr(order, "direction", None) or getattr(event, "direction", None)
-            code = event.code
-            fill_cost = price * qty + fee
-
             # 累计成交 + 扣减剩余冻结资金（ADR-010 V5：settle，内部守 min 截断 + remain 兜底 + ≥0）
             order.settle(qty, price, fee)
 
@@ -337,7 +340,77 @@ class PortfolioLive(PortfolioBase):
             self.update_worth()
             self.update_profit()
         except Exception as e:
-            GLOG.ERROR(f"on_order_partially_filled failed: {e}")
+            # 回滚 fill 路径所有可变状态；restore 自身抛降级 CRITICAL 记二阶异常，仍 re-raise 原异常
+            try:
+                self._restore_fill_state(snapshot, order)
+            except Exception as restore_err:
+                GLOG.CRITICAL(
+                    f"on_order_partially_filled ROLLBACK FAILED (secondary): "
+                    f"{restore_err}; original error: {e}. State may be inconsistent."
+                )
+            GLOG.CRITICAL(
+                f"on_order_partially_filled FILL ROLLED BACK: "
+                f"order={getattr(order, 'uuid', '?')}, code={code}, qty={qty}, "
+                f"price={price}, fee={fee}, error: {e}"
+            )
+            raise
+
+    def _snapshot_fill_state(self, order) -> dict:
+        """拍 fill 路径可变状态快照（#6741 事务边界）。
+
+        覆盖 Portfolio 内存账户簿（``_cash``/``_frozen``/``_fee``/``_worth``/``_profit``）
+        与 Order 成交字段（``_remain``/``_transaction_volume``/``_transaction_price``，
+        settle/release_frozen 改的状态）。
+
+        ``_positions`` 必须 **深拷贝** —— ``pos.deal`` 原地改 position 对象的
+        ``_cost``/``_volume`` 等字段，浅拷贝只拷 dict 引用，回滚还原的仍是已污染实例。
+        """
+        return {
+            "_cash": self._cash,
+            "_frozen": self._frozen,
+            "_fee": self._fee,
+            "_worth": self._worth,
+            "_profit": self._profit,
+            "_positions": self._deepcopy_positions(self._positions),
+            "order_remain": order._remain,
+            "order_transaction_volume": order._transaction_volume,
+            "order_transaction_price": order._transaction_price,
+        }
+
+    def _deepcopy_positions(self, positions: dict) -> dict:
+        """深拷贝 positions dict（#6741 事务快照）。
+
+        Position 继承的 ``loggers`` 字段持有 ``logging.Logger``（含 RLock，
+        不可 pickle）。loggers 是日志器单例引用、非业务状态，深拷贝时跳过——
+        副本共享原 loggers（回滚只还原业务字段，不触碰日志器）。
+        """
+        snap: dict = {}
+        for code, pos in positions.items():
+            saved_loggers = getattr(pos, "loggers", None)
+            if saved_loggers is not None:
+                pos.loggers = []
+            try:
+                snap[code] = copy.deepcopy(pos)
+            finally:
+                if saved_loggers is not None:
+                    pos.loggers = saved_loggers
+            snap[code].loggers = saved_loggers
+        return snap
+
+    def _restore_fill_state(self, snapshot: dict, order) -> None:
+        """还原 fill 路径状态到快照（#6741 事务回滚）。
+
+        ``_positions`` 直接接管快照里的深拷贝副本（快照一次性，方法结束即弃）。
+        """
+        self._cash = snapshot["_cash"]
+        self._frozen = snapshot["_frozen"]
+        self._fee = snapshot["_fee"]
+        self._worth = snapshot["_worth"]
+        self._profit = snapshot["_profit"]
+        self._positions = snapshot["_positions"]
+        order._remain = snapshot["order_remain"]
+        order._transaction_volume = snapshot["order_transaction_volume"]
+        order._transaction_price = snapshot["order_transaction_price"]
 
     def update_worth(self):
         pass

--- a/src/ginkgo/trading/portfolios/portfolio_live.py
+++ b/src/ginkgo/trading/portfolios/portfolio_live.py
@@ -315,7 +315,12 @@ class PortfolioLive(PortfolioBase):
                     )
                     self.add_position(p)
                 else:
-                    pos.deal(DIRECTION_TYPES.LONG, price, qty)
+                    # pos.deal 失败（cost<0/非 Decimal/异常）返回 False 不抛；转 raise 进事务 except 触发回滚
+                    if not pos.deal(DIRECTION_TYPES.LONG, price, qty):
+                        raise RuntimeError(
+                            f"LONG pos.deal rejected for {code}: {qty}@{price} "
+                            f"(total={pos.total_position}, frozen={pos.frozen_volume})"
+                        )
 
                 GLOG.INFO(f"PARTIAL LONG filled {code}: {qty}@{price}, fee={fee}, remain_frozen={order.remain}",
                 )
@@ -330,7 +335,12 @@ class PortfolioLive(PortfolioBase):
                     # add_cash/add_fee + CRITICAL + re-raise（修正原静默 ERROR 半应用资金，#6739 审计）
                     raise ValueError(f"Partial SHORT fill but no position found for {code}")
                 else:
-                    pos.deal(DIRECTION_TYPES.SHORT, price, qty)
+                    # pos.deal 失败（SHORT qty>frozen_volume/异常）返回 False 不抛；转 raise 进事务 except 触发回滚
+                    if not pos.deal(DIRECTION_TYPES.SHORT, price, qty):
+                        raise RuntimeError(
+                            f"SHORT pos.deal rejected for {code}: {qty}@{price} "
+                            f"(total={pos.total_position}, frozen={pos.frozen_volume})"
+                        )
                     self.clean_positions()
 
                 GLOG.INFO(f"PARTIAL SHORT filled {code}: {qty}@{price}, fee={fee}")

--- a/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
+++ b/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
@@ -8,6 +8,8 @@ PortfolioLive.on_order_partially_filled fill 应用事务性测试 (#6741)
 - AC4: 正常路径行为不变
 - AC5: re-raise 不崩 worker（PortfolioProcessor 主循环兜底）
 - AC6: SHORT 无持仓（pos None）→ raise + 全回滚（修正原静默 ERROR 半应用资金）
+- AC9: SHORT pos.deal return False（qty>frozen_volume）→ raise + 全回滚（修正 bool 失败不触发事务的 gap）
+- AC10: LONG pos.deal return False → raise + 全回滚
 """
 import sys
 import datetime
@@ -322,3 +324,71 @@ class TestFillTransactional:
         assert "000001.SZ" in p.positions
         assert p.positions["000001.SZ"].frozen_volume == 70
         assert order.transaction_volume == 30
+
+    def test_short_deal_return_false_triggers_rollback(self):
+        """AC9: SHORT pos.deal return False（qty>frozen_volume）→ raise + 全回滚。
+
+        _sold 在 volume>frozen_volume 时 return False 不抛（position.py _sold）；
+        修复前：无异常 → 事务 except 不触发 → 回滚跳过 → cash 已加/fee 已加/持仓未减（半应用）。
+        修复后：return False 转 raise RuntimeError → 进事务 except → snapshot-restore 全回滚。
+        """
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        # frozen_volume=30，但 fill qty=100 → _sold return False
+        pos = Position(
+            portfolio_id=p.uuid, engine_id="eid", task_id="rid",
+            code="000001.SZ", cost=Decimal("10.0"), volume=0, frozen_volume=30,
+        )
+        p.add_position(pos)
+        order = _make_order(
+            direction=DIRECTION_TYPES.SHORT, volume=100, portfolio_id=p.uuid,
+        )
+
+        entry_cash = p.cash
+        entry_fee = p.fee
+        entry_tv = order.transaction_volume
+
+        with patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_glog, \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            with pytest.raises(RuntimeError, match="SHORT pos.deal rejected"):
+                p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # 全回滚：add_cash(proceeds)/add_fee/settle 都被 snapshot-restore 还原
+        assert p.cash == entry_cash
+        assert p.fee == entry_fee
+        assert order.transaction_volume == entry_tv
+        # _sold 在 frozen_volume 检查前 return False 未改 pos；snapshot 副本亦为 30
+        assert p.get_position("000001.SZ").frozen_volume == 30
+        assert mock_glog.CRITICAL.called
+
+    def test_long_deal_return_false_triggers_rollback(self):
+        """AC10: LONG pos.deal return False → raise RuntimeError + 全回滚。
+
+        LONG 路径 _bought 失败（如 cost<0/异常）return False 不抛；修复前事务不触发，
+        修复后转 raise 进事务 except 全回滚。
+        """
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        p.freeze(Decimal("1005"))
+        pos = Position(
+            portfolio_id=p.uuid, engine_id="eid", task_id="rid",
+            code="000001.SZ", cost=Decimal("10.0"), volume=100,
+        )
+        p.add_position(pos)
+        order = _make_order(portfolio_id=p.uuid)
+
+        entry_cash = p.cash
+        entry_fee = p.fee
+        entry_tv = order.transaction_volume
+
+        with patch.object(pos, 'deal', return_value=False), \
+             patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_glog, \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            with pytest.raises(RuntimeError, match="LONG pos.deal rejected"):
+                p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # 全回滚：deduct_from_frozen/add_fee/settle 都被 snapshot-restore 还原
+        assert p.cash == entry_cash
+        assert p.fee == entry_fee
+        assert order.transaction_volume == entry_tv
+        assert mock_glog.CRITICAL.called

--- a/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
+++ b/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
@@ -1,0 +1,232 @@
+"""
+PortfolioLive.on_order_partially_filled fill 应用事务性测试 (#6741)
+
+验证 snapshot-restore 保证 fill 应用原子性：
+- AC1: LONG 分支 deduct_from_frozen 异常 → 全回滚 + CRITICAL + re-raise
+- AC2: pos.deal 异常 → _positions 深拷贝回滚生效（浅拷贝实现必败）
+- AC3: SHORT 分支异常 → 全回滚 + CRITICAL + re-raise
+- AC4: 正常路径行为不变
+- AC5: re-raise 不崩 worker（PortfolioProcessor 主循环兜底）
+"""
+import sys
+import datetime
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import Mock, MagicMock, patch
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.trading.portfolios.portfolio_live import PortfolioLive
+from ginkgo.entities.order import Order
+from ginkgo.entities.position import Position
+from ginkgo.trading.events.order_lifecycle_events import EventOrderPartiallyFilled
+from ginkgo.enums import DIRECTION_TYPES, ORDER_TYPES, ORDERSTATUS_TYPES
+
+
+def _make_portfolio(name="Portfolio", **kwargs):
+    p = PortfolioLive(name=name, use_default_analyzers=False, **kwargs)
+    # ContextMixin 的 engine_id/task_id 由 _context 提供（LONG 分支创建 Position 需非空）
+    mock_ctx = Mock()
+    mock_ctx.engine_id = "eid"
+    mock_ctx.task_id = "rid"
+    mock_ctx.portfolio_id = p.uuid
+    p._context = mock_ctx
+    return p
+
+
+def _make_order(code="000001.SZ", direction=DIRECTION_TYPES.LONG, volume=100,
+                limit_price=Decimal("10.0"), **overrides):
+    defaults = dict(
+        portfolio_id="pid", engine_id="eid", task_id="rid",
+        code=code, direction=direction, order_type=ORDER_TYPES.LIMITORDER,
+        status=ORDERSTATUS_TYPES.NEW, volume=volume,
+        limit_price=limit_price, frozen_money=volume * limit_price,
+    )
+    defaults.update(overrides)
+    return Order(**defaults)
+
+
+def _make_fill_event(order, filled_quantity=100, fill_price=Decimal("10.0"),
+                     commission=Decimal("5"), portfolio_id="pid"):
+    return EventOrderPartiallyFilled(
+        order=order, filled_quantity=filled_quantity,
+        fill_price=fill_price, commission=commission,
+        portfolio_id=portfolio_id, engine_id="eid", task_id="rid",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.live
+class TestFillTransactional:
+    """fill 应用事务性：异常全回滚 + CRITICAL + re-raise。"""
+
+    def test_long_deduct_from_frozen_failure_full_rollback(self):
+        """AC1: LONG deduct_from_frozen 抛异常 → 全回滚 + CRITICAL + raise。
+
+        settle 已先执行改 order 状态，回滚须还原 order 成交字段。
+        """
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        p.freeze(Decimal("1005"))
+        order = _make_order(portfolio_id=p.uuid)
+
+        entry_cash = p.cash
+        entry_frozen = p.frozen
+        entry_fee = p.fee
+        entry_tv = order.transaction_volume
+        entry_remain = order.remain
+
+        with patch.object(p, 'deduct_from_frozen',
+                          side_effect=ValueError("Insufficient frozen funds")), \
+             patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_glog, \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            with pytest.raises(ValueError):
+                p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # 全回滚：settle 已改 order，必须还原
+        assert p.cash == entry_cash
+        assert p.frozen == entry_frozen
+        assert p.fee == entry_fee
+        assert order.transaction_volume == entry_tv
+        assert order.remain == entry_remain
+        # CRITICAL 告警（非静默 ERROR）
+        assert mock_glog.CRITICAL.called
+
+    def test_pos_deal_failure_positions_deepcopied(self):
+        """AC2: pos.deal 改 position 后抛异常 → _positions 深拷贝回滚（浅拷贝必败）。"""
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        p.freeze(Decimal("1005"))
+        pos = Position(
+            portfolio_id=p.uuid, engine_id="eid", task_id="rid",
+            code="000001.SZ", cost=Decimal("10.0"), volume=100,
+        )
+        p.add_position(pos)
+        entry_pos_volume = pos.volume
+        entry_pos_cost = pos.cost
+
+        order = _make_order(portfolio_id=p.uuid)
+
+        original_deal = pos.deal
+
+        def deal_mutate_then_explode(*args, **kwargs):
+            original_deal(*args, **kwargs)  # 真实 _bought 原地改 position 对象
+            raise RuntimeError("deal exploded after mutation")
+
+        with patch.object(pos, 'deal', side_effect=deal_mutate_then_explode), \
+             patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_glog, \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            with pytest.raises(RuntimeError):
+                p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # 深拷贝回滚：portfolio 持有入口快照副本，position 内容回入口值
+        restored = p.get_position("000001.SZ")
+        assert restored is not pos
+        assert restored.volume == entry_pos_volume
+        assert restored.cost == entry_pos_cost
+        assert mock_glog.CRITICAL.called
+
+    def test_short_add_cash_failure_full_rollback(self):
+        """AC3: SHORT 分支 add_cash 抛异常 → 全回滚 + CRITICAL + raise。"""
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        pos = Position(
+            portfolio_id=p.uuid, engine_id="eid", task_id="rid",
+            code="000001.SZ", cost=Decimal("10.0"), volume=100,
+        )
+        p.add_position(pos)
+        order = _make_order(direction=DIRECTION_TYPES.SHORT, portfolio_id=p.uuid)
+
+        entry_cash = p.cash
+        entry_fee = p.fee
+        entry_tv = order.transaction_volume
+
+        with patch.object(p, 'add_cash', side_effect=RuntimeError("add_cash exploded")), \
+             patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_glog, \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            with pytest.raises(RuntimeError):
+                p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        assert p.cash == entry_cash
+        assert p.fee == entry_fee
+        assert order.transaction_volume == entry_tv
+        assert mock_glog.CRITICAL.called
+
+    def test_normal_fill_long_behavior_unchanged(self):
+        """AC4: 正常路径无异常 → fill 应用行为与改前一致（事务机制不改变正常语义）。"""
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        p.freeze(Decimal("1005"))
+        order = _make_order(portfolio_id=p.uuid)
+
+        entry_fee = p.fee
+
+        with patch('ginkgo.trading.portfolios.portfolio_live.GLOG'), \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # position 创建 + 加仓
+        assert "000001.SZ" in p.positions
+        assert p.positions["000001.SZ"].volume == 100
+        # order 成交累计
+        assert order.transaction_volume == 100
+        # fee 累加
+        assert p.fee == entry_fee + Decimal("5")
+        # is_final（qty=volume）→ release_frozen 清零 remain
+        assert order.remain == Decimal("0")
+
+    def test_reraise_does_not_crash_worker(self):
+        """AC5: re-raise 经 _route_event 内层 except + 主循环兜底，worker 不退出。
+
+        构造 PortfolioProcessor（mock Kafka），注入会抛异常的 fill 事件，
+        断言：主循环处理完异常事件后继续处理下一事件（continue）、is_running 仍 True
+        （worker 存活）、该 fill 被 CRITICAL 记录、fill 状态全回滚。
+        """
+        import time as _time
+        from queue import Queue
+        from ginkgo.workers.execution_node.portfolio_processor import PortfolioProcessor
+
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        p.freeze(Decimal("1005"))
+        order = _make_order(portfolio_id=p.uuid)
+        entry_tv = order.transaction_volume
+
+        in_q = Queue()
+        out_q = Queue()
+
+        with patch.object(p, 'deduct_from_frozen', side_effect=ValueError("Insufficient frozen funds")), \
+             patch('ginkgo.workers.execution_node.portfolio_processor.GinkgoConsumer', MagicMock()), \
+             patch('ginkgo.workers.execution_node.portfolio_processor.GCONF', MagicMock()), \
+             patch('ginkgo.workers.execution_node.portfolio_processor.KafkaTopics', MagicMock()), \
+             patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_live_glog, \
+             patch('ginkgo.workers.execution_node.portfolio_processor.GLOG', MagicMock()):
+            proc = PortfolioProcessor(p, in_q, out_q)
+            proc._control_consumer = None  # 禁 Kafka poll，_process_control_commands 直接 return
+            proc.start()
+            try:
+                # 注入两笔会抛异常的 fill（on_order_partially_filled → 回滚 + CRITICAL + re-raise）
+                in_q.put(_make_fill_event(order, portfolio_id=p.uuid))
+                in_q.put(_make_fill_event(order, portfolio_id=p.uuid))
+
+                # 等主循环处理完两笔（轮询 processed_count，超时 3s 兜底）
+                deadline = _time.time() + 3.0
+                while _time.time() < deadline and proc.processed_count < 2:
+                    _time.sleep(0.01)
+
+                # 主循环 continue：两笔异常事件都被路由处理（_route_event 吞 re-raise）
+                assert proc.processed_count >= 2
+                # worker 存活：is_running 仍 True（主循环外层 except 兜底，未退出）
+                assert proc.is_running is True
+                # 该 fill 被 portfolio_live 层 CRITICAL 记录（非静默 ERROR）
+                assert mock_live_glog.CRITICAL.called
+                # 事务回滚生效：order 成交字段未被两笔失败 fill 污染
+                assert order.transaction_volume == entry_tv
+            finally:
+                proc.stop()
+                proc.join(timeout=2.0)

--- a/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
+++ b/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
@@ -7,6 +7,7 @@ PortfolioLive.on_order_partially_filled fill 应用事务性测试 (#6741)
 - AC3: SHORT 分支异常 → 全回滚 + CRITICAL + re-raise
 - AC4: 正常路径行为不变
 - AC5: re-raise 不崩 worker（PortfolioProcessor 主循环兜底）
+- AC6: SHORT 无持仓（pos None）→ raise + 全回滚（修正原静默 ERROR 半应用资金）
 """
 import sys
 import datetime
@@ -155,6 +156,32 @@ class TestFillTransactional:
         assert p.cash == entry_cash
         assert p.fee == entry_fee
         assert order.transaction_volume == entry_tv
+        assert mock_glog.CRITICAL.called
+
+    def test_short_no_position_raises_and_rolls_back(self):
+        """AC6: SHORT 无持仓（pos None）→ raise + 全回滚 + CRITICAL。
+
+        SHORT 收到 fill 但无持仓属业务异常：add_cash/add_fee 已执行，须被事务回滚，
+        CRITICAL + re-raise，不再静默 ERROR 半应用资金（#6739 审计 flag）。
+        """
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        # 故意不建 SHORT 持仓 → get_position 返回 None
+        order = _make_order(direction=DIRECTION_TYPES.SHORT, portfolio_id=p.uuid)
+
+        entry_cash = p.cash
+        entry_fee = p.fee
+        entry_tv = order.transaction_volume
+
+        with patch('ginkgo.trading.portfolios.portfolio_live.GLOG') as mock_glog, \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            with pytest.raises(ValueError, match="no position found"):
+                p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # add_cash(proceeds)/add_fee(fee) 已执行但被 snapshot-restore 回滚
+        assert p.cash == entry_cash
+        assert p.fee == entry_fee
+        assert order.transaction_volume == entry_tv  # settle 改的也被回滚
         assert mock_glog.CRITICAL.called
 
     def test_normal_fill_long_behavior_unchanged(self):

--- a/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
+++ b/tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py
@@ -257,3 +257,68 @@ class TestFillTransactional:
             finally:
                 proc.stop()
                 proc.join(timeout=2.0)
+
+    def test_short_fill_clears_flat_position(self):
+        """AC7: SHORT 有持仓全部成交 → clean_positions 移除空持仓 + cash 到账。
+
+        覆盖 BUG-1 自然路径（不 mock 任何方法）：position 已冻结待卖（frozen_volume=100，
+        volume=0），SHORT fill 100 股 → _sold 清空 frozen → total_position=0 →
+        clean_positions 删除该 position。修复前此处抛 AttributeError 触发全回滚，
+        券商卖了票但 cash 未到账、position 未清理；修复后 fill 正常落地。
+        """
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        # 模拟下单冻结后的 position：volume 已转 frozen_volume（_sold 只减 frozen）
+        pos = Position(
+            portfolio_id=p.uuid, engine_id="eid", task_id="rid",
+            code="000001.SZ", cost=Decimal("10.0"), volume=0, frozen_volume=100,
+        )
+        p.add_position(pos)
+        order = _make_order(
+            direction=DIRECTION_TYPES.SHORT, volume=100, portfolio_id=p.uuid,
+        )
+
+        entry_cash = p.cash
+
+        with patch('ginkgo.trading.portfolios.portfolio_live.GLOG'), \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            p.on_order_partially_filled(_make_fill_event(order, portfolio_id=p.uuid))
+
+        # proceeds = 10*100 - 5 = 995 到账（无回滚）
+        assert p.cash == entry_cash + Decimal("995")
+        # 空持仓被 clean_positions 移除
+        assert "000001.SZ" not in p.positions
+        # order 成交累计
+        assert order.transaction_volume == 100
+
+    def test_short_partial_fill_keeps_residual_position(self):
+        """AC8: SHORT 部分成交（有残留）→ position 保留，frozen_volume 正确扣减。
+
+        frozen_volume=100 卖 30 → 残留 frozen_volume=70，total_position=70 > 0，
+        clean_positions 不移除。证明清理条件精确（仅清完全平仓），不误删残留持仓。
+        """
+        p = _make_portfolio()
+        p.add_cash(Decimal("100000"))
+        pos = Position(
+            portfolio_id=p.uuid, engine_id="eid", task_id="rid",
+            code="000001.SZ", cost=Decimal("10.0"), volume=0, frozen_volume=100,
+        )
+        p.add_position(pos)
+        order = _make_order(
+            direction=DIRECTION_TYPES.SHORT, volume=100, portfolio_id=p.uuid,
+        )
+
+        entry_cash = p.cash
+
+        with patch('ginkgo.trading.portfolios.portfolio_live.GLOG'), \
+             patch('ginkgo.trading.portfolios.portfolio_live.container'):
+            p.on_order_partially_filled(
+                _make_fill_event(order, filled_quantity=30, portfolio_id=p.uuid)
+            )
+
+        # proceeds = 10*30 - 5 = 295 到账
+        assert p.cash == entry_cash + Decimal("295")
+        # 残留持仓保留，frozen_volume 扣减到 70
+        assert "000001.SZ" in p.positions
+        assert p.positions["000001.SZ"].frozen_volume == 70
+        assert order.transaction_volume == 30


### PR DESCRIPTION
## Summary

落地 #6741：为 `PortfolioLive.on_order_partially_filled` 加 fill 应用事务性，止血实盘 fill 半应用损坏账户簿的潜在风险（实盘当前未在生产运行，属上线前硬性必修项；纯单元测试可验，不需 broker API）。

**问题**：`on_order_partially_filled` 把一次 fill 拆成一串有副作用步骤（`order.settle → deduct_from_frozen → add_fee → 持仓变更 → update_worth/profit`），整串包在宽 `except Exception` 里，捕获后只 `GLOG.ERROR`，**不回滚、不 re-raise**。链中任一步抛异常（最常见 `deduct_from_frozen` 在 `cost>frozen` 时 raise `ValueError`），前面已落地变更不撤销 → 账户簿半应用损坏，级联到下一笔 sizing 真值源，损坏持续无自动收敛。三条 fill 入口（`on_order_filled` 薄包装 / TradeGateway / PortfolioProcessor 路由）均汇聚到此方法，一处 bug 影响全部实盘 fill 路径。

**修复**：snapshot-restore 事务边界（遵循人类安全阀 3 点决策 2026-07-19）
- 方法入口 `_snapshot_fill_state`：拍 `_cash/_frozen/_fee/_worth/_profit/_positions`（**深拷贝**）+ order 成交字段（`_remain/_transaction_volume/_transaction_price`）
- 异常分支：全回滚 + `GLOG.CRITICAL`（含 order/code/qty/price/错误）+ re-raise，不静默漏记
- `_positions` 深拷贝关键：`pos.deal` 原地改 position 对象的 `_bought/_sold`，浅拷贝只拷 dict 引用，回滚还原的仍是已污染实例。深拷贝时临时摘除 `loggers`（`logging.Logger` 含 RLock 不可 pickle）后还原
- 二阶异常（restore 自身抛）降级 CRITICAL 记录，仍 re-raise 原异常
- re-raise 经 `on_order_filled` 薄包装上抛到 `_route_event` 内层 except + 主循环兜底，**worker 不退出**
- 决策落地：re-raise 不改外层 except（主循环天然兜底）、不引入 dirty 标记（最小化）、broker→内存对账机制独立 issue

## Test plan

新增 `tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py`（AC1-5，全绿）：
- **AC1**: LONG `deduct_from_frozen` 抛异常 → 全回滚（cash/frozen/fee/positions/order 字段全等于入口值）+ CRITICAL + re-raise
- **AC2**: `pos.deal` 抛异常 → `_positions` 深拷贝回滚生效（position 对象内容回入口值；浅拷贝实现必败）+ CRITICAL + re-raise
- **AC3**: SHORT 分支 `add_cash` 抛异常 → 全回滚 + CRITICAL + re-raise
- **AC4**: 正常路径无异常 → fill 应用行为与改前一致（订单累计/冻结扣减/持仓/fee）
- **AC5**: re-raise 不崩 worker（构造 PortfolioProcessor 真实线程 + mock Kafka，注入两笔会抛异常的 fill，断言主循环 continue / `is_running` 仍 True / CRITICAL 记录 / 状态全回滚）

本地三层 smoke：
- ✅ Layer1 `py_compile`（src+api 全量）
- ✅ Layer3 变更相关：portfolio_live 既有 11 + 新增 5 + subscription 6 = **22 全过**（防回归）
- Layer2 启动路径：36/37 过，1 红 `test_create_user_missing_name_fails` = **pre-existing**（stash 改动后 master 同红，typer rich 在 tty 下把 `--name` 渲染成带 ANSI 的 `-name`，与本次变更零关联；CI 非 tty 环境预期不红）

Closes #6741
