### PR TITLE
fix(web): 修正 nginx /api 反代路径双写致 Web UI 登录全失效

### DIFF
--- a/.conf/nginx.conf
+++ b/.conf/nginx.conf
@@ -53,8 +53,8 @@ http {
             proxy_send_timeout 3600s;
         }
 
-        location /api {
-            proxy_pass http://${API_HOST}:${API_PORT}/api/v1;
+        location /api/ {
+            proxy_pass http://${API_HOST}:${API_PORT}/api/;
             proxy_set_header Host $host; 
             proxy_set_header X-Real-IP $remote_addr; 
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 


### PR DESCRIPTION
## 问题
访问 Web UI(`:8080`)用 `admin/admin123` 无法登录。

## 根因
`.conf/nginx.conf` 的 `/api` 反代把路径**双写**:

```nginx
location /api {
    proxy_pass http://\${API_HOST}:\${API_PORT}/api/v1;
}
```

`proxy_pass` 带 URI(`/api/v1`)时,nginx 会把请求中**匹配 `location` 的前缀**(`/api`)替换为该 URI(`/api/v1`)。于是 web-ui 发出的 `/api/v1/auth/login` 在后端变成 **`/api/v1/v1/auth/login`**(双 v1),不在中间件 `PUBLIC_PATHS` 内,被全局 JWT 鉴权拦死 → `401 "Missing authentication token"`。

**与凭据无关**——登录端点本身根本没被路由到,任何账号都登不进。`admin/admin123` 是 `ginkgo init`→`_init_admin_user()` 建的默认账号(`src/ginkgo/client/core_cli.py:858/911`),本身正确。

## 实测证据(直 curl 192.168.50.12:8080)
| 请求 | 响应 | 说明 |
|---|---|---|
| `POST /api/v1/auth/login`(web-ui 实发) | `Missing authentication token` | 中间件拦(双写后路径不在 PUBLIC_PATHS) |
| `POST /api/auth/login`(少一层 v1,正好对上) | `Invalid username or password` | **穿到了登录处理器**(证明处理器与凭据逻辑正常) |

## 修复
改为 identity 映射(加尾斜杠,`/api/` → `/api/` 原样透传):

```nginx
location /api/ {
    proxy_pass http://\${API_HOST}:\${API_PORT}/api/;
}
```

### 路径映射对照(脚本模拟 nginx proxy_pass 语义)
| 请求 | 旧(BUG) | 新(FIX) |
|---|---|---|
| `/api/v1/auth/login` | `/api/v1/v1/auth/login` ❌ | `/api/v1/auth/login` ✅ |
| `/api/v1/settings/users` | `/api/v1/v1/settings/users` ❌ | `/api/v1/settings/users` ✅ |
| `/api/health` | `/api/v1/health` ❌ | `/api/health` ✅ |

### 影响面
web-ui 全部 API 调用(auth/backtests/data/deploy/orders/portfolios/positions/research/optimization/file/settings…)均为 `/api/v1/*` 前缀(`web-ui/src/api/modules/*.ts`),**无 `/api/xxx` 短路径调用**,故 identity 映射不破坏任何既有端点,并顺带修复同样被双写影响的 `/api/health`。

## 部署
改的是 `.conf/nginx.conf`,由 `.conf/Dockerfile.web` `COPY` 进 `nginx:1.27.0-alpine` 镜像。**需重新构建 web 镜像并重启容器**才生效。

🤖 Generated with [Claude Code](https://claude.com/claude-code)