### PR TITLE
fix(data): 修正 file_service.initialize 组件扫描路径漂移

### DIFF
--- a/src/ginkgo/data/services/file_service.py
+++ b/src/ginkgo/data/services/file_service.py
@@ -814,7 +814,9 @@ class FileService(FileSearchMixin, BaseService):
         if working_dir is None:
             working_dir = GCONF.WORKING_PATH
 
-        file_root = f"{working_dir}/src/ginkgo/backtest"
+        # NOTE: 组件源码已从 src/ginkgo/backtest 迁至 src/ginkgo/trading。
+        # 与 seeding.py 的 file_root 保持一致，否则目录扫描空跑。
+        file_root = f"{working_dir}/src/ginkgo/trading"
 
         # Validate base directory exists
         if not os.path.exists(file_root):
@@ -822,12 +824,13 @@ class FileService(FileSearchMixin, BaseService):
             self._logger.ERROR(error_msg)
             return ServiceResult.error(error_msg)
 
+        # folder 键对齐 src/ginkgo/trading 真实目录名（与 seeding.py 一致）
         file_type_map = {
             "analysis/analyzers": FILE_TYPES.ANALYZER,
-            "strategy/risk_managements": FILE_TYPES.RISKMANAGER,
-            "strategy/selectors": FILE_TYPES.SELECTOR,
-            "strategy/sizers": FILE_TYPES.SIZER,
-            "strategy/strategies": FILE_TYPES.STRATEGY,
+            "risk_management": FILE_TYPES.RISKMANAGER,
+            "selectors": FILE_TYPES.SELECTOR,
+            "sizers": FILE_TYPES.SIZER,
+            "strategies": FILE_TYPES.STRATEGY,
         }
 
         black_list = ["__", "base"]


### PR DESCRIPTION
## 背景

`FileService.initialize`（`file_service.py:793`）是组件脚本刷新的"正主方法"，但存在路径漂移：
- `file_root` 指向已迁移的 `src/ginkgo/backtest`（目录不存在）
- folder 映射键带 `strategy/` 前缀且 `risk_managements` 为复数

修复前即便被调用也在 `os.path.exists` 校验处空跑 `return error`，方法长期零调用且路径失效，易误导（看似可用实则不可用）。

## 改动

对齐 `seeding.py:323-332` 实际生效的路径与映射：
- `file_root`: `src/ginkgo/backtest` → `src/ginkgo/trading`
- folder 键: 去 `strategy/` 前缀，`strategy/risk_managements` → `risk_management`，余下 `selectors`/`sizers`/`strategies` 同步

## 验证

只读验证（不触 DB）：
- 修复前 `backtest/` 不存在 → 扫 **0** 文件
- 修复后 `trading/` 可扫 **57** 个组件，`cn_all_selector.py` 在 `selectors` 列内

## 说明

`ginkgo init` 实际走 `seeding.run()` 内联逻辑，本 PR 不改其行为。此修复仅消除 `file_service.initialize` 的路径漂移隐患，为后续去重/收敛到单一入口铺垫。该方法当前零调用、属执行类，是否清理另议。

🤖 Generated with [Claude Code](https://claude.com/claude-code)