### PR TITLE
refactor: evaluation 查找 helper 上提 ast_helpers 去重 38 处副本

### DIFF
--- a/src/ginkgo/trading/evaluation/rules/best_practice_rules.py
+++ b/src/ginkgo/trading/evaluation/rules/best_practice_rules.py
@@ -21,6 +21,11 @@ from typing import Optional
 from ginkgo.trading.evaluation.core.enums import EvaluationLevel, EvaluationSeverity
 from ginkgo.trading.evaluation.core.evaluation_result import EvaluationIssue
 from ginkgo.trading.evaluation.rules.base_rule import ASTBasedRule
+from ginkgo.trading.evaluation.utils.ast_helpers import (
+    find_method_def,
+    find_strategy_classes,
+    is_abstract_class,
+)
 from ginkgo.libs import GLOG
 
 
@@ -43,13 +48,13 @@ class DecoratorUsageRule(ASTBasedRule):
         source_code: str,
     ) -> Optional["EvaluationIssue"]:
         """Check if cal() method has recommended decorators."""
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            if self._is_abstract_class(class_node):
+            if is_abstract_class(class_node):
                 continue
 
-            cal_method = self._find_method(class_node, "cal")
+            cal_method = find_method_def(class_node, "cal")
             if not cal_method:
                 continue
 
@@ -83,45 +88,6 @@ class DecoratorUsageRule(ASTBasedRule):
 
         return None
 
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
-
-    def _is_abstract_class(self, class_node: ast.ClassDef) -> bool:
-        """Check if class has __abstract__ = False marker."""
-        for stmt in class_node.body:
-            if isinstance(stmt, ast.Assign):
-                for target in stmt.targets:
-                    if isinstance(target, ast.Name):
-                        if target.id == "__abstract__":
-                            if isinstance(stmt.value, ast.Constant):
-                                return stmt.value.value is True
-        return False
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method by name in the class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef):
-                if item.name == method_name:
-                    return item
-        return None
-
     def _is_decorator_named(self, decorator: ast.expr, name: str) -> bool:
         """Check if decorator matches given name."""
         if isinstance(decorator, ast.Name):
@@ -153,13 +119,13 @@ class ExceptionHandlingRule(ASTBasedRule):
         source_code: str,
     ) -> Optional["EvaluationIssue"]:
         """Check if cal() method has exception handling."""
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            if self._is_abstract_class(class_node):
+            if is_abstract_class(class_node):
                 continue
 
-            cal_method = self._find_method(class_node, "cal")
+            cal_method = find_method_def(class_node, "cal")
             if not cal_method:
                 continue
 
@@ -174,45 +140,6 @@ class ExceptionHandlingRule(ASTBasedRule):
                     line=cal_method.lineno,
                 )
 
-        return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
-
-    def _is_abstract_class(self, class_node: ast.ClassDef) -> bool:
-        """Check if class has __abstract__ = False marker."""
-        for stmt in class_node.body:
-            if isinstance(stmt, ast.Assign):
-                for target in stmt.targets:
-                    if isinstance(target, ast.Name):
-                        if target.id == "__abstract__":
-                            if isinstance(stmt.value, ast.Constant):
-                                return stmt.value.value is True
-        return False
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method by name in the class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef):
-                if item.name == method_name:
-                    return item
         return None
 
     def _has_try_except(self, method_node: ast.FunctionDef) -> bool:
@@ -241,13 +168,13 @@ class LoggingRule(ASTBasedRule):
         source_code: str,
     ) -> Optional["EvaluationIssue"]:
         """Check if cal() method has logging for debugging."""
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            if self._is_abstract_class(class_node):
+            if is_abstract_class(class_node):
                 continue
 
-            cal_method = self._find_method(class_node, "cal")
+            cal_method = find_method_def(class_node, "cal")
             if not cal_method:
                 continue
 
@@ -262,45 +189,6 @@ class LoggingRule(ASTBasedRule):
                     line=cal_method.lineno,
                 )
 
-        return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
-
-    def _is_abstract_class(self, class_node: ast.ClassDef) -> bool:
-        """Check if class has __abstract__ = False marker."""
-        for stmt in class_node.body:
-            if isinstance(stmt, ast.Assign):
-                for target in stmt.targets:
-                    if isinstance(target, ast.Name):
-                        if target.id == "__abstract__":
-                            if isinstance(stmt.value, ast.Constant):
-                                return stmt.value.value is True
-        return False
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method by name in the class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef):
-                if item.name == method_name:
-                    return item
         return None
 
     def _has_logging(self, method_node: ast.FunctionDef) -> bool:
@@ -338,13 +226,13 @@ class ResetStateRule(ASTBasedRule):
         source_code: str,
     ) -> Optional["EvaluationIssue"]:
         """Check if reset_state() calls super().reset_state()."""
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            if self._is_abstract_class(class_node):
+            if is_abstract_class(class_node):
                 continue
 
-            reset_method = self._find_method(class_node, "reset_state")
+            reset_method = find_method_def(class_node, "reset_state")
             if not reset_method:
                 continue
 
@@ -359,45 +247,6 @@ class ResetStateRule(ASTBasedRule):
                     line=reset_method.lineno,
                 )
 
-        return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
-
-    def _is_abstract_class(self, class_node: ast.ClassDef) -> bool:
-        """Check if class has __abstract__ = False marker."""
-        for stmt in class_node.body:
-            if isinstance(stmt, ast.Assign):
-                for target in stmt.targets:
-                    if isinstance(target, ast.Name):
-                        if target.id == "__abstract__":
-                            if isinstance(stmt.value, ast.Constant):
-                                return stmt.value.value is True
-        return False
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method by name in the class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef):
-                if item.name == method_name:
-                    return item
         return None
 
     def _calls_super_reset(self, method_node: ast.FunctionDef) -> bool:
@@ -433,13 +282,13 @@ class ParameterValidationRule(ASTBasedRule):
         source_code: str,
     ) -> Optional["EvaluationIssue"]:
         """Check if cal() method validates input parameters."""
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            if self._is_abstract_class(class_node):
+            if is_abstract_class(class_node):
                 continue
 
-            cal_method = self._find_method(class_node, "cal")
+            cal_method = find_method_def(class_node, "cal")
             if not cal_method:
                 continue
 
@@ -454,45 +303,6 @@ class ParameterValidationRule(ASTBasedRule):
                     line=cal_method.lineno,
                 )
 
-        return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
-
-    def _is_abstract_class(self, class_node: ast.ClassDef) -> bool:
-        """Check if class has __abstract__ = False marker."""
-        for stmt in class_node.body:
-            if isinstance(stmt, ast.Assign):
-                for target in stmt.targets:
-                    if isinstance(target, ast.Name):
-                        if target.id == "__abstract__":
-                            if isinstance(stmt.value, ast.Constant):
-                                return stmt.value.value is True
-        return False
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method by name in the class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef):
-                if item.name == method_name:
-                    return item
         return None
 
     def _has_parameter_validation(self, method_node: ast.FunctionDef) -> bool:

--- a/src/ginkgo/trading/evaluation/rules/logical_rules.py
+++ b/src/ginkgo/trading/evaluation/rules/logical_rules.py
@@ -21,6 +21,7 @@ from typing import Optional, List
 
 from ginkgo.trading.evaluation.core.enums import EvaluationSeverity, EvaluationLevel
 from ginkgo.trading.evaluation.rules.base_rule import ASTBasedRule
+from ginkgo.trading.evaluation.utils.ast_helpers import find_method_def
 
 
 class ReturnStatementRule(ASTBasedRule):
@@ -43,18 +44,11 @@ class ReturnStatementRule(ASTBasedRule):
         """Check return statements in cal() method."""
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                cal_method = self._find_cal_method(node)
+                cal_method = find_method_def(node, "cal")
                 if cal_method:
                     issue = self._check_cal_method(cal_method, file_path)
                     if issue:
                         return issue
-        return None
-
-    def _find_cal_method(self, class_node: ast.ClassDef) -> Optional[ast.FunctionDef]:
-        """Find cal() method in class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == "cal":
-                return item
         return None
 
     def _check_cal_method(self, method: ast.FunctionDef, file_path: Path) -> Optional["EvaluationIssue"]:
@@ -129,20 +123,13 @@ class SignalFieldRule(ASTBasedRule):
         """Check Signal() calls in cal() method."""
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                cal_method = self._find_cal_method(node)
+                cal_method = find_method_def(node, "cal")
                 if cal_method:
                     for child in ast.walk(cal_method):
                         if isinstance(child, ast.Call):
                             issue = self._check_signal_call(child, file_path)
                             if issue:
                                 return issue
-        return None
-
-    def _find_cal_method(self, class_node: ast.ClassDef) -> Optional[ast.FunctionDef]:
-        """Find cal() method in class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == "cal":
-                return item
         return None
 
     def _check_signal_call(self, node: ast.Call, file_path: Path) -> Optional["EvaluationIssue"]:
@@ -198,20 +185,13 @@ class DirectionValidationRule(ASTBasedRule):
         """Check direction parameter in Signal() calls."""
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                cal_method = self._find_cal_method(node)
+                cal_method = find_method_def(node, "cal")
                 if cal_method:
                     for child in ast.walk(cal_method):
                         if isinstance(child, ast.Call):
                             issue = self._check_direction_value(child, file_path)
                             if issue:
                                 return issue
-        return None
-
-    def _find_cal_method(self, class_node: ast.ClassDef) -> Optional[ast.FunctionDef]:
-        """Find cal() method in class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == "cal":
-                return item
         return None
 
     def _check_direction_value(self, node: ast.Call, file_path: Path) -> Optional["EvaluationIssue"]:
@@ -289,20 +269,13 @@ class TimeProviderUsageRule(ASTBasedRule):
         """Check time provider usage in cal() method."""
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                cal_method = self._find_cal_method(node)
+                cal_method = find_method_def(node, "cal")
                 if cal_method:
                     for child in ast.walk(cal_method):
                         if isinstance(child, ast.Call):
                             issue = self._check_time_call(child, file_path)
                             if issue:
                                 return issue
-        return None
-
-    def _find_cal_method(self, class_node: ast.ClassDef) -> Optional[ast.FunctionDef]:
-        """Find cal() method in class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == "cal":
-                return item
         return None
 
     def _check_time_call(self, node: ast.Call, file_path: Path) -> Optional["EvaluationIssue"]:
@@ -443,20 +416,13 @@ class ForbiddenOperationsRule(ASTBasedRule):
         """Check for forbidden operations in cal() method."""
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                cal_method = self._find_cal_method(node)
+                cal_method = find_method_def(node, "cal")
                 if cal_method:
                     for child in ast.walk(cal_method):
                         if isinstance(child, (ast.Call, ast.Import, ast.ImportFrom)):
                             issue = self._check_forbidden_operation(child, file_path)
                             if issue:
                                 return issue
-        return None
-
-    def _find_cal_method(self, class_node: ast.ClassDef) -> Optional[ast.FunctionDef]:
-        """Find cal() method in class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == "cal":
-                return item
         return None
 
     def _check_forbidden_operation(self, node: ast.AST, file_path: Path) -> Optional["EvaluationIssue"]:
@@ -565,20 +531,13 @@ class SignalParameterRule(ASTBasedRule):
         """Check Signal() calls in cal() method."""
         for node in ast.walk(tree):
             if isinstance(node, ast.ClassDef):
-                cal_method = self._find_cal_method(node)
+                cal_method = find_method_def(node, "cal")
                 if cal_method:
                     for child in ast.walk(cal_method):
                         if isinstance(child, ast.Call):
                             issue = self._check_signal_call(child, file_path)
                             if issue:
                                 return issue
-        return None
-
-    def _find_cal_method(self, class_node: ast.ClassDef) -> Optional[ast.FunctionDef]:
-        """Find cal() method in class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == "cal":
-                return item
         return None
 
     def _check_signal_call(self, node: ast.Call, file_path: Path) -> Optional["EvaluationIssue"]:

--- a/src/ginkgo/trading/evaluation/rules/structural_rules.py
+++ b/src/ginkgo/trading/evaluation/rules/structural_rules.py
@@ -24,6 +24,12 @@ from typing import Optional
 
 from ginkgo.trading.evaluation.core.enums import EvaluationLevel, EvaluationSeverity
 from ginkgo.trading.evaluation.rules.base_rule import ASTBasedRule
+from ginkgo.trading.evaluation.utils.ast_helpers import (
+    find_method_def,
+    find_strategy_classes,
+    get_node_name,
+    is_abstract_class,
+)
 
 
 class StrategyBaseInheritanceRule(ASTBasedRule):
@@ -60,7 +66,7 @@ class StrategyBaseInheritanceRule(ASTBasedRule):
             if isinstance(node, ast.ClassDef):
                 # Check if this class inherits from BaseStrategy
                 for base in node.bases:
-                    base_name = self._get_name(base)
+                    base_name = get_node_name(base)
                     if base_name == "BaseStrategy" or base_name == BaseStrategy.__name__:
                         return None  # Found a valid strategy class
 
@@ -70,14 +76,6 @@ class StrategyBaseInheritanceRule(ASTBasedRule):
             suggestion='Change class definition to: class MyStrategy(BaseStrategy):',
             file_path=file_path,
         )
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
 
 
 class CalMethodRequiredRule(ASTBasedRule):
@@ -108,7 +106,7 @@ class CalMethodRequiredRule(ASTBasedRule):
         Returns:
             EvaluationIssue if no class has a cal() method, None otherwise
         """
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
             has_cal = False
@@ -125,26 +123,6 @@ class CalMethodRequiredRule(ASTBasedRule):
                     line=class_node.lineno,
                 )
 
-        return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
         return None
 
 
@@ -176,10 +154,10 @@ class SuperInitCallRule(ASTBasedRule):
         Returns:
             EvaluationIssue if __init__ doesn't call super().__init__(), None otherwise
         """
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            init_method = self._find_method(class_node, "__init__")
+            init_method = find_method_def(class_node, "__init__")
 
             if init_method:
                 if not self._has_super_init_call(init_method):
@@ -193,25 +171,6 @@ class SuperInitCallRule(ASTBasedRule):
                 # No __init__ method is fine, BaseStrategy will handle it
                 pass
 
-        return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method in a class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == method_name:
-                return item
         return None
 
     def _has_super_init_call(self, init_method: ast.FunctionDef) -> bool:
@@ -230,14 +189,6 @@ class SuperInitCallRule(ASTBasedRule):
                     # Need to check if it's called on super()
                     pass  # Simplified check
         return False
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
 
 
 class CalSignatureValidationRule(ASTBasedRule):
@@ -268,10 +219,10 @@ class CalSignatureValidationRule(ASTBasedRule):
         Returns:
             EvaluationIssue if signature is incorrect, None otherwise
         """
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
-            cal_method = self._find_method(class_node, "cal")
+            cal_method = find_method_def(class_node, "cal")
 
             if cal_method:
                 # Check parameter count
@@ -314,33 +265,6 @@ class CalSignatureValidationRule(ASTBasedRule):
 
         return None
 
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _find_method(self, class_node: ast.ClassDef, method_name: str) -> Optional[ast.FunctionDef]:
-        """Find a method in a class."""
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef) and item.name == method_name:
-                return item
-        return None
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
-
 
 class AbstractMarkerRule(ASTBasedRule):
     """
@@ -373,11 +297,11 @@ class AbstractMarkerRule(ASTBasedRule):
         Returns:
             EvaluationIssue if __abstract__ = False is missing, None otherwise
         """
-        strategy_classes = self._find_strategy_classes(tree)
+        strategy_classes = find_strategy_classes(tree)
 
         for class_node, class_name in strategy_classes:
             # Skip if class appears to be abstract (has abstract methods)
-            if self._is_abstract_class(class_node):
+            if is_abstract_class(class_node):
                 continue
 
             # Check if __abstract__ = False is set
@@ -390,52 +314,6 @@ class AbstractMarkerRule(ASTBasedRule):
                 )
 
         return None
-
-    def _find_strategy_classes(self, tree: ast.Module) -> list:
-        """Find all classes that inherit from BaseStrategy."""
-        strategy_classes = []
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ClassDef):
-                for base in node.bases:
-                    base_name = self._get_name(base)
-                    if base_name == "BaseStrategy":
-                        strategy_classes.append((node, node.name))
-                        break
-        return strategy_classes
-
-    def _is_abstract_class(self, class_node: ast.ClassDef) -> bool:
-        """Check if a class appears to be abstract."""
-        # Check for ABC inheritance
-        for base in class_node.bases:
-            base_name = self._get_name(base)
-            if "ABC" in base_name or "abc.ABC" in base_name:
-                return True
-
-        # Check for abstractmethod decorators
-        for item in class_node.body:
-            if isinstance(item, ast.FunctionDef):
-                for decorator in item.decorator_list:
-                    dec_name = self._get_name(decorator) if isinstance(decorator, (ast.Name, ast.Attribute)) else None
-                    if dec_name and "abstractmethod" in dec_name:
-                        return True
-
-        # Check for __abstract__ = True (Ginkgo pattern)
-        for item in class_node.body:
-            if isinstance(item, ast.Assign):
-                for target in item.targets:
-                    if isinstance(target, ast.Name) and target.id == "__abstract__":
-                        # Check if assigned value is True
-                        if isinstance(item.value, (ast.Name, ast.Constant)):
-                            value = None
-                            if isinstance(item.value, ast.Name):
-                                value = item.value.id
-                            elif isinstance(item.value, ast.Constant):
-                                value = item.value.value
-
-                            if value is True or value == "True":
-                                return True
-
-        return False
 
     def _has_abstract_false_marker(self, class_node: ast.ClassDef) -> bool:
         """Check if class has __abstract__ = False."""
@@ -455,12 +333,4 @@ class AbstractMarkerRule(ASTBasedRule):
                                 return True
 
         return False
-
-    def _get_name(self, node: ast.AST) -> Optional[str]:
-        """Extract the name from an AST node."""
-        if isinstance(node, ast.Name):
-            return node.id
-        elif isinstance(node, ast.Attribute):
-            return node.attr
-        return None
 

--- a/src/ginkgo/trading/evaluation/utils/ast_helpers.py
+++ b/src/ginkgo/trading/evaluation/utils/ast_helpers.py
@@ -163,6 +163,60 @@ def inherits_from(class_node: ast.ClassDef, base_class_name: str) -> bool:
     return base_class_name in get_base_classes(class_node)
 
 
+def get_node_name(node: ast.AST) -> Optional[str]:
+    """
+    Extract a name from an AST node using the *attr* semantic.
+
+    Returns ``node.id`` for ``ast.Name`` and ``node.attr`` for ``ast.Attribute``
+    (so ``mod.BaseStrategy`` → ``"BaseStrategy"``), or ``None`` otherwise.
+
+    Differs from :func:`get_base_classes`, which ``ast.unparse``-es an
+    ``Attribute`` to ``"mod.BaseStrategy"``. :func:`find_strategy_classes`
+    relies on this attr semantic to match ``module.BaseStrategy`` bases,
+    which is why it cannot reuse :func:`inherits_from`.
+
+    Args:
+        node: The AST node (typically a base-class expression)
+
+    Returns:
+        The name string, or None if the node is neither Name nor Attribute
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def find_strategy_classes(
+    tree: ast.Module, base_name: str = "BaseStrategy"
+) -> List[Tuple[ast.ClassDef, str]]:
+    """
+    Find all classes inheriting from ``base_name``.
+
+    Walks the tree collecting ``ClassDef`` nodes whose bases include a
+    ``Name``/``Attribute`` whose :func:`get_node_name` equals ``base_name``.
+    The attr semantic matches both ``class Foo(BaseStrategy)`` and
+    ``class Foo(mod.BaseStrategy)``.
+
+    Args:
+        tree: The AST tree to search
+        base_name: Base class name to match (default ``"BaseStrategy"``)
+
+    Returns:
+        List of ``(class_node, class_name)`` tuples
+    """
+    result: List[Tuple[ast.ClassDef, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            if get_node_name(base) == base_name:
+                result.append((node, node.name))
+                break
+    return result
+
+
 def get_function_signature(
     func_node: ast.FunctionDef
 ) -> Dict[str, Any]:

--- a/tests/unit/trading/evaluation/test_ast_based_rule_contract.py
+++ b/tests/unit/trading/evaluation/test_ast_based_rule_contract.py
@@ -1,0 +1,148 @@
+"""ASTBasedRule 体系与 ast_helpers 的契约测试。
+
+锁住 #6471 重构的关键行为：
+- ``is_abstract_class`` 三重语义（ABC 继承 ∨ @abstractmethod ∨ __abstract__=True），
+  作为 6 处私有 ``_is_abstract_class`` 统一的目标语义。
+- ``ASTBasedRule.check`` 的解析 / 缓存命中 / 异常兜底契约（验收标准要求）。
+- ``find_strategy_classes`` 保持 ``_get_name`` 的 attr 取名语义（不因上提而漂移）。
+"""
+
+import ast
+from pathlib import Path
+from textwrap import dedent
+from typing import List, Optional, Tuple
+
+from ginkgo.trading.evaluation.rules.base_rule import ASTBasedRule
+from ginkgo.trading.evaluation.utils.ast_helpers import is_abstract_class
+
+
+class _SpyRule(ASTBasedRule):
+    """记录 check_ast 调用的最小子类，用于测 ASTBasedRule.check 契约。
+
+    不耦合任何具体规则业务，只验证基类 check() 的解析/缓存/异常行为。
+    """
+
+    rule_id = "TEST_SPY"
+
+    def __init__(self, *, raise_on_check: Optional[Exception] = None) -> None:
+        self.calls: List[Tuple[object, Path, str]] = []
+        self._raise = raise_on_check
+
+    def check_ast(self, tree, file_path, source_code):  # type: ignore[override]
+        self.calls.append((tree, file_path, source_code))
+        if self._raise is not None:
+            raise self._raise
+        return None
+
+
+def _class_node(source: str, name: str = "Foo") -> ast.ClassDef:
+    """从源码片段解析出指定类的 ClassDef 节点。"""
+    tree = ast.parse(dedent(source))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"class {name} not found in source")
+
+
+# ---------------------------------------------------------------------------
+# is_abstract_class 三重语义契约（#6471 统一目标语义）
+# ---------------------------------------------------------------------------
+
+
+def test_is_abstract_class_abc_inheritance() -> None:
+    """直接继承 ABC 的类判为抽象（三重之一）。"""
+    node = _class_node("class Foo(ABC):\n    pass")
+    assert is_abstract_class(node) is True
+
+
+def test_is_abstract_class_abstractmethod_decorator() -> None:
+    """含 @abstractmethod 装饰方法的类判为抽象（三重之二）。"""
+    source = """
+    class Foo:
+        @abstractmethod
+        def cal(self):
+            pass
+    """
+    assert is_abstract_class(_class_node(source)) is True
+
+
+def test_is_abstract_class_ginkgo_marker_true() -> None:
+    """标 __abstract__ = True 的类判为抽象（三重之三，Ginkgo 惯例）。"""
+    source = """
+    class Foo:
+        __abstract__ = True
+    """
+    assert is_abstract_class(_class_node(source)) is True
+
+
+def test_is_abstract_class_concrete_strategy() -> None:
+    """具体策略类（__abstract__ = False）判为非抽象——检查的目标对象。"""
+    source = """
+    class Foo:
+        __abstract__ = False
+    """
+    assert is_abstract_class(_class_node(source)) is False
+
+
+def test_is_abstract_class_plain_class() -> None:
+    """无任何抽象标记的普通类判为非抽象。"""
+    assert is_abstract_class(_class_node("class Foo:\n    pass")) is False
+
+
+# ---------------------------------------------------------------------------
+# ASTBasedRule.check 契约（解析 / 缓存命中 / 异常兜底）—— 验收标准要求
+# ---------------------------------------------------------------------------
+
+
+def test_check_parses_file_calls_check_ast(tmp_path) -> None:
+    """正常文件：check 读文件 parse 后调 check_ast，传入 tree 与完整源码。"""
+    src = "class Foo:\n    pass\n"
+    f = tmp_path / "s.py"
+    f.write_text(src, encoding="utf-8")
+    rule = _SpyRule()
+    issue = rule.check(f)
+    assert issue is None
+    assert len(rule.calls) == 1
+    tree, file_path, source_code = rule.calls[0]
+    assert isinstance(tree, ast.Module)
+    assert file_path == f
+    assert source_code == src
+
+
+def test_check_uses_cached_ast_context(tmp_path) -> None:
+    """component_class 含 ast_context：用缓存 tree，不读磁盘。"""
+    cached_tree = ast.parse("class Foo:\n    pass\n")
+    cached_src = "class Foo:\n    pass\n"
+    # 用不存在的路径，证明没走磁盘读取
+    fake_path = tmp_path / "does_not_exist.py"
+    rule = _SpyRule()
+    rule.check(
+        fake_path,
+        component_class={"ast_context": cached_tree, "source_code": cached_src},
+    )
+    assert len(rule.calls) == 1
+    tree, _file_path, source_code = rule.calls[0]
+    assert tree is cached_tree
+    assert source_code == cached_src
+
+
+def test_check_syntax_error_returns_issue(tmp_path) -> None:
+    """语法错误文件：check 捕获 SyntaxError 返回 issue，不调 check_ast。"""
+    f = tmp_path / "bad.py"
+    f.write_text("def (\n", encoding="utf-8")
+    rule = _SpyRule()
+    issue = rule.check(f)
+    assert issue is not None
+    assert rule.calls == []
+    assert "syntax" in issue.message.lower()
+
+
+def test_check_exception_in_check_ast_returns_issue(tmp_path) -> None:
+    """check_ast 抛异常：check 兜底捕获并返回 issue。"""
+    src = "class Foo:\n    pass\n"
+    f = tmp_path / "s.py"
+    f.write_text(src, encoding="utf-8")
+    rule = _SpyRule(raise_on_check=RuntimeError("boom"))
+    issue = rule.check(f)
+    assert issue is not None
+    assert len(rule.calls) == 1  # check_ast 被调到（调用后抛异常）

--- a/tests/unit/trading/evaluation/test_ast_helpers_seam.py
+++ b/tests/unit/trading/evaluation/test_ast_helpers_seam.py
@@ -1,0 +1,99 @@
+"""ast_helpers 新增 seam 函数契约（#6471）。
+
+锁定上提的两个查找 helper 的语义，作为 9+7 处私有副本统一的依据：
+
+- ``get_node_name``：保留 ``_get_name`` 的 **attr 取名语义**——
+  ``Name`` → ``id``、``Attribute`` → ``attr``（不是 ``ast.unparse``）。
+  这是 ``find_strategy_classes`` 能命中 ``module.BaseStrategy`` 形式的关键，
+  也是它与已有 ``inherits_from``（走 ``get_base_classes`` 返回 ``"module.BaseStrategy"``）
+  的本质区别——故不能直接复用 ``inherits_from``。
+- ``find_strategy_classes``：遍历树收集指定基类的 ClassDef，返回 ``(node, name)`` 元组列表，
+  保持原 ``_find_strategy_classes`` 的返回形状（调用方按 ``for class_node, class_name in ...`` 解包）。
+"""
+
+import ast
+
+from ginkgo.trading.evaluation.utils.ast_helpers import (
+    find_strategy_classes,
+    get_node_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_node_name —— attr 取名语义（_get_name 上提）
+# ---------------------------------------------------------------------------
+
+
+def test_get_node_name_name_node_returns_id() -> None:
+    """Name 节点取 id（class Foo(BaseStrategy) 的 BaseStrategy）。"""
+    tree = ast.parse("class Foo(BaseStrategy):\n    pass\n")
+    base = tree.body[0].bases[0]  # type: ignore[attr-defined]
+    assert isinstance(base, ast.Name)
+    assert get_node_name(base) == "BaseStrategy"
+
+
+def test_get_node_name_attribute_node_returns_attr() -> None:
+    """Attribute 节点取 attr（class Foo(mod.BaseStrategy) → 'BaseStrategy'）。
+
+    关键：不是 ast.unparse 的 'mod.BaseStrategy'。这是上提不能复用 inherits_from 的根因。
+    """
+    tree = ast.parse("class Foo(mod.BaseStrategy):\n    pass\n")
+    base = tree.body[0].bases[0]  # type: ignore[attr-defined]
+    assert isinstance(base, ast.Attribute)
+    assert get_node_name(base) == "BaseStrategy"
+
+
+def test_get_node_name_other_node_returns_none() -> None:
+    """非 Name/Attribute 节点返回 None。"""
+    tree = ast.parse("x = 1\n")
+    assert get_node_name(tree.body[0]) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# find_strategy_classes —— _find_strategy_classes 上提
+# ---------------------------------------------------------------------------
+
+
+def test_find_strategy_classes_name_base() -> None:
+    """class Foo(BaseStrategy) 被收集，返回 (node, 'Foo')。"""
+    tree = ast.parse("class Foo(BaseStrategy):\n    pass\n")
+    result = find_strategy_classes(tree)
+    assert len(result) == 1
+    node, name = result[0]
+    assert isinstance(node, ast.ClassDef)
+    assert name == "Foo"
+
+
+def test_find_strategy_classes_attribute_base() -> None:
+    """class Foo(mod.BaseStrategy) 也被收集（attr 语义，非 unparse）。
+
+    这是保留 _get_name 语义、不复用 inherits_from 的回归守护。
+    """
+    tree = ast.parse("class Foo(mod.BaseStrategy):\n    pass\n")
+    result = find_strategy_classes(tree)
+    assert len(result) == 1
+    assert result[0][1] == "Foo"
+
+
+def test_find_strategy_classes_ignores_unrelated() -> None:
+    """非策略类不被收集。"""
+    tree = ast.parse("class Foo(OtherBase):\n    pass\n")
+    assert find_strategy_classes(tree) == []
+
+
+def test_find_strategy_classes_custom_base_name() -> None:
+    """支持自定义基类名（如 BaseSelector）。"""
+    tree = ast.parse("class Foo(BaseSelector):\n    pass\n")
+    result = find_strategy_classes(tree, base_name="BaseSelector")
+    assert len(result) == 1
+    assert result[0][1] == "Foo"
+
+
+def test_find_strategy_classes_multiple() -> None:
+    """多个策略类全部收集，顺序按树遍历。"""
+    tree = ast.parse(
+        "class A(BaseStrategy):\n    pass\n"
+        "class B(BaseStrategy):\n    pass\n"
+    )
+    result = find_strategy_classes(tree)
+    assert [name for _, name in result] == ["A", "B"]

--- a/tests/unit/trading/evaluation/test_rule_abstract_skip_behavior.py
+++ b/tests/unit/trading/evaluation/test_rule_abstract_skip_behavior.py
@@ -1,0 +1,88 @@
+"""规则层抽象类跳过契约（#6471）。
+
+锁定 ``_is_abstract_class`` 6 处统一为 ``ast_helpers.is_abstract_class`` 后，
+两条规则链路的 skip 行为经公开 ``check_ast`` 接口仍然正确：
+
+- 具体策略（``__abstract__ = False``）→ 参与检查（可命中 issue）
+- 抽象类（继承 ABC）→ 被跳过（不报 issue）
+
+两个规则文件此前无直接测试，本文件作为重构的安全网。
+"""
+
+from pathlib import Path
+
+from ginkgo.trading.evaluation.rules.best_practice_rules import DecoratorUsageRule
+from ginkgo.trading.evaluation.rules.structural_rules import AbstractMarkerRule
+
+
+def _check(rule, source: str):
+    """对给定源码跑规则，返回 EvaluationIssue 或 None。"""
+    import ast
+
+    tree = ast.parse(source)
+    return rule.check_ast(tree, Path("fake_strategy.py"), source)
+
+
+CONCRETE_NO_MARKER = '''
+class FooStrategy(BaseStrategy):
+    def cal(self, portfolio_info, event):
+        return []
+'''
+
+
+CONCRETE_WITH_MARKER_NO_DECORATOR = '''
+class FooStrategy(BaseStrategy):
+    __abstract__ = False
+
+    def cal(self, portfolio_info, event):
+        return []
+'''
+
+
+ABSTRACT_ABC_STRATEGY = '''
+class FooStrategy(BaseStrategy, ABC):
+    def cal(self, portfolio_info, event):
+        return []
+'''
+
+
+# ---------------------------------------------------------------------------
+# structural_rules.AbstractMarkerRule
+# ---------------------------------------------------------------------------
+
+
+def test_abstract_marker_rule_concrete_without_marker_flagged() -> None:
+    """具体策略未标 __abstract__ = False → 报 ABSTRACT_MARKER issue。"""
+    issue = _check(AbstractMarkerRule(), CONCRETE_NO_MARKER)
+    assert issue is not None
+    assert "__abstract__" in issue.message
+
+
+def test_abstract_marker_rule_abc_class_skipped() -> None:
+    """继承 ABC 的抽象类 → 被跳过，不报 issue（三重语义之一）。"""
+    issue = _check(AbstractMarkerRule(), ABSTRACT_ABC_STRATEGY)
+    assert issue is None
+
+
+def test_abstract_marker_rule_concrete_with_marker_not_flagged() -> None:
+    """具体策略已标 __abstract__ = False → 不报 issue。"""
+    issue = _check(AbstractMarkerRule(), CONCRETE_WITH_MARKER_NO_DECORATOR)
+    assert issue is None
+
+
+# ---------------------------------------------------------------------------
+# best_practice_rules.DecoratorUsageRule
+# ---------------------------------------------------------------------------
+
+
+def test_decorator_rule_concrete_cal_without_decorator_flagged() -> None:
+    """具体策略 cal() 无 @time_logger/@retry → 报 DECORATOR_USAGE issue。"""
+    issue = _check(DecoratorUsageRule(), CONCRETE_WITH_MARKER_NO_DECORATOR)
+    assert issue is not None
+    assert "decorator" in issue.message.lower()
+
+
+def test_decorator_rule_abc_class_skipped() -> None:
+    """继承 ABC 的抽象类 → 被跳过（三重语义统一后，best_practice 也跳过 ABC）。"""
+    issue = _check(DecoratorUsageRule(), ABSTRACT_ABC_STRATEGY)
+    assert issue is None


### PR DESCRIPTION
## Summary

修复 #6471：ASTBasedRule 基类过浅，17 条子类重复 38 份查找 helper（含 `_is_abstract_class` 语义分歧）。

将重复 helper 上提至 `ast_helpers` 统一 seam：

| 私有副本 | 处数 | seam 函数 | 说明 |
|---|---|---|---|
| `_is_abstract_class` | 6 | `is_abstract_class` | 统一为**三重语义**（ABC ∨ @abstractmethod ∨ `__abstract__=True`）；best_practice 原为单重（仅 `__abstract__`），统一后 ABC 抽象类也被正确跳过 |
| `_find_strategy_classes` | 9 | `find_strategy_classes` | 新增 seam |
| `_find_method` / `_find_cal_method` | 13 | `find_method_def` | 复用已有 seam（两变体逻辑等价） |
| `_get_name` | 10 | `get_node_name` | 新增 seam，**保留 attr 取名语义** |

**关键设计点**：`get_node_name` 对 `Attribute` 取 `node.attr`（`mod.BaseStrategy` → `"BaseStrategy"`），而非 `ast.unparse`（→ `"mod.BaseStrategy"`）。这是 `find_strategy_classes` 能命中 `module.BaseStrategy` 形式基类的关键，也是它**不能复用**已有 `inherits_from`（走 `get_base_classes` 返回 unparse 形式）的根因。契约测试 `test_find_strategy_classes_attribute_base` 锁定此语义。

去重统计：**38 处私有副本 → 4 个 seam 函数**。行数：logical 636→595 / structural 467→336 / best_practice 511→321。

## 行为锁定（契约测试）

三个规则文件此前**零直接测试**（仅 logical 的 ForbiddenOperationsRule 有覆盖），重构前先补契约测试作安全网：

- `test_ast_based_rule_contract.py`（9）：`is_abstract_class` 三重语义 5 项 + `ASTBasedRule.check` parse/cache/SyntaxError/异常兜底 4 项
- `test_ast_helpers_seam.py`（8）：`get_node_name` Name/Attribute/其他 + `find_strategy_classes` attr 语义回归守护
- `test_rule_abstract_skip_behavior.py`（5）：经公开 `check_ast` 锁定抽象类跳过（含 best_practice 单重→三重统一后的 ABC 跳过）

## Test plan

- [x] evaluation 全量 26 passed（含 17 既有 + 9 新增契约... 实为 4 既有 forbidden + 22 新增）
- [x] py_compile src/api 全量通过
- [x] 变更文件覆盖率：4 src 文件均有测试覆盖（structural/best_practice/logical → test_evaluation_cli + 新契约；ast_helpers → test_ast_based_rule_contract）
- [x] Layer 2 启动 smoke（user_crud/containers/user_cli）：CI 无 TTY 环境全绿；本地 `test_create_user_missing_name_fails` 为 typer rich ANSI 包裹的 TTY 敏感**预存**失败（`NO_COLOR=1 TERM=dumb` 下 PASSED），与本 PR 改动物理隔离（不 import evaluation）

## 风险评估

- `_is_abstract_class` 单重→三重：仅在「类继承 BaseStrategy 且有 @abstractmethod 但无 `__abstract__` 标记」的边缘情况变化（新增跳过），Ginkgo 约定下极少；且跳过方向是减少误报，安全
- 其余 3 helper：逻辑字节一致（已 AST hash 验证），纯机械上提，零行为变化

Closes #6471