### PR TITLE
feat: ginkgo cleanup 命令 + destructive CLI 统一 --dry-run 预览

### DIFF
--- a/main.py
+++ b/main.py
@@ -165,6 +165,7 @@ def _register_all_commands():
     _main_app.command(name="status", help=":bar_chart: System status")(core_cli.status)
     _main_app.command(name="version", help=":rabbit: Version info")(core_cli.version if hasattr(core_cli, 'version') else lambda: None)
     _main_app.command(name="debug", help=":bug: Toggle debug mode")(core_cli.debug if hasattr(core_cli, 'debug') else lambda: None)
+    _main_app.command(name="cleanup", help=":broom: Cleanup orphaned data (mappings, params, dead tasks, cache)")(core_cli.cleanup if hasattr(core_cli, 'cleanup') else lambda: None)
     # serve 命令已移到 serve_cli.app (包含 api, webui, worker-data, worker-backtest 等子命令)
     # Configuration 已整合到 get/set config 命令中
 

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 from ginkgo.data.services.base_service import ServiceResult
-from ginkgo.client.cli_utils import build_list_result, format_result
+from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run
 
 console = Console(emoji=True, legacy_windows=False)
 app = typer.Typer(
@@ -418,6 +418,7 @@ def edit_task(
 def delete_task(
     task_id: str = typer.Argument(help="Task UUID to delete"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without deleting (skips confirm)"),
 ):
     """:wastebasket: Delete a backtest task (soft delete)."""
     from ginkgo.data.containers import container
@@ -432,6 +433,13 @@ def delete_task(
     task = result.data
     task_name = task.name if hasattr(task, "name") else task_id
     task_uuid = task.uuid if hasattr(task, "uuid") else task_id
+
+    if dry_run:
+        announce_dry_run(f"删除 task {task_name}", console=console)
+        console.print(
+            f"[cyan]:eye: Would delete task '{task_name}' ({task_uuid[:12]}).[/cyan]"
+        )
+        return
 
     if not confirm:
         confirmed = typer.confirm(f"Delete task '{task_name}' ({task_uuid[:12]})?")

--- a/src/ginkgo/client/cache_cli.py
+++ b/src/ginkgo/client/cache_cli.py
@@ -13,7 +13,7 @@ from typing import Optional
 from typing_extensions import Annotated
 from rich.console import Console
 from rich.table import Table
-from ginkgo.client.cli_utils import confirm_or_exit
+from ginkgo.client.cli_utils import confirm_or_exit, announce_dry_run
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeElapsedColumn
 
 console = Console()
@@ -46,6 +46,10 @@ def clear(
     force: Annotated[
         bool,
         typer.Option("--force", "-f", help=":warning: Skip confirmation prompt")
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help=":eye: Preview the scope to be cleared without deleting (skips confirm; no writes)")
     ] = False,
 ):
     """
@@ -81,8 +85,18 @@ def clear(
     
     # Confirmation prompt
     console.print(f":warning: [yellow]About to clear {operation_desc}[/yellow]")
+
+    # dry-run：预览 scope 后返回，不确认、不清除（精确计数用 `cache status`）
+    if dry_run:
+        announce_dry_run(f"清除 {operation_desc}", console=console)
+        console.print(
+            f"[cyan]:eye: Would clear {operation_desc}. No cache entries deleted.[/cyan]"
+        )
+        console.print("[dim]Run `ginkgo cache status` for per-type key counts.[/dim]")
+        return
+
     confirm_or_exit("Are you sure you want to proceed?", yes_flag=force)
-    
+
     # Perform cache clearing operations
     try:
         with Progress(

--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -315,6 +315,21 @@ def confirm_or_exit(message: str, *, yes_flag: bool = False) -> None:
         raise typer.Exit(0)
 
 
+def announce_dry_run(action: str, *, console: Optional[Console] = None) -> None:
+    """打印 dry-run 横幅（ADR-021 第 3 维，destructive 命令统一 UX）。
+
+    各 destructive 命令在 ``--dry-run`` 路径入口调用一次，统一三件事的对外口径：
+      1. 横幅明示"仅预览，不实际{action}"（与 ``ginkgo cleanup --dry-run`` 对齐）；
+      2. 提示已跳过确认（dry-run 不需要确认，也不应删除）；
+      3. 命令随后只 COUNT/枚举受影响范围，不触达删除/状态变更。
+
+    ``action`` 为动词短语，如"删除 portfolio"、"清理 Kafka 队列消息"。
+    """
+    (console or Console()).print(
+        f"[bold cyan]:eye: Dry-run 模式[/bold cyan]：仅预览，不实际{action}（已跳过确认）。"
+    )
+
+
 def make_progress(*, format: str, isatty: bool) -> Optional["Progress"]:
     """构造 rich Progress（ADR-021 第 8 维）。
 

--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -301,9 +301,12 @@ def _validate_system_health() -> dict:
 
     return health_status
 
-def _cleanup_invalid_data() -> dict:
+def _cleanup_invalid_data(dry_run: bool = False) -> dict:
     """
     清理系统中的无效数据，包括孤立映射、孤立参数、死任务等
+
+    Args:
+        dry_run: 仅统计将清理数量，不实际删除（透传给各 cleanup 方法）
 
     Returns:
         dict: 清理结果统计
@@ -314,25 +317,27 @@ def _cleanup_invalid_data() -> dict:
         "services_cleaned": [],
         "services_failed": [],
         "warnings": [],
-        "details": {}
+        "details": {},
+        "dry_run": dry_run,
     }
 
     try:
-        console.print(":broom: Cleaning invalid data...")
+        action_word = "Previewing" if dry_run else "Cleaning"
+        console.print(f":broom: {action_word} invalid data{' (dry-run)' if dry_run else ''}...")
         from ginkgo.data.containers import container
         from ginkgo.libs import GLOG
 
         # 1. 清理孤立的映射关系 (高优先级)
         try:
             mapping_service = container.mapping_service()
-            result = mapping_service.cleanup_orphaned_mappings()
+            result = mapping_service.cleanup_orphaned_mappings(dry_run=dry_run)
             if result.success:
                 count = result.data.get("cleaned_count", 0)
                 cleanup_result["cleaned_count"] += count
                 cleanup_result["services_cleaned"].append("mapping_service")
                 cleanup_result["details"]["mappings"] = count
                 if count > 0:
-                    console.print(f":white_check_mark: Cleaned {count} orphaned mappings")
+                    console.print(f":white_check_mark: {'Would clean' if dry_run else 'Cleaned'} {count} orphaned mappings")
             else:
                 cleanup_result["warnings"].append(f"Mapping cleanup: {result.error}")
         except Exception as e:
@@ -342,14 +347,14 @@ def _cleanup_invalid_data() -> dict:
         # 2. 清理孤立的参数 (高优先级)
         try:
             param_service = container.param_service()
-            result = param_service.cleanup_orphaned_params()
+            result = param_service.cleanup_orphaned_params(dry_run=dry_run)
             if result.success:
                 count = result.data.get("deleted_count", 0)
                 cleanup_result["cleaned_count"] += count
                 cleanup_result["services_cleaned"].append("param_service")
                 cleanup_result["details"]["params"] = count
                 if count > 0:
-                    console.print(f":white_check_mark: Cleaned {count} orphaned parameters")
+                    console.print(f":white_check_mark: {'Would clean' if dry_run else 'Cleaned'} {count} orphaned parameters")
             else:
                 cleanup_result["warnings"].append(f"Param cleanup: {result.error}")
         except Exception as e:
@@ -359,10 +364,10 @@ def _cleanup_invalid_data() -> dict:
         # 3. 清理Redis死任务 (中优先级)
         try:
             redis_service = container.redis_service()
-            count = redis_service.cleanup_dead_tasks(max_idle_time=3600)
+            count = redis_service.cleanup_dead_tasks(max_idle_time=3600, dry_run=dry_run)
             cleanup_result["cleaned_count"] += count
             if count > 0:
-                console.print(f":white_check_mark: Cleaned {count} dead tasks")
+                console.print(f":white_check_mark: {'Would clean' if dry_run else 'Cleaned'} {count} dead tasks")
         except Exception as e:
             cleanup_result["warnings"].append(f"Redis cleanup error: {str(e)}")
             GLOG.WARN(f"Redis cleanup failed: {e}")
@@ -370,10 +375,10 @@ def _cleanup_invalid_data() -> dict:
         # 4. 清理过期函数缓存 (中优先级)
         try:
             redis_service = container.redis_service()
-            count = redis_service.cleanup_expired_function_cache()
+            count = redis_service.cleanup_expired_function_cache(dry_run=dry_run)
             cleanup_result["cleaned_count"] += count
             if count > 0:
-                console.print(f":white_check_mark: Cleaned {count} expired cache entries")
+                console.print(f":white_check_mark: {'Would clean' if dry_run else 'Cleaned'} {count} expired cache entries")
         except Exception as e:
             cleanup_result["warnings"].append(f"Cache cleanup error: {str(e)}")
             GLOG.WARN(f"Cache cleanup failed: {e}")
@@ -381,14 +386,14 @@ def _cleanup_invalid_data() -> dict:
         # 5. 清理旧的信号追踪记录 (低优先级)
         try:
             signal_service = container.signal_tracking_service()
-            result = signal_service.cleanup(days_to_keep=30)
+            result = signal_service.cleanup(days_to_keep=30, dry_run=dry_run)
             if result.success:
                 count = result.data
                 cleanup_result["cleaned_count"] += count
                 cleanup_result["services_cleaned"].append("signal_tracking_service")
                 cleanup_result["details"]["signals"] = count
                 if count > 0:
-                    console.print(f":white_check_mark: Cleaned {count} old signal records")
+                    console.print(f":white_check_mark: {'Would clean' if dry_run else 'Cleaned'} {count} old signal records")
             else:
                 cleanup_result["warnings"].append(f"Signal cleanup: {result.error}")
         except Exception as e:
@@ -399,20 +404,22 @@ def _cleanup_invalid_data() -> dict:
         try:
             from ginkgo.data.streaming import CheckpointManager
             checkpoint_manager = CheckpointManager()
-            count = checkpoint_manager.cleanup_expired_checkpoints()
+            count = checkpoint_manager.cleanup_expired_checkpoints(dry_run=dry_run)
             cleanup_result["cleaned_count"] += count
             if count > 0:
-                console.print(f":white_check_mark: Cleaned {count} expired checkpoints")
+                console.print(f":white_check_mark: {'Would clean' if dry_run else 'Cleaned'} {count} expired checkpoints")
         except Exception as e:
             cleanup_result["warnings"].append(f"Checkpoint cleanup error: {str(e)}")
             GLOG.WARN(f"Checkpoint cleanup failed: {e}")
 
         # 显示清理摘要
         if cleanup_result["cleaned_count"] > 0:
+            outcome = "preview" if dry_run else "completed"
+            verb = "to clean" if dry_run else "cleaned"
             if cleanup_result["warnings"]:
-                console.print(f":information: Cleanup completed: {cleanup_result['cleaned_count']} items cleaned, {len(cleanup_result['warnings'])} warnings")
+                console.print(f":information: Cleanup {outcome}: {cleanup_result['cleaned_count']} items {verb}, {len(cleanup_result['warnings'])} warnings")
             else:
-                console.print(f":white_check_mark: Cleanup completed: {cleanup_result['cleaned_count']} items cleaned")
+                console.print(f":white_check_mark: Cleanup {outcome}: {cleanup_result['cleaned_count']} items {verb}")
         else:
             console.print(":information: No invalid data found, system is clean")
 
@@ -420,7 +427,7 @@ def _cleanup_invalid_data() -> dict:
             for warning in cleanup_result["warnings"]:
                 console.print(f":warning: {warning}")
 
-        GLOG.INFO(f"Cleanup completed: {cleanup_result['cleaned_count']} items cleaned")
+        GLOG.INFO(f"Cleanup {'preview' if dry_run else 'completed'}: {cleanup_result['cleaned_count']} items")
 
     except Exception as e:
         cleanup_result["success"] = False
@@ -428,6 +435,27 @@ def _cleanup_invalid_data() -> dict:
         GLOG.ERROR(f"Cleanup failed: {e}")
 
     return cleanup_result
+
+def cleanup(
+    yes: Annotated[bool, typer.Option("--yes", "-y", help="跳过确认提示")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="仅预览将清理的数量，不实际删除")] = False,
+):
+    """
+    :broom: 清理孤儿数据：废弃的绑定关系（映射）、孤立参数、Redis 死任务、过期缓存、旧信号记录、过期断点。
+
+    默认二次确认；--yes 跳过确认；--dry-run 仅预览不删除（预览无需确认）。
+    """
+    if dry_run:
+        console.print(":information: Dry-run 模式：仅统计，不删除任何数据")
+    elif not yes:
+        if not typer.confirm("即将清理孤儿数据（映射/参数/死任务/缓存/旧信号/断点），是否继续？"):
+            console.print(":x: 已取消")
+            raise typer.Exit(1)
+
+    result = _cleanup_invalid_data(dry_run=dry_run)
+    if not result["success"]:
+        raise typer.Exit(1)
+
 
 def get(
     data_type: Annotated[DataType, typer.Argument(help="Data type to fetch")],

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 import pandas as pd
 
 from ginkgo.data.services.base_service import ServiceResult
-from ginkgo.client.cli_utils import build_list_result, format_result
+from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run
 
 # 导入辅助函数（从 engine_cli_helpers.py 提取）
 from ginkgo.client.engine_cli_helpers import (
@@ -806,24 +806,36 @@ def run(
 def delete(
     engine_id: str = typer.Argument(..., help="Engine UUID"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview cascade scope (portfolio mappings) without deleting (skips confirm)"),
 ):
     """
     :wastebasket: Delete engine.
     """
-    if not confirm:
-        console.print(":x: Please use --confirm to delete engine")
+    # dry-run 安全：不删除，无需 --confirm；其余路径仍要求显式 --confirm
+    if not confirm and not dry_run:
+        console.print(":x: Please use --confirm to delete engine (or --dry-run to preview)")
         raise typer.Exit(1)
 
-    console.print(f":wastebasket: Deleting engine: {engine_id}")
+    if dry_run:
+        announce_dry_run(f"删除 engine {engine_id}（含 portfolio 映射级联）", console=console)
+    else:
+        console.print(f":wastebasket: Deleting engine: {engine_id}")
 
     try:
         from ginkgo.data.containers import container
 
         engine_service = container.engine_service()
-        result = engine_service.delete(engine_id)
+        result = engine_service.delete(engine_id, dry_run=dry_run)
 
         if result.success:
-            console.print(":white_check_mark: Engine deleted successfully")
+            if dry_run:
+                d = result.data or {}
+                console.print(
+                    f"[cyan]:eye: Would delete engine {engine_id}: "
+                    f"{d.get('mappings_would_delete', 0)} portfolio mapping(s) would be removed.[/cyan]"
+                )
+            else:
+                console.print(":white_check_mark: Engine deleted successfully")
         else:
             console.print(f":x: Failed to delete engine: {result.error}")
             raise typer.Exit(1)

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -988,13 +988,21 @@ def unbind_portfolio(
     engine_id: str = typer.Argument(..., help="Engine UUID or name"),
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID or name"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without unbinding (skips confirm)"),
 ):
     """
     :broken_link: Unbind an engine from a portfolio.
     """
-    if not confirm:
+    if not confirm and not dry_run:
         console.print(":x: Please use --confirm to unbind portfolio")
         raise typer.Exit(1)
+
+    if dry_run:
+        announce_dry_run(f"解绑 engine {engine_id} 的 portfolio {portfolio_id}", console=console)
+        console.print(
+            f"[cyan]:eye: Would unbind engine {engine_id} from portfolio {portfolio_id}.[/cyan]"
+        )
+        return
 
     from ginkgo.data.containers import container
 

--- a/src/ginkgo/client/execution_cli.py
+++ b/src/ginkgo/client/execution_cli.py
@@ -22,6 +22,7 @@ from rich.panel import Panel
 import signal
 import sys
 from ginkgo.interfaces.kafka_topics import KafkaTopics
+from ginkgo.client.cli_utils import announce_dry_run
 
 app = typer.Typer(help=":execution: ExecutionNode - Portfolio Execution Engine", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -551,7 +552,7 @@ def _is_node_active(redis_client, node_id: str) -> bool:
     return heartbeat_ttl >= _STALE_HEARTBEAT_TTL_THRESHOLD
 
 
-def _cleanup_node(redis_client, node_id: str, force: bool = False) -> tuple:
+def _cleanup_node(redis_client, node_id: str, force: bool = False, dry_run: bool = False) -> tuple:
     """清理单个 ExecutionNode 的 heartbeat + metrics（#5980 deep module，#4945 加活跃守卫）。
 
     返回 (skipped_active, heartbeat_deleted, metrics_deleted)：
@@ -559,6 +560,8 @@ def _cleanup_node(redis_client, node_id: str, force: bool = False) -> tuple:
     - 其余情况按 key 是否存在删除，返回删除标志，供调用方统计/输出。
 
     force=True 跳过活跃守卫，强制清理（用于运维明确知道要清的场景）。
+    dry_run=True 只做 exists 探测与活跃守卫判定，不实际 delete（返回值含义改为
+    "将删除"，供调用方预览）。活跃守卫在 dry_run 下仍生效（预览也应诚实反映跳过项）。
     """
     from ginkgo.data.redis_schema import RedisKeyBuilder
 
@@ -570,10 +573,11 @@ def _cleanup_node(redis_client, node_id: str, force: bool = False) -> tuple:
     metrics_key = f"node:metrics:{node_id}"
     heartbeat_exists = redis_client.exists(heartbeat_key)
     metrics_exists = redis_client.exists(metrics_key)
-    if heartbeat_exists:
-        redis_client.delete(heartbeat_key)
-    if metrics_exists:
-        redis_client.delete(metrics_key)
+    if not dry_run:
+        if heartbeat_exists:
+            redis_client.delete(heartbeat_key)
+        if metrics_exists:
+            redis_client.delete(metrics_key)
     return (False, bool(heartbeat_exists), bool(metrics_exists))
 
 
@@ -581,6 +585,7 @@ def _cleanup_node(redis_client, node_id: str, force: bool = False) -> tuple:
 def cleanup(
     node_id: Optional[str] = typer.Option(None, "--node-id", "-n", help="ExecutionNode ID to cleanup (default: scan all nodes from heartbeats)"),
     force: bool = typer.Option(False, "--force", help="Force cleanup even if heartbeat is still fresh (node appears running). Use only for stuck/zombie nodes."),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview which nodes/keys would be cleaned without deleting (skips confirm; no writes)."),
 ):
     """
     :broom: Cleanup stale data for an ExecutionNode.
@@ -592,6 +597,10 @@ def cleanup(
     --force is given, since deleting a live heartbeat makes the scheduler mark the
     node offline while it is actually still running.
 
+    --dry-run: enumerate heartbeat/metrics keys and report what WOULD be removed
+    without touching Redis (active-node guard still applies, so running nodes are
+    still reported as skipped). Useful to audit before a real cleanup.
+
     Without --node-id, scans all heartbeat keys and cleans every stale node
     (consistent with `execution status`); running nodes are skipped.
     With --node-id, cleans only that node (also guarded by --force).
@@ -600,7 +609,15 @@ def cleanup(
       ginkgo execution cleanup                      # Clean all stale nodes
       ginkgo execution cleanup --node-id node_1     # Clean specific node only
       ginkgo execution cleanup --node-id node_1 --force  # Force clean a running node
+      ginkgo execution cleanup --dry-run            # Preview without deleting
     """
+    if dry_run:
+        announce_dry_run("清理 ExecutionNode 残留数据", console=console)
+    # dry-run 下"已清理/已删除"统一改为"将清理/将删除"，动词随 dry_run 切换
+    verb_done = "would remove" if dry_run else "removed"
+    verb_node = "Would clean" if dry_run else "Cleaned"
+    verb_hb = "Would delete" if dry_run else "Deleted"
+
     try:
         from ginkgo.data.crud import RedisCRUD
         from ginkgo.data.redis_schema import (
@@ -632,7 +649,7 @@ def cleanup(
             total_skipped = 0
             for nid in node_ids:
                 # #4945: 三元组 (skipped_active, hb_deleted, mt_deleted)
-                skipped, hb_deleted, mt_deleted = _cleanup_node(redis_client, nid, force=force)
+                skipped, hb_deleted, mt_deleted = _cleanup_node(redis_client, nid, force=force, dry_run=dry_run)
                 if skipped:
                     total_skipped += 1
                     console.print(
@@ -644,12 +661,12 @@ def cleanup(
                     total_hb += 1
                 if mt_deleted:
                     total_mt += 1
-                console.print(f":white_check_mark: [green]Cleaned ExecutionNode '{nid}'[/green]")
+                console.print(f":white_check_mark: [green]{verb_node} ExecutionNode '{nid}'[/green]")
 
             cleaned_count = len(node_ids) - total_skipped
             console.print(
                 f"\n:information: Cleanup completed: {total_hb} heartbeat(s), "
-                f"{total_mt} metrics removed across {cleaned_count} node(s)"
+                f"{total_mt} metrics {verb_done} across {cleaned_count} node(s)"
             )
             if total_skipped:
                 console.print(
@@ -657,13 +674,14 @@ def cleanup(
                     f"(fresh heartbeat). Re-run with --force to clean them.[/yellow]"
                 )
             # 仅在确实清理了 stale 节点时才提示调度器将判定离线（语义对这些节点成立）
-            if cleaned_count:
+            # dry_run 下不删除，调度器判定不受影响，不打印此提示避免误导。
+            if cleaned_count and not dry_run:
                 console.print("[dim]Scheduler will detect cleaned nodes as offline on next schedule loop[/dim]")
         else:
             console.print(f":information: Cleaning up data for ExecutionNode '{node_id}'...")
 
             # #4945: 三元组 (skipped_active, hb_deleted, mt_deleted)
-            skipped, hb_deleted, mt_deleted = _cleanup_node(redis_client, node_id, force=force)
+            skipped, hb_deleted, mt_deleted = _cleanup_node(redis_client, node_id, force=force, dry_run=dry_run)
 
             if skipped:
                 # 节点仍在运行——拒绝清理，绝不声称"调度器会判定它离线"（那正是 bug 表象）
@@ -679,12 +697,13 @@ def cleanup(
                 return
 
             if hb_deleted:
-                console.print(":white_check_mark: [green]Deleted heartbeat data[/green]")
+                console.print(f":white_check_mark: [green]{verb_hb} heartbeat data[/green]")
             if mt_deleted:
-                console.print(":white_check_mark: [green]Deleted metrics data[/green]")
+                console.print(f":white_check_mark: [green]{verb_hb} metrics data[/green]")
 
             console.print(f"\n:information: Cleanup completed for ExecutionNode '{node_id}'")
-            console.print("[dim]Scheduler will detect this node as offline on next schedule loop[/dim]")
+            if not dry_run:
+                console.print("[dim]Scheduler will detect this node as offline on next schedule loop[/dim]")
 
     except Exception as e:
         console.print(f"[red]:x: Error cleaning up ExecutionNode data: {e}[/red]")

--- a/src/ginkgo/client/flat_cli.py
+++ b/src/ginkgo/client/flat_cli.py
@@ -15,7 +15,7 @@ from rich.table import Table
 import json
 import datetime
 
-from ginkgo.client.cli_utils import build_list_result, format_result
+from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run
 from ginkgo.data.services.base_service import ServiceResult
 
 from typing import Optional, List
@@ -491,6 +491,7 @@ def create(
 def delete(
     identifier: str = typer.Argument(..., help="Component UUID or name"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without deleting (skips confirm)"),
 ):
     """
     :wastebasket: Delete a component.
@@ -500,6 +501,13 @@ def delete(
     try:
         file_service = container.file_service()
         mfile = _resolve_file(file_service, identifier)
+
+        if dry_run:
+            announce_dry_run(f"删除 component {mfile.name}", console=console)
+            console.print(
+                f"[cyan]:eye: Would delete component '{mfile.name}' ({mfile.uuid[:8]}...).[/cyan]"
+            )
+            return
 
         if not force and not typer.confirm(f"Delete component '{mfile.name}' ({mfile.uuid[:8]}...)?"):
             raise typer.Exit(0)

--- a/src/ginkgo/client/group_cli.py
+++ b/src/ginkgo/client/group_cli.py
@@ -13,6 +13,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich import print as rprint
+from ginkgo.client.cli_utils import announce_dry_run
 
 app = typer.Typer(help=":people_hugging: User group management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -200,6 +201,7 @@ def cat_group(
 def delete_group(
     group_uuid: str = typer.Argument(..., help="Group UUID"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview deletion scope without deleting (skips confirm)"),
 ):
     """
     :wastebasket: Delete a group (cascades to user mappings).
@@ -209,6 +211,14 @@ def delete_group(
     """
     try:
         from ginkgo.data.containers import container
+
+        if dry_run:
+            announce_dry_run(f"删除 group {group_uuid}", console=console)
+            console.print(
+                f"[cyan]:eye: Would delete group {group_uuid} "
+                f"(cascades to user mappings).[/cyan]"
+            )
+            return
 
         if not confirm:
             confirm_delete = typer.confirm(f"Are you sure you want to delete group {group_uuid}?")
@@ -319,6 +329,7 @@ def add_user_to_group(
 def remove_user_from_group(
     user_uuid: Optional[str] = typer.Option(None, "--user", "-u", help="User UUID"),
     group_uuid: Optional[str] = typer.Option(None, "--group", "-g", help="Group UUID"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without removing (no mapping deleted)"),
 ):
     """
     :minus: Remove a user from a group.
@@ -377,6 +388,12 @@ def remove_user_from_group(
             sys.exit(0)
 
         group_service = container.user_group_service()
+        if dry_run:
+            announce_dry_run(f"从 group {group_uuid} 移除 user {user_uuid}", console=console)
+            console.print(
+                f"[cyan]:eye: Would remove user {user_uuid} from group {group_uuid}.[/cyan]"
+            )
+            return
         result = group_service.remove_user_from_group(user_uuid, group_uuid)
 
         if result.success:

--- a/src/ginkgo/client/kafka_cli.py
+++ b/src/ginkgo/client/kafka_cli.py
@@ -12,7 +12,7 @@ from typing import Optional
 from rich.console import Console
 
 from ginkgo.libs import GLOG
-from ginkgo.client.cli_utils import confirm_or_exit
+from ginkgo.client.cli_utils import confirm_or_exit, announce_dry_run
 
 app = typer.Typer(
     help=":satellite: Module for [bold medium_spring_green]KAFKA[/]. [grey62]Kafka queue management commands.[/grey62]",
@@ -31,21 +31,23 @@ def status():
 @app.command()
 def reset(
     queue_name: Optional[str] = typer.Option(None, help="指定队列名称，为空则重置所有"),
-    force: bool = typer.Option(False, "--force", help="强制重置，跳过确认")
+    force: bool = typer.Option(False, "--force", help="强制重置，跳过确认"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: 仅预览将受影响的 worker/主题，不停止 worker、不重建主题（跳过确认）"),
 ):
     """重置Kafka队列状态"""
     console.print("[bold yellow]:arrows_counterclockwise: Resetting Kafka queues...[/]")
-    _reset_kafka_queues(queue_name, force)
+    _reset_kafka_queues(queue_name, force, dry_run=dry_run)
 
 
 @app.command()
 def purge(
     queue_name: str = typer.Argument(..., help="要清理的队列名称"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="跳过确认提示"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: 仅预览将清理的消息数量，不实际消费/删除（跳过确认）"),
 ):
     """清理指定队列的所有消息"""
     console.print(f"[bold red][red]:wastebasket:[/red] Purging queue: {queue_name}[/]")
-    _purge_queue_messages(queue_name, confirm)
+    _purge_queue_messages(queue_name, confirm, dry_run=dry_run)
 
 
 @app.command()
@@ -141,20 +143,41 @@ def _check_queue_status():
         console.print(f"[red]{traceback.format_exc()}[/]")
 
 
-def _reset_kafka_queues(queue_name: Optional[str], force: bool):
-    """重置Kafka队列 - 基于install.py的kafka_reset逻辑"""
+def _reset_kafka_queues(queue_name: Optional[str], force: bool, *, dry_run: bool = False):
+    """重置Kafka队列 - 基于install.py的kafka_reset逻辑
+
+    dry_run=True：只读地报告将受影响的 worker 数与重建范围，不停止 worker、
+    不重建主题、跳过确认。
+    """
     try:
         from ginkgo.libs.core.threading import GinkgoThreadManager
         from ginkgo.data.drivers.ginkgo_kafka import kafka_topic_set
 
-        if queue_name:
-            console.print(f"[yellow]:warning: You are about to reset the Kafka queue: '{queue_name}'[/]")
-            console.print("[red]This will delete all messages and recreate the topic![/]")
+        scope = f"queue '{queue_name}'" if queue_name else "ALL Kafka queues"
+        if dry_run:
+            announce_dry_run(f"重置 {scope}（停止 worker + 重建主题）", console=console)
         else:
-            console.print("[yellow]:warning: You are about to reset ALL Kafka queues![/]")
-            console.print("[red]This will delete all topics and recreate them![/]")
+            if queue_name:
+                console.print(f"[yellow]:warning: You are about to reset the Kafka queue: '{queue_name}'[/]")
+                console.print("[red]This will delete all messages and recreate the topic![/]")
+            else:
+                console.print("[yellow]:warning: You are about to reset ALL Kafka queues![/]")
+                console.print("[red]This will delete all topics and recreate them![/]")
+            confirm_or_exit("[bold red]Are you sure you want to continue?[/]", yes_flag=force)
 
-        confirm_or_exit("[bold red]Are you sure you want to continue?[/]", yes_flag=force)
+        # dry-run：只读探 worker 数后预览返回，绝不 reset_all_workers / kafka_topic_set
+        if dry_run:
+            try:
+                gtm = GinkgoThreadManager()
+                worker_count = gtm.get_worker_count()
+            except Exception as e:
+                worker_count = None
+                console.print(f"[yellow]Warning: Could not read worker count: {e}[/]")
+            if worker_count is not None:
+                console.print(f"[cyan]:eye: {worker_count} worker(s) would be stopped.[/cyan]")
+            console.print(f"[cyan]:eye: {scope} topic(s) would be deleted and recreated.[/cyan]")
+            console.print("[cyan]No workers stopped, no topics recreated.[/cyan]")
+            return
 
         console.print("[yellow]:arrows_counterclockwise: Resetting Kafka queues...[/]")
 
@@ -205,17 +228,22 @@ def _reset_kafka_queues(queue_name: Optional[str], force: bool):
         console.print(f"[red]{traceback.format_exc()}[/]")
 
 
-def _purge_queue_messages(queue_name: str, confirm: bool):
-    """清理队列消息 - 使用KafkaService实现"""
+def _purge_queue_messages(queue_name: str, confirm: bool, *, dry_run: bool = False):
+    """清理队列消息 - 使用KafkaService实现
+
+    dry_run=True：仅探主题存在性 + 取当前消息数后预览返回，不消费/不删除、跳过确认。
+    """
     try:
         from ginkgo.data.containers import container
         import time
 
-        console.print(f"[yellow]:warning: You are about to purge ALL messages from queue: '{queue_name}'[/]")
-        console.print("[red]This will permanently delete all pending messages![/]")
-        confirm_or_exit("[bold red]Are you sure you want to continue?[/]", yes_flag=confirm)
-
-        console.print(f"[red]:wastebasket: Purging messages from queue: {queue_name}[/]")
+        if dry_run:
+            announce_dry_run(f"清理队列 '{queue_name}' 的全部消息", console=console)
+        else:
+            console.print(f"[yellow]:warning: You are about to purge ALL messages from queue: '{queue_name}'[/]")
+            console.print("[red]This will permanently delete all pending messages![/]")
+            confirm_or_exit("[bold red]Are you sure you want to continue?[/]", yes_flag=confirm)
+            console.print(f"[red]:wastebasket: Purging messages from queue: {queue_name}[/]")
 
         # 获取KafkaService实例
         kafka_service = container.kafka_service()
@@ -230,6 +258,14 @@ def _purge_queue_messages(queue_name: str, confirm: bool):
         console.print("[blue]Step 2: Getting initial message count...[/]")
         initial_count = kafka_service.get_message_count(queue_name)
         console.print(f"[blue]Initial messages in queue: {initial_count}[/]")
+
+        # dry-run：到此为止，仅预览，不进入消费/删除
+        if dry_run:
+            console.print(
+                f"[cyan]:eye: Would purge ~{initial_count} message(s) from '{queue_name}'. "
+                f"No messages consumed or deleted.[/cyan]"
+            )
+            return
 
         # 使用KafkaCRUD来消费和删除消息
         console.print("[blue]Step 3: Consuming and discarding messages...[/]")

--- a/src/ginkgo/client/notify_cli.py
+++ b/src/ginkgo/client/notify_cli.py
@@ -16,6 +16,7 @@ from rich import print as rprint
 import json
 
 from ginkgo.libs import GLOG
+from ginkgo.client.cli_utils import announce_dry_run
 
 app = typer.Typer(help=":bell: Notification sending", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -735,6 +736,7 @@ def add_recipient(
 @recipients_app.command("delete")
 def delete_recipient(
     uuid: str = typer.Argument(..., help="Recipient UUID to delete"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without deleting (no recipient removed)"),
 ):
     """
     :trash: Delete a notification recipient.
@@ -746,6 +748,10 @@ def delete_recipient(
         from ginkgo.data.containers import container
 
         service = container.notification_recipient_service()
+        if dry_run:
+            announce_dry_run(f"删除 recipient {uuid}", console=console)
+            console.print(f"[cyan]:eye: Would delete recipient {uuid}.[/cyan]")
+            return
         result = service.delete_recipient(uuid=uuid)
 
         if result.is_success():

--- a/src/ginkgo/client/param_cli.py
+++ b/src/ginkgo/client/param_cli.py
@@ -14,7 +14,7 @@ from typing import Optional
 from typing_extensions import Annotated
 from rich.console import Console
 from rich.table import Table
-from ginkgo.client.cli_utils import confirm_or_exit
+from ginkgo.client.cli_utils import confirm_or_exit, announce_dry_run
 
 app = typer.Typer(
     help=":wrench: Module for [bold medium_spring_green]PARAMETER[/] management. [grey62]CRUD operations for component parameters.[/grey62]",
@@ -112,11 +112,17 @@ def update(
 def delete(
     param_id: Annotated[str, typer.Option("--param", "-p", help="Parameter UUID")],
     force: Annotated[bool, typer.Option("--force", "-f", help="Skip confirmation")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run", help=":eye: Preview without deleting (skips confirm)")] = False,
 ):
     """
     :wastebasket: Delete a parameter.
     """
     from ginkgo.data.containers import container
+
+    if dry_run:
+        announce_dry_run(f"删除 parameter {param_id[:8]}...", console=console)
+        console.print(f"[cyan]:eye: Would delete parameter {param_id[:8]}...[/cyan]")
+        return
 
     confirm_or_exit(f":question: Delete parameter {param_id[:8]}...?", yes_flag=force)
 

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -715,13 +715,21 @@ def unbind_component(
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID or name"),
     file_id: str = typer.Argument(..., help="File UUID or name"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without unbinding (skips confirm)"),
 ):
     """
     :broken_link: Unbind a component from a portfolio.
     """
-    if not confirm:
+    if not confirm and not dry_run:
         console.print(":x: Please use --confirm to unbind component")
         raise typer.Exit(1)
+
+    if dry_run:
+        announce_dry_run(f"解绑 portfolio {portfolio_id} 的 component {file_id}", console=console)
+        console.print(
+            f"[cyan]:eye: Would unbind component {file_id} from portfolio {portfolio_id}.[/cyan]"
+        )
+        return
 
     from ginkgo.data.containers import container
 

--- a/src/ginkgo/client/portfolio_cli.py
+++ b/src/ginkgo/client/portfolio_cli.py
@@ -20,7 +20,7 @@ from rich import print as rprint
 from ginkgo.enums import PORTFOLIO_MODE_TYPES, PORTFOLIO_RUNSTATE_TYPES
 from ginkgo.libs import GLOG
 from ginkgo.data.services.base_service import ServiceResult
-from ginkgo.client.cli_utils import build_list_result, format_result
+from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run
 
 app = typer.Typer(help=":bank: Portfolio management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -517,12 +517,14 @@ def _resolve_portfolio_identifier(portfolio_service, identifier: str):
 def delete(
     portfolio_id: str = typer.Argument(..., help="Portfolio UUID, name, or partial UUID (fuzzy)"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview cascade scope (mappings/params/deployments) without deleting (skips confirm)"),
 ):
     """
     :wastebasket: Delete portfolio. Accepts full UUID, name, or partial UUID (fuzzy match).
     """
-    if not confirm:
-        console.print(":x: Please use --confirm to delete portfolio")
+    # dry-run 安全：不删除，无需 --confirm；其余路径仍要求显式 --confirm
+    if not confirm and not dry_run:
+        console.print(":x: Please use --confirm to delete portfolio (or --dry-run to preview)")
         raise typer.Exit(1)
 
     try:
@@ -538,11 +540,23 @@ def delete(
 
         if resolved_uuid != portfolio_id:
             console.print(f":wastebasket: Resolved '{portfolio_id}' -> {resolved_uuid}")
-        console.print(f":wastebasket: Deleting portfolio: {resolved_uuid}")
-        result = portfolio_service.delete(resolved_uuid)
+        if dry_run:
+            announce_dry_run(f"删除 portfolio {resolved_uuid}（含映射/参数/deployment 级联）", console=console)
+        else:
+            console.print(f":wastebasket: Deleting portfolio: {resolved_uuid}")
+        result = portfolio_service.delete(resolved_uuid, dry_run=dry_run)
 
         if result.success:
-            console.print(":white_check_mark: Portfolio deleted successfully")
+            if dry_run:
+                d = result.data or {}
+                console.print(
+                    f"[cyan]:eye: Would delete portfolio {resolved_uuid}: "
+                    f"{d.get('mappings_deleted', 0)} mapping(s), "
+                    f"{d.get('parameters_deleted', 0)} parameter(s), "
+                    f"{d.get('deployments_would_stop', 0)} deployment(s) would be stopped.[/cyan]"
+                )
+            else:
+                console.print(":white_check_mark: Portfolio deleted successfully")
         else:
             console.print(f":x: Failed to delete portfolio: {result.error}")
             raise typer.Exit(1)

--- a/src/ginkgo/client/templates_cli.py
+++ b/src/ginkgo/client/templates_cli.py
@@ -16,6 +16,7 @@ from rich import print as rprint
 from rich.syntax import Syntax
 import json
 from ginkgo.libs import GLOG
+from ginkgo.client.cli_utils import announce_dry_run
 
 app = typer.Typer(help=":memo: Notification template management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -297,6 +298,7 @@ def update_template(
 def delete_template(
     template_id: str = typer.Argument(..., help="Template ID"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without deleting (skips confirm)"),
 ):
     """
     :wastebasket: Delete a template (soft delete).
@@ -315,6 +317,12 @@ def delete_template(
         if not existing:
             console.print(f"[red]:x: Template not found: {template_id}[/red]")
             raise typer.Exit(1)
+
+        # dry-run：预览后返回（目标存在性已校验）
+        if dry_run:
+            announce_dry_run(f"删除 template {template_id}", console=console)
+            console.print(f"[cyan]:eye: Would delete template '{template_id}'.[/cyan]")
+            return
 
         # Confirm deletion
         if not confirm:

--- a/src/ginkgo/client/user_cli.py
+++ b/src/ginkgo/client/user_cli.py
@@ -14,6 +14,7 @@ from rich.table import Table
 from rich.panel import Panel
 from rich.tree import Tree
 from rich import print as rprint
+from ginkgo.client.cli_utils import announce_dry_run
 
 app = typer.Typer(help=":bust_in_silhouette: User management", rich_markup_mode="rich")
 console = Console(emoji=True, legacy_windows=False)
@@ -515,6 +516,7 @@ def set_primary_contact(
 def delete_contact(
     contact_uuid: str = typer.Argument(..., help="Contact UUID"),
     confirm: bool = typer.Option(False, "--yes", "-y", "--confirm", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help=":eye: Preview without deleting (skips confirm)"),
 ):
     """
     :wastebasket: Delete a contact.
@@ -524,6 +526,11 @@ def delete_contact(
     """
     try:
         from ginkgo.data.containers import container
+
+        if dry_run:
+            announce_dry_run(f"删除 contact {contact_uuid}", console=console)
+            console.print(f"[cyan]:eye: Would delete contact {contact_uuid}.[/cyan]")
+            return
 
         if not confirm:
             confirm_delete = typer.confirm(f"Are you sure you want to delete contact {contact_uuid}?")

--- a/src/ginkgo/data/services/engine_service.py
+++ b/src/ginkgo/data/services/engine_service.py
@@ -514,16 +514,17 @@ class EngineService(BaseService):
             return ServiceResult.error(f"更新引擎状态失败: {str(e)}")
 
     @retry(max_try=3)
-    def delete(self, engine_id: str, **kwargs) -> ServiceResult:
+    def delete(self, engine_id: str, dry_run: bool = False, **kwargs) -> ServiceResult:
         """
         删除引擎 - 包括清理相关的投资组合映射
 
         Args:
             engine_id: 引擎UUID
+            dry_run: 仅预览将清理的映射数，不执行 remove/soft_remove/删除后校验。
             **kwargs: 其他参数
 
         Returns:
-            ServiceResult: 删除结果
+            ServiceResult: 删除结果（dry_run=True 时 data 含 dry_run 标志与计数）
         """
         try:
             # 输入验证
@@ -533,16 +534,34 @@ class EngineService(BaseService):
             warnings = []
 
             with self._crud_repo.get_session() as session:
-                # 清理引擎-投资组合映射
+                # 清理引擎-投资组合映射（dry-run 只 find 计数，不 remove）
                 mappings_deleted = 0
                 try:
-                    mappings_deleted = self._mapping_repo.remove(
-                        filters={"engine_id": engine_id}, session=session
-                    )
-                    if mappings_deleted and mappings_deleted > 0:
-                        GLOG.INFO(f"删除引擎 {engine_id} 的 {mappings_deleted} 个投资组合映射")
+                    if dry_run:
+                        mappings_found = self._mapping_repo.find(
+                            filters={"engine_id": engine_id}
+                        )
+                        mappings_deleted = len(mappings_found) if mappings_found is not None else 0
+                    else:
+                        mappings_deleted = self._mapping_repo.remove(
+                            filters={"engine_id": engine_id}, session=session
+                        )
+                        if mappings_deleted and mappings_deleted > 0:
+                            GLOG.INFO(f"删除引擎 {engine_id} 的 {mappings_deleted} 个投资组合映射")
                 except Exception as e:
                     warnings.append(f"清理投资组合映射时出错: {str(e)}")
+
+                if dry_run:
+                    GLOG.INFO(f"预览删除引擎 {engine_id}：将清理 {mappings_deleted} 个映射")
+                    return ServiceResult.success(
+                        data={
+                            "engine_id": engine_id,
+                            "mappings_would_delete": mappings_deleted,
+                            "dry_run": True,
+                            "warnings": warnings,
+                        },
+                        message=f"引擎删除预览: {engine_id}"
+                    )
 
                 # 软删除引擎记录 (设置is_del=True)
                 self._crud_repo.soft_remove(filters={"uuid": engine_id})

--- a/src/ginkgo/data/services/kafka_service.py
+++ b/src/ginkgo/data/services/kafka_service.py
@@ -101,6 +101,20 @@ class KafkaService(BaseService):
         except Exception as e:
             return ServiceResult.error(f"Failed to count Kafka topics: {str(e)}")
 
+    def topic_exists(self, topic: str) -> bool:
+        """Check whether a Kafka topic exists (thin delegate to KafkaCRUD)."""
+        # 不包 try/except：与同模块其它 ServiceResult 方法不同，CLI purge 需要
+        # 原始 bool 且让 CRUD 异常向上冒泡到 CLI 的 except 响亮报错，避免掩盖失败。
+        return self._crud_repo.topic_exists(topic)
+
+    def get_message_count(self, topic: str) -> int:
+        """Get current message count of a topic (thin delegate to KafkaCRUD).
+
+        ``count()`` 已把同一 CRUD 调用包成 ServiceResult；CLI purge/dry-run 需要
+        原始 int，故提供此薄透传。不包 try/except，让异常冒泡响亮报错。
+        """
+        return self._crud_repo.get_message_count(topic)
+
     def validate(self, topic: str, message: Any = None) -> ServiceResult:
         """Validate Kafka data"""
         try:

--- a/src/ginkgo/data/services/mapping_service.py
+++ b/src/ginkgo/data/services/mapping_service.py
@@ -48,8 +48,12 @@ class MappingService(BaseService):
         self._param_crud = param_crud
 
     # 清理方法 - 当关联对象不存在时自动清理
-    def cleanup_orphaned_mappings(self) -> ServiceResult:
-        """清理孤立的映射关系（关联对象不存在的映射）"""
+    def cleanup_orphaned_mappings(self, dry_run: bool = False) -> ServiceResult:
+        """清理孤立的映射关系（关联对象不存在的映射）
+
+        Args:
+            dry_run: 仅统计将清理数量，不实际删除（默认 False 执行删除）
+        """
         try:
             from sqlalchemy import text
             from ginkgo.data.crud.engine_crud import EngineCRUD
@@ -59,85 +63,56 @@ class MappingService(BaseService):
             cleaned_count = 0
             cleaning_details = []
 
+            # (表名, WHERE 子句, 描述)：6 条同构规则收敛为循环，便于 dry-run 统一处理
+            rules = [
+                ("engine_portfolio_mapping",
+                 "engine_id NOT IN (SELECT uuid FROM engine WHERE is_del = 0)",
+                 "清理孤立Engine映射"),
+                ("engine_portfolio_mapping",
+                 "portfolio_id NOT IN (SELECT uuid FROM portfolio WHERE is_del = 0)",
+                 "清理孤立Portfolio映射"),
+                ("portfolio_file_mapping",
+                 "portfolio_id NOT IN (SELECT uuid FROM portfolio WHERE is_del = 0)",
+                 "清理孤立Portfolio-File映射"),
+                ("portfolio_file_mapping",
+                 "file_id NOT IN (SELECT uuid FROM file WHERE is_del = 0)",
+                 "清理孤立File映射"),
+                ("engine_handler_mapping",
+                 "engine_id NOT IN (SELECT uuid FROM engine WHERE is_del = 0)",
+                 "清理孤立Engine-Handler映射(Engine)"),
+                ("engine_handler_mapping",
+                 "handler_id NOT IN (SELECT uuid FROM handler WHERE is_del = 0)",
+                 "清理孤立Engine-Handler映射(Handler)"),
+            ]
+
             with self._engine_portfolio_mapping_crud.get_session() as session:
-                # 1. 清理孤立的Engine-Portfolio映射（Engine不存在）
-                stmt = text("""
-                    DELETE FROM engine_portfolio_mapping
-                    WHERE engine_id NOT IN (SELECT uuid FROM engine WHERE is_del = 0)
-                """)
-                result = session.execute(stmt)
-                count = result.rowcount
-                if count > 0:
-                    cleaned_count += count
-                    cleaning_details.append(f"清理孤立Engine映射: {count} 个")
-
-                # 2. 清理孤立的Engine-Portfolio映射（Portfolio不存在）
-                stmt = text("""
-                    DELETE FROM engine_portfolio_mapping
-                    WHERE portfolio_id NOT IN (SELECT uuid FROM portfolio WHERE is_del = 0)
-                """)
-                result = session.execute(stmt)
-                count = result.rowcount
-                if count > 0:
-                    cleaned_count += count
-                    cleaning_details.append(f"清理孤立Portfolio映射: {count} 个")
-
-                # 3. 清理孤立的Portfolio-File映射（Portfolio不存在）
-                stmt = text("""
-                    DELETE FROM portfolio_file_mapping
-                    WHERE portfolio_id NOT IN (SELECT uuid FROM portfolio WHERE is_del = 0)
-                """)
-                result = session.execute(stmt)
-                count = result.rowcount
-                if count > 0:
-                    cleaned_count += count
-                    cleaning_details.append(f"清理孤立Portfolio-File映射: {count} 个")
-
-                # 4. 清理孤立的Portfolio-File映射（File不存在）
-                stmt = text("""
-                    DELETE FROM portfolio_file_mapping
-                    WHERE file_id NOT IN (SELECT uuid FROM file WHERE is_del = 0)
-                """)
-                result = session.execute(stmt)
-                count = result.rowcount
-                if count > 0:
-                    cleaned_count += count
-                    cleaning_details.append(f"清理孤立File映射: {count} 个")
-
-                # 5. 清理孤立的Engine-Handler映射（Engine不存在）
-                stmt = text("""
-                    DELETE FROM engine_handler_mapping
-                    WHERE engine_id NOT IN (SELECT uuid FROM engine WHERE is_del = 0)
-                """)
-                result = session.execute(stmt)
-                count = result.rowcount
-                if count > 0:
-                    cleaned_count += count
-                    cleaning_details.append(f"清理孤立Engine-Handler映射(Engine): {count} 个")
-
-                # 6. 清理孤立的Engine-Handler映射（Handler不存在）
-                stmt = text("""
-                    DELETE FROM engine_handler_mapping
-                    WHERE handler_id NOT IN (SELECT uuid FROM handler WHERE is_del = 0)
-                """)
-                result = session.execute(stmt)
-                count = result.rowcount
-                if count > 0:
-                    cleaned_count += count
-                    cleaning_details.append(f"清理孤立Engine-Handler映射(Handler): {count} 个")
-
+                for table, where_clause, desc in rules:
+                    # 先 COUNT（dry-run 与实际清理均需统计）
+                    count = session.execute(
+                        text(f"SELECT COUNT(*) FROM {table} WHERE {where_clause}")
+                    ).scalar() or 0
+                    if count > 0:
+                        cleaned_count += count
+                        cleaning_details.append(f"{desc}: {count} 个")
+                        if not dry_run:
+                            session.execute(
+                                text(f"DELETE FROM {table} WHERE {where_clause}")
+                            )
 
             if cleaned_count > 0:
-                GLOG.INFO(f"清理了 {cleaned_count} 个孤立映射关系")
+                action = "将清理" if dry_run else "清理了"
+                GLOG.INFO(f"{action} {cleaned_count} 个孤立映射关系")
                 for detail in cleaning_details:
                     GLOG.DEBUG(f"  - {detail}")
             else:
                 GLOG.DEBUG("未发现孤立的映射关系")
 
+            msg = ("预览完成" if dry_run else "清理完成") + f"，发现 {cleaned_count} 个孤立映射"
             return ServiceResult.success({
                 "cleaned_count": cleaned_count,
-                "cleaning_details": cleaning_details
-            }, f"清理完成，处理了 {cleaned_count} 个孤立映射")
+                "cleaning_details": cleaning_details,
+                "dry_run": dry_run,
+            }, msg)
 
         except Exception as e:
             return ServiceResult.error(f"清理孤立映射失败: {str(e)}")

--- a/src/ginkgo/data/services/param_service.py
+++ b/src/ginkgo/data/services/param_service.py
@@ -684,11 +684,14 @@ class ParamService(BaseService):
 
     # ==================== 清理方法 ====================
 
-    def cleanup_orphaned_params(self) -> ServiceResult:
+    def cleanup_orphaned_params(self, dry_run: bool = False) -> ServiceResult:
         """清理孤立的参数（关联对象不存在的参数）
 
         注意：params 表通过 mapping_id 关联到 portfolio_file_mapping.uuid
         而不是直接关联到 portfolio.uuid
+
+        Args:
+            dry_run: 仅统计将清理数量，不实际删除（默认 False 执行删除）
         """
         try:
             from ginkgo.data.containers import container
@@ -703,8 +706,9 @@ class ParamService(BaseService):
                 # 如果没有有效的映射关系，删除所有参数
                 deleted_count = self._crud_repo.count(filters={"is_del": False})
                 if deleted_count > 0:
-                    self._crud_repo.remove(filters={"is_del": False})
-                    GLOG.INFO(f"清理了 {deleted_count} 个孤立参数（无有效映射关系）")
+                    if not dry_run:
+                        self._crud_repo.remove(filters={"is_del": False})
+                    GLOG.INFO(f"{'将清理' if dry_run else '清理了'} {deleted_count} 个孤立参数（无有效映射关系）")
             else:
                 # 获取所有关联不存在映射关系的参数
                 all_params = self._crud_repo.find(filters={"is_del": False})
@@ -713,21 +717,22 @@ class ParamService(BaseService):
                 for param in all_params:
                     # 检查 param.mapping_id 是否在有效的 mapping uuids 中
                     if param.mapping_id not in valid_mapping_uuids:
-                        # 删除孤立参数
-                        result = self._crud_repo.remove(filters={"uuid": param.uuid})
-                        if result > 0:
-                            orphaned_count += 1
+                        # 删除孤立参数（dry-run 只计数）
+                        if not dry_run:
+                            self._crud_repo.remove(filters={"uuid": param.uuid})
+                        orphaned_count += 1
 
                 if orphaned_count > 0:
-                    GLOG.INFO(f"清理了 {orphaned_count} 个孤立参数")
+                    GLOG.INFO(f"{'将清理' if dry_run else '清理了'} {orphaned_count} 个孤立参数")
                 else:
                     GLOG.DEBUG("未发现孤立的参数")
 
             deleted_count = orphaned_count if valid_mapping_uuids else self._crud_repo.count(filters={"is_del": False})
-
+            msg = ("预览完成" if dry_run else "清理完成") + f"，发现 {deleted_count} 个孤立参数"
             return ServiceResult.success({
-                "deleted_count": deleted_count
-            }, f"清理完成，处理了 {deleted_count} 个孤立参数")
+                "deleted_count": deleted_count,
+                "dry_run": dry_run,
+            }, msg)
 
         except Exception as e:
             GLOG.ERROR(f"清理孤立参数失败: {str(e)}")

--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -623,15 +623,18 @@ class PortfolioService(BaseService):
             return ServiceResult.error(f"停止投资组合失败: {str(e)}")
 
     @retry(max_try=3)
-    def delete(self, portfolio_id: str, **kwargs) -> ServiceResult:
+    def delete(self, portfolio_id: str, dry_run: bool = False, **kwargs) -> ServiceResult:
         """
         删除投资组合（包括清理相关文件映射和参数）
 
         Args:
             portfolio_id: 投资组合UUID
+            dry_run: 仅预览将清理的级联范围（映射数/参数数/将停止的 deployment），
+                不执行任何 remove/soft_remove/状态变更。存在性与运行状态守卫仍生效
+                （dry-run 也会拒绝预览删除一个正在运行的 PAPER/LIVE 组合）。
 
         Returns:
-            ServiceResult: 删除结果
+            ServiceResult: 删除结果（dry_run=True 时 result_data 含 dry_run 标志与计数）
         """
         try:
             # 输入验证
@@ -659,61 +662,78 @@ class PortfolioService(BaseService):
                             f"组合正在{state_name}状态，请先停止后再删除"
                         )
 
-            deleted_count = 0
             mappings_deleted = 0
             parameters_deleted = 0
+            deployments_would_stop = 0
             warnings = []
 
-            # 清理投资组合-文件映射和参数
+            # 清理投资组合-文件映射和参数（dry-run 只枚举计数，不删除）
             try:
                 file_mappings = self._portfolio_file_mapping_crud.find(
                     filters={"portfolio_id": portfolio_id}
                 )
+                mappings_deleted = len(file_mappings)
 
                 for mapping in file_mappings:
-                    # 删除关联参数
-                    try:
-                        self._param_crud.remove(
-                            filters={"mapping_id": mapping.uuid}
-                        )
-                    except Exception as e:
-                        warnings.append(f"删除映射参数失败 {mapping.uuid}: {str(e)}")
+                    if dry_run:
+                        # 预览：统计该映射关联参数数，不删除
+                        try:
+                            params = self._param_crud.find(
+                                filters={"mapping_id": mapping.uuid}
+                            )
+                            parameters_deleted += len(params) if params is not None else 0
+                        except Exception as e:
+                            warnings.append(f"预览统计参数失败 {mapping.uuid}: {str(e)}")
+                    else:
+                        try:
+                            self._param_crud.remove(
+                                filters={"mapping_id": mapping.uuid}
+                            )
+                        except Exception as e:
+                            warnings.append(f"删除映射参数失败 {mapping.uuid}: {str(e)}")
 
-                # 删除投资组合-文件映射
-                self._portfolio_file_mapping_crud.remove(
-                    filters={"portfolio_id": portfolio_id}
-                )
+                if not dry_run:
+                    # 删除投资组合-文件映射
+                    self._portfolio_file_mapping_crud.remove(
+                        filters={"portfolio_id": portfolio_id}
+                    )
 
             except Exception as e:
                 warnings.append(f"清理映射关系时出错: {str(e)}")
 
-            # 软删除投资组合
-            self._crud_repo.soft_remove(
-                filters={"uuid": portfolio_id}
-            )
+            # 软删除投资组合（dry-run 跳过）
+            if not dry_run:
+                self._crud_repo.soft_remove(
+                    filters={"uuid": portfolio_id}
+                )
 
             # 如果是已部署的 target，将对应 deployment 状态更新为 STOPPED
+            # dry-run 只枚举将停止的 deployment，不改状态
             if hasattr(self, '_deployment_crud') and self._deployment_crud:
                 deployments = self._deployment_crud.find(
                     filters={"target_portfolio_id": portfolio_id}
                 )
                 for d in deployments:
                     if getattr(d, 'status', -1) == 1:  # DEPLOYED
-                        self._deployment_crud.modify(
-                            filters={"uuid": d.uuid},
-                            updates={"status": 3},  # STOPPED
-                        )
+                        deployments_would_stop += 1
+                        if not dry_run:
+                            self._deployment_crud.modify(
+                                filters={"uuid": d.uuid},
+                                updates={"status": 3},  # STOPPED
+                            )
 
-            GLOG.INFO(f"成功删除投资组合 {portfolio_id}")
+            GLOG.INFO(f"{'预览删除投资组合' if dry_run else '成功删除投资组合'} {portfolio_id}")
 
             result_data = {
                 "portfolio_id": portfolio_id,
                 "mappings_deleted": mappings_deleted,
                 "parameters_deleted": parameters_deleted,
-                "warnings": warnings
+                "deployments_would_stop": deployments_would_stop,
+                "dry_run": dry_run,
+                "warnings": warnings,
             }
 
-            message = f"投资组合删除成功: {portfolio_id}"
+            message = ("投资组合删除预览" if dry_run else "投资组合删除成功") + f": {portfolio_id}"
             if warnings:
                 message += f" (附带{len(warnings)}个警告)"
 

--- a/src/ginkgo/data/services/redis_service.py
+++ b/src/ginkgo/data/services/redis_service.py
@@ -657,38 +657,43 @@ class RedisService(BaseService):
             self._logger.ERROR(f"Failed to update task status: {e}")
             return False
     
-    def cleanup_dead_tasks(self, max_idle_time: int = 3600) -> int:
+    def cleanup_dead_tasks(self, max_idle_time: int = 3600, dry_run: bool = False) -> int:
         """
         清理超过最大空闲时间的死任务，维护Redis存储空间
 
         Args:
             max_idle_time: 最大空闲时间（秒），默认1小时
+            dry_run: 仅统计将清理数量，不实际删除（默认 False 执行删除）
 
         Returns:
             int: 清理的任务数量
         """
         try:
             import time
-            
+
             current_time = time.time()
             cleaned_count = 0
-            
+
             # 获取所有任务键
             task_keys = self._crud_repo.keys("ginkgo_task_*")
-            
+
             for task_key in task_keys:
                 task_status = self.get_task_status_by_key(task_key)
                 if task_status and 'updated_at' in task_status:
                     last_update = task_status['updated_at']
                     if current_time - last_update > max_idle_time:
-                        # 任务超过最大空闲时间，删除
-                        if self._crud_repo.delete(task_key):
+                        # 任务超过最大空闲时间，删除（dry-run 只计数）
+                        if dry_run:
+                            cleaned_count += 1
+                            self._logger.DEBUG(f"[dry-run] would clean dead task: {task_key}")
+                        elif self._crud_repo.delete(task_key):
                             cleaned_count += 1
                             self._logger.DEBUG(f"Cleaned dead task: {task_key}")
-            
+
             if cleaned_count > 0:
-                self._logger.INFO(f"Cleaned {cleaned_count} dead tasks")
-            
+                action = "Will clean" if dry_run else "Cleaned"
+                self._logger.INFO(f"{action} {cleaned_count} dead tasks")
+
             return cleaned_count
         except Exception as e:
             self._logger.ERROR(f"Failed to cleanup dead tasks: {e}")
@@ -1221,11 +1226,16 @@ class RedisService(BaseService):
             self._logger.ERROR(f"Failed to get function cache stats: {e}")
             return {"total_entries": 0, "by_function": {}, "error": str(e)}
     
-    def cleanup_expired_function_cache(self) -> int:
+    def cleanup_expired_function_cache(self, dry_run: bool = False) -> int:
         """
         检查并统计过期的函数缓存条目数量
 
-        Note: Redis会自动清理过期的键，但这个方法可以用于手动检查和统计
+        Note: Redis会自动清理过期的键，但这个方法可以用于手动检查和统计。
+        本方法只统计不删除（Redis TTL 自动回收过期键），dry_run 形参仅为
+        与其他 cleanup 方法接口一致而保留，不改变行为。
+
+        Args:
+            dry_run: 接口对齐用（本方法始终只统计，不实际删除）
 
         Returns:
             int: 检查的缓存条目数量
@@ -1234,14 +1244,14 @@ class RedisService(BaseService):
             from ginkgo.data.redis_schema import RedisKeyPrefix
             cache_pattern = f"{RedisKeyPrefix.FUNC_CACHE}_*"
             cache_keys = self._crud_repo.keys(cache_pattern)
-            
+
             checked_count = 0
             for cache_key in cache_keys:
                 # 尝试获取TTL，如果返回-2则表示键已过期或不存在
                 ttl = self._crud_repo.ttl(cache_key)
                 if ttl == -2:  # Key doesn't exist (expired)
                     checked_count += 1
-                    
+
             self._logger.DEBUG(f"Checked {len(cache_keys)} function cache entries, {checked_count} were expired")
             return checked_count
         except Exception as e:

--- a/src/ginkgo/data/services/signal_tracking_service.py
+++ b/src/ginkgo/data/services/signal_tracking_service.py
@@ -419,12 +419,13 @@ class SignalTrackingService(BaseService):
 
     
     @retry(max_try=3)
-    def cleanup(self, days_to_keep: int = 30) -> ServiceResult:
+    def cleanup(self, days_to_keep: int = 30, dry_run: bool = False) -> ServiceResult:
         """
         清理旧的追踪记录
 
         Args:
             days_to_keep: 保留天数
+            dry_run: 仅统计将清理数量，不实际删除（默认 False 执行删除）
 
         Returns:
             ServiceResult[int]: 删除的记录数
@@ -441,9 +442,12 @@ class SignalTrackingService(BaseService):
                 if record.create_at and record.create_at < cutoff_date:
                     to_delete.append(record)
 
-            # 逐条删除
+            # 逐条删除（dry-run 只计数）
             deleted_count = 0
             for record in to_delete:
+                if dry_run:
+                    deleted_count += 1
+                    continue
                 try:
                     self._crud_repo.delete_by_uuid(record.uuid)
                     deleted_count += 1
@@ -451,7 +455,8 @@ class SignalTrackingService(BaseService):
                     GLOG.WARN(f"Failed to delete signal tracking record {record.uuid}: {e}")
 
             if deleted_count > 0:
-                GLOG.INFO(f"Cleaned up {deleted_count} old signal tracking records")
+                action = "Will clean up" if dry_run else "Cleaned up"
+                GLOG.INFO(f"{action} {deleted_count} old signal tracking records")
             else:
                 GLOG.DEBUG("No old signal tracking records to clean up")
 

--- a/src/ginkgo/data/streaming/checkpoint.py
+++ b/src/ginkgo/data/streaming/checkpoint.py
@@ -353,9 +353,12 @@ class CheckpointManager:
             GLOG.ERROR(f"Failed to list checkpoints: {e}")
             return []
 
-    def cleanup_expired_checkpoints(self) -> int:
+    def cleanup_expired_checkpoints(self, dry_run: bool = False) -> int:
         """
         清理过期断点
+
+        Args:
+            dry_run: 仅统计将清理数量，不实际删除（默认 False 执行删除）
 
         Returns:
             清理的断点数量
@@ -369,11 +372,13 @@ class CheckpointManager:
 
             for checkpoint in all_checkpoints:
                 if checkpoint.expires_at and current_time > checkpoint.expires_at:
-                    self.delete_checkpoint(checkpoint.checkpoint_id)
+                    if not dry_run:
+                        self.delete_checkpoint(checkpoint.checkpoint_id)
                     expired_count += 1
 
             if expired_count > 0:
-                GLOG.INFO(f"Cleaned up {expired_count} expired checkpoints")
+                action = "Will clean up" if dry_run else "Cleaned up"
+                GLOG.INFO(f"{action} {expired_count} expired checkpoints")
 
             return expired_count
 

--- a/tests/unit/client/test_cleanup_cli.py
+++ b/tests/unit/client/test_cleanup_cli.py
@@ -1,0 +1,274 @@
+"""
+性能: ~轻量, 快速
+Unit tests for `ginkgo cleanup` command (core_cli.cleanup) + dry_run 透传。
+
+覆盖：
+  1. Help/注册：cleanup 出现在 root help；--help 列出 --yes/-y 与 --dry-run
+  2. 命令确认流：--dry-run 跳过确认；--yes 跳过确认；无 flag 走 typer.confirm
+     （接受放行 / 拒绝 exit 1）；失败 exit 1
+  3. _cleanup_invalid_data 透传：dry_run=True/False 都把 flag 传到 6 个 service 调用
+  4. service 层 dry_run 行为：mapping_service.cleanup_orphaned_mappings
+     dry_run=True 只 COUNT 不 DELETE；dry_run=False 执行 DELETE
+"""
+
+import os
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_main_app():
+    """Return the Typer main app (lazy-loaded)."""
+    from main import get_main_app
+    return get_main_app()
+
+
+def _ok_cleanup_result():
+    """_cleanup_invalid_data 的成功桩返回值。"""
+    return {
+        "success": True,
+        "cleaned_count": 0,
+        "services_cleaned": [],
+        "services_failed": [],
+        "warnings": [],
+        "details": {},
+        "dry_run": False,
+    }
+
+
+def _make_container():
+    """构造 mock container，各 service 清理方法返回安全 0 计数（避免 MagicMock > 0 报错）。
+
+    返回 (container, services) 以便断言调用参数。
+    """
+    container = MagicMock()
+
+    mapping_svc = MagicMock()
+    mapping_svc.cleanup_orphaned_mappings.return_value = ServiceResult.success(
+        {"cleaned_count": 0, "cleaning_details": [], "dry_run": False}
+    )
+    container.mapping_service.return_value = mapping_svc
+
+    param_svc = MagicMock()
+    param_svc.cleanup_orphaned_params.return_value = ServiceResult.success(
+        {"deleted_count": 0, "dry_run": False}
+    )
+    container.param_service.return_value = param_svc
+
+    redis_svc = MagicMock()
+    redis_svc.cleanup_dead_tasks.return_value = 0
+    redis_svc.cleanup_expired_function_cache.return_value = 0
+    container.redis_service.return_value = redis_svc
+
+    signal_svc = MagicMock()
+    signal_svc.cleanup.return_value = ServiceResult.success(0)
+    container.signal_tracking_service.return_value = signal_svc
+
+    services = {
+        "mapping": mapping_svc,
+        "param": param_svc,
+        "redis": redis_svc,
+        "signal": signal_svc,
+    }
+    return container, services
+
+
+# ===========================================================================
+# 1. Help / 注册
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCleanupHelp:
+    def test_root_help_shows_cleanup(self, cli_runner):
+        """cleanup 已注册到 root app。"""
+        result = cli_runner.invoke(_get_main_app(), ["--help"])
+        assert result.exit_code == 0
+        assert "cleanup" in result.output
+
+    def test_cleanup_help_shows_options(self, cli_runner):
+        """cleanup --help 列出 --yes/-y 与 --dry-run。
+
+        用中文描述断言（Rich 给选项名加 ANSI 色码会把 --yes 字面量切断，
+        但 help 描述文本无样式）。
+        """
+        result = cli_runner.invoke(_get_main_app(), ["cleanup", "--help"])
+        assert result.exit_code == 0
+        assert "跳过确认提示" in result.output
+        assert "仅预览将清理的数量" in result.output
+
+
+# ===========================================================================
+# 2. 命令确认流
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCleanupConfirmFlow:
+    def test_dry_run_skips_confirm_and_passes_true(self, cli_runner):
+        """--dry-run 不触发确认，打印 Dry-run 横幅，并以 dry_run=True 调下层。"""
+        with patch(
+            "ginkgo.client.core_cli._cleanup_invalid_data",
+            return_value=_ok_cleanup_result(),
+        ) as m, patch("ginkgo.client.core_cli.typer.confirm") as conf:
+            result = cli_runner.invoke(_get_main_app(), ["cleanup", "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry-run" in result.output
+        conf.assert_not_called()
+        m.assert_called_once_with(dry_run=True)
+
+    def test_yes_flag_skips_confirm_and_passes_false(self, cli_runner):
+        """--yes 跳过确认，以 dry_run=False 调下层。"""
+        with patch(
+            "ginkgo.client.core_cli._cleanup_invalid_data",
+            return_value=_ok_cleanup_result(),
+        ) as m, patch("ginkgo.client.core_cli.typer.confirm") as conf:
+            result = cli_runner.invoke(_get_main_app(), ["cleanup", "--yes"])
+        assert result.exit_code == 0
+        conf.assert_not_called()
+        m.assert_called_once_with(dry_run=False)
+
+    def test_confirm_accepted_proceeds(self, cli_runner):
+        """无 flag + 用户确认 → 放行，dry_run=False。"""
+        with patch("ginkgo.client.core_cli.typer.confirm", return_value=True) as conf, \
+             patch(
+                 "ginkgo.client.core_cli._cleanup_invalid_data",
+                 return_value=_ok_cleanup_result(),
+             ) as m:
+            result = cli_runner.invoke(_get_main_app(), ["cleanup"])
+        assert result.exit_code == 0
+        conf.assert_called_once()
+        m.assert_called_once_with(dry_run=False)
+
+    def test_confirm_rejected_exits_1_and_skips_cleanup(self, cli_runner):
+        """无 flag + 用户拒绝 → exit 1，打印已取消，不调下层清理。"""
+        with patch("ginkgo.client.core_cli.typer.confirm", return_value=False), \
+             patch("ginkgo.client.core_cli._cleanup_invalid_data") as m:
+            result = cli_runner.invoke(_get_main_app(), ["cleanup"])
+        assert result.exit_code == 1
+        assert "已取消" in result.output
+        m.assert_not_called()
+
+    def test_failure_exits_1(self, cli_runner):
+        """下层返回 success=False → exit 1（--yes 避开确认噪音）。"""
+        fail = _ok_cleanup_result()
+        fail["success"] = False
+        with patch("ginkgo.client.core_cli._cleanup_invalid_data", return_value=fail):
+            result = cli_runner.invoke(_get_main_app(), ["cleanup", "--yes"])
+        assert result.exit_code == 1
+
+
+# ===========================================================================
+# 3. _cleanup_invalid_data 透传 dry_run 到 6 个 service 调用
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCleanupInvalidDataPropagation:
+    def test_dry_run_true_propagates_to_all_services(self):
+        """dry_run=True 透传到 mapping/param/redis(dead+cache)/signal 全部调用点。"""
+        container, svcs = _make_container()
+        with patch("ginkgo.data.containers.container", container):
+            from ginkgo.client.core_cli import _cleanup_invalid_data
+            result = _cleanup_invalid_data(dry_run=True)
+        assert result["success"] is True
+        assert result["dry_run"] is True
+        svcs["mapping"].cleanup_orphaned_mappings.assert_called_once_with(dry_run=True)
+        svcs["param"].cleanup_orphaned_params.assert_called_once_with(dry_run=True)
+        svcs["redis"].cleanup_dead_tasks.assert_called_once_with(max_idle_time=3600, dry_run=True)
+        svcs["redis"].cleanup_expired_function_cache.assert_called_once_with(dry_run=True)
+        svcs["signal"].cleanup.assert_called_once_with(days_to_keep=30, dry_run=True)
+
+    def test_dry_run_false_propagates_to_all_services(self):
+        """dry_run=False 透传到全部调用点（默认删除路径）。"""
+        container, svcs = _make_container()
+        with patch("ginkgo.data.containers.container", container):
+            from ginkgo.client.core_cli import _cleanup_invalid_data
+            result = _cleanup_invalid_data(dry_run=False)
+        assert result["success"] is True
+        assert result["dry_run"] is False
+        svcs["mapping"].cleanup_orphaned_mappings.assert_called_once_with(dry_run=False)
+        svcs["param"].cleanup_orphaned_params.assert_called_once_with(dry_run=False)
+        svcs["redis"].cleanup_dead_tasks.assert_called_once_with(max_idle_time=3600, dry_run=False)
+        svcs["redis"].cleanup_expired_function_cache.assert_called_once_with(dry_run=False)
+        svcs["signal"].cleanup.assert_called_once_with(days_to_keep=30, dry_run=False)
+
+
+# ===========================================================================
+# 4. service 层 dry_run 行为：mapping_service（重构后的 rules 循环）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestMappingServiceDryRun:
+    """mapping_service.cleanup_orphaned_mappings：dry_run 只 COUNT 不 DELETE。"""
+
+    def _make_svc_and_session(self, counts):
+        """counts: list of 6 ints 对应 6 条 rule 的 COUNT 标量返回。"""
+        mock_ep = MagicMock()
+        mock_pf = MagicMock()
+        mock_eh = MagicMock()
+        mock_param = MagicMock()
+        from ginkgo.data.services.mapping_service import MappingService
+        svc = MappingService(
+            engine_portfolio_mapping_crud=mock_ep,
+            portfolio_file_mapping_crud=mock_pf,
+            engine_handler_mapping_crud=mock_eh,
+            param_crud=mock_param,
+        )
+        mock_session = MagicMock()
+        mock_ep.get_session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_ep.get_session.return_value.__exit__ = MagicMock(return_value=False)
+
+        # 实现里 COUNT 与 DELETE 在规则循环内交替执行（COUNT 必先于该规则的 DELETE，
+        # 且 COUNT 按规则顺序触发）。故按 SQL 文本路由：COUNT → 弹出下一个计数，
+        # DELETE → 返回 rowcount。与交替顺序无关，最稳。
+        count_queue = list(counts)
+
+        def _execute_side_effect(stmt, *_a, **_k):
+            result = MagicMock()
+            if "COUNT" in str(stmt).upper():
+                result.scalar.return_value = count_queue.pop(0)
+            else:  # DELETE
+                result.rowcount = 1
+            return result
+
+        mock_session.execute.side_effect = _execute_side_effect
+        return svc, mock_session
+
+    def test_dry_run_true_does_not_delete(self):
+        """dry_run=True：仅 6 次 COUNT，无 DELETE 被执行。"""
+        svc, mock_session = self._make_svc_and_session([1, 0, 1, 0, 0, 0])
+        result = svc.cleanup_orphaned_mappings(dry_run=True)
+        assert result.success is True
+        # 只应有 6 次 COUNT 查询，0 次 DELETE
+        assert mock_session.execute.call_count == 6
+        # 统计到 2 个孤立映射（第 1、3 条 rule 各 1）
+        assert result.data["cleaned_count"] == 2
+        assert result.data["dry_run"] is True
+
+    def test_dry_run_false_executes_delete(self):
+        """dry_run=False：6 次 COUNT + 命中 rule 各 1 次 DELETE。"""
+        svc, mock_session = self._make_svc_and_session([1, 0, 1, 0, 0, 0])
+        result = svc.cleanup_orphaned_mappings(dry_run=False)
+        assert result.success is True
+        # 6 COUNT + 2 DELETE = 8 次 execute
+        assert mock_session.execute.call_count == 8
+        assert result.data["cleaned_count"] == 2
+        assert result.data["dry_run"] is False
+
+    def test_dry_run_true_zero_orphans_issues_no_delete(self):
+        """dry_run=True 且零孤立：仅 COUNT，DELETE 0 次。"""
+        svc, mock_session = self._make_svc_and_session([0, 0, 0, 0, 0, 0])
+        result = svc.cleanup_orphaned_mappings(dry_run=True)
+        assert result.success is True
+        assert mock_session.execute.call_count == 6
+        assert result.data["cleaned_count"] == 0

--- a/tests/unit/client/test_dry_run_cli.py
+++ b/tests/unit/client/test_dry_run_cli.py
@@ -1,0 +1,255 @@
+"""
+性能: ~轻量, 快速
+destructive 命令的 --dry-run 预览统一测试（核心 6：execution cleanup / kafka purge /
+kafka reset / cache clear / portfolio delete / engine delete）。
+
+每命令断言三件事：
+  1. --dry-run 出现在 --help（用无样式描述子串，规避 Rich ANSI 切断 --xxx 字面量）
+  2. dry-run 路径下破坏性调用（delete / remove / soft_remove / consume / reset_all_workers
+     / kafka_topic_set / redis clear）**未被触发**
+  3. dry_run=True 透传到 service 层（portfolio/engine），或横幅/计数打印到位
+
+ANSI 剥离：CLI 各模块用模块级 ``Console(emoji=True)`` 强制着色，Rich 会在词边界插入
+``\\x1b[1;36m`` 色码把 ``--dry-run``/``2 mapping`` 这类字面量切断，裸子串匹配假阴。
+统一用 ``_strip_ansi`` 预处理 output 后再断言。
+"""
+
+import os
+import re
+
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from ginkgo.data.services.base_service import ServiceResult
+
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(s: str) -> str:
+    return _ANSI.sub("", s)
+
+
+def _get_main_app():
+    from main import get_main_app
+    return get_main_app()
+
+
+# ===========================================================================
+# 公共 helper
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestAnnounceDryRun:
+    def test_prints_banner_with_action(self):
+        from ginkgo.client.cli_utils import announce_dry_run
+        from rich.console import Console
+        import io
+        buf = io.StringIO()
+        announce_dry_run("删除 portfolio", console=Console(file=buf, color_system=None, emoji=False))
+        out = _strip_ansi(buf.getvalue())
+        assert "Dry-run" in out
+        assert "仅预览" in out
+        assert "删除 portfolio" in out
+        assert "已跳过确认" in out
+
+
+# ===========================================================================
+# execution cleanup
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestExecutionCleanupDryRun:
+    def test_help_lists_dry_run(self, cli_runner):
+        res = cli_runner.invoke(_get_main_app(), ["execution", "cleanup", "--help"])
+        assert res.exit_code == 0
+        assert "without deleting" in _strip_ansi(res.output)
+
+    def test_cleanup_node_dry_run_does_not_delete(self):
+        """_cleanup_node(dry_run=True)：exists 探测仍跑，delete 不被调用。"""
+        from ginkgo.client.execution_cli import _cleanup_node
+        rc = MagicMock()
+        rc.exists.return_value = 1  # key 存在
+        rc.ttl.return_value = 2  # < _STALE_HEARTBEAT_TTL_THRESHOLD(5) → 视为非活跃，放行清理
+        skipped, hb, mt = _cleanup_node(rc, "node_1", force=False, dry_run=True)
+        assert skipped is False
+        assert hb is True and mt is True
+        rc.exists.assert_called()  # 探测仍发生
+        rc.delete.assert_not_called()  # 关键：dry-run 不删
+
+    def test_cleanup_node_real_run_deletes(self):
+        """对照：dry_run=False 仍调用 delete。"""
+        from ginkgo.client.execution_cli import _cleanup_node
+        rc = MagicMock()
+        rc.exists.return_value = 1
+        rc.ttl.return_value = 2
+        _cleanup_node(rc, "node_1", force=False, dry_run=False)
+        assert rc.delete.call_count == 2  # heartbeat + metrics
+
+    def test_command_passes_dry_run_to_cleanup_node(self, cli_runner):
+        """execution cleanup --node-id n1 --dry-run → _cleanup_node 收到 dry_run=True。"""
+        mock_redis = MagicMock()
+        mock_crud = MagicMock()
+        mock_crud.redis = mock_redis
+        with patch("ginkgo.data.crud.RedisCRUD", return_value=mock_crud), \
+             patch("ginkgo.client.execution_cli._cleanup_node", return_value=(False, True, True)) as m:
+            res = cli_runner.invoke(_get_main_app(), ["execution", "cleanup", "--node-id", "n1", "--dry-run"])
+        assert res.exit_code == 0
+        m.assert_called_once()
+        assert m.call_args.kwargs.get("dry_run") is True
+        # dry-run 横幅 + dry-run 文案（单节点路径用 verb_hb="Would delete"）
+        out = _strip_ansi(res.output)
+        assert "Dry-run" in out
+        assert "Would delete heartbeat" in out
+
+
+# ===========================================================================
+# kafka purge
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestKafkaPurgeDryRun:
+    def test_help_lists_dry_run(self, cli_runner):
+        res = cli_runner.invoke(_get_main_app(), ["kafka", "purge", "--help"])
+        assert res.exit_code == 0
+        assert "不实际消费" in _strip_ansi(res.output)
+
+    def test_dry_run_counts_without_consuming(self, cli_runner):
+        """purge --dry-run：get_message_count 被调，consume_messages 不被调，打印 Would purge。"""
+        kafka_svc = MagicMock()
+        kafka_svc.topic_exists.return_value = True
+        kafka_svc.get_message_count.return_value = 7
+        cont = MagicMock()
+        cont.kafka_service.return_value = kafka_svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["kafka", "purge", "mytopic", "--dry-run"])
+        assert res.exit_code == 0
+        kafka_svc.get_message_count.assert_called_once_with("mytopic")
+        # 关键：没有进入消费/删除循环
+        kafka_svc._crud_repo.consume_messages.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Dry-run" in out
+        assert "Would purge" in out and "7" in out
+
+
+# ===========================================================================
+# kafka reset
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestKafkaResetDryRun:
+    def test_help_lists_dry_run(self, cli_runner):
+        res = cli_runner.invoke(_get_main_app(), ["kafka", "reset", "--help"])
+        assert res.exit_code == 0
+        assert "不重建主题" in _strip_ansi(res.output)
+
+    def test_dry_run_reports_workers_without_resetting(self, cli_runner):
+        """reset --dry-run：get_worker_count 被调，reset_all_workers/kafka_topic_set 不被调。"""
+        gtm = MagicMock()
+        gtm.get_worker_count.return_value = 3
+        with patch("ginkgo.libs.core.threading.GinkgoThreadManager", return_value=gtm), \
+             patch("ginkgo.data.drivers.ginkgo_kafka.kafka_topic_set") as topic_set:
+            res = cli_runner.invoke(_get_main_app(), ["kafka", "reset", "--dry-run"])
+        assert res.exit_code == 0
+        gtm.get_worker_count.assert_called_once()
+        gtm.reset_all_workers.assert_not_called()  # 关键：未停 worker
+        topic_set.assert_not_called()  # 关键：未重建主题
+        out = _strip_ansi(res.output)
+        assert "Dry-run" in out
+        assert "3 worker" in out
+
+
+# ===========================================================================
+# cache clear
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestCacheClearDryRun:
+    def test_help_lists_dry_run(self, cli_runner):
+        res = cli_runner.invoke(_get_main_app(), ["cache", "clear", "--help"])
+        assert res.exit_code == 0
+        assert "Preview the scope" in _strip_ansi(res.output)
+
+    def test_dry_run_does_not_clear(self, cli_runner):
+        """clear --dry-run：不触达 redis_service.clear_*，打印 Would clear。"""
+        redis_svc = MagicMock()
+        cont = MagicMock()
+        cont.redis_service.return_value = redis_svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["cache", "clear", "--dry-run"])
+        assert res.exit_code == 0
+        redis_svc.clear_function_cache.assert_not_called()
+        redis_svc.clear_all_sync_progress.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Dry-run" in out
+        assert "Would clear" in out
+
+
+# ===========================================================================
+# portfolio delete（service 层 dry_run）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestPortfolioDeleteDryRun:
+    def _svc(self):
+        svc = MagicMock()
+        svc.exists.return_value = ServiceResult.success({"exists": True})
+        svc.delete.return_value = ServiceResult.success(
+            {"portfolio_id": "P1", "mappings_deleted": 2, "parameters_deleted": 5,
+             "deployments_would_stop": 1, "dry_run": True, "warnings": []}
+        )
+        return svc
+
+    def test_help_lists_dry_run(self, cli_runner):
+        res = cli_runner.invoke(_get_main_app(), ["portfolio", "delete", "--help"])
+        assert res.exit_code == 0
+        assert "Preview cascade scope" in _strip_ansi(res.output)
+
+    def test_dry_run_bypasses_confirm_and_passes_true(self, cli_runner):
+        """--dry-run 无需 --confirm 即放行，且 delete(dry_run=True)。"""
+        svc = self._svc()
+        cont = MagicMock()
+        cont.portfolio_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["portfolio", "delete", "P1", "--dry-run"])
+        assert res.exit_code == 0
+        out = _strip_ansi(res.output)
+        assert "Please use --confirm" not in out  # 守卫被旁路
+        assert svc.delete.call_args.kwargs.get("dry_run") is True
+        assert "2 mapping" in out and "5 parameter" in out and "1 deployment" in out
+
+
+# ===========================================================================
+# engine delete（service 层 dry_run）
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestEngineDeleteDryRun:
+    def test_help_lists_dry_run(self, cli_runner):
+        res = cli_runner.invoke(_get_main_app(), ["engine", "delete", "--help"])
+        assert res.exit_code == 0
+        assert "Preview cascade scope" in _strip_ansi(res.output)
+
+    def test_dry_run_bypasses_confirm_and_passes_true(self, cli_runner):
+        svc = MagicMock()
+        svc.delete.return_value = ServiceResult.success(
+            {"engine_id": "E1", "mappings_would_delete": 3, "dry_run": True, "warnings": []}
+        )
+        cont = MagicMock()
+        cont.engine_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["engine", "delete", "E1", "--dry-run"])
+        assert res.exit_code == 0
+        out = _strip_ansi(res.output)
+        assert "Please use --confirm" not in out
+        assert svc.delete.call_args.kwargs.get("dry_run") is True
+        assert "3 portfolio mapping" in out

--- a/tests/unit/client/test_dry_run_cli.py
+++ b/tests/unit/client/test_dry_run_cli.py
@@ -253,3 +253,179 @@ class TestEngineDeleteDryRun:
         assert "Please use --confirm" not in out
         assert svc.delete.call_args.kwargs.get("dry_run") is True
         assert "3 portfolio mapping" in out
+
+
+# ===========================================================================
+# Wave 3：单记录软删 / 解绑类（统一 if dry_run: announce + return 短路）
+# 每命令断言：破坏性 service/crud 调用**未触发** + 横幅/"Would ..." 文案到位
+# ===========================================================================
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestGroupDeleteDryRun:
+    def test_dry_run_skips_service(self, cli_runner):
+        """group delete --dry-run：confirm 被旁路，delete_group 未调用。"""
+        svc = MagicMock()
+        cont = MagicMock()
+        cont.user_group_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["group", "delete", "gid", "--dry-run"])
+        assert res.exit_code == 0
+        svc.delete_group.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Dry-run" in out and "Would delete group" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestGroupRemoveDryRun:
+    def test_dry_run_skips_service(self, cli_runner):
+        """group remove --dry-run（无 confirm 守卫）：remove_user_from_group 未调用。"""
+        svc = MagicMock()
+        cont = MagicMock()
+        cont.user_group_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(
+                _get_main_app(), ["group", "remove", "--user", "u1", "--group", "g1", "--dry-run"]
+            )
+        assert res.exit_code == 0
+        svc.remove_user_from_group.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would remove user" in out and "g1" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestParamDeleteDryRun:
+    def test_dry_run_skips_crud(self, cli_runner):
+        """param delete --dry-run：confirm_or_exit 被旁路，delete_by_uuid 未调用。"""
+        crud = MagicMock()
+        cont = MagicMock()
+        cont.cruds.param.return_value = crud
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(
+                _get_main_app(), ["param", "delete", "--param", "pid1234567890ab", "--dry-run"]
+            )
+        assert res.exit_code == 0
+        crud.delete_by_uuid.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would delete parameter" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestComponentDeleteDryRun:
+    def test_dry_run_resolves_then_skips(self, cli_runner):
+        """component delete --dry-run：_resolve_file 仍跑（校验存在），soft_delete 未调用。"""
+        mfile = MagicMock()
+        mfile.name = "MyComp"
+        mfile.uuid = "comp12345678abcdef"
+        file_svc = MagicMock()
+        cont = MagicMock()
+        cont.file_service.return_value = file_svc
+        with patch("ginkgo.data.containers.container", cont), \
+             patch("ginkgo.client.flat_cli._resolve_file", return_value=mfile):
+            res = cli_runner.invoke(_get_main_app(), ["component", "delete", "MyComp", "--dry-run"])
+        assert res.exit_code == 0
+        file_svc.soft_delete.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would delete component" in out and "MyComp" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestBacktestDeleteDryRun:
+    def test_dry_run_skips_soft_delete(self, cli_runner):
+        """backtest delete --dry-run：get_by_id 仍跑（校验存在），update(is_del=True) 未调用。"""
+        task = MagicMock()
+        task.name = "mytask"
+        task.uuid = "abc123def456"
+        svc = MagicMock()
+        svc.get_by_id.return_value = ServiceResult.success(task)
+        cont = MagicMock()
+        cont.backtest_task_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["backtest", "delete", "tid", "--dry-run"])
+        assert res.exit_code == 0
+        svc.update.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would delete task" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestTemplateDeleteDryRun:
+    def test_dry_run_skips_crud_delete(self, cli_runner):
+        """templates delete --dry-run：get_by_template_id 仍跑，crud.delete 未调用。"""
+        existing = MagicMock()
+        existing.uuid = "tpl-uuid-123"
+        crud = MagicMock()
+        crud.get_by_template_id.return_value = existing
+        cont = MagicMock()
+        cont.notification_template_crud.return_value = crud
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["templates", "delete", "tpl1", "--dry-run"])
+        assert res.exit_code == 0
+        crud.delete.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would delete template" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestUserContactDeleteDryRun:
+    def test_dry_run_skips_service(self, cli_runner):
+        """user contact delete --dry-run：confirm 被旁路，delete_contact 未调用。"""
+        svc = MagicMock()
+        cont = MagicMock()
+        cont.user_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["user", "contact", "delete", "cid", "--dry-run"])
+        assert res.exit_code == 0
+        svc.delete_contact.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would delete contact" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestNotifyRecipientDeleteDryRun:
+    def test_dry_run_skips_service(self, cli_runner):
+        """notify recipients delete --dry-run（无 confirm 守卫）：delete_recipient 未调用。"""
+        svc = MagicMock()
+        cont = MagicMock()
+        cont.notification_recipient_service.return_value = svc
+        with patch("ginkgo.data.containers.container", cont):
+            res = cli_runner.invoke(_get_main_app(), ["notify", "recipients", "delete", "rid", "--dry-run"])
+        assert res.exit_code == 0
+        svc.delete_recipient.assert_not_called()
+        out = _strip_ansi(res.output)
+        assert "Would delete recipient" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestPortfolioUnbindDryRun:
+    def test_dry_run_bypasses_confirm(self, cli_runner):
+        """portfolio unbind-component --dry-run：--confirm 守卫旁路，不触达 container。"""
+        res = cli_runner.invoke(
+            _get_main_app(), ["portfolio", "unbind-component", "pid", "fid", "--dry-run"]
+        )
+        assert res.exit_code == 0
+        out = _strip_ansi(res.output)
+        assert "Please use --confirm" not in out
+        assert "Would unbind component" in out
+
+
+@pytest.mark.unit
+@pytest.mark.cli
+class TestEngineUnbindDryRun:
+    def test_dry_run_bypasses_confirm(self, cli_runner):
+        """engine unbind-portfolio --dry-run：--confirm 守卫旁路，不触达 container。"""
+        res = cli_runner.invoke(
+            _get_main_app(), ["engine", "unbind-portfolio", "eid", "pid", "--dry-run"]
+        )
+        assert res.exit_code == 0
+        out = _strip_ansi(res.output)
+        assert "Please use --confirm" not in out
+        assert "Would unbind engine" in out

--- a/tests/unit/client/test_engine_cli.py
+++ b/tests/unit/client/test_engine_cli.py
@@ -654,7 +654,7 @@ class TestDelete:
             result = cli_runner.invoke(engine_cli.app, ["delete", "aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", "-y"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
-        svc.delete.assert_called_once_with("aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa")
+        svc.delete.assert_called_once_with("aaaaaaaa-1111-aaaa-1111-aaaaaaaaaaaa", dry_run=False)
 
     @pytest.mark.unit
     @pytest.mark.cli

--- a/tests/unit/client/test_portfolio_cli.py
+++ b/tests/unit/client/test_portfolio_cli.py
@@ -560,7 +560,7 @@ class TestPortfolioDelete:
         result = cli_runner.invoke(portfolio_cli.app, ["delete", "portfolio-uuid-001", "--confirm"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
-        mock_service.delete.assert_called_once_with("portfolio-uuid-001")
+        mock_service.delete.assert_called_once_with("portfolio-uuid-001", dry_run=False)
 
     def test_delete_missing_confirm(self, cli_runner):
         """缺少 --confirm 时拒绝删除"""
@@ -584,7 +584,7 @@ class TestPortfolioDelete:
         result = cli_runner.invoke(portfolio_cli.app, ["delete", "deploy_test", "--confirm"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
-        mock_service.delete.assert_called_once_with("resolved-uuid-999")
+        mock_service.delete.assert_called_once_with("resolved-uuid-999", dry_run=False)
 
     @patch("ginkgo.data.containers.container")
     def test_delete_by_partial_uuid_fuzzy(self, mock_container, cli_runner):
@@ -601,7 +601,7 @@ class TestPortfolioDelete:
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
         mock_service.fuzzy_search.assert_called_once_with("deadbeef")
-        mock_service.delete.assert_called_once_with("deadbeefdeadbeefdeadbeefdeadbeef")
+        mock_service.delete.assert_called_once_with("deadbeefdeadbeefdeadbeefdeadbeef", dry_run=False)
 
     @patch("ginkgo.data.containers.container")
     def test_delete_ambiguous_fuzzy_rejected(self, mock_container, cli_runner):
@@ -658,7 +658,7 @@ class TestPortfolioDelete:
         result = cli_runner.invoke(portfolio_cli.app, ["delete", "portfolio-uuid-001", "-y"])
         assert result.exit_code == 0
         assert "deleted successfully" in result.output
-        mock_service.delete.assert_called_once_with("portfolio-uuid-001")
+        mock_service.delete.assert_called_once_with("portfolio-uuid-001", dry_run=False)
 
 
 # ============================================================================

--- a/tests/unit/data/services/test_kafka_service.py
+++ b/tests/unit/data/services/test_kafka_service.py
@@ -109,6 +109,22 @@ class TestKafkaServiceConstruction:
         assert hasattr(kafka_service, 'kafka')
         assert kafka_service.kafka is not None
 
+    def test_topic_exists_delegates_to_crud(self):
+        """topic_exists 应薄委托到 _crud_repo.topic_exists（CLI purge 前置探测依赖它）。"""
+        mock_crud = MagicMock()
+        mock_crud.topic_exists.return_value = True
+        svc = KafkaService(kafka_crud=mock_crud)
+        assert svc.topic_exists("mytopic") is True
+        mock_crud.topic_exists.assert_called_once_with("mytopic")
+
+    def test_get_message_count_delegates_to_crud(self):
+        """get_message_count 应薄委托到 _crud_repo.get_message_count，返回原始 int。"""
+        mock_crud = MagicMock()
+        mock_crud.get_message_count.return_value = 7
+        svc = KafkaService(kafka_crud=mock_crud)
+        assert svc.get_message_count("mytopic") == 7
+        mock_crud.get_message_count.assert_called_once_with("mytopic")
+
 
 # ============================================================================
 # 测试类 - 主题管理


### PR DESCRIPTION
## 概述

为所有 destructive CLI 操作统一 `--dry-run` 预览能力：横幅明示"仅预览不实际 {action}"、跳过确认、破坏性调用前短路（COUNT/枚举但不删）。分三部分：新增 `ginkgo cleanup` 命令 + 推广 dry-run 到既有 16 个 destructive 命令。

## 改动一：ginkgo cleanup（commit 1）

聚合 `_cleanup_invalid_data` 既有 6 类孤儿数据清理，暴露为顶层命令。软删除（is_del=1）下 DB CASCADE 无效，废弃绑定关系（映射指向 is_del=1 或不存在的 engine/portfolio/file/handler）以孤儿残留；`_cleanup_invalid_data` 已实现 6 类但只被 `ginkgo init` 内部调用，无独立入口、无预览。

- `ginkgo cleanup`：默认二次确认；`--yes` 跳过；`--dry-run` 仅预览数量不删；失败 exit 1
- 6 个 service 方法加 `dry_run` 形参（mapping / param / redis×2 / signal_tracking / CheckpointManager）
- `tests/unit/client/test_cleanup_cli.py` 12 用例

## 改动二：核心 6 命令（commit 2）

| 命令 | dry-run 行为 |
|---|---|
| `execution cleanup` | exists 探测仍跑，Redis delete 短路 |
| `kafka purge` | get_message_count 仍跑，consume 循环短路 |
| `kafka reset` | get_worker_count 仍跑，reset_all_workers / kafka_topic_set 短路 |
| `cache clear` | 打印 scope，redis clear_* 短路（精确计数用 `cache status`） |
| `portfolio delete` | service 层 dry_run：枚举 mapping/param/deployment 计数，remove / soft_remove / modify 短路 |
| `engine delete` | service 层 dry_run：枚举 mapping 计数，remove / soft_remove 短路 |

公共 helper `cli_utils.announce_dry_run(action)` 统一横幅 UX（ADR-021 第 3 维）。

## 改动三：单记录软删 / 解绑 10 命令（commit 3）

统一 `if dry_run: announce + return` 短路（破坏性 service/crud 调用前，无 service 改动）：

- group delete / group remove
- param delete
- component delete
- backtest delete
- templates delete
- user contact delete
- notify recipients delete
- portfolio unbind-component
- engine unbind-portfolio

对无 confirm 守卫的 `group remove` / `notify recipients delete`，dry-run 成为首个安全预览（**未**新增 confirm，避免破坏既有脚本）。

## 验证

- `py_compile` 全部改动文件通过
- `tests/unit/client/test_dry_run_cli.py` **25 passed**（核心6 = 15 + 单记录10）
- `test_cleanup_cli.py` + `test_execution_cli_cleanup.py` + `test_cli_utils*.py` 合跑 **96 passed** 无回归

## 检查清单

- [x] 未改 Base 类（service dry_run 在具体实现层）
- [x] 无手动 ALTER TABLE
- [x] 测试在 `tests/` 顶层
- [x] dry_run 默认 False，不破坏既有调用方（`ginkgo init` 仍实际清理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
