### PR TITLE
fix(config): 解耦 DEBUGMODE 与 DB 集群选择,新增 GINKGO_ENV 单一旋钮 (ADR-027护栏+ADR-028解耦)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,11 +40,16 @@ KAFKA_AUTO_CREATE_TOPICS_ENABLE=false
 GINKGO_REDIS_HOST=redis-master
 GINKGO_REDIS_PORT=6379
 
-# MySQL (由 CLI debug 命令自动切换)
+# Ginkgo 集群选择（ADR-026：单一决定连 master 还是 test 集群）
+# 切换：ginkgo config set env DEVELOPMENT|PRODUCTION（别名 DEV|PROD）
+# DEVELOPMENT → 下方 host 切到 *-test；PRODUCTION → 切到 *-master。DEBUGMODE 现仅控日志，不再切库。
+GINKGO_ENV=DEVELOPMENT
+
+# MySQL (由 `ginkgo config set env` 自动切换 host)
 GINKGO_MYSQL_HOST=mysql-test
 GINKGO_MYSQL_PORT=3306
 
-# ClickHouse (由 CLI debug 命令自动切换)
+# ClickHouse (由 `ginkgo config set env` 自动切换 host)
 GINKGO_CLICKHOUSE_HOST=clickhouse-test
 GINKGO_CLICKHOUSE_PORT=8123
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,17 @@ jobs:
           uv run python -m pytest \
             tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: GINKGO_ENV + cluster guard smoke (PR6773 ADR-028 集群选择+护栏)
+        # #6773 config.py 新增 ENV property（bridge 推断）/ IS_DEV_ENV / set_env /
+        # _assert_cluster_consistency 被 import 链触达但方法体无 smoke 调用（gate 测试
+        # 不读 CLICKHOST/MYSQLHOST 故 _assert 不触发）→ diff coverage gate 红（20%）。
+        # 本 smoke 调起方法体补覆盖信号，并锁定集群选择 + 护栏新契约（bridge/冲突
+        # raise/SKIP 逃生/幂等横幅）。独立 step 使 push→master 时也跑，同时纳入下方
+        # gate 合集采集 coverage。
+        run: |
+          uv run python -m pytest \
+            tests/unit/libs/test_config_env_cluster_guard_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
@@ -208,6 +219,7 @@ jobs:
             tests/unit/client/test_deploy_cli_list_smoke.py \
             tests/unit/client/test_record_cli_list_smoke.py \
             tests/unit/libs/test_config_generate_smoke.py \
+            tests/unit/libs/test_config_env_cluster_guard_smoke.py \
             tests/unit/features/test_expression_registry.py \
             tests/unit/features/test_operator_registry.py \
             tests/unit/features/test_expression_engine.py \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,11 +35,12 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 
 ### 数据库
 - **禁止手动 ALTER TABLE**，表由 Model 定义 + `ginkgo init` 自动创建
-- Docker 双实例：Master(非Debug) | Test(Debug，端口首位+1)
+- Docker 双实例：Master(PRODUCTION) | Test(DEVELOPMENT，端口首位+1)
 - ClickHouse=时序 | MySQL=关系 | Redis=缓存 | MongoDB=文档
 
-### Debug 模式
-数据库操作前必须开启：`ginkgo debug on`
+### 集群与 Debug（ADR-028 解耦）
+- 集群选择：`ginkgo config set env PRODUCTION|DEVELOPMENT`（PRODUCTION=Master / DEVELOPMENT=Test，DEV 端口首位 +1）
+- Debug：`ginkgo debug on` 仅开日志/退避，**不再切库**（ADR-028 起与集群解耦）
 
 ### 基础组件
 **禁止擅自修改 Base 类**（BaseCRUD、BaseService 等），在具体实现层处理
@@ -61,7 +62,8 @@ Ginkgo: Python 量化交易库。事件驱动回测引擎，支持 ClickHouse/My
 ## Key Commands
 ```bash
 ginkgo version / status                       # 版本/状态
-ginkgo debug on                               # 开启 debug（必须）
+ginkgo config set env DEVELOPMENT             # 切 Test 集群（端口 +1）；PRODUCTION=Master
+ginkgo debug on                               # 开日志/退避（ADR-028 起不再切库）
 ginkgo serve api                              # API 服务器 (:8000)
 ginkgo serve webui                            # Web UI (:5173)
 ginkgo serve worker-backtest --id test2       # 回测 Worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,9 @@ x-worker-common: &worker-common
     # config.py 的 CLICKPORT/MYSQLPORT +1 守卫据此跳过 +1，使容器内服务连内部端口 3306/8123
     # 而非宿主映射端口（ADR-024，修复 TaskTimer→DataWorker 连 mysql-test:13306 ECONNREFUSED）。
     DOCKER_CONTAINER: "true"
+    # ADR-026: GINKGO_ENV 单一决定集群（host 由下方 GINKGO_*_HOST 插值，+1 守卫判据用 IS_DEV_ENV）。
+    # 与 DEBUGMODE 解耦：DEBUGMODE 退为纯日志/退避。默认 DEVELOPMENT 对齐下方 -test host 默认。
+    GINKGO_ENV: ${GINKGO_ENV:-DEVELOPMENT}
     GINKGO_KAFKA_HOST: kafka1
     GINKGO_KAFKA_PORT: 9092
     GINKGO_REDIS_HOST: redis-master
@@ -104,10 +107,6 @@ services:
       # :? 守卫: .env 漏配 SECRET_KEY 时 compose 启动即失败, 避免空串静默绕过 #5464 validator
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set via environment}
       DEBUG: ${DEBUG:-False}
-      # bind mount 宿主 ~/.ginkgo(开发机 config debug=True, 连 Test 实例宿主 13306) 致
-      # GCONF.DEBUGMODE=True → MYSQLPORT 端口首位+1(3306→13306, config.py:584);
-      # 容器内 mysql-test 仅 3306, 13306 连接被拒. 显式 False 覆盖, 对齐 worker
-      GINKGO_DEBUG_MODE: "False"
     volumes:
       - ginkgo-logs:/var/log/ginkgo
       - ${HOME}/.ginkgo:/home/ginkgo/.ginkgo:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ x-worker-common: &worker-common
     # config.py 的 CLICKPORT/MYSQLPORT +1 守卫据此跳过 +1，使容器内服务连内部端口 3306/8123
     # 而非宿主映射端口（ADR-024，修复 TaskTimer→DataWorker 连 mysql-test:13306 ECONNREFUSED）。
     DOCKER_CONTAINER: "true"
-    # ADR-026: GINKGO_ENV 单一决定集群（host 由下方 GINKGO_*_HOST 插值，+1 守卫判据用 IS_DEV_ENV）。
+    # ADR-028: GINKGO_ENV 单一决定集群（host 由下方 GINKGO_*_HOST 插值，+1 守卫判据用 IS_DEV_ENV）。
     # 与 DEBUGMODE 解耦：DEBUGMODE 退为纯日志/退避。默认 DEVELOPMENT 对齐下方 -test host 默认。
     GINKGO_ENV: ${GINKGO_ENV:-DEVELOPMENT}
     GINKGO_KAFKA_HOST: kafka1
@@ -107,6 +107,10 @@ services:
       # :? 守卫: .env 漏配 SECRET_KEY 时 compose 启动即失败, 避免空串静默绕过 #5464 validator
       SECRET_KEY: ${SECRET_KEY:?SECRET_KEY must be set via environment}
       DEBUG: ${DEBUG:-False}
+      # ADR-013: GINKGO_DEBUG_MODE 经 :ro 挂载的宿主 ~/.ginkgo/config.yml(debug=True) 回落进容器
+      # (config.py:772 env 未设时读 config.yml)，致 @retry 不退避(30s×backoff^i 失效)→ tushare 封禁。
+      # 端口 +1 判据本 PR 已改 IS_DEV_ENV，但 DEBUGMODE 仍驱动 @retry 退避，故覆盖保留。
+      GINKGO_DEBUG_MODE: "False"
     volumes:
       - ginkgo-logs:/var/log/ginkgo
       - ${HOME}/.ginkgo:/home/ginkgo/.ginkgo:ro

--- a/docs/adrs/ADR-024-db-port-injection-debug-semantics.md
+++ b/docs/adrs/ADR-024-db-port-injection-debug-semantics.md
@@ -8,7 +8,7 @@
 
 ADR-004 确立 Docker 双实例：**Master（生产，内部 3306 / 宿主映射 3306）+ Test（调试，内部 3306 / 宿主映射 13306）**，Debug 模式切换连哪个实例。当前 debug 切换由**两处配合**完成：
 
-- `config_cli.update_env_for_debug`（config_cli.py:34-38）切 `.env` 的 **HOST**：`mysql-master ↔ mysql-test`（mongo 恒 master，无 test 实例）。容器侧 debug 切实例靠它。
+- `config_cli.update_env_for_debug`（config_cli.py:34-38）切 `.env` 的 **HOST**：`mysql-master ↔ mysql-test`（mongo/redis 恒 master，均无 test 实例，不随 debug 切）。容器侧 debug 切实例靠它。
 - `config.py` 的 `CLICKPORT`/`MYSQLPORT`（config.py:568-587）在 `DEBUGMODE=True` 时做 `"1"+port` 字符串拼接（3306→13306、8123→18123）切 **PORT**。宿主侧 debug 切端口靠它（宿主 CLI 的 `~/.ginkgo/config.yml` 无 mysql 节，port 全靠默认 + 此 +1 派生）。
 
 `+1` 魔法的**意图**是正确的：宿主机经 Docker 映射端口访问 test 实例（`127.0.0.1:13306:3306`），宿主 CLI 该连 13306。
@@ -72,7 +72,7 @@ def MYSQLPORT(self) -> int:
 
 ### 5. CLI 双模（本地直连 / 外部 API）—— 关联方向，另立 ADR
 
-同一 `ginkgo` CLI 二进制，`Backend` 适配层按 `GINKGO_API_URL` 切：未设 → `LocalBackend` 直连 Service/DB（本地运维特权，含 bootstrap 元命令、长任务、调试）；设为 URL → `HTTPBackend` 打 api-server（外部/远程）。bootstrap 元命令（`init` / `debug` / `serve` / `status`）锁定本地模式（api-server 依赖 DB，逻辑上先于 api-server）。此为独立大工程，**本 ADR 仅记录方向，实施细节另立 ADR-025**。
+同一 `ginkgo` CLI 二进制，`Backend` 适配层按 `GINKGO_API_URL` 切：未设 → `LocalBackend` 直连 Service/DB（本地运维特权，含 bootstrap 元命令、长任务、调试）；设为 URL → `HTTPBackend` 打 api-server（外部/远程）。bootstrap 元命令（`init` / `debug` / `serve` / `status`）锁定本地模式（api-server 依赖 DB，逻辑上先于 api-server）。此为独立大工程，**本 ADR 仅记录方向，实施细节另立 ADR**（编号待定；ADR-025 已用于启动期集群一致性护栏）。
 
 ## Rationale
 
@@ -92,7 +92,7 @@ def MYSQLPORT(self) -> int:
 - **supersede ADR-004 端口约定部分**：ADR-004 的双实例概念（Master/Test）保留，"+1 端口派生"约定**收窄为仅宿主客户端**（加容器守卫），不再是无差别规则。ADR-004 顶部标注 `部分 supersede by ADR-024`。
 - **DEBUGMODE 不变之处**：ADR-013（@retry 退避）、日志标注、宿主 +1 触发仍用 DEBUGMODE，本 ADR 不动这些。
 - **关联 memory 更新**：`arch_database_debug_mode`（+1 加容器守卫）、`project_schedule_data_update_broken`（根因实施修复指向本 ADR）。
-- **未决（与本 ADR 正交）**：CLI 双模（Decision 5）的实施、api-server REST 端点对 CLI 命令的覆盖率——另立 ADR-025 + 工程，不阻塞本 ADR 的 config 止血。
+- **未决（与本 ADR 正交）**：CLI 双模（Decision 5）的实施、api-server REST 端点对 CLI 命令的覆盖率——另立 ADR + 工程，不阻塞本 ADR 的 config 止血。
 - **未来增量（非本 ADR 强制）**：若后续 config.yml 引入显式 mysql 节（port 字段），可进一步完全删 +1（config.py 零端口知识），本 ADR 的守卫是通往该终态的增量第一步。
 
 ## 判定标准自检

--- a/docs/adrs/ADR-024-db-port-injection-debug-semantics.md
+++ b/docs/adrs/ADR-024-db-port-injection-debug-semantics.md
@@ -4,7 +4,7 @@
 **Date:** 2026-07-20
 **关联:** 源自 `mysql-test` 连接根因排查（memory `project_schedule_data_update_broken`）+ config 统一重构（#6640）；细化并部分 supersede ADR-004（Docker 双实例与 Debug 模式）的端口约定；关联 ADR-013（Debug 改 @retry 退避语义，仍依赖 DEBUGMODE 标记）；关联 memory `arch_database_debug_mode` / `arch_docker_mysql_test_port_13306`。
 
-> **演进说明（ADR-026，2026-07-25）**：本 ADR 的 **Decision 1**（+1 守卫判据）与 **Decision 2**（DEBUGMODE 作为"连哪个库"的语义标记）已被 ADR-026 supersede——集群选择改由 `GINKGO_ENV` 单一决定，+1 与断言判据改用 `IS_DEV_ENV`，DEBUGMODE 退回纯日志。Decision 3（切换机制）实质由 `ginkgo config set env` 接管。Decision 4/5（远程访问、CLI 双模）不受影响。容器守卫（`is_container_environment()`）与幂等逻辑保留，仅判据替换。
+> **演进说明（ADR-028，2026-07-25）**：本 ADR 的 **Decision 1**（+1 守卫判据）与 **Decision 2**（DEBUGMODE 作为"连哪个库"的语义标记）已被 ADR-028 supersede——集群选择改由 `GINKGO_ENV` 单一决定，+1 与断言判据改用 `IS_DEV_ENV`，DEBUGMODE 退回纯日志。Decision 3（切换机制）实质由 `ginkgo config set env` 接管。Decision 4/5（远程访问、CLI 双模）不受影响。容器守卫（`is_container_environment()`）与幂等逻辑保留，仅判据替换。
 
 ## Context
 
@@ -74,7 +74,7 @@ def MYSQLPORT(self) -> int:
 
 ### 5. CLI 双模（本地直连 / 外部 API）—— 关联方向，另立 ADR
 
-同一 `ginkgo` CLI 二进制，`Backend` 适配层按 `GINKGO_API_URL` 切：未设 → `LocalBackend` 直连 Service/DB（本地运维特权，含 bootstrap 元命令、长任务、调试）；设为 URL → `HTTPBackend` 打 api-server（外部/远程）。bootstrap 元命令（`init` / `debug` / `serve` / `status`）锁定本地模式（api-server 依赖 DB，逻辑上先于 api-server）。此为独立大工程，**本 ADR 仅记录方向，实施细节另立 ADR**（编号待定；ADR-025 已用于启动期集群一致性护栏）。
+同一 `ginkgo` CLI 二进制，`Backend` 适配层按 `GINKGO_API_URL` 切：未设 → `LocalBackend` 直连 Service/DB（本地运维特权，含 bootstrap 元命令、长任务、调试）；设为 URL → `HTTPBackend` 打 api-server（外部/远程）。bootstrap 元命令（`init` / `debug` / `serve` / `status`）锁定本地模式（api-server 依赖 DB，逻辑上先于 api-server）。此为独立大工程，**本 ADR 仅记录方向，实施细节另立 ADR**（编号待定；ADR-027 已用于启动期集群一致性护栏）。
 
 ## Rationale
 

--- a/docs/adrs/ADR-024-db-port-injection-debug-semantics.md
+++ b/docs/adrs/ADR-024-db-port-injection-debug-semantics.md
@@ -4,6 +4,8 @@
 **Date:** 2026-07-20
 **关联:** 源自 `mysql-test` 连接根因排查（memory `project_schedule_data_update_broken`）+ config 统一重构（#6640）；细化并部分 supersede ADR-004（Docker 双实例与 Debug 模式）的端口约定；关联 ADR-013（Debug 改 @retry 退避语义，仍依赖 DEBUGMODE 标记）；关联 memory `arch_database_debug_mode` / `arch_docker_mysql_test_port_13306`。
 
+> **演进说明（ADR-026，2026-07-25）**：本 ADR 的 **Decision 1**（+1 守卫判据）与 **Decision 2**（DEBUGMODE 作为"连哪个库"的语义标记）已被 ADR-026 supersede——集群选择改由 `GINKGO_ENV` 单一决定，+1 与断言判据改用 `IS_DEV_ENV`，DEBUGMODE 退回纯日志。Decision 3（切换机制）实质由 `ginkgo config set env` 接管。Decision 4/5（远程访问、CLI 双模）不受影响。容器守卫（`is_container_environment()`）与幂等逻辑保留，仅判据替换。
+
 ## Context
 
 ADR-004 确立 Docker 双实例：**Master（生产，内部 3306 / 宿主映射 3306）+ Test（调试，内部 3306 / 宿主映射 13306）**，Debug 模式切换连哪个实例。当前 debug 切换由**两处配合**完成：

--- a/docs/adrs/ADR-025-env-cluster-consistency-guard.md
+++ b/docs/adrs/ADR-025-env-cluster-consistency-guard.md
@@ -4,6 +4,8 @@
 **Date:** 2026-07-25
 **关联:** 源自 #6756 / PR #6773；建立在 [ADR-004](ADR-004-dual-db-debug.md)（双实例）与 [ADR-024](ADR-024-db-port-injection-debug-semantics.md)（端口 + debug 语义）之上；关联 memory `arch_database_debug_mode`。
 
+> **演进说明（ADR-026，2026-07-25）**：本 ADR 的 **Decision 1**（断言判据用 DEBUGMODE）已被 ADR-026 supersede——判据改用 `IS_DEV_ENV`（DEVELOPMENT/PRODUCTION），错误提示改 `ginkgo config set env DEVELOPMENT|PRODUCTION`。护栏本身（横幅 + 逃生口 + 幂等 + 范围）保留，仍是 host/env 错配的兜底。Context 描述的"三合一旋钮"根因由 ADR-026 彻底解耦。
+
 ## Context
 
 ADR-004/024 确立的机制下，`DEBUGMODE` 是**"三合一旋钮"**——一个布尔同时决定多件事：

--- a/docs/adrs/ADR-025-env-cluster-consistency-guard.md
+++ b/docs/adrs/ADR-025-env-cluster-consistency-guard.md
@@ -1,0 +1,53 @@
+# ADR-025: 启动期集群一致性护栏（防 debug/host 漂移静默连错库）
+
+**Status:** Accepted
+**Date:** 2026-07-25
+**关联:** 源自 #6756 / PR #6773；建立在 [ADR-004](ADR-004-dual-db-debug.md)（双实例）与 [ADR-024](ADR-024-db-port-injection-debug-semantics.md)（端口 + debug 语义）之上；关联 memory `arch_database_debug_mode`。
+
+## Context
+
+ADR-004/024 确立的机制下，`DEBUGMODE` 是**"三合一旋钮"**——一个布尔同时决定多件事：
+
+| 维度 | debug=on（测试） | debug=off（生产） |
+|---|---|---|
+| MySQL host | `mysql-test` | `mysql-master` |
+| ClickHouse host | `clickhouse-test` | `clickhouse-master` |
+| Redis host | `redis-master`（**不切**） | `redis-master` |
+| MongoDB host | `mongo-master`（**不切**） | `mongo-master` |
+| 宿主客户端端口 | 首位 +1（`13306`/`18123`） | 原始（`3306`/`8123`） |
+| 日志 / @retry 退避 | debug 态（ADR-013） | 生产态 |
+
+切换由 `ginkgo config set debug on/off` 完成：写 config 文件 `debug` 字段 + `update_env_for_debug` 改写 `.env` 的 MYSQL/CLICKHOUSE host + `docker compose up` 重启。Redis/Mongo **无 `-test` 实例**，恒连 master（docker-compose 仅 `redis-master`/`mongo-master`）。
+
+**脆弱点**：`.env` 是**可变共享态**——一次 `debug on` 把 `mysql-test` 写进去，忘翻回来，下次"真实运行"就**静默连测试库**，无报错、无提示。更糟：worker env **烘焙不可变**（ADR-024），改 `.env` + 重启对**已活着的 worker** 不一定生效，等于这层护栏对实盘链路是漏的。"真实运行经常配到测试环境却无人察觉"——这正是本 ADR 要止血的。
+
+## Decision
+
+在 `GCONF.MYSQLHOST`/`CLICKHOST` 首次访问时**惰性**做一致性校验 + 打集群横幅（`_assert_cluster_consistency()`，幂等）：
+
+1. **断言**：host 落 `*-master`/`*-test` 体系时，后缀必须与 `DEBUGMODE` 一致（debug=on 期望 `-test`，off 期望 `-master`），否则 `RuntimeError` 拒启，并提示 `ginkgo config set debug on/off` 重对齐。
+2. **横幅**：每进程首行 stderr 打印 `=== [PROD] MySQL=… / ClickHouse=… ===`（prod 红 / test 绿），一眼可辨。
+3. **不误伤**：localhost / 外部域名不在 master/test 体系 → 断言跳过（外部部署、单测直传 localhost 不受影响）。
+4. **逃生口**：`GINKGO_SKIP_CLUSTER_GUARD=1` 仅跳断言、横幅照打（测试环境 / 特殊部署）。
+5. **幂等**：`GinkgoConfig._cluster_guard_done` 类属性保证每进程只执行一次。
+6. **范围**：只校验 MySQL + ClickHouse（这两才随 debug 切）；Redis/Mongo 恒 master，不校验。
+
+## Rationale
+
+- **为何不彻底解耦（独立 `GINJKGO_ENV` 选库 + debug 退回纯日志开关）**：与 ADR-024「守卫优先于彻底删 +1」同思路——彻底解耦须重构 config.yml 结构 + `set_debug` + 存量迁移，面大、有迁移风险；最小护栏（一个 property 内的断言）以 ~30 行达到**同等止血**（错配不再静默）。纯粹性的收益不足以抵消重构成本。彻底解耦留作未来增量（见 Consequences）。
+- **为何放 property 惰性触发**：覆盖所有走 `GCONF.MYSQLHOST/CLICKHOST` 建连接的入口（serve/worker/CLI/回测），无需改各入口；测试里直传 host 的 driver 不经 property，天然不受影响。
+- **逃生口的必要性**：测试与外部部署 host 不在 master/test 体系，强制断言会大面积红；逃生口让横幅照打（仍声明实际连接）、断言可跳，平衡"治本"与"不破坏现有测试"。
+- **横幅走 stderr 而非 GLOG**：property 在进程极早期被访问，GLOG 此刻可能未就绪，stderr 最稳且始终可见。
+
+## Consequences
+
+- **冲突部署首次启动会被拦**：现存 `.env` 若与 config 文件 `debug` 字段不一致，serve/worker 启动即 `RuntimeError`。这是**预期行为**（暴露现存漂移），修复方式是 `ginkgo config set debug on/off` 重对齐后重启。
+- **Redis/Mongo 不切是已知坑**：debug=on 时这两库仍打 master（compose 无 `-test` 实例）。护栏不覆盖它们——若需隔离须先补 test 实例。
+- **未来彻底解耦时本护栏可精简**：引入 `GINJKGO_ENV` 后 host 与 env 一致性天然成立，断言变冗余可删；横幅仍保留（声明性输出有价值）。
+- **worker env 烘焙问题未根治**：护栏能在 worker**下次重启**时拦下错配，但对**运行中**的 worker 仍无效（env 已烘焙）。彻底解法是 worker 启动期读最新配置而非烘焙——属 ADR-024 Decision 5（CLI 双模 / 配置注入）范畴。
+
+## 判定标准自检
+
+- ① **难逆转**：启动期拒启是 behavioral change，所有部署首次升级都受影响——中。
+- ② **反直觉**：debug off 却连 `-test` 被拒启，不理解 debug/host 耦合的人会困惑"为什么不让我启动"——满足。
+- ③ **真实权衡**：彻底解耦（`GINJKGO_ENV`，重构大）vs 最小护栏（断言，~30 行同等止血）+ 逃生口取舍——满足。

--- a/docs/adrs/ADR-026-env-cluster-decouple-debugmode.md
+++ b/docs/adrs/ADR-026-env-cluster-decouple-debugmode.md
@@ -1,0 +1,79 @@
+# ADR-026: GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）
+
+**Status:** Accepted
+**Date:** 2026-07-25
+**关联:**建立在 [ADR-004](ADR-004-dual-db-debug.md)（双实例）、[ADR-024](ADR-024-db-port-injection-debug-semantics.md)（端口 + debug 语义）、[ADR-025](ADR-025-env-cluster-consistency-guard.md)（启动期护栏）之上；**Supersedes ADR-024 Decision 1/2**（+1 判据与 "DEBUGMODE 标记连哪个库"）、**Supersedes ADR-025 Decision 1**（护栏断言判据由 DEBUGMODE 改 IS_DEV_ENV）；复用仓库已存在的 `GINKGO_ENV` 读取点（`livecore/trade_gateway_adapter.py`）。关联 memory `arch_database_debug_mode`。
+
+## Context
+
+ADR-025 的启动期护栏只是**止血**——它不消除根因，只在错配发生时拒启。根因是 ADR-024/025 都默认接受的强耦合：**`DEBUGMODE` 是"三合一旋钮"**，一个布尔同时管 ① 日志/@retry 退避（ADR-013）② MySQL/ClickHouse host（master/test）③ 宿主客户端端口首位 +1。
+
+三合一耦合 + `.env` 可变共享态 = 两类真实事故：
+
+1. **忘翻 debug / `.env` 残留**：一次 `debug on` 把 `mysql-test` 写进 `.env`，忘翻回来，下次"真实运行"静默连测试库（ADR-025 能在下一次启动拦下，但运行中 worker env 烘焙不可变，护栏对实盘链路仍漏）。
+2. **临时 `set_debug(True)` 隐式切库**：`engine run` / `core test` 为开日志调 `set_debug(True)`，**副作用是隐式切到 test 集群**——调用方本意是日志，却改了 DB。解耦后 `set_debug` 不再切库，这个隐式副作用消失，但**反向风险浮现**：解耦后 `set_debug(True)` 在 PRODUCTION env 下不再切库，回测会**直连 master 写数据**。
+
+仓库已存在 `GINKGO_ENV`（`trade_gateway_adapter.py:297` 用 `os.getenv("GINKGO_ENV","development")=="production"` 判 MVP 模拟成交是否执行），但它是**裸读小写默认值、不经 GCONF、不触发 ADR-025 bridge**的孤岛读口，与新增的大写语义冲突。
+
+判定三条全中（难逆转 / 反直觉 / 真实取舍），立本 ADR 彻底解耦。
+
+## Decision
+
+### 1. 新增 `GINKGO_ENV ∈ {PRODUCTION, DEVELOPMENT}` 为集群选择单一旋钮
+
+`GCONF.ENV` property（`config.py`）读 `GINKGO_ENV` env，取值**大写**（`.upper()`），单一决定连 master 还是 test：
+
+- `DEVELOPMENT` → test 集群（`*-test` host + 宿主客户端端口 +1）
+- `PRODUCTION` → master 集群（`*-master` host + 原端口）
+
+`IS_DEV_ENV = (ENV == "DEVELOPMENT")`。`DEBUGMODE` **退回 ADR-013 纯日志/@retry 退避语义**，不再决定 host、不再决定 +1。
+
+### 2. bridge-default：未设时从 DEBUGMODE 推断（零行为变化迁移）
+
+`GINKGO_ENV` 未显式设置时，`GCONF.ENV` bridge 推断 `"DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"` 并写回 `os.environ`（材料化）。这保证**首次启动零行为变化**：现存部署（未设 `GINKGO_ENV`）的集群选择与解耦前完全一致。一旦用户执行 `ginkgo config set env ...` 把 `GINKGO_ENV` 写进 `.env`，bridge 不再触发，env 成为显式部署态。
+
+### 3. +1 守卫与启动护栏判据改用 IS_DEV_ENV（supersede ADR-024 D1 / ADR-025 D1）
+
+- `CLICKPORT`/`MYSQLPORT` +1 条件（ADR-024 Decision 1）：`self.DEBUGMODE` → `self.IS_DEV_ENV`。容器守卫（`is_container_environment()`）与幂等（`startswith("1")`）保留不变。
+- `_assert_cluster_consistency` 断言判据（ADR-025 Decision 1）：期望后缀 `-test`/`-master` 对应 `IS_DEV_ENV` True/False（即 DEVELOPMENT/PRODUCTION），错误提示改 `ginkgo config set env DEVELOPMENT|PRODUCTION`。横幅 label 与颜色来源同步改 IS_DEV_ENV。
+
+### 4. 回测/测试防误连：PRODUCTION env 下拒跑（防反向风险）
+
+解耦后 `set_debug(True)` 不再切库，反向风险是回测在 PRODUCTION env 下直连 master 写数据。故在 `engine_cli.py`（engine run）、`core_cli.py`（backtest run / core test）的 `set_debug(True)` **之前**加守卫：`if GCONF.ENV == "PRODUCTION": 拒绝 + 提示 ginkgo config set env DEVELOPMENT; raise typer.Exit(1)`。`set_debug(True)` 仍保留（开日志）。`ginkgo debug on/off` 输出加 hint「集群选择请用 `ginkgo config set env`」。
+
+### 5. CLI 闸门：`set env` 写 .env + 重启；`set debug` 退纯日志
+
+- 新增 `ginkgo config set env DEVELOPMENT|PRODUCTION`（别名 DEV/PROD，normalize 大写）：`update_env_for_env` 写 `.env` 的 `GINKGO_ENV` + CLICKHOUSE/MYSQL host（DEVELOPMENT→`*-test` / PRODUCTION→`*-master`，Mongo 恒 master）+ `set_env` 同步本进程 + `docker compose up -d` 重启使 worker env 重新插值。
+- `ginkgo config set debug on/off` **移除** `.env` 改写与 compose 重启副作用，仅 `set_debug` 写 config.yml（退纯日志）。
+
+### 6. set_env 持久层是 .env 而非 config.yml
+
+`set_env` 只同步本进程 `os.environ`，**不写 config.yml**。理由：① compose 需 `${GINKGO_ENV:-DEVELOPMENT}` 插值注入容器，持久值必须在 `.env`；② config.yml 在容器内 `:ro` 挂载（`docker-compose.yml` worker volume），容器侧不可写。`GINKGO_ENV` 是**部署态**（prod/dev），与 config.yml 的**用户偏好态**（debug 日志、cpu_ratio、路径）分层不同。
+
+### 7. 统一读口：trade_gateway_adapter 改走 GCONF.ENV
+
+`trade_gateway_adapter.py:297` 的 `os.getenv("GINKGO_ENV","development")=="production"` 改为 `GCONF.ENV == "PRODUCTION"`。消除孤岛读口（裸读小写默认、不经 GCONF、不触发 bridge）与大小写冲突。`system_service` status 上报新增 `env` 字段。
+
+## Rationale
+
+- **为何彻底解耦（而非继续守卫优先）**：ADR-024/025 的守卫/护栏是"够好的修复"，但根因（三合一耦合）仍在，事故会以新形态复发（本次发现的"临时 set_debug 隐式切库"反向风险即是）。`GINKGO_ENV` 读取点仓库已存在，解耦的边际成本主要是 config.py 一个 property + CLI 一个分支 + 判据替换，远小于 ADR-024 当初评估的"重构 config.yml 结构 + 存量迁移"——因为 bridge-default 把迁移成本降到了零（未设 env 时行为不变）。这是 ADR-025 Consequences 明确点名的"未来彻底解耦"增量。
+- **bridge-default 的取舍**：备选是"强制所有部署显式设 GINKGO_ENV，不设就拒启"。但现存部署全未设，强制会大面积红。bridge 以零行为变化换取平滑迁移：现存部署继续工作，用户主动 `set env` 后才材料化为显式态。代价是 bridge 期间（env 未设）DEBUGMODE 仍间接影响集群（经 bridge）——但这是迁移期不可避免的过渡，且 ADR-025 护栏仍兜底。
+- **为何回测拒跑生产而非仅警告**：回测写数据到 DB（signal/order/position 落库）。PRODUCTION env 下回测 = 写生产库，是真实数据污染。警告会被忽略（CLAUDE.md 归因纪律：宁可响亮报错不留静默兜底）。拒跑是 fail-loud，用户须显式 `set env DEVELOPMENT` 才能跑——一次明确的认知动作消除整个事故类。
+- **为何 +1 判据用 IS_DEV_ENV 单判（不保留 DEBUGMODE 兜底）**：宿主 CLI 工作流是 localhost + env 决定集群。若保留 `DEBUGMODE or IS_DEV_ENV` 双判，DEBUGMODE=True 但 env=PRODUCTION 时仍会 +1，与"env 单一决定"矛盾且 reintroduce 耦合。单判 IS_DEV_ENV 让端口严格跟随集群，可预测。
+- **secure.yml host 旁路**：`config.py:120` 的 `setdefault` 块是 host 的另一写入源（`~/.ginkgo/secure.yml`）。worker 容器不挂 secure.yml（`_has_local_secure=False`），整段跳过，host 全来自 env——故 secure.yml 不是 worker 连库来源，本 ADR 不动它。宿主侧 secure.yml 若显式设了 host，会覆盖 env 推断，此时以 secure.yml 为准（与解耦前行为一致）。
+
+## Consequences
+
+- **`ginkgo config set env DEVELOPMENT|PRODUCTION` 成为切换集群的唯一命令**；`ginkgo config set debug on/off` 仅切日志。两者正交。
+- **ADR-024 Decision 1/2 superseded**：+1 判据改 IS_DEV_ENV；DEBUGMODE 不再是"连哪个库"的语义标记（退纯日志）。ADR-024 Decision 3（切换机制）实质由本 ADR 的 `set env` 接管。ADR-024 顶部标注演进说明。
+- **ADR-025 Decision 1 superseded**：断言判据改 IS_DEV_ENV。ADR-025 护栏本身保留（横幅 + 逃生口 + 幂等不变），仍是错配兜底。ADR-025 顶部标注演进说明。
+- **worker env 烘焙问题仍未根治**：`set env` 改 `.env` + `docker compose up -d` 重建容器才生效；**运行中** worker 带旧 env 仍连错。彻底解法是 worker 启动期读最新配置而非烘焙（ADR-024 Decision 5 范畴），本 ADR 不涉及。
+- **Redis/Mongo 仍恒 master**：`update_env_for_env` 只切 MySQL/ClickHouse host（compose 无 `redis-test`/`mongo-test` 实例）。DEVELOPMENT env 下这两库仍打 master——已知坑，未变。
+- **回测/测试在 PRODUCTION env 下被拒**：所有依赖 `engine run` / `core test` 的工作流须先 `set env DEVELOPMENT`。这是有意的行为变化（防误连生产）。
+- **bridge 期 DEBUGMODE 仍间接影响集群**：env 未显式设时，bridge 从 DEBUGMODE 推断——故此期间改 DEBUGMODE 仍会经 bridge 切集群。材料化（`set env` 写 .env）后此间接影响消失。
+
+## 判定标准自检
+
+- ① **难逆转**：集群选择旋钮从布尔 DEBUGMODE 改为枚举 GINKGO_ENV，触及 config.py 核心 + CLI 闸门 + 守卫判据 + 回测准入——高。
+- ② **反直觉**：①"debug 不再切库"对老用户反直觉；② bridge-default"未设 env 时从 debug 推断"是隐藏迁移逻辑；③回测在 PRODUCTION 被拒跑——满足。
+- ③ **真实权衡**：彻底解耦（本 ADR，bridge 降迁移成本到零）vs 继续守卫优先（ADR-024/025，根因不除事故复发）vs 强制显式 env（大面积红）——有取舍支撑——满足。

--- a/docs/adrs/ADR-027-env-cluster-consistency-guard.md
+++ b/docs/adrs/ADR-027-env-cluster-consistency-guard.md
@@ -36,7 +36,7 @@ ADR-004/024 确立的机制下，`DEBUGMODE` 是**"三合一旋钮"**——一�
 
 ## Rationale
 
-- **为何不彻底解耦（独立 `GINJKGO_ENV` 选库 + debug 退回纯日志开关）**：与 ADR-024「守卫优先于彻底删 +1」同思路——彻底解耦须重构 config.yml 结构 + `set_debug` + 存量迁移，面大、有迁移风险；最小护栏（一个 property 内的断言）以 ~30 行达到**同等止血**（错配不再静默）。纯粹性的收益不足以抵消重构成本。彻底解耦留作未来增量（见 Consequences）。
+- **为何不彻底解耦（独立 `GINKGO_ENV` 选库 + debug 退回纯日志开关）**：与 ADR-024「守卫优先于彻底删 +1」同思路——彻底解耦须重构 config.yml 结构 + `set_debug` + 存量迁移，面大、有迁移风险；最小护栏（一个 property 内的断言）以 ~30 行达到**同等止血**（错配不再静默）。纯粹性的收益不足以抵消重构成本。彻底解耦留作未来增量（见 Consequences）。
 - **为何放 property 惰性触发**：覆盖所有走 `GCONF.MYSQLHOST/CLICKHOST` 建连接的入口（serve/worker/CLI/回测），无需改各入口；测试里直传 host 的 driver 不经 property，天然不受影响。
 - **逃生口的必要性**：测试与外部部署 host 不在 master/test 体系，强制断言会大面积红；逃生口让横幅照打（仍声明实际连接）、断言可跳，平衡"治本"与"不破坏现有测试"。
 - **横幅走 stderr 而非 GLOG**：property 在进程极早期被访问，GLOG 此刻可能未就绪，stderr 最稳且始终可见。
@@ -45,11 +45,11 @@ ADR-004/024 确立的机制下，`DEBUGMODE` 是**"三合一旋钮"**——一�
 
 - **冲突部署首次启动会被拦**：现存 `.env` 若与 config 文件 `debug` 字段不一致，serve/worker 启动即 `RuntimeError`。这是**预期行为**（暴露现存漂移），修复方式是 `ginkgo config set debug on/off` 重对齐后重启。
 - **Redis/Mongo 不切是已知坑**：debug=on 时这两库仍打 master（compose 无 `-test` 实例）。护栏不覆盖它们——若需隔离须先补 test 实例。
-- **未来彻底解耦时本护栏可精简**：引入 `GINJKGO_ENV` 后 host 与 env 一致性天然成立，断言变冗余可删；横幅仍保留（声明性输出有价值）。
+- **未来彻底解耦时本护栏可精简**：引入 `GINKGO_ENV` 后 host 与 env 一致性天然成立，断言变冗余可删；横幅仍保留（声明性输出有价值）。
 - **worker env 烘焙问题未根治**：护栏能在 worker**下次重启**时拦下错配，但对**运行中**的 worker 仍无效（env 已烘焙）。彻底解法是 worker 启动期读最新配置而非烘焙——属 ADR-024 Decision 5（CLI 双模 / 配置注入）范畴。
 
 ## 判定标准自检
 
 - ① **难逆转**：启动期拒启是 behavioral change，所有部署首次升级都受影响——中。
 - ② **反直觉**：debug off 却连 `-test` 被拒启，不理解 debug/host 耦合的人会困惑"为什么不让我启动"——满足。
-- ③ **真实权衡**：彻底解耦（`GINJKGO_ENV`，重构大）vs 最小护栏（断言，~30 行同等止血）+ 逃生口取舍——满足。
+- ③ **真实权衡**：彻底解耦（`GINKGO_ENV`，重构大）vs 最小护栏（断言，~30 行同等止血）+ 逃生口取舍——满足。

--- a/docs/adrs/ADR-027-env-cluster-consistency-guard.md
+++ b/docs/adrs/ADR-027-env-cluster-consistency-guard.md
@@ -1,10 +1,10 @@
-# ADR-025: 启动期集群一致性护栏（防 debug/host 漂移静默连错库）
+# ADR-027: 启动期集群一致性护栏（防 debug/host 漂移静默连错库）
 
 **Status:** Accepted
 **Date:** 2026-07-25
 **关联:** 源自 #6756 / PR #6773；建立在 [ADR-004](ADR-004-dual-db-debug.md)（双实例）与 [ADR-024](ADR-024-db-port-injection-debug-semantics.md)（端口 + debug 语义）之上；关联 memory `arch_database_debug_mode`。
 
-> **演进说明（ADR-026，2026-07-25）**：本 ADR 的 **Decision 1**（断言判据用 DEBUGMODE）已被 ADR-026 supersede——判据改用 `IS_DEV_ENV`（DEVELOPMENT/PRODUCTION），错误提示改 `ginkgo config set env DEVELOPMENT|PRODUCTION`。护栏本身（横幅 + 逃生口 + 幂等 + 范围）保留，仍是 host/env 错配的兜底。Context 描述的"三合一旋钮"根因由 ADR-026 彻底解耦。
+> **演进说明（ADR-028，2026-07-25）**：本 ADR 的 **Decision 1**（断言判据用 DEBUGMODE）已被 ADR-028 supersede——判据改用 `IS_DEV_ENV`（DEVELOPMENT/PRODUCTION），错误提示改 `ginkgo config set env DEVELOPMENT|PRODUCTION`。护栏本身（横幅 + 逃生口 + 幂等 + 范围）保留，仍是 host/env 错配的兜底。Context 描述的"三合一旋钮"根因由 ADR-028 彻底解耦。
 
 ## Context
 

--- a/docs/adrs/ADR-028-env-cluster-decouple-debugmode.md
+++ b/docs/adrs/ADR-028-env-cluster-decouple-debugmode.md
@@ -1,19 +1,19 @@
-# ADR-026: GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）
+# ADR-028: GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）
 
 **Status:** Accepted
 **Date:** 2026-07-25
-**关联:**建立在 [ADR-004](ADR-004-dual-db-debug.md)（双实例）、[ADR-024](ADR-024-db-port-injection-debug-semantics.md)（端口 + debug 语义）、[ADR-025](ADR-025-env-cluster-consistency-guard.md)（启动期护栏）之上；**Supersedes ADR-024 Decision 1/2**（+1 判据与 "DEBUGMODE 标记连哪个库"）、**Supersedes ADR-025 Decision 1**（护栏断言判据由 DEBUGMODE 改 IS_DEV_ENV）；复用仓库已存在的 `GINKGO_ENV` 读取点（`livecore/trade_gateway_adapter.py`）。关联 memory `arch_database_debug_mode`。
+**关联:**建立在 [ADR-004](ADR-004-dual-db-debug.md)（双实例）、[ADR-024](ADR-024-db-port-injection-debug-semantics.md)（端口 + debug 语义）、[ADR-027](ADR-027-env-cluster-consistency-guard.md)（启动期护栏）之上；**Supersedes ADR-024 Decision 1/2**（+1 判据与 "DEBUGMODE 标记连哪个库"）、**Supersedes ADR-027 Decision 1**（护栏断言判据由 DEBUGMODE 改 IS_DEV_ENV）；复用仓库已存在的 `GINKGO_ENV` 读取点（`livecore/trade_gateway_adapter.py`）。关联 memory `arch_database_debug_mode`。
 
 ## Context
 
-ADR-025 的启动期护栏只是**止血**——它不消除根因，只在错配发生时拒启。根因是 ADR-024/025 都默认接受的强耦合：**`DEBUGMODE` 是"三合一旋钮"**，一个布尔同时管 ① 日志/@retry 退避（ADR-013）② MySQL/ClickHouse host（master/test）③ 宿主客户端端口首位 +1。
+ADR-027 的启动期护栏只是**止血**——它不消除根因，只在错配发生时拒启。根因是 ADR-024/025 都默认接受的强耦合：**`DEBUGMODE` 是"三合一旋钮"**，一个布尔同时管 ① 日志/@retry 退避（ADR-013）② MySQL/ClickHouse host（master/test）③ 宿主客户端端口首位 +1。
 
 三合一耦合 + `.env` 可变共享态 = 两类真实事故：
 
-1. **忘翻 debug / `.env` 残留**：一次 `debug on` 把 `mysql-test` 写进 `.env`，忘翻回来，下次"真实运行"静默连测试库（ADR-025 能在下一次启动拦下，但运行中 worker env 烘焙不可变，护栏对实盘链路仍漏）。
+1. **忘翻 debug / `.env` 残留**：一次 `debug on` 把 `mysql-test` 写进 `.env`，忘翻回来，下次"真实运行"静默连测试库（ADR-027 能在下一次启动拦下，但运行中 worker env 烘焙不可变，护栏对实盘链路仍漏）。
 2. **临时 `set_debug(True)` 隐式切库**：`engine run` / `core test` 为开日志调 `set_debug(True)`，**副作用是隐式切到 test 集群**——调用方本意是日志，却改了 DB。解耦后 `set_debug` 不再切库，这个隐式副作用消失，但**反向风险浮现**：解耦后 `set_debug(True)` 在 PRODUCTION env 下不再切库，回测会**直连 master 写数据**。
 
-仓库已存在 `GINKGO_ENV`（`trade_gateway_adapter.py:297` 用 `os.getenv("GINKGO_ENV","development")=="production"` 判 MVP 模拟成交是否执行），但它是**裸读小写默认值、不经 GCONF、不触发 ADR-025 bridge**的孤岛读口，与新增的大写语义冲突。
+仓库已存在 `GINKGO_ENV`（`trade_gateway_adapter.py:297` 用 `os.getenv("GINKGO_ENV","development")=="production"` 判 MVP 模拟成交是否执行），但它是**裸读小写默认值、不经 GCONF、不触发 ADR-027 bridge**的孤岛读口，与新增的大写语义冲突。
 
 判定三条全中（难逆转 / 反直觉 / 真实取舍），立本 ADR 彻底解耦。
 
@@ -32,10 +32,10 @@ ADR-025 的启动期护栏只是**止血**——它不消除根因，只在错�
 
 `GINKGO_ENV` 未显式设置时，`GCONF.ENV` bridge 推断 `"DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"` 并写回 `os.environ`（材料化）。这保证**首次启动零行为变化**：现存部署（未设 `GINKGO_ENV`）的集群选择与解耦前完全一致。一旦用户执行 `ginkgo config set env ...` 把 `GINKGO_ENV` 写进 `.env`，bridge 不再触发，env 成为显式部署态。
 
-### 3. +1 守卫与启动护栏判据改用 IS_DEV_ENV（supersede ADR-024 D1 / ADR-025 D1）
+### 3. +1 守卫与启动护栏判据改用 IS_DEV_ENV（supersede ADR-024 D1 / ADR-027 D1）
 
 - `CLICKPORT`/`MYSQLPORT` +1 条件（ADR-024 Decision 1）：`self.DEBUGMODE` → `self.IS_DEV_ENV`。容器守卫（`is_container_environment()`）与幂等（`startswith("1")`）保留不变。
-- `_assert_cluster_consistency` 断言判据（ADR-025 Decision 1）：期望后缀 `-test`/`-master` 对应 `IS_DEV_ENV` True/False（即 DEVELOPMENT/PRODUCTION），错误提示改 `ginkgo config set env DEVELOPMENT|PRODUCTION`。横幅 label 与颜色来源同步改 IS_DEV_ENV。
+- `_assert_cluster_consistency` 断言判据（ADR-027 Decision 1）：期望后缀 `-test`/`-master` 对应 `IS_DEV_ENV` True/False（即 DEVELOPMENT/PRODUCTION），错误提示改 `ginkgo config set env DEVELOPMENT|PRODUCTION`。横幅 label 与颜色来源同步改 IS_DEV_ENV。
 
 ### 4. 回测/测试防误连：PRODUCTION env 下拒跑（防反向风险）
 
@@ -56,8 +56,8 @@ ADR-025 的启动期护栏只是**止血**——它不消除根因，只在错�
 
 ## Rationale
 
-- **为何彻底解耦（而非继续守卫优先）**：ADR-024/025 的守卫/护栏是"够好的修复"，但根因（三合一耦合）仍在，事故会以新形态复发（本次发现的"临时 set_debug 隐式切库"反向风险即是）。`GINKGO_ENV` 读取点仓库已存在，解耦的边际成本主要是 config.py 一个 property + CLI 一个分支 + 判据替换，远小于 ADR-024 当初评估的"重构 config.yml 结构 + 存量迁移"——因为 bridge-default 把迁移成本降到了零（未设 env 时行为不变）。这是 ADR-025 Consequences 明确点名的"未来彻底解耦"增量。
-- **bridge-default 的取舍**：备选是"强制所有部署显式设 GINKGO_ENV，不设就拒启"。但现存部署全未设，强制会大面积红。bridge 以零行为变化换取平滑迁移：现存部署继续工作，用户主动 `set env` 后才材料化为显式态。代价是 bridge 期间（env 未设）DEBUGMODE 仍间接影响集群（经 bridge）——但这是迁移期不可避免的过渡，且 ADR-025 护栏仍兜底。
+- **为何彻底解耦（而非继续守卫优先）**：ADR-024/025 的守卫/护栏是"够好的修复"，但根因（三合一耦合）仍在，事故会以新形态复发（本次发现的"临时 set_debug 隐式切库"反向风险即是）。`GINKGO_ENV` 读取点仓库已存在，解耦的边际成本主要是 config.py 一个 property + CLI 一个分支 + 判据替换，远小于 ADR-024 当初评估的"重构 config.yml 结构 + 存量迁移"——因为 bridge-default 把迁移成本降到了零（未设 env 时行为不变）。这是 ADR-027 Consequences 明确点名的"未来彻底解耦"增量。
+- **bridge-default 的取舍**：备选是"强制所有部署显式设 GINKGO_ENV，不设就拒启"。但现存部署全未设，强制会大面积红。bridge 以零行为变化换取平滑迁移：现存部署继续工作，用户主动 `set env` 后才材料化为显式态。代价是 bridge 期间（env 未设）DEBUGMODE 仍间接影响集群（经 bridge）——但这是迁移期不可避免的过渡，且 ADR-027 护栏仍兜底。
 - **为何回测拒跑生产而非仅警告**：回测写数据到 DB（signal/order/position 落库）。PRODUCTION env 下回测 = 写生产库，是真实数据污染。警告会被忽略（CLAUDE.md 归因纪律：宁可响亮报错不留静默兜底）。拒跑是 fail-loud，用户须显式 `set env DEVELOPMENT` 才能跑——一次明确的认知动作消除整个事故类。
 - **为何 +1 判据用 IS_DEV_ENV 单判（不保留 DEBUGMODE 兜底）**：宿主 CLI 工作流是 localhost + env 决定集群。若保留 `DEBUGMODE or IS_DEV_ENV` 双判，DEBUGMODE=True 但 env=PRODUCTION 时仍会 +1，与"env 单一决定"矛盾且 reintroduce 耦合。单判 IS_DEV_ENV 让端口严格跟随集群，可预测。
 - **secure.yml host 旁路**：`config.py:120` 的 `setdefault` 块是 host 的另一写入源（`~/.ginkgo/secure.yml`）。worker 容器不挂 secure.yml（`_has_local_secure=False`），整段跳过，host 全来自 env——故 secure.yml 不是 worker 连库来源，本 ADR 不动它。宿主侧 secure.yml 若显式设了 host，会覆盖 env 推断，此时以 secure.yml 为准（与解耦前行为一致）。
@@ -66,7 +66,7 @@ ADR-025 的启动期护栏只是**止血**——它不消除根因，只在错�
 
 - **`ginkgo config set env DEVELOPMENT|PRODUCTION` 成为切换集群的唯一命令**；`ginkgo config set debug on/off` 仅切日志。两者正交。
 - **ADR-024 Decision 1/2 superseded**：+1 判据改 IS_DEV_ENV；DEBUGMODE 不再是"连哪个库"的语义标记（退纯日志）。ADR-024 Decision 3（切换机制）实质由本 ADR 的 `set env` 接管。ADR-024 顶部标注演进说明。
-- **ADR-025 Decision 1 superseded**：断言判据改 IS_DEV_ENV。ADR-025 护栏本身保留（横幅 + 逃生口 + 幂等不变），仍是错配兜底。ADR-025 顶部标注演进说明。
+- **ADR-027 Decision 1 superseded**：断言判据改 IS_DEV_ENV。ADR-027 护栏本身保留（横幅 + 逃生口 + 幂等不变），仍是错配兜底。ADR-027 顶部标注演进说明。
 - **worker env 烘焙问题仍未根治**：`set env` 改 `.env` + `docker compose up -d` 重建容器才生效；**运行中** worker 带旧 env 仍连错。彻底解法是 worker 启动期读最新配置而非烘焙（ADR-024 Decision 5 范畴），本 ADR 不涉及。
 - **Redis/Mongo 仍恒 master**：`update_env_for_env` 只切 MySQL/ClickHouse host（compose 无 `redis-test`/`mongo-test` 实例）。DEVELOPMENT env 下这两库仍打 master——已知坑，未变。
 - **回测/测试在 PRODUCTION env 下被拒**：所有依赖 `engine run` / `core test` 的工作流须先 `set env DEVELOPMENT`。这是有意的行为变化（防误连生产）。

--- a/docs/adrs/ADR-028-env-cluster-decouple-debugmode.md
+++ b/docs/adrs/ADR-028-env-cluster-decouple-debugmode.md
@@ -21,16 +21,22 @@ ADR-027 的启动期护栏只是**止血**——它不消除根因，只在错�
 
 ### 1. 新增 `GINKGO_ENV ∈ {PRODUCTION, DEVELOPMENT}` 为集群选择单一旋钮
 
-`GCONF.ENV` property（`config.py`）读 `GINKGO_ENV` env，取值**大写**（`.upper()`），单一决定连 master 还是 test：
+`GCONF.ENV` property（`config.py`）按**优先级链**解析集群取值（统一 `.upper()`），单一决定连 master 还是 test：
+
+1. `os.environ["GINKGO_ENV"]`——显式 env var，**最高**优先级（容器经 compose 插值注入、`set env` 同步本进程、CI/一次性覆盖）
+2. `config.yml` 的 `env` 字位——本地 CLI 部署态（`set_env` 写入，新进程经 `ENV` property 读取；review Q5 补，见 Decision 6）
+3. bridge 推断（见 Decision 2，**最低**——前两层都缺时从 DEBUGMODE 兜底）
 
 - `DEVELOPMENT` → test 集群（`*-test` host + 宿主客户端端口 +1）
 - `PRODUCTION` → master 集群（`*-master` host + 原端口）
 
 `IS_DEV_ENV = (ENV == "DEVELOPMENT")`。`DEBUGMODE` **退回 ADR-013 纯日志/@retry 退避语义**，不再决定 host、不再决定 +1。
 
-### 2. bridge-default：未设时从 DEBUGMODE 推断（零行为变化迁移）
+### 2. bridge-default：env var 与 config.yml env 字位均缺时从 DEBUGMODE 推断（零行为变化迁移）
 
-`GINKGO_ENV` 未显式设置时，`GCONF.ENV` bridge 推断 `"DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"` 并写回 `os.environ`（材料化）。这保证**首次启动零行为变化**：现存部署（未设 `GINKGO_ENV`）的集群选择与解耦前完全一致。一旦用户执行 `ginkgo config set env ...` 把 `GINKGO_ENV` 写进 `.env`，bridge 不再触发，env 成为显式部署态。
+`GINKGO_ENV` 未设 env var **且** config.yml 无 `env` 字位时，`GCONF.ENV` bridge 推断 `"DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"` 并写回 `os.environ`（材料化）。这保证**首次启动零行为变化**：现存部署（未设 `GINKGO_ENV` 且 config.yml 无 env 字位）的集群选择与解耦前完全一致。一旦用户执行 `ginkgo config set env ...`（写 config.yml env 字位 + 容器场景额外写 .env），env 材料化，bridge 不再触发。
+
+**优先级链 rationale**（review Q5 补）：os.environ > config.yml env 字位 > bridge。os.environ 最高保证容器 compose 插值与单次进程覆盖优先；config.yml 层保证本地 CLI 新进程（不读 .env）拿到 `set env` 持久化的集群；bridge 兜底保证迁移零行为变化。
 
 ### 3. +1 守卫与启动护栏判据改用 IS_DEV_ENV（supersede ADR-024 D1 / ADR-027 D1）
 
@@ -46,9 +52,17 @@ ADR-027 的启动期护栏只是**止血**——它不消除根因，只在错�
 - 新增 `ginkgo config set env DEVELOPMENT|PRODUCTION`（别名 DEV/PROD，normalize 大写）：`update_env_for_env` 写 `.env` 的 `GINKGO_ENV` + CLICKHOUSE/MYSQL host（DEVELOPMENT→`*-test` / PRODUCTION→`*-master`，Mongo 恒 master）+ `set_env` 同步本进程 + `docker compose up -d` 重启使 worker env 重新插值。
 - `ginkgo config set debug on/off` **移除** `.env` 改写与 compose 重启副作用，仅 `set_debug` 写 config.yml（退纯日志）。
 
-### 6. set_env 持久层是 .env 而非 config.yml
+### 6. set_env 两层持久化：config.yml（本地 CLI）+ .env（容器）+ os.environ（本进程）
 
-`set_env` 只同步本进程 `os.environ`，**不写 config.yml**。理由：① compose 需 `${GINKGO_ENV:-DEVELOPMENT}` 插值注入容器，持久值必须在 `.env`；② config.yml 在容器内 `:ro` 挂载（`docker-compose.yml` worker volume），容器侧不可写。`GINKGO_ENV` 是**部署态**（prod/dev），与 config.yml 的**用户偏好态**（debug 日志、cpu_ratio、路径）分层不同。
+`set_env` 三路写（review Q5 演进）：
+
+- **`config.yml` 的 `env` 字位**：本地 CLI 部署态持久化。本地 CLI 不读 `.env`（无 dotenv 加载），新进程经 `ENV` property 优先级链读 config.yml env 字位拿到集群。**Q5 修复根因**：初版 `set_env` 仅写本进程 `os.environ`，新进程无该 env var 且 config.yml 无 env 字位，bridge 从 DEBUGMODE 推断覆盖用户 `set env` 的意图——本地 CLI 场景 `set env` 完全不持久化。
+- **`.env`**（容器场景，CLI 层）：`update_env_for_env` 写 `.env` 的 `GINKGO_ENV` + host，供 compose `${GINKGO_ENV:-DEVELOPMENT}` 插值注入容器；仅在 `COMPOSE_FILE_PATH` 存在时执行（本地 CLI 无 compose 则跳过）。
+- **`os.environ`**：本进程即时生效。
+
+**与 set_debug 对称**：`set_debug` 持久化层是 config.yml（纯用户偏好态），`set_env` 新增 config.yml 层与其对称——env 虽是"部署态"，但本地 CLI 场景的部署态本质也是用户偏好（连 test 还是 master），分层一致。容器内 config.yml `:ro` 挂载不影响（容器走 .env 插值，不依赖 config.yml 写入）。
+
+> **演进注记**：初版 Decision 6 判定 `set_env` 持久层**仅 .env**，理由是 config.yml 容器内 `:ro`。review Q5 发现本地 CLI 不读 .env，导致 `ginkgo config set env` 在本地 CLI 场景下完全不持久化（新进程被 bridge 覆盖）。修订为两层持久化：config.yml 层服务本地 CLI、.env 层服务容器，互不干扰。
 
 ### 7. 统一读口：trade_gateway_adapter 改走 GCONF.ENV
 
@@ -70,7 +84,8 @@ ADR-027 的启动期护栏只是**止血**——它不消除根因，只在错�
 - **worker env 烘焙问题仍未根治**：`set env` 改 `.env` + `docker compose up -d` 重建容器才生效；**运行中** worker 带旧 env 仍连错。彻底解法是 worker 启动期读最新配置而非烘焙（ADR-024 Decision 5 范畴），本 ADR 不涉及。
 - **Redis/Mongo 仍恒 master**：`update_env_for_env` 只切 MySQL/ClickHouse host（compose 无 `redis-test`/`mongo-test` 实例）。DEVELOPMENT env 下这两库仍打 master——已知坑，未变。
 - **回测/测试在 PRODUCTION env 下被拒**：所有依赖 `engine run` / `core test` 的工作流须先 `set env DEVELOPMENT`。这是有意的行为变化（防误连生产）。
-- **bridge 期 DEBUGMODE 仍间接影响集群**：env 未显式设时，bridge 从 DEBUGMODE 推断——故此期间改 DEBUGMODE 仍会经 bridge 切集群。材料化（`set env` 写 .env）后此间接影响消失。
+- **bridge 期 DEBUGMODE 仍间接影响集群**：env 未显式设（os.environ 无）**且** config.yml 无 env 字位时，bridge 从 DEBUGMODE 推断——故此纯迁移态下改 DEBUGMODE 仍会经 bridge 切集群。材料化（本地 `set env` 写 config.yml / 容器写 .env）后此间接影响消失。
+- **本地 CLI `set env` 现可持久化**（review Q5 修复）：`ginkgo config set env DEVELOPMENT` 写 config.yml env 字位，本地 CLI 新进程经 `ENV` property 优先级链读到，不再被陈旧 DEBUGMODE 经 bridge 覆盖。容器场景仍额外写 .env + compose 重启（行为不变）。
 
 ## 判定标准自检
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,8 +36,9 @@
 | ADR-021 | [CLI 输出层契约（TTY 守卫 + --format/--limit + 序列化规范）](ADR-021-cli-output-layer.md) | Accepted | 2026-07-04 |
 | ADR-022 | [抽象层收敛（命名约定 + 死抽象判定）](ADR-022-abstract-layer-naming.md) | Accepted | 2026-07-12 |
 | ADR-023 | [时间 Seam 边界（Business Time 走 TimeProvider，Infra Time 走墙钟）](ADR-023-time-seam-business-infra-split.md) | Accepted | 2026-07-18 |
-| ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed | 2026-07-20 |
-| ADR-025 | [启动期集群一致性护栏（防 debug/host 漂移静默连错库）](ADR-025-env-cluster-consistency-guard.md) | Accepted | 2026-07-25 |
+| ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed（D1/2 ⟵ ADR-026） | 2026-07-20 |
+| ADR-025 | [启动期集群一致性护栏（防 debug/host 漂移静默连错库）](ADR-025-env-cluster-consistency-guard.md) | Accepted（D1 ⟵ ADR-026） | 2026-07-25 |
+| ADR-026 | [GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）](ADR-026-env-cluster-decouple-debugmode.md) | Accepted | 2026-07-25 |
 
 ## 如何新增 / 修订
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -37,6 +37,7 @@
 | ADR-022 | [抽象层收敛（命名约定 + 死抽象判定）](ADR-022-abstract-layer-naming.md) | Accepted | 2026-07-12 |
 | ADR-023 | [时间 Seam 边界（Business Time 走 TimeProvider，Infra Time 走墙钟）](ADR-023-time-seam-business-infra-split.md) | Accepted | 2026-07-18 |
 | ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed | 2026-07-20 |
+| ADR-025 | [启动期集群一致性护栏（防 debug/host 漂移静默连错库）](ADR-025-env-cluster-consistency-guard.md) | Accepted | 2026-07-25 |
 
 ## 如何新增 / 修订
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,9 +36,9 @@
 | ADR-021 | [CLI 输出层契约（TTY 守卫 + --format/--limit + 序列化规范）](ADR-021-cli-output-layer.md) | Accepted | 2026-07-04 |
 | ADR-022 | [抽象层收敛（命名约定 + 死抽象判定）](ADR-022-abstract-layer-naming.md) | Accepted | 2026-07-12 |
 | ADR-023 | [时间 Seam 边界（Business Time 走 TimeProvider，Infra Time 走墙钟）](ADR-023-time-seam-business-infra-split.md) | Accepted | 2026-07-18 |
-| ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed（D1/2 ⟵ ADR-026） | 2026-07-20 |
-| ADR-025 | [启动期集群一致性护栏（防 debug/host 漂移静默连错库）](ADR-025-env-cluster-consistency-guard.md) | Accepted（D1 ⟵ ADR-026） | 2026-07-25 |
-| ADR-026 | [GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）](ADR-026-env-cluster-decouple-debugmode.md) | Accepted | 2026-07-25 |
+| ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed（D1/2 ⟵ ADR-028） | 2026-07-20 |
+| ADR-027 | [启动期集群一致性护栏（防 debug/host 漂移静默连错库）](ADR-027-env-cluster-consistency-guard.md) | Accepted（D1 ⟵ ADR-028） | 2026-07-25 |
+| ADR-028 | [GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）](ADR-028-env-cluster-decouple-debugmode.md) | Accepted | 2026-07-25 |
 
 ## 如何新增 / 修订
 

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -198,6 +198,14 @@ def run_task(
     bg: bool = typer.Option(False, "--bg", help="Run in background thread"),
 ):
     """:rocket: Run a backtest task locally."""
+    # ADR-028: 回测防误连生产 —— 守卫须在 container.backtest_task_service()（DB 调用）之前
+    # fail-fast，且在下方 try 之外（typer.Exit 否则被 except Exception 吞掉，#6590）。
+    from ginkgo.libs import GCONF
+    if GCONF.ENV == "PRODUCTION":
+        console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
+        console.print("[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]")
+        raise typer.Exit(1)
+
     import json as _json
     import threading
     from ginkgo import services

--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -134,10 +134,10 @@ def set(
             debug_value = value.lower() in ['on', 'true', '1', 'yes']
             GCONF.set_debug(debug_value)
             console.print(f":white_check_mark: Set {key} = {debug_value}")
-            # ADR-026: debug 现仅控日志/@retry 退避，不再切库。集群选择用 `set env`。
+            # ADR-028: debug 现仅控日志/@retry 退避，不再切库。集群选择用 `set env`。
             console.print(":bulb: 集群选择请用 `ginkgo config set env DEVELOPMENT|PRODUCTION`（debug 已与 DB 解耦）")
         elif key.lower() == 'env':
-            # ADR-026: GINKGO_ENV 单一决定集群（host + 宿主端口 +1）。DEBUGMODE 退为纯日志。
+            # ADR-028: GINKGO_ENV 单一决定集群（host + 宿主端口 +1）。DEBUGMODE 退为纯日志。
             aliases = {"prod": "PRODUCTION", "dev": "DEVELOPMENT"}
             env_value = aliases.get(value.lower(), value.upper())
             if env_value not in ("PRODUCTION", "DEVELOPMENT"):

--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -143,15 +143,24 @@ def set(
             if env_value not in ("PRODUCTION", "DEVELOPMENT"):
                 console.print(":x: env must be PRODUCTION|DEVELOPMENT (alias: PROD|DEV)")
                 return
-            env_file = GCONF.COMPOSE_FILE_PATH
-            if not env_file:
-                console.print(":x: COMPOSE_FILE_PATH 未配置，无法定位 .env")
+            env_label = "DEVELOPMENT(test)" if env_value == "DEVELOPMENT" else "PRODUCTION(master)"
+            # 始终持久化：set_env 写 config.yml 的 env 字位 + 同步本进程 os.environ。
+            # 本地 CLI 不读 .env，新进程经 ENV property 读 config.yml 拿到正确集群（review Q5 修复）。
+            # 容器场景额外写 .env + compose 重启（下方），本地 CLI 无 compose 也已持久化。
+            try:
+                GCONF.set_env(env_value)
+            except ValueError:
+                console.print(":x: env must be PRODUCTION|DEVELOPMENT (alias: PROD|DEV)")
                 return
+            console.print(f":white_check_mark: env = {env_value} ({env_label})，已写入 config.yml（本地 CLI 新进程生效）")
+            # 容器部署态：写 .env（compose ${GINKGO_ENV:-DEVELOPMENT} 插值注入）+ 重启容器
+            # （worker-env 烘焙不可变，改 .env 须 compose up -d 重建）。本地 CLI 无 compose 则止于此。
+            env_file = GCONF.COMPOSE_FILE_PATH
+            if not env_file or not os.path.exists(env_file):
+                return  # 本地 CLI 场景：config.yml 已持久化，无 .env/compose 可操作
             env_path = os.path.join(os.path.dirname(env_file), ".env")
             try:
                 changed = update_env_for_env(env_path, env_value)
-                GCONF.set_env(env_value)  # 同步本进程
-                env_label = "DEVELOPMENT(test)" if env_value == "DEVELOPMENT" else "PRODUCTION(master)"
                 if changed:
                     summary = ", ".join(f"{k}={v}" for k, v in changed.items())
                     console.print(f":white_check_mark: .env updated → {env_label} ({summary})")
@@ -160,34 +169,32 @@ def set(
             except Exception as e:
                 console.print(f":warning: Failed to update .env: {e}")
                 return
-            # 重启容器使 worker-env 重新插值（env 烘焙不可变，改 .env 须重建）
-            if os.path.exists(env_file):
-                import subprocess
-                try:
-                    compose_dir = os.path.dirname(env_file)
-                    console.print(":whale: Restarting docker containers...")
-                    result = subprocess.run(
-                        ["docker", "compose", "up", "-d"],
-                        cwd=compose_dir,
-                        capture_output=True, text=True, timeout=60,
-                    )
-                    if result.returncode == 0:
-                        # 解析输出显示重建的容器
-                        recreated = [l for l in result.stdout.splitlines() if "Created" in l or "Started" in l or "Recreat" in l]
-                        if recreated:
-                            for line in recreated:
-                                console.print(f"  {line.strip()}")
-                        else:
-                            console.print("  No containers changed")
-                        console.print(":white_check_mark: Docker containers restarted")
+            import subprocess
+            try:
+                compose_dir = os.path.dirname(env_file)
+                console.print(":whale: Restarting docker containers...")
+                result = subprocess.run(
+                    ["docker", "compose", "up", "-d"],
+                    cwd=compose_dir,
+                    capture_output=True, text=True, timeout=60,
+                )
+                if result.returncode == 0:
+                    # 解析输出显示重建的容器
+                    recreated = [l for l in result.stdout.splitlines() if "Created" in l or "Started" in l or "Recreat" in l]
+                    if recreated:
+                        for line in recreated:
+                            console.print(f"  {line.strip()}")
                     else:
-                        console.print(f":warning: Docker compose: {result.stderr.strip()}")
-                except FileNotFoundError:
-                    console.print(":memo: Docker not installed, skipped container restart")
-                except subprocess.TimeoutExpired:
-                    console.print(":warning: Docker compose timed out")
-                except Exception as e:
-                    console.print(f":warning: Docker compose: {e}")
+                        console.print("  No containers changed")
+                    console.print(":white_check_mark: Docker containers restarted")
+                else:
+                    console.print(f":warning: Docker compose: {result.stderr.strip()}")
+            except FileNotFoundError:
+                console.print(":memo: Docker not installed, skipped container restart")
+            except subprocess.TimeoutExpired:
+                console.print(":warning: Docker compose timed out")
+            except Exception as e:
+                console.print(f":warning: Docker compose: {e}")
         elif key.lower() == 'quiet':
             quiet_value = value.lower() in ['on', 'true', '1', 'yes']
             GCONF.set_quiet(quiet_value)

--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -21,19 +21,21 @@ from rich.table import Table
 from ginkgo.libs import GLOG
 
 
-def update_env_for_debug(env_file: str, debug_on: bool) -> dict:
-    """更新 .env 文件中的数据库主机变量以匹配 debug 模式。
+def update_env_for_env(env_file: str, env_value: str) -> dict:
+    """更新 .env 文件中的 GINKGO_ENV 与数据库主机变量以匹配指定集群。
 
     Args:
         env_file: .env 文件路径
-        debug_on: True=测试环境, False=生产环境
+        env_value: DEVELOPMENT=研发(test) / PRODUCTION=生产(master)
 
     Returns:
         变化的变量 dict，如果无变化返回空 dict
     """
+    is_dev = env_value == "DEVELOPMENT"
     host_mapping = {
-        "GINKGO_CLICKHOUSE_HOST": "clickhouse-test" if debug_on else "clickhouse-master",
-        "GINKGO_MYSQL_HOST": "mysql-test" if debug_on else "mysql-master",
+        "GINKGO_ENV": env_value,
+        "GINKGO_CLICKHOUSE_HOST": "clickhouse-test" if is_dev else "clickhouse-master",
+        "GINKGO_MYSQL_HOST": "mysql-test" if is_dev else "mysql-master",
         "GINKGO_MONGODB_HOST": "mongo-master",
     }
 
@@ -76,6 +78,8 @@ def get(
             # 获取特定配置
             if key.lower() == 'debug':
                 console.print(f":white_check_mark: debug: {GCONF.DEBUGMODE}")
+            elif key.lower() == 'env':
+                console.print(f":white_check_mark: env: {GCONF.ENV}")
             elif key.lower() == 'quiet':
                 console.print(f":white_check_mark: quiet: {GCONF.QUIET}")
             elif key.lower() == 'cpu_ratio':
@@ -98,6 +102,7 @@ def get(
             table.add_column("Description", style="dim", width=30)
 
             table.add_row("debug", str(GCONF.DEBUGMODE), "Enable detailed logging")
+            table.add_row("env", str(GCONF.ENV), "DB cluster (PRODUCTION|DEVELOPMENT)")
             table.add_row("quiet", str(GCONF.QUIET), "Suppress verbose output")
             table.add_row("cpu_ratio", f"{GCONF.CPURATIO*100}%", "CPU usage limit")
             table.add_row("log_path", str(GCONF.LOGGING_PATH), "Log files location")
@@ -129,26 +134,34 @@ def set(
             debug_value = value.lower() in ['on', 'true', '1', 'yes']
             GCONF.set_debug(debug_value)
             console.print(f":white_check_mark: Set {key} = {debug_value}")
-
-            # 确保 config 已加载（_has_local_config 可能为 None）
-            GCONF._read_config()
-
-            # 更新 .env 文件中的数据库主机
+            # ADR-026: debug 现仅控日志/@retry 退避，不再切库。集群选择用 `set env`。
+            console.print(":bulb: 集群选择请用 `ginkgo config set env DEVELOPMENT|PRODUCTION`（debug 已与 DB 解耦）")
+        elif key.lower() == 'env':
+            # ADR-026: GINKGO_ENV 单一决定集群（host + 宿主端口 +1）。DEBUGMODE 退为纯日志。
+            aliases = {"prod": "PRODUCTION", "dev": "DEVELOPMENT"}
+            env_value = aliases.get(value.lower(), value.upper())
+            if env_value not in ("PRODUCTION", "DEVELOPMENT"):
+                console.print(":x: env must be PRODUCTION|DEVELOPMENT (alias: PROD|DEV)")
+                return
             env_file = GCONF.COMPOSE_FILE_PATH
-            if env_file:
-                env_path = os.path.join(os.path.dirname(env_file), ".env")
-                try:
-                    changed = update_env_for_debug(env_path, debug_on=debug_value)
-                    env_label = "test" if debug_value else "production"
-                    if changed:
-                        console.print(f":white_check_mark: .env updated → {env_label} (ClickHouse={changed.get('GINKGO_CLICKHOUSE_HOST', '?')}, MySQL={changed.get('GINKGO_MYSQL_HOST', '?')})")
-                    else:
-                        console.print(f":white_check_mark: .env already set to {env_label}")
-                except Exception as e:
-                    console.print(f":warning: Failed to update .env: {e}")
-
-            # 重启有变化的 Docker 容器
-            if env_file and os.path.exists(env_file):
+            if not env_file:
+                console.print(":x: COMPOSE_FILE_PATH 未配置，无法定位 .env")
+                return
+            env_path = os.path.join(os.path.dirname(env_file), ".env")
+            try:
+                changed = update_env_for_env(env_path, env_value)
+                GCONF.set_env(env_value)  # 同步本进程
+                env_label = "DEVELOPMENT(test)" if env_value == "DEVELOPMENT" else "PRODUCTION(master)"
+                if changed:
+                    summary = ", ".join(f"{k}={v}" for k, v in changed.items())
+                    console.print(f":white_check_mark: .env updated → {env_label} ({summary})")
+                else:
+                    console.print(f":white_check_mark: .env already set to {env_label}")
+            except Exception as e:
+                console.print(f":warning: Failed to update .env: {e}")
+                return
+            # 重启容器使 worker-env 重新插值（env 烘焙不可变，改 .env 须重建）
+            if os.path.exists(env_file):
                 import subprocess
                 try:
                     compose_dir = os.path.dirname(env_file)
@@ -216,6 +229,7 @@ def list():
         table.add_column("Description", style="white", width=40)
 
         table.add_row("debug", "boolean", "Enable detailed logging (on/off)")
+        table.add_row("env", "string", "DB cluster: PRODUCTION|DEVELOPMENT")
         table.add_row("quiet", "boolean", "Suppress verbose output (on/off)")
         table.add_row("cpu_ratio", "number", "CPU usage limit (0-100)")
         table.add_row("log_path", "string", "Log files location")
@@ -224,6 +238,7 @@ def list():
         console.print(table)
 
         console.print("\n[bold yellow]:bulb: Usage Examples:[/bold yellow]")
+        console.print("  ginkgo config set env DEVELOPMENT  # Switch to test cluster")
         console.print("  ginkgo config set debug on      # Enable debug mode")
         console.print("  ginkgo config get debug         # Get debug status")
         console.print("  ginkgo config set cpu_ratio 70 # Set CPU limit to 70%")

--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -530,11 +530,11 @@ def run(
     """
     :rocket: Run backtest (simplified from 'backtest run').
     """
-    # ADR-026: 回测防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
+    # ADR-028: 回测防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
     from ginkgo.libs import GCONF
     if GCONF.ENV == "PRODUCTION":
         console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
-        console.print("[dim]请先切到研发集群：ginkgo config set env DEVELOPMENT[/dim]")
+        console.print("[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]")
         raise typer.Exit(1)
 
     try:
@@ -703,11 +703,11 @@ def test(
     """
     :test_tube: Run tests (simplified from 'pytest run').
     """
-    # ADR-026: 测试防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
+    # ADR-028: 测试防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
     from ginkgo.libs import GCONF
     if GCONF.ENV == "PRODUCTION":
         console.print("[red]:x: 测试在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
-        console.print("[dim]请先切到研发集群：ginkgo config set env DEVELOPMENT[/dim]")
+        console.print("[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]")
         raise typer.Exit(1)
 
     try:

--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -142,11 +142,13 @@ def debug(mode: Annotated[DebugMode, typer.Argument(help="Debug mode: on/off")])
             console.print("[green]:white_check_mark: Debug mode enabled[/green]")
             console.print("[dim]This enables detailed logging and error information[/dim]")
             console.print("[dim]Configuration saved to ~/.ginkgo/config.yml[/dim]")
+            console.print("[dim]:bulb: 集群选择请用 `ginkgo config set env DEVELOPMENT|PRODUCTION`（debug 已与 DB 解耦）[/dim]")
         else:
             GCONF.set_debug(False)  # 正确的调用方式，会写入配置文件
             console.print("[yellow]:muted_speaker: Debug mode disabled[/yellow]")
             console.print("[dim]Switched to production logging level[/dim]")
             console.print("[dim]Configuration saved to ~/.ginkgo/config.yml[/dim]")
+            console.print("[dim]:bulb: 集群选择请用 `ginkgo config set env DEVELOPMENT|PRODUCTION`（debug 已与 DB 解耦）[/dim]")
             
     except Exception as e:
         console.print(f"[red]Error setting debug mode: {e}[/red]")
@@ -528,13 +530,19 @@ def run(
     """
     :rocket: Run backtest (simplified from 'backtest run').
     """
+    # ADR-026: 回测防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
+    from ginkgo.libs import GCONF
+    if GCONF.ENV == "PRODUCTION":
+        console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
+        console.print("[dim]请先切到研发集群：ginkgo config set env DEVELOPMENT[/dim]")
+        raise typer.Exit(1)
+
     try:
         console.print(f"[bold blue]:rocket: Running backtest: {engine_id}[/bold blue]")
-        
+
         from ginkgo.trading.core.containers import container as backtest_container
-        
+
         if debug_mode:
-            from ginkgo.libs import GCONF
             GCONF.set_debug(True)
             console.print("[dim]Debug mode enabled for this run[/dim]")
         
@@ -695,11 +703,17 @@ def test(
     """
     :test_tube: Run tests (simplified from 'pytest run').
     """
+    # ADR-026: 测试防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
+    from ginkgo.libs import GCONF
+    if GCONF.ENV == "PRODUCTION":
+        console.print("[red]:x: 测试在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
+        console.print("[dim]请先切到研发集群：ginkgo config set env DEVELOPMENT[/dim]")
+        raise typer.Exit(1)
+
     try:
         console.print("[bold blue]:test_tube: Running tests...[/bold blue]")
-        
+
         # Enable debug mode for testing
-        from ginkgo.libs import GCONF
         original_debug = GCONF.DEBUGMODE
         GCONF.set_debug(True)
         

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -485,6 +485,14 @@ def run(
     console.print("   Use [cyan]'ginkgo backtest run <task_id>'[/cyan] instead.")
     console.print()
 
+    # ADR-026: 回测防误连生产 —— set_debug 现仅开日志不再切库，PRODUCTION env 下回测直连 master 写数据，故拒跑
+    # 置于 resolve_engine_id（DB 调用）之前 fail-fast，避免生产 env 下做无谓 DB 查询
+    from ginkgo.libs import GCONF as _GCONF_ENGINE_RUN
+    if _GCONF_ENGINE_RUN.ENV == "PRODUCTION":
+        console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
+        console.print("[dim]请先切到研发集群：ginkgo config set env DEVELOPMENT[/dim]")
+        raise typer.Exit(1)
+
     # 如果提供了engine_id，尝试解析为UUID
     if engine_id:
         original_identifier = engine_id

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -485,7 +485,7 @@ def run(
     console.print("   Use [cyan]'ginkgo backtest run <task_id>'[/cyan] instead.")
     console.print()
 
-    # ADR-026: 回测防误连生产 —— set_debug 现仅开日志不再切库，PRODUCTION env 下回测直连 master 写数据，故拒跑
+    # ADR-028: 回测防误连生产 —— set_debug 现仅开日志不再切库，PRODUCTION env 下回测直连 master 写数据，故拒跑
     # 置于 resolve_engine_id（DB 调用）之前 fail-fast，避免生产 env 下做无谓 DB 查询
     from ginkgo.libs import GCONF as _GCONF_ENGINE_RUN
     if _GCONF_ENGINE_RUN.ENV == "PRODUCTION":

--- a/src/ginkgo/core/services/system_service.py
+++ b/src/ginkgo/core/services/system_service.py
@@ -51,6 +51,7 @@ class SystemService:
                 "modules": self._get_module_status(),
                 "infrastructure": self._check_infrastructure(),
                 "debug_mode": GCONF.DEBUGMODE,
+                "env": GCONF.ENV,
             }
         except Exception as e:
             GLOG.ERROR(f"Failed to get system status: {e}")

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 class GinkgoConfig(object):
     _instance_lock = threading.Lock()
+    # #6756: 启动期集群一致性护栏幂等标志（断言+横幅只执行一次）
+    _cluster_guard_done = False
 
     def __new__(cls, *args, **kwargs) -> object:
         if not hasattr(GinkgoConfig, "_instance"):
@@ -550,13 +552,50 @@ class GinkgoConfig(object):
     def CLICKHOST(self) -> str:
         """ClickHouse 主机（核心基础设施，有默认值）"""
         self._ensure_env_vars()
+        self._assert_cluster_consistency()
         return os.environ.get("GINKGO_CLICKHOUSE_HOST", "localhost")
 
     @property
     def MYSQLHOST(self) -> str:
         """MySQL 主机（核心基础设施，有默认值）"""
         self._ensure_env_vars()
+        self._assert_cluster_consistency()
         return os.environ.get("GINKGO_MYSQL_HOST", "localhost")
+
+    def _assert_cluster_consistency(self) -> None:
+        """启动期护栏：DEBUGMODE 与 DB host 后缀一致性校验 + 集群横幅（幂等）。
+
+        防"忘翻 debug 致 .env 残留 test host、真实运行静默连错集群"（#6756）。
+        - 横幅无条件打一次到 stderr：声明当前实际连接的 MySQL/ClickHouse host。
+        - 断言仅在 host 落 master/test 体系时触发；localhost/外部域名跳过，不误伤外部部署。
+        - GINKGO_SKIP_CLUSTER_GUARD=1 仅跳断言、横幅照打（测试/特殊部署逃生用）。
+        """
+        if GinkgoConfig._cluster_guard_done:
+            return
+        GinkgoConfig._cluster_guard_done = True
+        debug = self.DEBUGMODE
+        env_label, expect_suffix = ("TEST", "-test") if debug else ("PROD", "-master")
+        hosts = {
+            "MySQL": os.environ.get("GINKGO_MYSQL_HOST", ""),
+            "ClickHouse": os.environ.get("GINKGO_CLICKHOUSE_HOST", ""),
+        }
+        if os.environ.get("GINKGO_SKIP_CLUSTER_GUARD", "") != "1":
+            for name, host in hosts.items():
+                if host.endswith("-test") or host.endswith("-master"):
+                    if host.endswith("-test") != debug:
+                        raise RuntimeError(
+                            f"[Ginkgo Env Guard] {name} host={host!r} 与 DEBUGMODE={debug} "
+                            f"冲突：debug={'on(应 -test)' if debug else 'off(应 -master)'}。"
+                            f"运行 `ginkgo config set debug {'on' if debug else 'off'}` "
+                            f"重对齐 .env 后重启。"
+                        )
+        import sys
+        color = "31" if not debug else "32"  # PROD 红 / TEST 绿
+        line = (
+            f"=== [{env_label}] MySQL={hosts['MySQL']} / "
+            f"ClickHouse={hosts['ClickHouse']} ==="
+        )
+        print(f"\033[{color}m{line}\033[0m", file=sys.stderr, flush=True)
 
     @property
     def MONGOHOST(self) -> str:

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -791,17 +791,25 @@ class GinkgoConfig(object):
         DEVELOPMENT → test 集群（mysql-test/clickhouse-test，宿主端口首位 +1）。
         与 DEBUGMODE（纯日志/@retry 退避，ADR-013）解耦——详见 ADR-028。
 
-        取值优先级：GINKGO_ENV env > bridge-default（未设时从 DEBUGMODE 推断）。
-        bridge 保证解耦后首次启动零行为变化：DEBUGMODE=True→DEVELOPMENT，
-        DEBUGMODE=False→PRODUCTION。用户首次 `ginkgo config set env ...` 材料化到
-        .env 后 bridge 不再触发，DEBUGMODE 彻底无关集群。
+        取值优先级：GINKGO_ENV env > config.yml 的 env 字段 > bridge-default。
+        - env var：容器由 compose `${GINKGO_ENV:-DEVELOPMENT}` 注入，权威。
+        - config.yml env 字段：本地 CLI 持久化层（本地 CLI 不读 .env，`set env` 写
+          config.yml 使新进程读到，对称 `debug` 字位）。详见 ADR-028 Q5 决策。
+        - bridge-default：env 字段未设时从 DEBUGMODE 推断（True→DEVELOPMENT，
+          False→PRODUCTION），保证解耦后首次启动零行为变化。用户首次
+          `ginkgo config set env ...` 写入 env 字段后 bridge 不再触发。
         """
         key = "GINKGO_ENV"
         val = os.environ.get(key, None)
         if val is None:
-            # 迁移桥：未显式设 GINKGO_ENV 时从 DEBUGMODE 推断，保证零行为变化
-            val = "DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"
-            os.environ[key] = val
+            # 本地 CLI 持久化层：读 config.yml 的 env 字段（set_env 写入）
+            cfg_env = self._read_config().get("env")
+            if cfg_env is not None:
+                val = str(cfg_env)
+            else:
+                # 迁移桥：未设 env 字段时从 DEBUGMODE 推断，保证零行为变化
+                val = "DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"
+            os.environ[key] = str(val)
         return str(val).upper()
 
     @property
@@ -810,16 +818,19 @@ class GinkgoConfig(object):
         return self.ENV == "DEVELOPMENT"
 
     def set_env(self, value: str) -> None:
-        """同步本进程 GINKGO_ENV（持久化 .env 由 CLI update_env_for_env 负责）。
+        """持久化 GINKGO_ENV 到 config.yml + 同步本进程 os.environ。
 
-        与 set_debug 异处：set_debug 写 ~/.ginkgo/config.yml（用户偏好层）；
-        set_env 只同步本进程 os.environ——GINKGO_ENV 是部署态，持久层是 .env
-        （compose 需 ${GINKGO_ENV:-DEVELOPMENT} 插值注入容器，且 config.yml 在
-        容器内以 :ro 挂载不可写）。详见 ADR-028。
+        对称 set_debug（写 ~/.ginkgo/config.yml 的 debug 字位）：写 config.yml 的 env
+        字位，使本地 CLI 新进程（不读 .env）经 ENV property 读到正确集群——修复 review
+        Q5（本地 CLI `set env` 后新进程仍被生产守卫拒）。容器部署态的 .env 持久化由 CLI
+        `update_env_for_env` 负责（compose `${GINKGO_ENV:-DEVELOPMENT}` 插值注入容器）。
+        set_env 仅在 CLI（宿主）调用——容器内 config.yml 以 :ro 挂载不可写，但容器内
+        不跑 `ginkgo config` CLI。详见 ADR-028。
         """
         val = str(value).upper()
         if val not in ("PRODUCTION", "DEVELOPMENT"):
             raise ValueError(f"GINKGO_ENV must be PRODUCTION|DEVELOPMENT, got {value!r}")
+        self._write_config("env", val)  # 本地 CLI 持久化（新进程 ENV property 读得到）
         os.environ["GINKGO_ENV"] = val
 
     # 装饰器配置属性

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -563,9 +563,9 @@ class GinkgoConfig(object):
         return os.environ.get("GINKGO_MYSQL_HOST", "localhost")
 
     def _assert_cluster_consistency(self) -> None:
-        """启动期护栏：DEBUGMODE 与 DB host 后缀一致性校验 + 集群横幅（幂等）。
+        """启动期护栏：GINKGO_ENV 与 DB host 后缀一致性校验 + 集群横幅（幂等）。
 
-        防"忘翻 debug 致 .env 残留 test host、真实运行静默连错集群"（#6756）。
+        防"env 与 .env host 漂移致真实运行静默连错集群"（#6756，ADR-025 / ADR-026）。
         - 横幅无条件打一次到 stderr：声明当前实际连接的 MySQL/ClickHouse host。
         - 断言仅在 host 落 master/test 体系时触发；localhost/外部域名跳过，不误伤外部部署。
         - GINKGO_SKIP_CLUSTER_GUARD=1 仅跳断言、横幅照打（测试/特殊部署逃生用）。
@@ -573,8 +573,8 @@ class GinkgoConfig(object):
         if GinkgoConfig._cluster_guard_done:
             return
         GinkgoConfig._cluster_guard_done = True
-        debug = self.DEBUGMODE
-        env_label, expect_suffix = ("TEST", "-test") if debug else ("PROD", "-master")
+        is_dev = self.IS_DEV_ENV
+        env_label, expect_suffix = ("TEST", "-test") if is_dev else ("PROD", "-master")
         hosts = {
             "MySQL": os.environ.get("GINKGO_MYSQL_HOST", ""),
             "ClickHouse": os.environ.get("GINKGO_CLICKHOUSE_HOST", ""),
@@ -582,15 +582,15 @@ class GinkgoConfig(object):
         if os.environ.get("GINKGO_SKIP_CLUSTER_GUARD", "") != "1":
             for name, host in hosts.items():
                 if host.endswith("-test") or host.endswith("-master"):
-                    if host.endswith("-test") != debug:
+                    if host.endswith("-test") != is_dev:
                         raise RuntimeError(
-                            f"[Ginkgo Env Guard] {name} host={host!r} 与 DEBUGMODE={debug} "
-                            f"冲突：debug={'on(应 -test)' if debug else 'off(应 -master)'}。"
-                            f"运行 `ginkgo config set debug {'on' if debug else 'off'}` "
+                            f"[Ginkgo Env Guard] {name} host={host!r} 与 GINKGO_ENV={self.ENV} "
+                            f"冲突：env={'DEVELOPMENT(应 -test)' if is_dev else 'PRODUCTION(应 -master)'}。"
+                            f"运行 `ginkgo config set env {'DEVELOPMENT' if is_dev else 'PRODUCTION'}` "
                             f"重对齐 .env 后重启。"
                         )
         import sys
-        color = "31" if not debug else "32"  # PROD 红 / TEST 绿
+        color = "31" if not is_dev else "32"  # PROD 红 / TEST 绿
         line = (
             f"=== [{env_label}] MySQL={hosts['MySQL']} / "
             f"ClickHouse={hosts['ClickHouse']} ==="
@@ -608,14 +608,14 @@ class GinkgoConfig(object):
         """ClickHouse 端口（核心基础设施，有默认值）"""
         self._ensure_env_vars()
         port = os.environ.get("GINKGO_CLICKHOUSE_PORT", "8123")
-        # DEBUG 模式端口首位 +1 是"宿主机经 Docker 映射端口访问 test 实例"的约定
+        # DEVELOPMENT 环境端口首位 +1 是"宿主机经 Docker 映射端口访问 test 实例"的约定
         # （Master 内部 8123 / Test 宿主映射 18123，见 ADR-004）。仅宿主客户端适用；
         # 容器内服务走容器网络用内部端口，不应 +1。原无差别 +1 对容器内服务误用，
-        # 致 DataWorker 连 clickhouse-test:18123 ECONNREFUSED → 停滞。详见 ADR-024。
-        # 惰性 import 规避 config ↔ log_utils 包初始化循环。
+        # 致 DataWorker 连 clickhouse-test:18123 ECONNREFUSED → 停滞。详见 ADR-024 / ADR-026。
+        # 判据用 IS_DEV_ENV（集群选择），与 DEBUGMODE（纯日志）解耦。惰性 import 规避循环。
         from ginkgo.libs.utils.log_utils import is_container_environment
         if (
-            self.DEBUGMODE
+            self.IS_DEV_ENV
             and not is_container_environment()
             and not str(port).startswith("1")
         ):
@@ -627,15 +627,16 @@ class GinkgoConfig(object):
         """MySQL 端口（核心基础设施，有默认值）"""
         self._ensure_env_vars()
         port = os.environ.get("GINKGO_MYSQL_PORT", "3306")
-        # DEBUG 模式端口首位 +1 是"宿主机经 Docker 映射端口访问 test 实例"的约定
+        # DEVELOPMENT 环境端口首位 +1 是"宿主机经 Docker 映射端口访问 test 实例"的约定
         # （Master 内部 3306 / Test 宿主映射 13306，见 ADR-004）。仅宿主客户端适用；
         # 容器内服务走容器网络用内部端口，不应 +1。原无差别 +1 对容器内服务误用，
         # 致 TaskTimer 连 mysql-test:13306 ECONNREFUSED → health_check 失败 →
         # _get_all_stock_codes 返空 → bar_snapshot "No stocks found" 停滞 8.5 月。
-        # 详见 ADR-024。惰性 import 规避 config ↔ log_utils 包初始化循环。
+        # 详见 ADR-024 / ADR-026。判据用 IS_DEV_ENV（集群选择），与 DEBUGMODE（纯日志）解耦。
+        # 惰性 import 规避 config ↔ log_utils 包初始化循环。
         from ginkgo.libs.utils.log_utils import is_container_environment
         if (
-            self.DEBUGMODE
+            self.IS_DEV_ENV
             and not is_container_environment()
             and not str(port).startswith("1")
         ):
@@ -781,6 +782,45 @@ class GinkgoConfig(object):
         key = "GINKGO_DEBUG_MODE"
         if isinstance(value, bool):
             self._write_config("debug", value)
+
+    @property
+    def ENV(self) -> str:
+        """GINKGO_ENV：集群选择单一旋钮（PRODUCTION | DEVELOPMENT）。
+
+        PRODUCTION → master 集群（mysql-master/clickhouse-master，宿主端口不 +1）；
+        DEVELOPMENT → test 集群（mysql-test/clickhouse-test，宿主端口首位 +1）。
+        与 DEBUGMODE（纯日志/@retry 退避，ADR-013）解耦——详见 ADR-026。
+
+        取值优先级：GINKGO_ENV env > bridge-default（未设时从 DEBUGMODE 推断）。
+        bridge 保证解耦后首次启动零行为变化：DEBUGMODE=True→DEVELOPMENT，
+        DEBUGMODE=False→PRODUCTION。用户首次 `ginkgo config set env ...` 材料化到
+        .env 后 bridge 不再触发，DEBUGMODE 彻底无关集群。
+        """
+        key = "GINKGO_ENV"
+        val = os.environ.get(key, None)
+        if val is None:
+            # 迁移桥：未显式设 GINKGO_ENV 时从 DEBUGMODE 推断，保证零行为变化
+            val = "DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"
+            os.environ[key] = val
+        return str(val).upper()
+
+    @property
+    def IS_DEV_ENV(self) -> bool:
+        """是否连 test 集群（DEVELOPMENT）。+1 端口与一致性护栏的判据。"""
+        return self.ENV == "DEVELOPMENT"
+
+    def set_env(self, value: str) -> None:
+        """同步本进程 GINKGO_ENV（持久化 .env 由 CLI update_env_for_env 负责）。
+
+        与 set_debug 异处：set_debug 写 ~/.ginkgo/config.yml（用户偏好层）；
+        set_env 只同步本进程 os.environ——GINKGO_ENV 是部署态，持久层是 .env
+        （compose 需 ${GINKGO_ENV:-DEVELOPMENT} 插值注入容器，且 config.yml 在
+        容器内以 :ro 挂载不可写）。详见 ADR-026。
+        """
+        val = str(value).upper()
+        if val not in ("PRODUCTION", "DEVELOPMENT"):
+            raise ValueError(f"GINKGO_ENV must be PRODUCTION|DEVELOPMENT, got {value!r}")
+        os.environ["GINKGO_ENV"] = val
 
     # 装饰器配置属性
     @property

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -565,7 +565,7 @@ class GinkgoConfig(object):
     def _assert_cluster_consistency(self) -> None:
         """启动期护栏：GINKGO_ENV 与 DB host 后缀一致性校验 + 集群横幅（幂等）。
 
-        防"env 与 .env host 漂移致真实运行静默连错集群"（#6756，ADR-025 / ADR-026）。
+        防"env 与 .env host 漂移致真实运行静默连错集群"（#6756，ADR-027 / ADR-028）。
         - 横幅无条件打一次到 stderr：声明当前实际连接的 MySQL/ClickHouse host。
         - 断言仅在 host 落 master/test 体系时触发；localhost/外部域名跳过，不误伤外部部署。
         - GINKGO_SKIP_CLUSTER_GUARD=1 仅跳断言、横幅照打（测试/特殊部署逃生用）。
@@ -611,7 +611,7 @@ class GinkgoConfig(object):
         # DEVELOPMENT 环境端口首位 +1 是"宿主机经 Docker 映射端口访问 test 实例"的约定
         # （Master 内部 8123 / Test 宿主映射 18123，见 ADR-004）。仅宿主客户端适用；
         # 容器内服务走容器网络用内部端口，不应 +1。原无差别 +1 对容器内服务误用，
-        # 致 DataWorker 连 clickhouse-test:18123 ECONNREFUSED → 停滞。详见 ADR-024 / ADR-026。
+        # 致 DataWorker 连 clickhouse-test:18123 ECONNREFUSED → 停滞。详见 ADR-024 / ADR-028。
         # 判据用 IS_DEV_ENV（集群选择），与 DEBUGMODE（纯日志）解耦。惰性 import 规避循环。
         from ginkgo.libs.utils.log_utils import is_container_environment
         if (
@@ -632,7 +632,7 @@ class GinkgoConfig(object):
         # 容器内服务走容器网络用内部端口，不应 +1。原无差别 +1 对容器内服务误用，
         # 致 TaskTimer 连 mysql-test:13306 ECONNREFUSED → health_check 失败 →
         # _get_all_stock_codes 返空 → bar_snapshot "No stocks found" 停滞 8.5 月。
-        # 详见 ADR-024 / ADR-026。判据用 IS_DEV_ENV（集群选择），与 DEBUGMODE（纯日志）解耦。
+        # 详见 ADR-024 / ADR-028。判据用 IS_DEV_ENV（集群选择），与 DEBUGMODE（纯日志）解耦。
         # 惰性 import 规避 config ↔ log_utils 包初始化循环。
         from ginkgo.libs.utils.log_utils import is_container_environment
         if (
@@ -789,7 +789,7 @@ class GinkgoConfig(object):
 
         PRODUCTION → master 集群（mysql-master/clickhouse-master，宿主端口不 +1）；
         DEVELOPMENT → test 集群（mysql-test/clickhouse-test，宿主端口首位 +1）。
-        与 DEBUGMODE（纯日志/@retry 退避，ADR-013）解耦——详见 ADR-026。
+        与 DEBUGMODE（纯日志/@retry 退避，ADR-013）解耦——详见 ADR-028。
 
         取值优先级：GINKGO_ENV env > bridge-default（未设时从 DEBUGMODE 推断）。
         bridge 保证解耦后首次启动零行为变化：DEBUGMODE=True→DEVELOPMENT，
@@ -815,7 +815,7 @@ class GinkgoConfig(object):
         与 set_debug 异处：set_debug 写 ~/.ginkgo/config.yml（用户偏好层）；
         set_env 只同步本进程 os.environ——GINKGO_ENV 是部署态，持久层是 .env
         （compose 需 ${GINKGO_ENV:-DEVELOPMENT} 插值注入容器，且 config.yml 在
-        容器内以 :ro 挂载不可写）。详见 ADR-026。
+        容器内以 :ro 挂载不可写）。详见 ADR-028。
         """
         val = str(value).upper()
         if val not in ("PRODUCTION", "DEVELOPMENT"):

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -45,7 +45,7 @@ from ginkgo.trading.brokers.base_broker import BaseBroker
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoConsumer, GinkgoProducer
 from ginkgo.enums import DIRECTION_TYPES, ORDER_TYPES
 from ginkgo.interfaces.kafka_topics import KafkaTopics
-from ginkgo.libs import GLOG
+from ginkgo.libs import GLOG, GCONF
 
 
 class TradeGatewayAdapter(Thread):
@@ -293,8 +293,8 @@ class TradeGatewayAdapter(Thread):
                     continue
 
                 # #3961 MVP阶段：模拟成交逻辑 - 仅在非生产环境执行
-                import os
-                is_production = os.getenv("GINKGO_ENV", "development") == "production"
+                # ADR-026：集群判据统一走 GCONF.ENV（大写），不再裸读小写 env var（避免 bridge 不触发 + 大小写冲突）
+                is_production = GCONF.ENV == "PRODUCTION"
                 if is_production:
                     continue
 

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -79,6 +79,9 @@ class TradeGatewayAdapter(Thread):
         self.expired_orders = 0  # 超时订单
         self.failed_orders = 0  # 失败订单
 
+        # P3: PRODUCTION env 下模拟成交被禁的一次性告警去重（避免每 tick 刷屏）
+        self._prod_mock_fill_warned = False
+
         # 运行状态
         self.is_running = False
 
@@ -293,9 +296,16 @@ class TradeGatewayAdapter(Thread):
                     continue
 
                 # #3961 MVP阶段：模拟成交逻辑 - 仅在非生产环境执行
-                # ADR-026：集群判据统一走 GCONF.ENV（大写），不再裸读小写 env var（避免 bridge 不触发 + 大小写冲突）
+                # ADR-028：集群判据统一走 GCONF.ENV（大写），不再裸读小写 env var（避免 bridge 不触发 + 大小写冲突）
+                # P3: PRODUCTION 下模拟成交被禁；非容器 paper worker(宿主直跑)若 config.yml debug=False
+                #     且未设 GINKGO_ENV → bridge 推断 PRODUCTION → 订单卡 SUBMITTED。开发场景设
+                #     GINKGO_ENV=DEVELOPMENT 即恢复模拟成交。一次性 WARN 兼顾可诊断与不刷屏。
                 is_production = GCONF.ENV == "PRODUCTION"
                 if is_production:
+                    if not self._prod_mock_fill_warned:
+                        GLOG.WARN("PRODUCTION env 下模拟成交已禁用，订单将保持 SUBMITTED；"
+                                  "paper worker 开发场景请设 GINKGO_ENV=DEVELOPMENT")
+                        self._prod_mock_fill_warned = True
                     continue
 
                 if time_elapsed >= 1.0 and order.status == ORDERSTATUS_TYPES.SUBMITTED:

--- a/tests/unit/client/test_config_set_env_cli.py
+++ b/tests/unit/client/test_config_set_env_cli.py
@@ -1,8 +1,8 @@
 # Upstream: client/config_cli.py, client/engine_cli.py, client/core_cli.py
 # Downstream: -
-# Role: ADR-026 CLI 闸门回归：set env 写 .env+触发 compose；set debug 不再触发；回测拒跑生产
+# Role: ADR-028 CLI 闸门回归：set env 写 .env+触发 compose；set debug 不再触发；回测拒跑生产
 
-"""ADR-026 CLI 闸门回归测试。
+"""ADR-028 CLI 闸门回归测试。
 
 覆盖：
 - `config set env DEVELOPMENT`：写 .env（GINKGO_ENV + host）+ 触发 docker compose 重启

--- a/tests/unit/client/test_config_set_env_cli.py
+++ b/tests/unit/client/test_config_set_env_cli.py
@@ -1,0 +1,136 @@
+# Upstream: client/config_cli.py, client/engine_cli.py, client/core_cli.py
+# Downstream: -
+# Role: ADR-026 CLI 闸门回归：set env 写 .env+触发 compose；set debug 不再触发；回测拒跑生产
+
+"""ADR-026 CLI 闸门回归测试。
+
+覆盖：
+- `config set env DEVELOPMENT`：写 .env（GINKGO_ENV + host）+ 触发 docker compose 重启
+- `config set debug on`：不再写 .env / 不再触发 compose（解耦 regression）
+- `engine run` / `backtest run` / `core test`：PRODUCTION env 下拒跑（防误连生产写数据）
+"""
+
+import os
+import pytest
+import typer
+from ginkgo.libs.core.config import GCONF, GinkgoConfig
+
+
+@pytest.fixture
+def compose_dir(tmp_path):
+    """临时 compose 目录：含 docker-compose.yml 占位 + 不存在的 .env。"""
+    (tmp_path / "docker-compose.yml").write_text("services:\n  x:\n    image: x\n")
+    return str(tmp_path)
+
+
+@pytest.mark.unit
+class TestConfigSetEnvCli:
+    def test_set_env_development_writes_env_and_restarts(self, monkeypatch, compose_dir):
+        """set env DEVELOPMENT → 写 .env（GINKGO_ENV + -test host）+ 触发 compose 重启。"""
+        compose_file = os.path.join(compose_dir, "docker-compose.yml")
+        monkeypatch.setattr(GinkgoConfig, "COMPOSE_FILE_PATH",
+                            property(lambda self: compose_file))
+        monkeypatch.setattr(GCONF, "set_env", lambda v: None)  # 不污染进程 env
+        captured = {"called": False}
+
+        import ginkgo.client.config_cli as cli
+        import subprocess as _sp
+        monkeypatch.setattr(_sp, "run", lambda *a, **k: (captured.__setitem__("called", True) or
+                                                        _SimpleResult(0)))
+
+        cli.set("env", "DEVELOPMENT")
+
+        env_path = os.path.join(compose_dir, ".env")
+        content = open(env_path).read()
+        assert "GINKGO_ENV=DEVELOPMENT" in content
+        assert "GINKGO_MYSQL_HOST=mysql-test" in content
+        assert captured["called"] is True
+
+    def test_set_env_accepts_dev_alias(self, monkeypatch, compose_dir):
+        """别名 DEV → DEVELOPMENT。"""
+        compose_file = os.path.join(compose_dir, "docker-compose.yml")
+        monkeypatch.setattr(GinkgoConfig, "COMPOSE_FILE_PATH",
+                            property(lambda self: compose_file))
+        captured_env = {}
+        monkeypatch.setattr(GCONF, "set_env", lambda v: captured_env.__setitem__("v", v))
+        import subprocess as _sp
+        monkeypatch.setattr(_sp, "run", lambda *a, **k: _SimpleResult(0))
+
+        import ginkgo.client.config_cli as cli
+        cli.set("env", "DEV")
+        assert captured_env["v"] == "DEVELOPMENT"
+
+    def test_set_env_rejects_invalid(self, monkeypatch, compose_dir):
+        """非法值 → 不写 .env、不重启。"""
+        compose_file = os.path.join(compose_dir, "docker-compose.yml")
+        monkeypatch.setattr(GinkgoConfig, "COMPOSE_FILE_PATH",
+                            property(lambda self: compose_file))
+        import subprocess as _sp
+        monkeypatch.setattr(_sp, "run", lambda *a, **k: pytest.fail("compose 不应被调用"))
+
+        import ginkgo.client.config_cli as cli
+        cli.set("env", "STAGING")  # 非 PRODUCTION|DEVELOPMENT
+        assert not os.path.exists(os.path.join(compose_dir, ".env"))
+
+    def test_set_debug_on_does_not_restart(self, monkeypatch, compose_dir):
+        """regression：set debug on 不再触发 docker compose（debug 与 DB 解耦）。"""
+        monkeypatch.setattr(GCONF, "set_debug", lambda v: None)  # 不写 config.yml
+        import subprocess as _sp
+        monkeypatch.setattr(_sp, "run", lambda *a, **k: pytest.fail("compose 不应被调用"))
+
+        import ginkgo.client.config_cli as cli
+        cli.set("debug", "on")  # 不应触发 subprocess
+
+
+class _SimpleResult:
+    def __init__(self, code):
+        self.returncode = code
+        self.stdout = ""
+        self.stderr = ""
+
+
+# --- 回测/测试拒跑生产守卫 ---
+
+def _set_env(monkeypatch, env_value):
+    monkeypatch.setattr(GinkgoConfig, "ENV", property(lambda self: env_value))
+    GinkgoConfig._cluster_guard_done = False
+
+
+@pytest.mark.unit
+class TestRefuseProduction:
+    def test_engine_run_refuses_production(self, monkeypatch):
+        """engine run 在 PRODUCTION env 下 Exit(1)。"""
+        _set_env(monkeypatch, "PRODUCTION")
+        from ginkgo.client import engine_cli
+        with pytest.raises(typer.Exit):
+            engine_cli.run(engine_id="any")
+
+    def test_backtest_run_refuses_production(self, monkeypatch):
+        """backtest run（core_cli.run）在 PRODUCTION env 下 Exit(1)。"""
+        _set_env(monkeypatch, "PRODUCTION")
+        from ginkgo.client import core_cli
+        with pytest.raises(typer.Exit):
+            core_cli.run(engine_id="any")
+
+    def test_core_test_refuses_production(self, monkeypatch):
+        """core test 在 PRODUCTION env 下 Exit(1)。"""
+        _set_env(monkeypatch, "PRODUCTION")
+        from ginkgo.client import core_cli
+        with pytest.raises(typer.Exit):
+            core_cli.test()
+
+    def test_backtest_run_allows_development(self, monkeypatch):
+        """DEVELOPMENT env 下守卫不触发 Exit（不误伤研发工作流）。
+
+        守卫在函数顶部、try 之外，PRODUCTION 才抛 typer.Exit。DEVELOPMENT
+        会放行进入真实装配，装配可能因无 DB 失败，但那与守卫无关——
+        只要不是 typer.Exit 即证明守卫未误伤。
+        """
+        _set_env(monkeypatch, "DEVELOPMENT")
+        from ginkgo.client import core_cli
+        try:
+            core_cli.run(engine_id="any")
+        except typer.Exit:
+            pytest.fail("DEVELOPMENT env 不应触发生产拒跑守卫")
+        except Exception:
+            pass  # 后续真实装配失败，与守卫行为无关

--- a/tests/unit/client/test_config_set_env_cli.py
+++ b/tests/unit/client/test_config_set_env_cli.py
@@ -119,6 +119,18 @@ class TestRefuseProduction:
         with pytest.raises(typer.Exit):
             core_cli.test()
 
+    def test_backtest_run_task_refuses_production(self, monkeypatch):
+        """`ginkgo backtest run`（backtest_cli.run_task，真入口）在 PRODUCTION env 下 Exit(1)。
+
+        ADR-028 Decision 4 守卫须覆盖真实活动入口。早期版本误把守卫加在 deprecated
+        的 engine_cli.run，真入口 backtest_cli.run_task（ginkgo backtest run 的实际派发
+        目标）漏覆盖，PRODUCTION 下最常用回测命令仍直连 master 写数据（review P1）。
+        """
+        _set_env(monkeypatch, "PRODUCTION")
+        from ginkgo.client import backtest_cli
+        with pytest.raises(typer.Exit):
+            backtest_cli.run_task(task_id="any")
+
     def test_backtest_run_allows_development(self, monkeypatch):
         """DEVELOPMENT env 下守卫不触发 Exit（不误伤研发工作流）。
 

--- a/tests/unit/client/test_env_switching.py
+++ b/tests/unit/client/test_env_switching.py
@@ -1,11 +1,12 @@
-"""
-统一环境切换测试
+"""统一集群切换测试（ADR-026）
 
-验证 ginkgo config set debug on/off 自动更新 .env 文件：
-- debug=on → CLICKHOUSE_HOST=clickhouse-test, MYSQL_HOST=mysql-test
-- debug=off → CLICKHOUSE_HOST=clickhouse-master, MYSQL_HOST=mysql-master
+验证 ginkgo config set env DEVELOPMENT|PRODUCTION 经 update_env_for_env 更新 .env：
+- DEVELOPMENT → GINKGO_ENV=DEVELOPMENT + CLICKHOUSE_HOST=clickhouse-test + MYSQL_HOST=mysql-test
+- PRODUCTION → GINKGO_ENV=PRODUCTION + CLICKHOUSE_HOST=clickhouse-master + MYSQL_HOST=mysql-master
+- Mongo 恒 master（无 -test 实例）
 - .env 不存在时自动创建
 - 其他变量不受影响
+- 幂等：目标值已一致时返回空 dict
 """
 
 import os
@@ -14,40 +15,55 @@ import pytest
 
 @pytest.mark.unit
 class TestEnvUpdateLogic:
-    """验证 update_env_for_debug 函数的核心逻辑"""
+    """验证 update_env_for_env 函数的核心逻辑"""
 
-    def test_debug_on_sets_test_hosts(self, tmp_path):
-        """debug=on 时写入 test 环境主机"""
-        from ginkgo.client.config_cli import update_env_for_debug
+    def test_development_sets_test_hosts(self, tmp_path):
+        """DEVELOPMENT 写入 test 集群主机"""
+        from ginkgo.client.config_cli import update_env_for_env
 
         env_file = str(tmp_path / ".env")
-        changed = update_env_for_debug(env_file, debug_on=True)
+        changed = update_env_for_env(env_file, "DEVELOPMENT")
 
         with open(env_file) as f:
             content = f.read()
 
+        assert "GINKGO_ENV=DEVELOPMENT" in content
         assert "GINKGO_CLICKHOUSE_HOST=clickhouse-test" in content
         assert "GINKGO_MYSQL_HOST=mysql-test" in content
-        assert "GINKGO_CLICKHOUSE_HOST" in changed
-        assert "GINKGO_MYSQL_HOST" in changed
+        assert "GINKGO_ENV" in changed
 
-    def test_debug_off_sets_master_hosts(self, tmp_path):
-        """debug=off 时写入 master 环境主机"""
-        from ginkgo.client.config_cli import update_env_for_debug
+    def test_production_sets_master_hosts(self, tmp_path):
+        """PRODUCTION 写入 master 集群主机"""
+        from ginkgo.client.config_cli import update_env_for_env
 
         env_file = str(tmp_path / ".env")
-        changed = update_env_for_debug(env_file, debug_on=False)
+        changed = update_env_for_env(env_file, "PRODUCTION")
 
         with open(env_file) as f:
             content = f.read()
 
+        assert "GINKGO_ENV=PRODUCTION" in content
         assert "GINKGO_CLICKHOUSE_HOST=clickhouse-master" in content
         assert "GINKGO_MYSQL_HOST=mysql-master" in content
-        assert "GINKGO_CLICKHOUSE_HOST" in changed
+
+    def test_mongo_always_master(self, tmp_path):
+        """Mongo 恒 master（无 -test 实例，不随 env 切）"""
+        from ginkgo.client.config_cli import update_env_for_env
+
+        env_file = str(tmp_path / ".env")
+        update_env_for_env(env_file, "DEVELOPMENT")
+        with open(env_file) as f:
+            content_dev = f.read()
+        assert "GINKGO_MONGODB_HOST=mongo-master" in content_dev
+
+        update_env_for_env(env_file, "PRODUCTION")
+        with open(env_file) as f:
+            content_prod = f.read()
+        assert "GINKGO_MONGODB_HOST=mongo-master" in content_prod
 
     def test_preserves_other_env_vars(self, tmp_path):
         """更新时保留其他环境变量"""
-        from ginkgo.client.config_cli import update_env_for_debug
+        from ginkgo.client.config_cli import update_env_for_env
 
         env_file = str(tmp_path / ".env")
         with open(env_file, "w") as f:
@@ -55,7 +71,7 @@ class TestEnvUpdateLogic:
             f.write("GINKGO_CLICKHOUSE_HOST=clickhouse-test\n")
             f.write("SOME_OTHER_VAR=keep_me\n")
 
-        changed = update_env_for_debug(env_file, debug_on=False)
+        update_env_for_env(env_file, "PRODUCTION")
 
         with open(env_file) as f:
             content = f.read()
@@ -66,45 +82,36 @@ class TestEnvUpdateLogic:
 
     def test_creates_env_file_if_not_exists(self, tmp_path):
         """.env 不存在时自动创建"""
-        from ginkgo.client.config_cli import update_env_for_debug
+        from ginkgo.client.config_cli import update_env_for_env
 
         env_file = str(tmp_path / ".env")
         assert not os.path.exists(env_file)
 
-        changed = update_env_for_debug(env_file, debug_on=True)
+        changed = update_env_for_env(env_file, "DEVELOPMENT")
 
         assert os.path.exists(env_file)
         assert len(changed) > 0
 
     def test_no_change_returns_empty(self, tmp_path):
-        """当前值与目标一致时返回空 dict"""
-        from ginkgo.client.config_cli import update_env_for_debug
+        """当前值与目标一致时返回空 dict（幂等）"""
+        from ginkgo.client.config_cli import update_env_for_env
 
         env_file = str(tmp_path / ".env")
-        # 先设为 test
-        update_env_for_debug(env_file, debug_on=True)
-        # 再设为 test，应无变化
-        changed = update_env_for_debug(env_file, debug_on=True)
+        update_env_for_env(env_file, "DEVELOPMENT")
+        changed = update_env_for_env(env_file, "DEVELOPMENT")
         assert changed == {}
 
-    def test_debug_mapping_table(self, tmp_path):
-        """验证完整的 debug → 数据库映射"""
-        from ginkgo.client.config_cli import update_env_for_debug
+    def test_switching_prod_then_dev_reports_changes(self, tmp_path):
+        """PRODUCTION → DEVELOPMENT 切换，报告变化的 key"""
+        from ginkgo.client.config_cli import update_env_for_env
 
         env_file = str(tmp_path / ".env")
+        update_env_for_env(env_file, "PRODUCTION")
+        changed = update_env_for_env(env_file, "DEVELOPMENT")
 
-        # debug=on
-        changed_on = update_env_for_debug(env_file, debug_on=True)
         with open(env_file) as f:
-            content_on = f.read()
-        assert "GINKGO_CLICKHOUSE_HOST=clickhouse-test" in content_on
-        assert "GINKGO_MYSQL_HOST=mysql-test" in content_on
-        assert "GINKGO_MONGODB_HOST=mongo-master" in content_on
-
-        # debug=off
-        changed_off = update_env_for_debug(env_file, debug_on=False)
-        with open(env_file) as f:
-            content_off = f.read()
-        assert "GINKGO_CLICKHOUSE_HOST=clickhouse-master" in content_off
-        assert "GINKGO_MYSQL_HOST=mysql-master" in content_off
-        assert "GINKGO_MONGODB_HOST=mongo-master" in content_off
+            content = f.read()
+        assert "GINKGO_ENV=DEVELOPMENT" in content
+        assert "GINKGO_MYSQL_HOST=mysql-test" in content
+        assert "GINKGO_ENV" in changed
+        assert "GINKGO_MYSQL_HOST" in changed

--- a/tests/unit/client/test_env_switching.py
+++ b/tests/unit/client/test_env_switching.py
@@ -1,4 +1,4 @@
-"""统一集群切换测试（ADR-026）
+"""统一集群切换测试（ADR-028）
 
 验证 ginkgo config set env DEVELOPMENT|PRODUCTION 经 update_env_for_env 更新 .env：
 - DEVELOPMENT → GINKGO_ENV=DEVELOPMENT + CLICKHOUSE_HOST=clickhouse-test + MYSQL_HOST=mysql-test

--- a/tests/unit/libs/test_cluster_env_guard.py
+++ b/tests/unit/libs/test_cluster_env_guard.py
@@ -1,0 +1,66 @@
+# Upstream: libs/core/config.py
+# Downstream: -
+# Role: 回归测试 #6756 启动期集群一致性护栏（DEBUGMODE vs DB host 后缀）
+
+"""#6756 启动期护栏：DEBUGMODE 与 DB host 后缀（master/test 体系）不一致拒启。
+
+护栏在 GCONF.MYSQLHOST/CLICKHOST 首次访问时惰性触发，幂等。本套件每用例
+重置幂等标志 + monkeypatch 环境变量隔离验证。
+"""
+
+import pytest
+from ginkgo.libs.core.config import GCONF, GinkgoConfig
+
+
+def _trigger(monkeypatch, dbg: str, mh: str, ch: str, skip: str = "0") -> str:
+    """重置护栏幂等标志并按给定环境触发一次校验，返回解析的 MySQL host。"""
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", dbg)
+    monkeypatch.setenv("GINKGO_MYSQL_HOST", mh)
+    monkeypatch.setenv("GINKGO_CLICKHOUSE_HOST", ch)
+    monkeypatch.setenv("GINKGO_SKIP_CLUSTER_GUARD", skip)
+    GinkgoConfig._cluster_guard_done = False
+    return GCONF.MYSQLHOST
+
+
+def test_conflict_prod_mode_but_test_host_raises(monkeypatch):
+    """debug=off(生产) 却连 -test 集群 → 拒启（防真实运行静默连 test）。"""
+    with pytest.raises(RuntimeError, match="Ginkgo Env Guard"):
+        _trigger(monkeypatch, "FALSE", "mysql-test", "clickhouse-test")
+
+
+def test_conflict_test_mode_but_master_host_raises(monkeypatch):
+    """debug=on(测试) 却连 -master 集群 → 拒启（防测试写脏生产数据）。"""
+    with pytest.raises(RuntimeError, match="Ginkgo Env Guard"):
+        _trigger(monkeypatch, "TRUE", "mysql-master", "clickhouse-master")
+
+
+def test_consistent_test_env_ok(monkeypatch):
+    """debug=on + -test 集群 → 放行。"""
+    assert _trigger(monkeypatch, "TRUE", "mysql-test", "clickhouse-test") == "mysql-test"
+
+
+def test_consistent_prod_env_ok(monkeypatch):
+    """debug=off + -master 集群 → 放行。"""
+    assert _trigger(monkeypatch, "FALSE", "mysql-master", "clickhouse-master") == "mysql-master"
+
+
+def test_localhost_host_skips_assertion(monkeypatch):
+    """localhost/外部域名不在 master/test 体系 → 断言跳过，不误伤外部部署。"""
+    assert _trigger(monkeypatch, "FALSE", "localhost", "localhost") == "localhost"
+
+
+def test_skip_guard_escape_hatch(monkeypatch):
+    """GINKGO_SKIP_CLUSTER_GUARD=1 → 冲突也放行（测试/特殊部署逃生口）。"""
+    assert _trigger(monkeypatch, "FALSE", "mysql-test", "clickhouse-test", skip="1") == "mysql-test"
+
+
+def test_guard_is_idempotent(monkeypatch):
+    """幂等：同进程第二次访问 host 不再重复触发断言/横幅。"""
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", "TRUE")
+    monkeypatch.setenv("GINKGO_MYSQL_HOST", "mysql-test")
+    monkeypatch.setenv("GINKGO_CLICKHOUSE_HOST", "clickhouse-test")
+    GinkgoConfig._cluster_guard_done = False
+    assert GCONF.MYSQLHOST == "mysql-test"
+    # 第二次把环境改成冲突态，因幂等已不再校验，不应抛
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", "FALSE")
+    assert GCONF.MYSQLHOST == "mysql-test"

--- a/tests/unit/libs/test_cluster_env_guard.py
+++ b/tests/unit/libs/test_cluster_env_guard.py
@@ -1,20 +1,21 @@
 # Upstream: libs/core/config.py
 # Downstream: -
-# Role: 回归测试 #6756 启动期集群一致性护栏（DEBUGMODE vs DB host 后缀）
+# Role: 回归测试启动期集群一致性护栏（ADR-026：GINKGO_ENV vs DB host 后缀）
 
-"""#6756 启动期护栏：DEBUGMODE 与 DB host 后缀（master/test 体系）不一致拒启。
+"""启动期护栏：GINKGO_ENV（DEVELOPMENT/PRODUCTION）与 DB host 后缀不一致拒启。
 
+ADR-026 起，护栏判据从 DEBUGMODE 改为 IS_DEV_ENV（集群选择单一旋钮）。
 护栏在 GCONF.MYSQLHOST/CLICKHOST 首次访问时惰性触发，幂等。本套件每用例
-重置幂等标志 + monkeypatch 环境变量隔离验证。
+重置幂等标志 + monkeypatch 环境变量隔离验证，另覆盖 bridge-default 迁移逻辑。
 """
 
 import pytest
 from ginkgo.libs.core.config import GCONF, GinkgoConfig
 
 
-def _trigger(monkeypatch, dbg: str, mh: str, ch: str, skip: str = "0") -> str:
-    """重置护栏幂等标志并按给定环境触发一次校验，返回解析的 MySQL host。"""
-    monkeypatch.setenv("GINKGO_DEBUG_MODE", dbg)
+def _trigger(monkeypatch, env: str, mh: str, ch: str, skip: str = "0") -> str:
+    """重置护栏幂等标志并按给定 GINKGO_ENV 触发一次校验，返回解析的 MySQL host。"""
+    monkeypatch.setenv("GINKGO_ENV", env)
     monkeypatch.setenv("GINKGO_MYSQL_HOST", mh)
     monkeypatch.setenv("GINKGO_CLICKHOUSE_HOST", ch)
     monkeypatch.setenv("GINKGO_SKIP_CLUSTER_GUARD", skip)
@@ -22,45 +23,79 @@ def _trigger(monkeypatch, dbg: str, mh: str, ch: str, skip: str = "0") -> str:
     return GCONF.MYSQLHOST
 
 
-def test_conflict_prod_mode_but_test_host_raises(monkeypatch):
-    """debug=off(生产) 却连 -test 集群 → 拒启（防真实运行静默连 test）。"""
+def test_conflict_prod_env_but_test_host_raises(monkeypatch):
+    """PRODUCTION 却连 -test 集群 → 拒启（防真实运行静默连 test）。"""
     with pytest.raises(RuntimeError, match="Ginkgo Env Guard"):
-        _trigger(monkeypatch, "FALSE", "mysql-test", "clickhouse-test")
+        _trigger(monkeypatch, "PRODUCTION", "mysql-test", "clickhouse-test")
 
 
-def test_conflict_test_mode_but_master_host_raises(monkeypatch):
-    """debug=on(测试) 却连 -master 集群 → 拒启（防测试写脏生产数据）。"""
+def test_conflict_dev_env_but_master_host_raises(monkeypatch):
+    """DEVELOPMENT 却连 -master 集群 → 拒启（防测试写脏生产数据）。"""
     with pytest.raises(RuntimeError, match="Ginkgo Env Guard"):
-        _trigger(monkeypatch, "TRUE", "mysql-master", "clickhouse-master")
+        _trigger(monkeypatch, "DEVELOPMENT", "mysql-master", "clickhouse-master")
 
 
-def test_consistent_test_env_ok(monkeypatch):
-    """debug=on + -test 集群 → 放行。"""
-    assert _trigger(monkeypatch, "TRUE", "mysql-test", "clickhouse-test") == "mysql-test"
+def test_consistent_dev_env_ok(monkeypatch):
+    """DEVELOPMENT + -test 集群 → 放行。"""
+    assert _trigger(monkeypatch, "DEVELOPMENT", "mysql-test", "clickhouse-test") == "mysql-test"
 
 
 def test_consistent_prod_env_ok(monkeypatch):
-    """debug=off + -master 集群 → 放行。"""
-    assert _trigger(monkeypatch, "FALSE", "mysql-master", "clickhouse-master") == "mysql-master"
+    """PRODUCTION + -master 集群 → 放行。"""
+    assert _trigger(monkeypatch, "PRODUCTION", "mysql-master", "clickhouse-master") == "mysql-master"
 
 
 def test_localhost_host_skips_assertion(monkeypatch):
     """localhost/外部域名不在 master/test 体系 → 断言跳过，不误伤外部部署。"""
-    assert _trigger(monkeypatch, "FALSE", "localhost", "localhost") == "localhost"
+    assert _trigger(monkeypatch, "PRODUCTION", "localhost", "localhost") == "localhost"
 
 
 def test_skip_guard_escape_hatch(monkeypatch):
     """GINKGO_SKIP_CLUSTER_GUARD=1 → 冲突也放行（测试/特殊部署逃生口）。"""
-    assert _trigger(monkeypatch, "FALSE", "mysql-test", "clickhouse-test", skip="1") == "mysql-test"
+    assert _trigger(monkeypatch, "PRODUCTION", "mysql-test", "clickhouse-test", skip="1") == "mysql-test"
 
 
 def test_guard_is_idempotent(monkeypatch):
     """幂等：同进程第二次访问 host 不再重复触发断言/横幅。"""
-    monkeypatch.setenv("GINKGO_DEBUG_MODE", "TRUE")
+    monkeypatch.setenv("GINKGO_ENV", "DEVELOPMENT")
     monkeypatch.setenv("GINKGO_MYSQL_HOST", "mysql-test")
     monkeypatch.setenv("GINKGO_CLICKHOUSE_HOST", "clickhouse-test")
     GinkgoConfig._cluster_guard_done = False
     assert GCONF.MYSQLHOST == "mysql-test"
     # 第二次把环境改成冲突态，因幂等已不再校验，不应抛
-    monkeypatch.setenv("GINKGO_DEBUG_MODE", "FALSE")
+    monkeypatch.setenv("GINKGO_ENV", "PRODUCTION")
     assert GCONF.MYSQLHOST == "mysql-test"
+
+
+# --- bridge-default 迁移逻辑（ADR-026 Decision 2）---
+
+def test_bridge_unset_debug_true_is_dev(monkeypatch):
+    """GINKGO_ENV 未设 + DEBUGMODE=True → bridge 推断 DEVELOPMENT。"""
+    monkeypatch.delenv("GINKGO_ENV", raising=False)
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", "TRUE")
+    assert GCONF.ENV == "DEVELOPMENT"
+    assert GCONF.IS_DEV_ENV is True
+
+
+def test_bridge_unset_debug_false_is_prod(monkeypatch):
+    """GINKGO_ENV 未设 + DEBUGMODE=False → bridge 推断 PRODUCTION。"""
+    monkeypatch.delenv("GINKGO_ENV", raising=False)
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", "FALSE")
+    assert GCONF.ENV == "PRODUCTION"
+    assert GCONF.IS_DEV_ENV is False
+
+
+def test_explicit_env_overrides_debugmode(monkeypatch):
+    """显式 GINKGO_ENV 优先于 DEBUGMODE（bridge 不触发）。"""
+    monkeypatch.setenv("GINKGO_ENV", "PRODUCTION")
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", "TRUE")
+    assert GCONF.ENV == "PRODUCTION"
+    assert GCONF.IS_DEV_ENV is False
+
+
+def test_env_lowercase_normalized(monkeypatch):
+    """取值统一大写（小写输入经 .upper() 归一）。"""
+    monkeypatch.setenv("GINKGO_ENV", "development")
+    assert GCONF.ENV == "DEVELOPMENT"
+    monkeypatch.setenv("GINKGO_ENV", "production")
+    assert GCONF.ENV == "PRODUCTION"

--- a/tests/unit/libs/test_cluster_env_guard.py
+++ b/tests/unit/libs/test_cluster_env_guard.py
@@ -13,6 +13,25 @@ import pytest
 from ginkgo.libs.core.config import GCONF, GinkgoConfig
 
 
+@pytest.fixture(autouse=True)
+def _isolate_config_yml(monkeypatch, tmp_path):
+    """隔离 config.yml：防 set_env 写 env 字位污染全局 GCONF 单例的 bridge 测试。
+
+    ADR-028 review Q5 修复后 ENV property 优先读 config.yml env 字位；若其他测试
+    （如 smoke 的 test_set_env_valid_and_invalid）调 set_env 写了真实 ~/.ginkgo/config.yml
+    的 env 字位，本套件 bridge 测试（期望未设 env 时从 DEBUGMODE 推断）会读到残留而失效。
+    把 setting_path 指到 tmp_path 干净 config.yml（无 env 字位）保证 bridge 正常触发。
+    """
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("debug: False\n")
+    monkeypatch.setattr(GinkgoConfig, "setting_path", property(lambda self: str(cfg)))
+    GCONF._config_cache = {}
+    GCONF._config_mtime = 0
+    yield
+    GCONF._config_cache = {}
+    GCONF._config_mtime = 0
+
+
 def _trigger(monkeypatch, env: str, mh: str, ch: str, skip: str = "0") -> str:
     """重置护栏幂等标志并按给定 GINKGO_ENV 触发一次校验，返回解析的 MySQL host。"""
     monkeypatch.setenv("GINKGO_ENV", env)

--- a/tests/unit/libs/test_cluster_env_guard.py
+++ b/tests/unit/libs/test_cluster_env_guard.py
@@ -1,10 +1,10 @@
 # Upstream: libs/core/config.py
 # Downstream: -
-# Role: 回归测试启动期集群一致性护栏（ADR-026：GINKGO_ENV vs DB host 后缀）
+# Role: 回归测试启动期集群一致性护栏（ADR-027 护栏；ADR-028 判据改 IS_DEV_ENV vs DB host 后缀）
 
 """启动期护栏：GINKGO_ENV（DEVELOPMENT/PRODUCTION）与 DB host 后缀不一致拒启。
 
-ADR-026 起，护栏判据从 DEBUGMODE 改为 IS_DEV_ENV（集群选择单一旋钮）。
+ADR-028 起，护栏判据从 DEBUGMODE 改为 IS_DEV_ENV（集群选择单一旋钮）。
 护栏在 GCONF.MYSQLHOST/CLICKHOST 首次访问时惰性触发，幂等。本套件每用例
 重置幂等标志 + monkeypatch 环境变量隔离验证，另覆盖 bridge-default 迁移逻辑。
 """
@@ -86,7 +86,7 @@ def test_guard_is_idempotent(monkeypatch):
     assert GCONF.MYSQLHOST == "mysql-test"
 
 
-# --- bridge-default 迁移逻辑（ADR-026 Decision 2）---
+# --- bridge-default 迁移逻辑（ADR-028：ENV 未设从 DEBUGMODE 推断，向后兼容）---
 
 def test_bridge_unset_debug_true_is_dev(monkeypatch):
     """GINKGO_ENV 未设 + DEBUGMODE=True → bridge 推断 DEVELOPMENT。"""

--- a/tests/unit/libs/test_config_env_cluster_guard_smoke.py
+++ b/tests/unit/libs/test_config_env_cluster_guard_smoke.py
@@ -1,0 +1,113 @@
+# Upstream: libs/core/config.py
+# Downstream: -
+# Role: ADR-028 GINKGO_ENV + 启动期集群护栏 smoke（diff coverage gate #6135 采集）
+
+"""ADR-028 GINKGO_ENV 单一旋钮 + 启动期集群一致性护栏 smoke。
+
+#6756/#6773 PR 在 config.py 新增的可执行逻辑——ENV property（bridge 推断）、
+IS_DEV_ENV、set_env、_assert_cluster_consistency——被 import 链触达（几乎所有
+gate 测试 from ginkgo.libs import GCONF）但方法体无 smoke 调用：gate 测试不读
+CLICKHOST/MYSQLHOST 故 _assert 从不触发，ENV 也只在 IS_DEV_ENV/_assert 间接
+读取。→ diff coverage gate 红（20% < 80%）。
+
+本 smoke 调起方法体补覆盖信号，并锁定集群选择 + 护栏新契约：
+- bridge：GINKGO_ENV 未设时从 DEBUGMODE 推断（True→DEVELOPMENT）并材料化到 environ
+- ENV 显式值 upper() 归一
+- set_env 合法/非法校验
+- _assert：DEV 一致（不 raise+绿横幅）/ 幂等（二次静默）/ 冲突 raise / SKIP 逃生
+"""
+
+import os
+import pytest
+from ginkgo.libs.core.config import GinkgoConfig, GCONF
+
+_ENV_KEYS = (
+    "GINKGO_ENV",
+    "GINKGO_SKIP_CLUSTER_GUARD",
+    "GINKGO_MYSQL_HOST",
+    "GINKGO_CLICKHOUSE_HOST",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env():
+    """每测试重置护栏幂等标志 + 清理相关 env，防跨测试污染。"""
+    GinkgoConfig._cluster_guard_done = False
+    saved = {k: os.environ.get(k) for k in _ENV_KEYS}
+    for k in _ENV_KEYS:
+        os.environ.pop(k, None)
+    yield
+    GinkgoConfig._cluster_guard_done = False
+    for k, v in saved.items():
+        if v is not None:
+            os.environ[k] = v
+        else:
+            os.environ.pop(k, None)
+
+
+@pytest.mark.unit
+class TestEnvClusterGuardSmoke:
+    def test_env_bridge_from_debugmode_true(self, monkeypatch):
+        """GINKGO_ENV 未设 + DEBUGMODE=True → bridge 推断 DEVELOPMENT 并材料化。"""
+        monkeypatch.setattr(GinkgoConfig, "DEBUGMODE", property(lambda self: True))
+        assert os.environ.get("GINKGO_ENV") is None
+        assert GCONF.ENV == "DEVELOPMENT"
+        assert os.environ["GINKGO_ENV"] == "DEVELOPMENT"
+        assert GCONF.IS_DEV_ENV is True
+
+    def test_env_bridge_from_debugmode_false(self, monkeypatch):
+        """GINKGO_ENV 未设 + DEBUGMODE=False → bridge 推断 PRODUCTION。"""
+        monkeypatch.setattr(GinkgoConfig, "DEBUGMODE", property(lambda self: False))
+        assert GCONF.ENV == "PRODUCTION"
+        assert GCONF.IS_DEV_ENV is False
+
+    def test_env_explicit_upper_normalized(self):
+        """显式 GINKGO_ENV 小写值 → upper() 归一。"""
+        os.environ["GINKGO_ENV"] = "development"
+        assert GCONF.ENV == "DEVELOPMENT"
+
+    def test_set_env_valid_and_invalid(self):
+        """set_env：合法值 upper 后写入；非法值 raise ValueError。
+
+        set_env 不做别名（DEV→DEVELOPMENT 别名在 config_cli.set 层），只接受
+        PRODUCTION/DEVELOPMENT（upper 归一后）。
+        """
+        GCONF.set_env("development")
+        assert os.environ["GINKGO_ENV"] == "DEVELOPMENT"
+        GCONF.set_env("production")
+        assert os.environ["GINKGO_ENV"] == "PRODUCTION"
+        with pytest.raises(ValueError):
+            GCONF.set_env("STAGING")
+
+    def test_assert_dev_consistent_banner(self, monkeypatch, capsys):
+        """DEV + mysql-test/clickhouse-test → 不 raise，打绿色 [TEST] 横幅。"""
+        monkeypatch.setattr(GinkgoConfig, "DEBUGMODE", property(lambda self: True))
+        os.environ["GINKGO_MYSQL_HOST"] = "mysql-test"
+        os.environ["GINKGO_CLICKHOUSE_HOST"] = "clickhouse-test"
+        # 读 CLICKHOST 触发 _assert_cluster_consistency
+        assert GCONF.CLICKHOST == "clickhouse-test"
+        assert GCONF.MYSQLHOST == "mysql-test"
+        assert "[TEST]" in capsys.readouterr().err
+
+    def test_assert_idempotent(self, monkeypatch, capsys):
+        """二次读 host 不再打横幅（幂等）。"""
+        monkeypatch.setattr(GinkgoConfig, "DEBUGMODE", property(lambda self: True))
+        _ = GCONF.MYSQLHOST
+        _ = GCONF.CLICKHOST
+        assert capsys.readouterr().err.count("[TEST]") == 1
+
+    def test_assert_conflict_raises(self, monkeypatch):
+        """PRODUCTION env 但 host=-test → raise RuntimeError。"""
+        os.environ["GINKGO_ENV"] = "PRODUCTION"
+        os.environ["GINKGO_MYSQL_HOST"] = "mysql-test"
+        with pytest.raises(RuntimeError, match="Env Guard"):
+            _ = GCONF.MYSQLHOST
+
+    def test_assert_skip_flag_bypasses_assertion(self, monkeypatch, capsys):
+        """GINKGO_SKIP_CLUSTER_GUARD=1 跳断言（冲突也不 raise，横幅照打）。"""
+        os.environ["GINKGO_ENV"] = "PRODUCTION"
+        os.environ["GINKGO_MYSQL_HOST"] = "mysql-test"
+        os.environ["GINKGO_SKIP_CLUSTER_GUARD"] = "1"
+        # 不 raise（SKIP 生效）
+        assert GCONF.MYSQLHOST == "mysql-test"
+        assert "[PROD]" in capsys.readouterr().err

--- a/tests/unit/libs/test_config_env_cluster_guard_smoke.py
+++ b/tests/unit/libs/test_config_env_cluster_guard_smoke.py
@@ -30,14 +30,26 @@ _ENV_KEYS = (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_env():
-    """每测试重置护栏幂等标志 + 清理相关 env，防跨测试污染。"""
+def _isolate_env(monkeypatch, tmp_path):
+    """每测试重置护栏幂等标志 + 清理相关 env + 隔离 config.yml，防跨测试污染。
+
+    set_env 写 config.yml 的 env 字位后会污染全局 GCONF 单例的 bridge 测试
+   （ENV property 优先读 config.yml env 字位，bridge 不再触发），故把 setting_path
+    指到 tmp_path 干净 config.yml（仅 debug:False，无 env 字位 → bridge 正常触发）。
+    """
     GinkgoConfig._cluster_guard_done = False
     saved = {k: os.environ.get(k) for k in _ENV_KEYS}
     for k in _ENV_KEYS:
         os.environ.pop(k, None)
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("debug: False\n")
+    monkeypatch.setattr(GinkgoConfig, "setting_path", property(lambda self: str(cfg)))
+    GCONF._config_cache = {}
+    GCONF._config_mtime = 0
     yield
     GinkgoConfig._cluster_guard_done = False
+    GCONF._config_cache = {}
+    GCONF._config_mtime = 0
     for k, v in saved.items():
         if v is not None:
             os.environ[k] = v
@@ -111,3 +123,31 @@ class TestEnvClusterGuardSmoke:
         # 不 raise（SKIP 生效）
         assert GCONF.MYSQLHOST == "mysql-test"
         assert "[PROD]" in capsys.readouterr().err
+
+    # --- review Q5 修复：set_env 持久化到 config.yml，本地 CLI 新进程读到 ---
+
+    def test_set_env_persists_for_new_process(self, monkeypatch):
+        """review Q5：set_env 写 config.yml → 新进程（无 env var）ENV 仍读到。
+
+        本地 CLI 不读 .env，新进程经 ENV property 读 config.yml env 字位拿到集群。
+        fixture 初始化 config.yml debug:False（bridge 应推断 PRODUCTION）；set_env
+        ('DEVELOPMENT') 写 env 字位后清 env var 模拟新进程，读到 DEVELOPMENT 即证明
+        从 config.yml env 字位读到（非 bridge），持久化修复生效。
+        """
+        GCONF.set_env("DEVELOPMENT")
+        monkeypatch.delenv("GINKGO_ENV", raising=False)  # 模拟新进程
+        GCONF._config_cache = {}  # 清缓存强制重读 config.yml
+        assert GCONF.ENV == "DEVELOPMENT"  # config.yml env 字位命中，非 bridge(PRODUCTION)
+
+    def test_env_config_yml_overrides_bridge(self, monkeypatch):
+        """ENV property 优先级：config.yml env 字位 > bridge(DEBUGMODE)。
+
+        DEBUGMODE=True（bridge 应推断 DEVELOPMENT）但 config.yml env=PRODUCTION 时，
+        ENV 读到 PRODUCTION——证明 config.yml env 字位优先于 bridge。Q5 持久化使本地
+        CLI 新进程不再被陈旧 DEBUGMODE 误导集群选择。
+        """
+        GCONF.set_env("PRODUCTION")  # 写 config.yml env: PRODUCTION
+        monkeypatch.delenv("GINKGO_ENV", raising=False)
+        monkeypatch.setattr(GinkgoConfig, "DEBUGMODE", property(lambda self: True))  # bridge 会推断 DEVELOPMENT
+        GCONF._config_cache = {}
+        assert GCONF.ENV == "PRODUCTION"  # config.yml env 字位优先于 bridge

--- a/tests/unit/libs/test_port_injection_env.py
+++ b/tests/unit/libs/test_port_injection_env.py
@@ -1,0 +1,64 @@
+# Upstream: libs/core/config.py
+# Downstream: -
+# Role: 回归测试端口 +1 守卫判据改用 IS_DEV_ENV（ADR-026，与 DEBUGMODE 解耦）
+
+"""端口 +1 守卫测试（ADR-026）。
+
+CLICKPORT/MYSQLPORT 的首位 +1 判据从 DEBUGMODE 改为 IS_DEV_ENV（集群选择），
+容器守卫与幂等保留。覆盖：
+- DEVELOPMENT 非容器 → +1（13306/18123）
+- PRODUCTION → 不 +1（3306/8123）
+- PRODUCTION + DEBUGMODE=True → 不 +1（解耦核心回归：DEBUGMODE 不再驱动 +1）
+- 容器内 DEVELOPMENT → 守卫跳过 +1（连内部端口）
+- 幂等：端口已以 1 开头（映射端口）不重复加
+"""
+
+import pytest
+import ginkgo.libs.utils.log_utils as _lu
+from ginkgo.libs.core.config import GCONF, GinkgoConfig
+
+
+def _setup(monkeypatch, env, container, debug="FALSE",
+           mysql_port="3306", click_port="8123"):
+    """隔离环境 + 确定性容器检测，聚焦端口派生逻辑。"""
+    monkeypatch.setenv("GINKGO_ENV", env)
+    monkeypatch.setenv("GINKGO_DEBUG_MODE", debug)
+    monkeypatch.setenv("GINKGO_MYSQL_PORT", mysql_port)
+    monkeypatch.setenv("GINKGO_CLICKHOUSE_PORT", click_port)
+    monkeypatch.setenv("GINKGO_SKIP_CLUSTER_GUARD", "1")  # 跳 host 断言，聚焦端口
+    monkeypatch.setattr(_lu, "is_container_environment", lambda: container)
+    GinkgoConfig._cluster_guard_done = False
+
+
+@pytest.mark.unit
+class TestPortInjectionEnv:
+    def test_dev_non_container_plus_one(self, monkeypatch):
+        """DEVELOPMENT + 宿主客户端 → 端口首位 +1。"""
+        _setup(monkeypatch, "DEVELOPMENT", container=False, debug="TRUE")
+        assert GCONF.MYSQLPORT == 13306
+        assert GCONF.CLICKPORT == 18123
+
+    def test_prod_no_plus_one(self, monkeypatch):
+        """PRODUCTION → 原端口，不 +1。"""
+        _setup(monkeypatch, "PRODUCTION", container=False, debug="FALSE")
+        assert GCONF.MYSQLPORT == 3306
+        assert GCONF.CLICKPORT == 8123
+
+    def test_prod_with_debug_true_no_plus_one(self, monkeypatch):
+        """解耦核心回归：PRODUCTION + DEBUGMODE=True → 仍 3306（DEBUGMODE 不再驱动 +1）。"""
+        _setup(monkeypatch, "PRODUCTION", container=False, debug="TRUE")
+        assert GCONF.MYSQLPORT == 3306
+        assert GCONF.CLICKPORT == 8123
+
+    def test_dev_in_container_no_plus_one(self, monkeypatch):
+        """容器内 DEVELOPMENT → 守卫跳过 +1（连内部端口 3306/8123）。"""
+        _setup(monkeypatch, "DEVELOPMENT", container=True, debug="TRUE")
+        assert GCONF.MYSQLPORT == 3306
+        assert GCONF.CLICKPORT == 8123
+
+    def test_idempotent_already_mapped_port(self, monkeypatch):
+        """幂等：端口已以 1 开头（已是映射端口）不重复加。"""
+        _setup(monkeypatch, "DEVELOPMENT", container=False, debug="TRUE",
+               mysql_port="13306", click_port="18123")
+        assert GCONF.MYSQLPORT == 13306
+        assert GCONF.CLICKPORT == 18123

--- a/tests/unit/libs/test_port_injection_env.py
+++ b/tests/unit/libs/test_port_injection_env.py
@@ -1,8 +1,8 @@
 # Upstream: libs/core/config.py
 # Downstream: -
-# Role: 回归测试端口 +1 守卫判据改用 IS_DEV_ENV（ADR-026，与 DEBUGMODE 解耦）
+# Role: 回归测试端口 +1 守卫判据改用 IS_DEV_ENV（ADR-028，与 DEBUGMODE 解耦）
 
-"""端口 +1 守卫测试（ADR-026）。
+"""端口 +1 守卫测试（ADR-028）。
 
 CLICKPORT/MYSQLPORT 的首位 +1 判据从 DEBUGMODE 改为 IS_DEV_ENV（集群选择），
 容器守卫与幂等保留。覆盖：


### PR DESCRIPTION
## 背景

`DEBUGMODE` 是「三合一旋钮」:日志/退避 + DB host + 宿主端口 +1。`.env` 可变共享态 + 三合一耦合,是「忘翻 debug / 残留 test host 静默连错库」的根因。本 PR 两段递进交付:

- **ADR-027(止血)**:启动期 host/debug 一致性护栏,host 与 debug 漂移时拒启,堵住静默连错库。
- **ADR-028(根治,supersedes ADR-024 D1/2、ADR-027 D1)**:`GINKGO_ENV ∈ {PRODUCTION, DEVELOPMENT}`(大写)单一决定集群,`DEBUGMODE` 退回纯日志/退避,两者正交。

## 改动(ADR-028 解耦)

- **config.py**:新增 `ENV` property(未设时 bridge 自 DEBUGMODE 推断 → 零行为迁移)、`IS_DEV_ENV`、`set_env`;端口 +1 判据与集群一致性断言判据改用 `IS_DEV_ENV`。
- **config_cli.py**:`set debug` 退纯日志(删写 `.env` + compose 副作用);新增 `set env`(别名 `PROD`/`DEV`,写 `.env` 的 `GINKGO_ENV` + host + compose 重启)。
- **拒跑生产**:`engine run` / `core run` / `core test` 在 `PRODUCTION` env 下 `Exit(1)`(防误连生产写数据)。守卫置于 `try` 之外,防 `typer.Exit` 被 `except Exception` 吞掉。
- **docker-compose**:worker-env 锚点加 `GINKGO_ENV` 插值;删 api-server 的 `GINKGO_DEBUG_MODE: "False"` hack。
- **统一读口**:`trade_gateway_adapter` / `system_service` 改经 `GCONF.ENV` 读集群判据。
- **ADR-028** + ADR-024/025 演进标注 + README。

## 切换用法

```bash
ginkgo config set env DEVELOPMENT   # 研发(test 集群,宿主端口 +1)
ginkgo config set env PRODUCTION    # 生产(master 集群)
ginkgo config set env DEV|PROD      # 别名
ginkgo config get env
ginkgo config set debug on          # 现仅开日志/退避,不再切库
```

## 验证

- 4 个目标测试文件全绿(`test_cluster_env_guard` / `test_port_injection_env` / `test_env_switching` / `test_config_set_env_cli`,含端口解耦核心回归 + 拒跑生产)。
- `tests/unit/libs/ tests/unit/client/` `-n auto`:1183 passed。43 失败均为**预存** rich 渲染环境问题(help 文本断言),已取 master 基线(be38f8f0)对比确认同批失败,与本 PR 无关。

## 取舍

| 点 | 选定 | 理由 |
|---|---|---|
| 取值 | 大写 | 用户指定 |
| ENV 默认 | bridge from DEBUGMODE | 零行为变化迁移 |
| set_env 写哪 | `.env` | compose 插值 + config.yml 容器 `:ro` |
| worker env 烘焙 | 未根治 | docker `${VAR:-default}` 一次性烘焙,改 `.env` 须 `compose up -d`(已在 `set env` 内自动触发) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)