### PR TITLE
feat(adr-025): Kafka 入站 MessageMapper + 5 处死路径修复 (DTO 信使复位 §2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
             tests/unit/features/test_operator_registry.py \
             tests/unit/features/test_expression_engine.py \
             tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py \
+            tests/unit/interfaces/test_message_mapper.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,12 +17,16 @@ _Avoid_: Entity（现状与之同承 Base，待分离）
 _Avoid_: Entity、DTO
 
 **DTO**:
-跨边界、搬运有状态对象的状态投影、以**隔离两个不耦合世界**为目的的纯数据载体（无自身生命周期）。亚型：BusDTO(Kafka)、WebResponse(HTTP)、CacheEntry(Redis)。
-_Avoid_: 把 ORM Model 或 ValueObject 称为 DTO
+跨边界、搬运有状态对象的状态投影、以**隔离两个不耦合世界**为目的的纯数据载体（无自身生命周期）。亚型：BusDTO(Kafka)、WebResponse(HTTP)、CacheEntry(Redis)。信使**双侧对称**：出站封装（Entity→DTO→wire）与入站反序列化（wire→DTO→Entity）都必须经 DTO——禁单侧使用（只出站不经入站）或 consumer 手抓 dict 重组领域对象（drift 温床，ADR-025）。
+_Avoid_: 把 ORM Model 或 ValueObject 称为 DTO；单侧使用 DTO；手抓 dict 重组领域对象
+
+**Mapper**:
+跨边界转换的**唯一转换点**，独立于 CRUD（不 import CRUD）。覆盖四边界亚型：`XxxMapper`(DB, ORM↔Entity↔DTO) / `MessageMapper`(Kafka, wire↔BusDTO↔Event) / `ResponseMapper`(HTTP, Entity↔WebResponse) / `CacheMapper`(Redis, wire↔CacheEntry↔Entity)。分**纯转换**（`XxxMapper`/`ResponseMapper`）与 **IO 转换**（`MessageMapper`/`CacheMapper` 带 wire 依赖）两亚型。决策见 ADR-010 §1（DB 边界）+ ADR-025（推广四边界）。
+_Avoid_: 在 Entity/DTO 类内嵌转换方法；绕过 Mapper 手抓 dict / 裸 `json.dumps`；新建与 Mapper 平行的第二个转换层（违反 ADR-022 原则 3 单一接缝）
 
 ## Relationships
 
-- **Entity 是状态的主体，DTO 是状态的信使，ORM Model 是状态的归宿。**
+- **Entity 是状态的主体，DTO 是状态的信使，ORM Model 是状态的归宿。Mapper 是唯一转换点**：Entity↔ORM Model↔DTO 所有跨形态转换经 Mapper，四边界各一亚型（ADR-025）。
 - 三者是同一业务对象的不同形态：DTO 不持有不变量，ORM Model 不持有行为，Entity 二者皆有。
 - **ValueObject** 与 Entity 同属领域层，区别在有无身份；二者皆不可与 DTO 混称。
 

--- a/docs/adrs/ADR-025-dto-messenger-full-restoration.md
+++ b/docs/adrs/ADR-025-dto-messenger-full-restoration.md
@@ -1,0 +1,68 @@
+# ADR-025: DTO 信使角色全面复位（Mapper 家族覆盖四边界）
+
+**Status:** Accepted
+**Date:** 2026-07-24
+**关联:** ADR-010（三层角色分离，本文档推广其 Mapper 概念）· ADR-022（原则3 单一接缝 / 原则4 注册冲突检测）· `CONTEXT.md`（DTO / Mapper 术语）· Epic「DTO 信使复位」（本文档 + 后续四步 PR 序列）
+
+## Context
+
+ADR-010 把 **DTO** 定位为"跨边界、**隔离两个不耦合世界**的信使"，三亚型 `BusDTO`(Kafka) / `WebResponse`(HTTP) / `CacheEntry`(Redis)；并把 **Mapper** 定为"唯一转换点、独立于 CRUD"。但实测（2026-07-24，`src/ginkgo` 全量）落实程度仅 **1.5 / 4**：
+
+| 边界 | ADR-010 期望 | 现状 |
+|---|---|---|
+| Kafka 出站 | 信使封装 wire 载荷 | ✅ 10 个 BusDTO 定义载荷，producer `model_dump` 序列化（`node.py:1072`） |
+| Kafka 入站 | wire→DTO→Entity | ❌ **15/16 consumer 手抓 dict 重组 Event**，全 livecore/workers 仅 `portfolio_processor.py:499` 一处 `ControlCommandDTO(**data)` |
+| HTTP 响应 | WebResponse | ❌ `api/` **0 个 `response_model`**，无统一响应 schema 层（仅 `backtest_task_schemas.py` 孤例） |
+| Redis | CacheEntry | ❌ 通用 `redis_crud` 全程 `json.dumps/loads` 任意 dict；`CacheEntry` 仅 `data/streaming/cache/cache_manager.py:68` 局部用 |
+
+**后果不止整洁**：DTO 从"信使"退化为"**出站发货单**"——只定义发什么，收货侧不认单子、直接拆裸 dict。drift 藏在缝里：`OrderFeedback` consumer 用 `filled_volume`/`fill_price`（错）而非 `filled_quantity`/`fill_price` 构造 `EventOrderPartiallyFilled` → `TypeError`（缺必需的 `order: Order`）→ 被 `node.py:932` `except` 静默吞，**整条 fill-feedback 路径从未跑通**。HTTP 无契约保护前端，Redis 无类型安全。
+
+**根因**：ADR-010 §1 把 Mapper 定为唯一转换点，但只建了 **DB 边界 + Kafka 出站**。Mapper 概念未对称覆盖四边。
+
+## Decision
+
+### 原则 1 · Mapper 家族覆盖四边界（推广 ADR-010 §1）
+
+每边一个亚型，都遵循"唯一转换点 + 独立于 CRUD"：
+
+| 边界 | Mapper 亚型 | 转换 | 现状→目标 |
+|---|---|---|---|
+| DB | `XxxMapper`（ADR-010 已立） | ORM↔Entity↔DTO | §4 V1/V3/V9 收尾 |
+| Kafka | `MessageMapper` | wire↔BusDTO↔Event | 出站✓ / 入站补全 |
+| HTTP | `ResponseMapper` | Entity/ORM↔WebResponse | 从无到有 + `response_model` |
+| Redis | `CacheMapper` | wire↔CacheEntry↔Entity | 从无到有，替 `json.dumps` 任意 dict |
+
+`MessageMapper`/`ResponseMapper`/`CacheMapper` **不是新抽象层**，是 ADR-010 Mapper 概念在各自边界的实例——符合 ADR-022 原则 3（单一接缝：每边界一个权威转换点）。其中 `MessageMapper` 因带 wire 依赖（kafka-python）与纯类型转换的 `XxxMapper` 异质，承认 Mapper 家族含**纯转换 / IO 转换**两亚型，不硬塞纯转换家族。
+
+### 原则 2 · 严格模式（呼应 CLAUDE.md「失败必须响亮」+ ADR-022 原则 4）
+
+绕过 DTO / 手抓 dict 的旧路径不复保留为 deprecated 双轨：
+
+- **注册期校验**：Mapper 注册 `(DTO, Event)` 对时校验字段对齐，drift（`symbol` vs `code`、`filled_volume` vs `filled_quantity`）**启动即报错**，非运行时静默。
+- **运行时响亮失败**：未经 Mapper 的裸 dict 重组 / 裸 `json.dumps` 缓存写入 / 未声明 `response_model` 的端点，启动期或调用期失败，禁 `except` 吞 + `return` stub 兜底（#4652 同源教训）。
+- **不取柔性双轨**：柔性（deprecated 并存）留 drift 漏洞，而 drift 正是本复位驱动力——留漏洞等于没解决。
+
+### 原则 3 · 分阶段 PR 序列（非单 PR）
+
+共享 Mapper 抽象，按边界拆，每 PR 独立可验证：
+
+1. 本文档（ADR + `CONTEXT.md`）
+2. Kafka 入站 `MessageMapper`（`OrderFeedback` drift 是活 bug，打头）
+3. HTTP `ResponseMapper`
+4. Redis `CacheMapper`
+5. DB Mapper 收尾（ADR-010 §4 V1/V3/V9）
+
+## Rationale
+
+- **为何全面复位而非局部补 Kafka 入站**：DTO 角色落实 1.5/4，局部补只到 2.5/4，HTTP/Redis 空白仍在，drift 类风险（契约/类型不匹配）在另两边同样潜伏。半截复位让"信使"定义与实现长期背离，维护者须记"哪边认 DTO 哪边不认"——认知负担比全空更高。
+- **为何严格而非柔性**：柔性留 drift 漏洞，而 drift 正是 `OrderFeedback` 死路径根因——留漏洞等于保留 bug 温床。严格模式把 drift 从"运行时静默"提前到"启动响亮"，一次性消灭。代价是迁移期痛，但分 PR 序列可承受。
+- **为何复用 Mapper 家族而非新抽象（如独立 Codec 层）**：ADR-010 §1 Mapper 已是"唯一转换点"，推广到四边是概念的自然完备，非新增层。新建 Codec 会与 Mapper 形成"两个转换真相源"（ADR-022 原则 3 禁）。
+- **三条全中**：① 难逆转（四边契约一旦立，回退即重新引入 drift）② 反直觉（1.5/4 还能跑？靠出站严格 + 入站手抓 + 动态语言容忍 + 前端配合凑合，代价是死路径与脆弱契约）③ 真实取舍（严格 vs 柔性 / 复用 Mapper vs 新抽象 / 单 PR vs 序列）。
+
+## Consequences
+
+- **五步 PR 序列**见原则 3。每步验收：对应边界 drift 在注册期被拦截 + 旧手抓/裸路径清零。
+- **迁移影响**：③ HTTP 改 `response_model` 影响前端契约（web-ui `request.ts` 已 unwrap 一层，response 结构变更须同步前端）；④ Redis 改 `CacheEntry` 影响所有缓存读写（需迁移既有 json dict 缓存键）。
+- **严格模式迁移期**：每边 PR 须把该边所有手抓/裸路径一次性改对，否则启动报错阻断。每边 PR 配该边全量冒烟（启动 + 关键路径）。
+- **删除测试**：删 Mapper 家族任一亚型，该边复杂度（drift 风险 + 手抓重组 + 契约脆弱）回散至 N 调用方 = 在发挥作用，非 pass-through。
+- **`CONTEXT.md` 同步**：新增 Mapper 词条（唯一转换点、覆盖四边、纯/IO 亚型）、强化 DTO 词条（信使双侧性，禁单侧）。

--- a/docs/adrs/ADR-025-dto-messenger-full-restoration.md
+++ b/docs/adrs/ADR-025-dto-messenger-full-restoration.md
@@ -2,7 +2,7 @@
 
 **Status:** Accepted
 **Date:** 2026-07-24
-**关联:** ADR-010（三层角色分离，本文档推广其 Mapper 概念）· ADR-022（原则3 单一接缝 / 原则4 注册冲突检测）· `CONTEXT.md`（DTO / Mapper 术语）· Epic「DTO 信使复位」（本文档 + 后续四步 PR 序列）
+**关联:** ADR-010（三层角色分离，本文档推广其 Mapper 概念）· ADR-022（原则3 单一接缝 / 原则4 注册冲突检测）· `CONTEXT.md`（DTO / Mapper 术语）· Epic E #6701（CRUD/Mapper seam 集中化）· Epic F #6702（ADR 兑现）
 
 ## Context
 
@@ -11,11 +11,11 @@ ADR-010 把 **DTO** 定位为"跨边界、**隔离两个不耦合世界**的信�
 | 边界 | ADR-010 期望 | 现状 |
 |---|---|---|
 | Kafka 出站 | 信使封装 wire 载荷 | ✅ 10 个 BusDTO 定义载荷，producer `model_dump` 序列化（`node.py:1072`） |
-| Kafka 入站 | wire→DTO→Entity | ❌ **15/16 consumer 手抓 dict 重组 Event**，全 livecore/workers 仅 `portfolio_processor.py:499` 一处 `ControlCommandDTO(**data)` |
+| Kafka 入站 | wire→DTO→Entity | ❌ **15/16 consumer 手抓 dict 重组 Event**，全 `workers/execution_node/` 仅 `portfolio_processor.py:499` 一处 `ControlCommandDTO(**data)` |
 | HTTP 响应 | WebResponse | ❌ `api/` **0 个 `response_model`**，无统一响应 schema 层（仅 `backtest_task_schemas.py` 孤例） |
 | Redis | CacheEntry | ❌ 通用 `redis_crud` 全程 `json.dumps/loads` 任意 dict；`CacheEntry` 仅 `data/streaming/cache/cache_manager.py:68` 局部用 |
 
-**后果不止整洁**：DTO 从"信使"退化为"**出站发货单**"——只定义发什么，收货侧不认单子、直接拆裸 dict。drift 藏在缝里：`OrderFeedback` consumer 用 `filled_volume`/`fill_price`（错）而非 `filled_quantity`/`fill_price` 构造 `EventOrderPartiallyFilled` → `TypeError`（缺必需的 `order: Order`）→ 被 `node.py:932` `except` 静默吞，**整条 fill-feedback 路径从未跑通**。HTTP 无契约保护前端，Redis 无类型安全。
+**后果不止整洁**：DTO 从"信使"退化为"**出站发货单**"——只定义发什么，收货侧不认单子、直接拆裸 dict。drift 藏在缝里：`OrderFeedback` consumer 用 `filled_volume`/`filled_price`（错）而非 `filled_quantity`/`fill_price` 构造 `EventOrderPartiallyFilled` → `KeyError`（`node.py:919` 读 `event_data['filled_volume']` 而 wire 发 `filled_quantity`，实参求值期即抛，构造未及进入缺 `order` 的 `TypeError`）→ 被 `node.py:932` `except` 静默吞，**整条 fill-feedback 路径从未跑通**。HTTP 无契约保护前端，Redis 无类型安全。
 
 **根因**：ADR-010 §1 把 Mapper 定为唯一转换点，但只建了 **DB 边界 + Kafka 出站**。Mapper 概念未对称覆盖四边。
 
@@ -29,7 +29,7 @@ ADR-010 把 **DTO** 定位为"跨边界、**隔离两个不耦合世界**的信�
 |---|---|---|---|
 | DB | `XxxMapper`（ADR-010 已立） | ORM↔Entity↔DTO | §4 V1/V3/V9 收尾 |
 | Kafka | `MessageMapper` | wire↔BusDTO↔Event | 出站✓ / 入站补全 |
-| HTTP | `ResponseMapper` | Entity/ORM↔WebResponse | 从无到有 + `response_model` |
+| HTTP | `ResponseMapper` | Entity↔WebResponse | 从无到有 + `response_model` |
 | Redis | `CacheMapper` | wire↔CacheEntry↔Entity | 从无到有，替 `json.dumps` 任意 dict |
 
 `MessageMapper`/`ResponseMapper`/`CacheMapper` **不是新抽象层**，是 ADR-010 Mapper 概念在各自边界的实例——符合 ADR-022 原则 3（单一接缝：每边界一个权威转换点）。其中 `MessageMapper` 因带 wire 依赖（kafka-python）与纯类型转换的 `XxxMapper` 异质，承认 Mapper 家族含**纯转换 / IO 转换**两亚型，不硬塞纯转换家族。

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -37,6 +37,7 @@
 | ADR-022 | [抽象层收敛（命名约定 + 死抽象判定）](ADR-022-abstract-layer-naming.md) | Accepted | 2026-07-12 |
 | ADR-023 | [时间 Seam 边界（Business Time 走 TimeProvider，Infra Time 走墙钟）](ADR-023-time-seam-business-infra-split.md) | Accepted | 2026-07-18 |
 | ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed | 2026-07-20 |
+| ADR-025 | [DTO 信使角色全面复位（Mapper 家族覆盖四边界）](ADR-025-dto-messenger-full-restoration.md) | Accepted | 2026-07-24 |
 
 ## 如何新增 / 修订
 

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -36,8 +36,10 @@
 | ADR-021 | [CLI 输出层契约（TTY 守卫 + --format/--limit + 序列化规范）](ADR-021-cli-output-layer.md) | Accepted | 2026-07-04 |
 | ADR-022 | [抽象层收敛（命名约定 + 死抽象判定）](ADR-022-abstract-layer-naming.md) | Accepted | 2026-07-12 |
 | ADR-023 | [时间 Seam 边界（Business Time 走 TimeProvider，Infra Time 走墙钟）](ADR-023-time-seam-business-infra-split.md) | Accepted | 2026-07-18 |
-| ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed | 2026-07-20 |
+| ADR-024 | [数据库端口 +1 魔法加容器守卫 + Debug 模式语义重定义](ADR-024-db-port-injection-debug-semantics.md) | Proposed（D1/2 ⟵ ADR-028） | 2026-07-20 |
 | ADR-025 | [DTO 信使角色全面复位（Mapper 家族覆盖四边界）](ADR-025-dto-messenger-full-restoration.md) | Accepted | 2026-07-24 |
+| ADR-027 | [启动期集群一致性护栏（防 debug/host 漂移静默连错库）](ADR-027-env-cluster-consistency-guard.md) | Accepted（D1 ⟵ ADR-028） | 2026-07-25 |
+| ADR-028 | [GINKGO_ENV 与 DEBUGMODE 彻底解耦（集群选择单一旋钮）](ADR-028-env-cluster-decouple-debugmode.md) | Accepted | 2026-07-25 |
 
 ## 如何新增 / 修订
 

--- a/src/ginkgo/interfaces/dtos/order_feedback_dto.py
+++ b/src/ginkgo/interfaces/dtos/order_feedback_dto.py
@@ -26,5 +26,10 @@ class OrderFeedbackDTO(BaseModel):
     fill_price: float = Field(..., description="成交价格")
     timestamp: str = Field(..., description="成交时间戳（ISO格式）")
 
+    # 订单终态 (review #6778 altitude): broker 权威来源, ORDERSTATUS_TYPES.value 的 str
+    # (同 direction wire 格式)。FILLED=订单终结; None=未提供 → consumer 累积量 fallback
+    # (兼容旧消息 / 模拟路径未填, 消除"单笔 DTO 无法自陈是否终笔"的歧义)。
+    order_status: Optional[str] = Field(default=None, description="订单终态 (ORDERSTATUS_TYPES.value str; None=未提供→累积fallback)")
+
     # 来源标识
     source: Optional[str] = Field(default="trade_gateway", description="反馈来源")

--- a/src/ginkgo/interfaces/mappers/__init__.py
+++ b/src/ginkgo/interfaces/mappers/__init__.py
@@ -1,0 +1,7 @@
+# Upstream: Kafka consumers (node.py / trade_gateway_adapter / data_manager / portfolio_processor)
+# Downstream: 领域 Event / Entity (EventPriceUpdate / EventOrderPartiallyFilled / Order)
+# Role: ADR-025 四边界 Mapper 家族的 Kafka 入站亚型 —— consumer 唯一转换点
+
+from .message_mapper import MessageMapper
+
+__all__ = ["MessageMapper"]

--- a/src/ginkgo/interfaces/mappers/message_mapper.py
+++ b/src/ginkgo/interfaces/mappers/message_mapper.py
@@ -1,0 +1,161 @@
+# Upstream: Kafka consumers (node.py / trade_gateway_adapter / data_manager / portfolio_processor)
+# Downstream: 领域 Event / Entity (EventPriceUpdate / EventOrderPartiallyFilled / Order)
+# Role: ADR-025 四边界 Mapper 家族的 Kafka 入站亚型 —— consumer 唯一转换点
+
+"""
+Kafka 入站 MessageMapper (ADR-025 第②步)
+
+四边界 Mapper 家族的 Kafka 亚型。consumer 统一入口::
+
+    raw dict ──decode──▶ DTO (pydantic model_validate) ──xxx_to_event──▶ 领域 Event/Entity
+
+严格模式 (ADR-025 §3 β 运行期构造校验):
+    decode 走 pydantic model_validate —— 字段缺失 / 类型错立刻 ValidationError,
+    本层转 ValueError 响亮 raise (禁 except 吞 + return stub, #4652 教训)。
+
+消灭的反模式: consumer 拿 raw dict 直接 ``EventXxx(**event_data)`` ——
+字段名 drift (symbol↔code / filled_volume↔filled_quantity / limit_price↔price)
+与签名 mismatch (EventPriceUpdate 要 payload=Bar 非 code/price/volume) 必崩,
+旧代码靠 except 吞 + sleep(1) 静默死路径。
+"""
+
+from datetime import datetime
+from typing import Type, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from ginkgo.interfaces.dtos import (
+    PriceUpdateDTO,
+    OrderFeedbackDTO,
+    OrderSubmissionDTO,
+)
+from ginkgo.entities import Order, Bar
+from ginkgo.enums import (
+    FREQUENCY_TYPES,
+    DIRECTION_TYPES,
+    ORDER_TYPES,
+    ORDERSTATUS_TYPES,
+)
+from ginkgo.trading.events.price_update import EventPriceUpdate
+from ginkgo.trading.events.order_lifecycle_events import EventOrderPartiallyFilled
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class MessageMapper:
+    """Kafka 入站消息转换器 (DTO ↔ Event/Entity)。
+
+    唯一转换点: consumer 拿到 raw dict 后必经此类。
+    任何 "裸 dict 直构造 Event" 都是 ADR-025 要消灭的反模式。
+
+    不碰 CRUD/DB: feedback_to_event 所需的 Order 由 consumer 从内存注册表
+    (ExecutionNode._pending_orders) 注入, Mapper 只做纯转换。
+    """
+
+    # ------------------------------------------------------------------
+    # decode: raw dict → DTO (β 运行期构造校验)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def decode(raw: dict, dto_cls: Type[T]) -> T:
+        """pydantic model_validate 校验, 失败响亮 raise (不吞不 stub)。
+
+        Args:
+            raw: Kafka ``message.value`` (json.loads 后的 dict)。
+            dto_cls: 目标 DTO 类。
+
+        Returns:
+            校验通过的 DTO 实例。
+
+        Raises:
+            ValueError: 字段缺失 / 类型错 (内含 ValidationError 细节)。
+        """
+        try:
+            return dto_cls.model_validate(raw)
+        except ValidationError as e:
+            raise ValueError(
+                f"MessageMapper.decode({dto_cls.__name__}) validation failed: {e}"
+            ) from e
+
+    # ------------------------------------------------------------------
+    # PriceUpdateDTO → EventPriceUpdate
+    # ------------------------------------------------------------------
+    @staticmethod
+    def price_update_to_event(dto: PriceUpdateDTO) -> EventPriceUpdate:
+        """PriceUpdateDTO → EventPriceUpdate(payload=Bar)。
+
+        生产端 (data_manager) 发 PriceUpdateDTO (symbol / price / OHLC / volume / amount);
+        消费端构造 Bar 当 payload (沿用 PriceUpdateDTO.to_bar_dict 的 OHLC↔price 兜底)。
+
+        frequency: DTO 未携带 → DAY (当日累计 K 线语义, 同 data/mappers/bar_mapper 兜底)。
+        修正旧 drift: 旧代码 ``EventPriceUpdate(code=.., price=.., volume=..)`` 既读错字段
+        (生产端发 symbol 非 code), 又传错签名 (EventPriceUpdate 要 payload=Bar)。
+        """
+        price = dto.price
+        ts = dto.timestamp
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        bar = Bar(
+            code=dto.symbol,
+            open=dto.open_price or price or 0.0,
+            high=dto.high_price or price or 0.0,
+            low=dto.low_price or price or 0.0,
+            close=price or 0.0,
+            volume=dto.volume or 0.0,
+            amount=dto.amount or 0.0,
+            frequency=FREQUENCY_TYPES.DAY,
+            timestamp=ts,
+        )
+        return EventPriceUpdate(payload=bar)
+
+    # ------------------------------------------------------------------
+    # OrderFeedbackDTO + Order → EventOrderPartiallyFilled
+    # ------------------------------------------------------------------
+    @staticmethod
+    def feedback_to_event(
+        dto: OrderFeedbackDTO,
+        order: Order,
+    ) -> EventOrderPartiallyFilled:
+        """OrderFeedbackDTO + 原 Order → EventOrderPartiallyFilled。
+
+        Order 由 consumer 从 _pending_orders 注册表取出注入 (Mapper 不碰 CRUD/DB)。
+        修正旧 drift: filled_volume→filled_quantity, filled_price→fill_price,
+        且签名要 (order, filled_quantity, fill_price) 非 (order_id, code, direction, ...)。
+        """
+        ts = dto.timestamp
+        if isinstance(ts, str):
+            ts = datetime.fromisoformat(ts)
+        return EventOrderPartiallyFilled(
+            order=order,
+            filled_quantity=dto.filled_quantity,
+            fill_price=dto.fill_price,
+            timestamp=ts,
+            portfolio_id=dto.portfolio_id,
+            engine_id=dto.engine_id,
+            task_id=dto.task_id,
+        )
+
+    # ------------------------------------------------------------------
+    # OrderSubmissionDTO → Order (骨架, 供 gateway 重建)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def submission_to_order(dto: OrderSubmissionDTO) -> Order:
+        """OrderSubmissionDTO → 骨架 Order (gateway 重建用)。
+
+        修正旧 drift: DTO 无 limit_price 字段, 旧代码 ``order_data['limit_price']`` 必 KeyError;
+        正解 limit_price 取 dto.price (字符串格式, 需 float 转换)。
+        engine_id / task_id DTO 未携带 → 沿用 gateway 旧默认 (live_engine / live_run)。
+        direction: listener_thread 发 ``event.direction.value`` (int), DTO str 字段强转为 str,
+        此处 ``int(dto.direction)`` 还原回 enum value (与 order_mapper DIRECTION_TYPES(int) 一致)。
+        """
+        return Order(
+            portfolio_id=dto.portfolio_id,
+            engine_id="live_engine",
+            task_id="live_run",
+            code=dto.code,
+            direction=DIRECTION_TYPES(int(dto.direction)),
+            order_type=ORDER_TYPES.LIMITORDER,
+            status=ORDERSTATUS_TYPES.NEW,
+            volume=dto.volume,
+            limit_price=float(dto.price) if dto.price is not None else 0.0,
+        )

--- a/src/ginkgo/interfaces/mappers/message_mapper.py
+++ b/src/ginkgo/interfaces/mappers/message_mapper.py
@@ -119,6 +119,8 @@ class MessageMapper:
         """OrderFeedbackDTO + 原 Order → EventOrderPartiallyFilled。
 
         Order 由 consumer 从 _pending_orders 注册表取出注入 (Mapper 不碰 CRUD/DB)。
+        order_status 透传 (review #6778 altitude): dto.order_status 还原 enum → event.order_status,
+        下游 PortfolioT1Backtest.is_final 据此判 release_frozen (#5492 闭环); None 时不覆盖。
         修正旧 drift: filled_volume→filled_quantity, filled_price→fill_price,
         且签名要 (order, filled_quantity, fill_price) 非 (order_id, code, direction, ...)。
         """
@@ -133,6 +135,7 @@ class MessageMapper:
             portfolio_id=dto.portfolio_id,
             engine_id=dto.engine_id,
             task_id=dto.task_id,
+            order_status=ORDERSTATUS_TYPES(int(dto.order_status)) if dto.order_status else None,
         )
 
     # ------------------------------------------------------------------

--- a/src/ginkgo/interfaces/mappers/message_mapper.py
+++ b/src/ginkgo/interfaces/mappers/message_mapper.py
@@ -142,6 +142,10 @@ class MessageMapper:
     def submission_to_order(dto: OrderSubmissionDTO) -> Order:
         """OrderSubmissionDTO → 骨架 Order (gateway 重建用)。
 
+        uuid 贯穿 (review #6778 问题②): dto.order_id → Order.uuid, 保证 gateway 成交后
+        发回的 OrderFeedbackDTO(order_id=Order.uuid) 与 producer 注册的
+        _pending_orders[原 order_id] 同 key, consumer pop 命中, feedback 链路端到端打通。
+        旧代码不传 uuid → Base.__init__ 自动生成新 uuid → consumer pop 必 None → 100% drop。
         修正旧 drift: DTO 无 limit_price 字段, 旧代码 ``order_data['limit_price']`` 必 KeyError;
         正解 limit_price 取 dto.price (字符串格式, 需 float 转换)。
         engine_id / task_id DTO 未携带 → 沿用 gateway 旧默认 (live_engine / live_run)。
@@ -149,6 +153,7 @@ class MessageMapper:
         字段拒 int、不强转); 此处 ``int(dto.direction)`` 还原回 enum value (LONG=1/SHORT=2)。
         """
         return Order(
+            uuid=dto.order_id,
             portfolio_id=dto.portfolio_id,
             engine_id="live_engine",
             task_id="live_run",

--- a/src/ginkgo/interfaces/mappers/message_mapper.py
+++ b/src/ginkgo/interfaces/mappers/message_mapper.py
@@ -145,8 +145,8 @@ class MessageMapper:
         修正旧 drift: DTO 无 limit_price 字段, 旧代码 ``order_data['limit_price']`` 必 KeyError;
         正解 limit_price 取 dto.price (字符串格式, 需 float 转换)。
         engine_id / task_id DTO 未携带 → 沿用 gateway 旧默认 (live_engine / live_run)。
-        direction: listener_thread 发 ``event.direction.value`` (int), DTO str 字段强转为 str,
-        此处 ``int(dto.direction)`` 还原回 enum value (与 order_mapper DIRECTION_TYPES(int) 一致)。
+        direction: listener_thread 显式 ``str(event.direction.value)`` 发送 (pydantic v2 str
+        字段拒 int、不强转); 此处 ``int(dto.direction)`` 还原回 enum value (LONG=1/SHORT=2)。
         """
         return Order(
             portfolio_id=dto.portfolio_id,

--- a/src/ginkgo/livecore/data_manager.py
+++ b/src/ginkgo/livecore/data_manager.py
@@ -418,28 +418,38 @@ class DataManager(threading.Thread):
         GLOG.INFO("DataManager main loop ended")
 
     def _process_interest_updates(self) -> None:
-        """处理 interest updates 消息"""
-        try:
-            for message in self._consumer_interest.consume(timeout_ms=100):
+        """处理 interest updates 消息 (ADR-025 第②步: 经 MessageMapper.decode β 校验)"""
+        from ginkgo.interfaces.mappers import MessageMapper
+
+        consumer = self._consumer_interest.consumer if self._consumer_interest else None
+        if consumer is None:
+            return
+        # ADR-025 第②步: GinkgoConsumer 无 .consume(); 底层 kafka-python KafkaConsumer
+        # 用 .poll() 非阻塞轮询, 返回 {TopicPartition: [Message]}。message.value 已是 dict。
+        poll_result = consumer.poll(timeout_ms=100, max_records=100)
+        for messages in poll_result.values():
+            for message in messages:
                 try:
-                    dto = InterestUpdateDTO.model_validate_json(message.value)
+                    dto = MessageMapper.decode(message.value, InterestUpdateDTO)
                     self.update_subscriptions(dto)
                 except Exception as e:
                     GLOG.ERROR(f"Failed to process interest update: {e}")
-        except Exception as e:
-            pass  # 超时是正常的
 
     def _process_control_commands(self) -> None:
-        """处理 control commands 消息"""
-        try:
-            for message in self._consumer_control.consume(timeout_ms=100):
+        """处理 control commands 消息 (ADR-025 第②步: 经 MessageMapper.decode β 校验)"""
+        from ginkgo.interfaces.mappers import MessageMapper
+
+        consumer = self._consumer_control.consumer if self._consumer_control else None
+        if consumer is None:
+            return
+        poll_result = consumer.poll(timeout_ms=100, max_records=100)
+        for messages in poll_result.values():
+            for message in messages:
                 try:
-                    dto = ControlCommandDTO.model_validate_json(message.value)
+                    dto = MessageMapper.decode(message.value, ControlCommandDTO)
                     self._handle_control_command(dto)
                 except Exception as e:
                     GLOG.ERROR(f"Failed to process control command: {e}")
-        except Exception as e:
-            pass  # 超时是正常的
 
     def update_subscriptions(self, dto: InterestUpdateDTO) -> None:
         """

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -296,7 +296,9 @@ class TradeGatewayAdapter(Thread):
                     continue
 
                 if time_elapsed >= 1.0 and order.status == ORDERSTATUS_TYPES.SUBMITTED:
-                    # 生成成交事件
+                    # 模拟成交 = 全量成交终态; 显式 order_status=FILLED 让 DTO 自描述终态
+                    # (review #6778 altitude), 避免 fallback order.status=SUBMITTED 致
+                    # consumer 永不 pop / 下游 is_final 漏判 release_frozen (#5492)。
                     fill_event = EventOrderPartiallyFilled(
                         order=order,
                         filled_quantity=float(order.volume),  # 全部成交
@@ -305,7 +307,8 @@ class TradeGatewayAdapter(Thread):
                         commission=Decimal('5.25'),  # 模拟手续费
                         portfolio_id=order.portfolio_id,
                         engine_id=order.engine_id,
-                        task_id=order.task_id
+                        task_id=order.task_id,
+                        order_status=ORDERSTATUS_TYPES.FILLED,
                     )
 
                     # 发布到Kafka
@@ -348,7 +351,8 @@ class TradeGatewayAdapter(Thread):
                 direction=str(fill_event.order.direction.value),
                 filled_quantity=fill_event.filled_quantity,
                 fill_price=fill_event.fill_price,
-                timestamp=fill_event.timestamp.isoformat()
+                timestamp=fill_event.timestamp.isoformat(),
+                order_status=str(fill_event.order_status.value) if fill_event.order_status else None,
             )
 
             # 发布到Kafka

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -186,18 +186,15 @@ class TradeGatewayAdapter(Thread):
         self.total_orders += 1
 
         try:
-            # 构造Order对象
-            order = Order(
-                portfolio_id=order_data['portfolio_id'],
-                engine_id=order_data.get('engine_id', 'live_engine'),
-                task_id=order_data.get('task_id', 'live_run'),
-                code=order_data['code'],
-                direction=DIRECTION_TYPES(order_data['direction']),
-                order_type=ORDER_TYPES.LIMITORDER,
-                status=ORDERSTATUS_TYPES.NEW,
-                volume=order_data['volume'],
-                limit_price=order_data['limit_price']
-            )
+            # ADR-025 第②步: raw dict → OrderSubmissionDTO (model_validate β 校验)
+            # → MessageMapper.submission_to_order 构造骨架 Order。
+            # 修正旧 drift: DTO 无 limit_price 字段, 旧代码 order_data['limit_price'] 必 KeyError;
+            # 正解 limit_price 取 dto.price (见 MessageMapper.submission_to_order)。
+            from ginkgo.interfaces.dtos import OrderSubmissionDTO
+            from ginkgo.interfaces.mappers import MessageMapper
+
+            dto = MessageMapper.decode(order_data, OrderSubmissionDTO)
+            order = MessageMapper.submission_to_order(dto)
 
             # 提交到TradeGateway（同步，确认提交）
             # TODO: Phase 3调用TradeGateway.submit_order()

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -345,7 +345,7 @@ class TradeGatewayAdapter(Thread):
                 engine_id=fill_event.engine_id,
                 task_id=fill_event.task_id,
                 code=fill_event.order.code,
-                direction=fill_event.order.direction.value,
+                direction=str(fill_event.order.direction.value),
                 filled_quantity=fill_event.filled_quantity,
                 fill_price=fill_event.fill_price,
                 timestamp=fill_event.timestamp.isoformat()

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -89,6 +89,12 @@ class ExecutionNode:
         # Kafka生产者（订单提交）
         self.order_producer = GinkgoProducer()
 
+        # ADR-025 第②步: 已提交待 feedback 的 Order 注册表 (uuid → Order)。
+        # 提交订单后注册, feedback 回来按 order_id 取原 Order 注入
+        # MessageMapper.feedback_to_event; pop None = 非本节点提交 → GLOG.ERROR 响亮丢弃。
+        # (Mapper 不碰 CRUD/DB, consumer 内存态是唯一 Order 来源。)
+        self._pending_orders = {}
+
         # 运行状态（同时存储到Redis）
         self.is_running = False
         self.is_paused = False
@@ -822,12 +828,13 @@ class ExecutionNode:
         消费市场数据线程（单线程快速消费和路由）
 
         线程职责：
-        1. 从Kafka快速消费EventPriceUpdate消息
+        1. 从Kafka快速消费 PriceUpdateDTO → EventPriceUpdate (ADR-025 第②步经 MessageMapper)
         2. 查询InterestMap获取订阅该股票的Portfolio列表
         3. 非阻塞分发消息到各PortfolioProcessor的Queue
         4. 消息成功放入队列后立即提交 offset
         """
-        from ginkgo.trading.events.price_update import EventPriceUpdate
+        from ginkgo.interfaces.dtos import PriceUpdateDTO
+        from ginkgo.interfaces.mappers import MessageMapper
 
         GLOG.INFO(f"Market data consumer thread started for node {self.node_id}")
 
@@ -851,23 +858,22 @@ class ExecutionNode:
                     if self.is_paused:
                         break
 
-                    event_data = message.value
+                    raw = message.value
 
                     # T069/T070: 恢复分布式追踪上下文（从 PriceUpdateDTO 的 trace_id/span_id）
-                    trace_id = event_data.get('trace_id')
-                    span_id = event_data.get('span_id')
+                    trace_id = raw.get('trace_id')
+                    span_id = raw.get('span_id')
                     if trace_id:
                         GLOG.set_trace_id(trace_id)
                     if span_id:
                         GLOG.set_span_id(span_id)
 
-                    # 解析EventPriceUpdate
-                    event = EventPriceUpdate(
-                        code=event_data['code'],
-                        timestamp=datetime.fromisoformat(event_data['timestamp']),
-                        price=event_data['price'],
-                        volume=event_data.get('volume', 0)
-                    )
+                    # ADR-025 第②步: raw dict → PriceUpdateDTO (model_validate β 校验)
+                    # → EventPriceUpdate(payload=Bar)。
+                    # 消灭旧死路径: EventPriceUpdate(code=.., price=..) 既读错字段
+                    # (生产端发 symbol 非 code) 又传错签名 (要 payload=Bar)。
+                    dto = MessageMapper.decode(raw, PriceUpdateDTO)
+                    event = MessageMapper.price_update_to_event(dto)
 
                     # 路由到对应的Portfolio
                     self._route_event_to_portfolios(event)
@@ -878,13 +884,22 @@ class ExecutionNode:
 
             except Exception as e:
                 if self.is_running:
+                    # ADR-025 §3 严格模式: 失败响亮报错 (不再 sleep 静默吞)
+                    GLOG.ERROR(
+                        f"Market data consume error for node {self.node_id}: {e}"
+                    )
                     time.sleep(1)  # 消费异常时延迟
 
         GLOG.INFO(f"Market data consumer thread stopped for node {self.node_id}")
 
     def _consume_order_feedback(self):
-        """消费订单回报线程 - 消息成功放入队列后立即提交 offset"""
-        from ginkgo.trading.events.order_lifecycle_events import EventOrderPartiallyFilled
+        """消费订单回报线程 - 消息成功放入队列后立即提交 offset
+
+        ADR-025 第②步: raw dict → OrderFeedbackDTO (model_validate β 校验)
+        → 取回本节点提交的原 Order → MessageMapper.feedback_to_event → EventOrderPartiallyFilled。
+        """
+        from ginkgo.interfaces.dtos import OrderFeedbackDTO
+        from ginkgo.interfaces.mappers import MessageMapper
 
         GLOG.INFO(f"Order feedback consumer thread started for node {self.node_id}")
 
@@ -908,22 +923,34 @@ class ExecutionNode:
                     if self.is_paused:
                         break
 
-                    event_data = message.value
+                    raw = message.value
 
-                    # 解析EventOrderPartiallyFilled
-                    event = EventOrderPartiallyFilled(
-                        order_id=event_data['order_id'],
-                        code=event_data['code'],
-                        timestamp=datetime.fromisoformat(event_data['timestamp']),
-                        direction=event_data['direction'],
-                        filled_volume=event_data['filled_volume'],
-                        filled_price=event_data['filled_price']
-                    )
+                    # ADR-025 第②步: raw dict → OrderFeedbackDTO (model_validate 校验)
+                    dto = MessageMapper.decode(raw, OrderFeedbackDTO)
+
+                    # 取回本节点提交的原 Order (consumer 内存注册表, Mapper 不碰 CRUD/DB)。
+                    # pop None = 非本节点提交 / 进程重启后丢失 → 响亮丢弃, 不伪造骨架 Order。
+                    order = self._pending_orders.pop(dto.order_id, None)
+                    if order is None:
+                        GLOG.ERROR(
+                            f"Order feedback for {dto.order_id} has no matching "
+                            f"pending order on node {self.node_id}; dropping "
+                            f"(code={dto.code}, filled={dto.filled_quantity}@{dto.fill_price})"
+                        )
+                        self.order_feedback_consumer.commit()
+                        continue
+
+                    event = MessageMapper.feedback_to_event(dto, order)
 
                     # 路由到对应的Portfolio
-                    portfolio_id = event_data.get('portfolio_id')
+                    portfolio_id = dto.portfolio_id
                     if portfolio_id and portfolio_id in self.portfolios:
                         self.input_queues[portfolio_id].put(event)
+                    else:
+                        GLOG.WARN(
+                            f"Order feedback portfolio {portfolio_id} not in node "
+                            f"{self.node_id} portfolios; event {dto.order_id} dropped"
+                        )
 
                     # 消息成功放入队列后立即提交 offset
                     # 此时消息已经在 ExecutionNode 的内存中，不会丢失（除非进程崩溃）
@@ -931,6 +958,10 @@ class ExecutionNode:
 
             except Exception as e:
                 if self.is_running:
+                    # ADR-025 §3 严格模式: 失败响亮报错 (不再 sleep 静默吞)
+                    GLOG.ERROR(
+                        f"Order feedback consume error for node {self.node_id}: {e}"
+                    )
                     time.sleep(1)  # 消费异常时延迟
 
         GLOG.INFO(f"Order feedback consumer thread stopped for node {self.node_id}")
@@ -1071,6 +1102,9 @@ class ExecutionNode:
                         # 发送到Kafka
                         success = self.order_producer.send(KafkaTopics.ORDERS_SUBMISSION, order_dto.model_dump())
                         if success:
+                            # ADR-025 第②步: 注册待 feedback 的原 Order,
+                            # feedback 回来按 order_id 取回注入 MessageMapper.feedback_to_event。
+                            self._pending_orders[str(event.uuid)] = event
                             GLOG.INFO(f"Order {event.uuid} sent to Kafka via output_queue")
                         else:
                             GLOG.ERROR(f"[ERROR] Failed to send order {event.uuid} to Kafka")

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -89,17 +89,11 @@ class ExecutionNode:
         # Kafka生产者（订单提交）
         self.order_producer = GinkgoProducer()
 
-        # ADR-025 第②步: 已提交待 feedback 的 Order 注册表 (uuid → Order)。
-        # 提交订单后注册, feedback 回来按 order_id 取原 Order 注入
-        # MessageMapper.feedback_to_event; pop None = 非本节点提交 → GLOG.ERROR 响亮丢弃。
-        # (Mapper 不碰 CRUD/DB, consumer 内存态是唯一 Order 来源。)
+        # ADR-025 第②步 + review #6778 问题③: 已提交待 feedback 的注册表
+        # (uuid → [Order, cumulative_filled])。partial fill 多笔共享 order_id,
+        # 累积达 order.volume 才 pop, 中间笔保留。cumulative 与 Order 同 dict 避免
+        # 双注册表孤儿; 不改 Order.transaction_volume (event 持引用会污染下游 remaining)。
         self._pending_orders = {}
-        # review #6778 问题③: 累积已成交量 (uuid → cumulative filled)。
-        # 真实 broker 常分多笔回报 (1000 手拆 500+300+200), _pending_orders.pop
-        # 在第一笔就移除 → 后续 partial 必 None → drop。改用累积判终态,
-        # 仅累积 >= volume 才 pop。独立字典, 不改原 Order (避免污染已路由 event
-        # 的 remaining, 也避免越界调 Order.settle 资金语义)。
-        self._pending_filled = {}
 
         # 运行状态（同时存储到Redis）
         self.is_running = False
@@ -899,38 +893,27 @@ class ExecutionNode:
         GLOG.INFO(f"Market data consumer thread stopped for node {self.node_id}")
 
     def _reconcile_feedback(self, dto):
-        """单笔成交回报 → event + 条件 pop 注册表 (review #6778 问题③)。
+        """单笔回报 → event;累积达 order.volume 才 pop 注册表 (review #6778 问题③)。
 
-        真实 broker 常分多笔回报 (如 1000 手拆 500+300+200)。旧代码
-        ``_pending_orders.pop(dto.order_id)`` 在第一笔就移除 entry → 第二笔
-        pop 返回 None → GLOG.ERROR 丢弃 → 持仓错账, 正确性被钉死在"gateway 必须
-        一发完"。
+        partial fill 多笔共享 order_id (真实 broker 常拆 500+300+200), 中间笔
+        保留 entry 供后续回报取回。不调 Order.settle —— event 持同一 order 引用,
+        改其 transaction_volume 会污染已路由 event 的 remaining (实时 property),
+        且 settle 是资金语义属下游 portfolio 职责。
 
-        正解: 累积本次 filled 量, 仅当累积达 order.volume (最终 filled) 才 pop;
-        中间笔保留 entry 供后续回报取回。用独立 ``_pending_filled`` 字典累积,
-        **不改原 Order.transaction_volume** —— 避免污染已路由 event 的 remaining
-        (event 持 order 引用, settle/赋值会让下游读到的 remaining 失真), 也避免
-        越界调 ``Order.settle`` (资金语义属下游 portfolio 职责, consumer 不碰)。
-
-        Args:
-            dto: OrderFeedbackDTO (已经 MessageMapper.decode 校验)。
-
-        Returns:
-            EventOrderPartiallyFilled, 或 None (非本节点提交 / 进程重启后丢失
-            → consumer 层响亮 drop, 不伪造骨架 Order)。
+        Returns: EventOrderPartiallyFilled, 或 None (非本节点提交 → consumer 响亮 drop)。
         """
         from ginkgo.interfaces.mappers import MessageMapper
 
-        order = self._pending_orders.get(dto.order_id)
-        if order is None:
+        entry = self._pending_orders.get(dto.order_id)
+        if entry is None:
             return None
+        order, cumulative = entry
         event = MessageMapper.feedback_to_event(dto, order)
-        cumulative = self._pending_filled.get(dto.order_id, 0.0) + dto.filled_quantity
-        if cumulative >= float(order.volume):
+        cumulative += dto.filled_quantity
+        if cumulative >= order.volume:
             self._pending_orders.pop(dto.order_id, None)
-            self._pending_filled.pop(dto.order_id, None)
         else:
-            self._pending_filled[dto.order_id] = cumulative
+            entry[1] = cumulative
         return event
 
     def _consume_order_feedback(self):
@@ -969,10 +952,7 @@ class ExecutionNode:
                     # ADR-025 第②步: raw dict → OrderFeedbackDTO (model_validate 校验)
                     dto = MessageMapper.decode(raw, OrderFeedbackDTO)
 
-                    # 取回本节点提交的原 Order + 累积判终态 (review #6778 问题③)。
-                    # _reconcile_feedback 返回 event 或 None (非本节点提交 / 进程重启后
-                    # 丢失 → None)。partial fill 多笔共享 order_id: 仅最终 filled 才 pop,
-                    # 中间笔保留 entry, 避免后续 partial 取 None → drop → 持仓错账。
+                    # 取回原 Order + 累积判终态 (review #6778 问题③); None = 非本节点提交。
                     event = self._reconcile_feedback(dto)
                     if event is None:
                         GLOG.ERROR(
@@ -1143,11 +1123,10 @@ class ExecutionNode:
                         # 发送到Kafka
                         success = self.order_producer.send(KafkaTopics.ORDERS_SUBMISSION, order_dto.model_dump())
                         if success:
-                            # ADR-025 第②步: 注册待 feedback 的原 Order,
-                            # feedback 回来按 order_id 取回注入 MessageMapper.feedback_to_event。
-                            # review #6778 问题③: 同步初始化累积计数器 (partial fill 多笔)。
-                            self._pending_orders[str(event.uuid)] = event
-                            self._pending_filled[str(event.uuid)] = 0.0
+                            # ADR-025 第②步 + review #6778 问题③: 注册待 feedback 的
+                            # 原 Order [order, cumulative_filled=0]; feedback 回来按 order_id
+                            # 取回, partial fill 多笔累积达 volume 才 pop。
+                            self._pending_orders[str(event.uuid)] = [event, 0.0]
                             GLOG.INFO(f"Order {event.uuid} sent to Kafka via output_queue")
                         else:
                             GLOG.ERROR(f"[ERROR] Failed to send order {event.uuid} to Kafka")

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -893,12 +893,12 @@ class ExecutionNode:
         GLOG.INFO(f"Market data consumer thread stopped for node {self.node_id}")
 
     def _reconcile_feedback(self, dto):
-        """单笔回报 → event;累积达 order.volume 才 pop 注册表 (review #6778 问题③)。
+        """单笔回报 → event;终态才 pop 注册表 (review #6778 问题③ + altitude)。
 
-        partial fill 多笔共享 order_id (真实 broker 常拆 500+300+200), 中间笔
-        保留 entry 供后续回报取回。不调 Order.settle —— event 持同一 order 引用,
-        改其 transaction_volume 会污染已路由 event 的 remaining (实时 property),
-        且 settle 是资金语义属下游 portfolio 职责。
+        终态判定见 _is_final_fill: dto.order_status==FILLED 优先 (broker 自描述),
+        缺省/解析失败回退累积量 >= order.volume。partial fill 多笔共享 order_id,
+        中间笔保留 entry。不调 Order.settle —— event 持同一 order 引用, 改其
+        transaction_volume 会污染已路由 event 的 remaining (实时 property)。
 
         Returns: EventOrderPartiallyFilled, 或 None (非本节点提交 → consumer 响亮 drop)。
         """
@@ -910,11 +910,26 @@ class ExecutionNode:
         order, cumulative = entry
         event = MessageMapper.feedback_to_event(dto, order)
         cumulative += dto.filled_quantity
-        if cumulative >= order.volume:
+        if self._is_final_fill(dto, cumulative, order.volume):
             self._pending_orders.pop(dto.order_id, None)
         else:
             entry[1] = cumulative
         return event
+
+    @staticmethod
+    def _is_final_fill(dto, cumulative, volume):
+        """终态判定: dto.order_status==FILLED 优先 (broker 权威), 缺省/解析失败回退累积量。
+
+        status 优先消除"靠累积量猜终态"的脆弱性 (broker 漏报尾笔时累积永不到 volume →
+        entry 永不 pop → 内存泄漏); 回退累积量兼容旧 DTO / 模拟路径未填 status。
+        """
+        if dto.order_status:
+            try:
+                from ginkgo.enums import ORDERSTATUS_TYPES
+                return ORDERSTATUS_TYPES(int(dto.order_status)) == ORDERSTATUS_TYPES.FILLED
+            except (ValueError, TypeError):
+                pass  # status 不可解析 → 累积兜底
+        return cumulative >= volume
 
     def _consume_order_feedback(self):
         """消费订单回报线程 - 消息成功放入队列后立即提交 offset

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -1131,7 +1131,7 @@ class ExecutionNode:
                             code=event.code,
                             direction=str(event.direction.value),
                             volume=event.volume,
-                            price=str(event.price) if event.price else None,
+                            price=str(event.limit_price) if event.limit_price else None,
                             timestamp=event.timestamp.isoformat() if event.timestamp else None
                         )
 

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -1093,7 +1093,7 @@ class ExecutionNode:
                             order_id=str(event.uuid),
                             portfolio_id=event.portfolio_id,
                             code=event.code,
-                            direction=event.direction.value,
+                            direction=str(event.direction.value),
                             volume=event.volume,
                             price=str(event.price) if event.price else None,
                             timestamp=event.timestamp.isoformat() if event.timestamp else None

--- a/src/ginkgo/workers/execution_node/node.py
+++ b/src/ginkgo/workers/execution_node/node.py
@@ -94,6 +94,12 @@ class ExecutionNode:
         # MessageMapper.feedback_to_event; pop None = 非本节点提交 → GLOG.ERROR 响亮丢弃。
         # (Mapper 不碰 CRUD/DB, consumer 内存态是唯一 Order 来源。)
         self._pending_orders = {}
+        # review #6778 问题③: 累积已成交量 (uuid → cumulative filled)。
+        # 真实 broker 常分多笔回报 (1000 手拆 500+300+200), _pending_orders.pop
+        # 在第一笔就移除 → 后续 partial 必 None → drop。改用累积判终态,
+        # 仅累积 >= volume 才 pop。独立字典, 不改原 Order (避免污染已路由 event
+        # 的 remaining, 也避免越界调 Order.settle 资金语义)。
+        self._pending_filled = {}
 
         # 运行状态（同时存储到Redis）
         self.is_running = False
@@ -892,6 +898,41 @@ class ExecutionNode:
 
         GLOG.INFO(f"Market data consumer thread stopped for node {self.node_id}")
 
+    def _reconcile_feedback(self, dto):
+        """单笔成交回报 → event + 条件 pop 注册表 (review #6778 问题③)。
+
+        真实 broker 常分多笔回报 (如 1000 手拆 500+300+200)。旧代码
+        ``_pending_orders.pop(dto.order_id)`` 在第一笔就移除 entry → 第二笔
+        pop 返回 None → GLOG.ERROR 丢弃 → 持仓错账, 正确性被钉死在"gateway 必须
+        一发完"。
+
+        正解: 累积本次 filled 量, 仅当累积达 order.volume (最终 filled) 才 pop;
+        中间笔保留 entry 供后续回报取回。用独立 ``_pending_filled`` 字典累积,
+        **不改原 Order.transaction_volume** —— 避免污染已路由 event 的 remaining
+        (event 持 order 引用, settle/赋值会让下游读到的 remaining 失真), 也避免
+        越界调 ``Order.settle`` (资金语义属下游 portfolio 职责, consumer 不碰)。
+
+        Args:
+            dto: OrderFeedbackDTO (已经 MessageMapper.decode 校验)。
+
+        Returns:
+            EventOrderPartiallyFilled, 或 None (非本节点提交 / 进程重启后丢失
+            → consumer 层响亮 drop, 不伪造骨架 Order)。
+        """
+        from ginkgo.interfaces.mappers import MessageMapper
+
+        order = self._pending_orders.get(dto.order_id)
+        if order is None:
+            return None
+        event = MessageMapper.feedback_to_event(dto, order)
+        cumulative = self._pending_filled.get(dto.order_id, 0.0) + dto.filled_quantity
+        if cumulative >= float(order.volume):
+            self._pending_orders.pop(dto.order_id, None)
+            self._pending_filled.pop(dto.order_id, None)
+        else:
+            self._pending_filled[dto.order_id] = cumulative
+        return event
+
     def _consume_order_feedback(self):
         """消费订单回报线程 - 消息成功放入队列后立即提交 offset
 
@@ -928,10 +969,12 @@ class ExecutionNode:
                     # ADR-025 第②步: raw dict → OrderFeedbackDTO (model_validate 校验)
                     dto = MessageMapper.decode(raw, OrderFeedbackDTO)
 
-                    # 取回本节点提交的原 Order (consumer 内存注册表, Mapper 不碰 CRUD/DB)。
-                    # pop None = 非本节点提交 / 进程重启后丢失 → 响亮丢弃, 不伪造骨架 Order。
-                    order = self._pending_orders.pop(dto.order_id, None)
-                    if order is None:
+                    # 取回本节点提交的原 Order + 累积判终态 (review #6778 问题③)。
+                    # _reconcile_feedback 返回 event 或 None (非本节点提交 / 进程重启后
+                    # 丢失 → None)。partial fill 多笔共享 order_id: 仅最终 filled 才 pop,
+                    # 中间笔保留 entry, 避免后续 partial 取 None → drop → 持仓错账。
+                    event = self._reconcile_feedback(dto)
+                    if event is None:
                         GLOG.ERROR(
                             f"Order feedback for {dto.order_id} has no matching "
                             f"pending order on node {self.node_id}; dropping "
@@ -939,8 +982,6 @@ class ExecutionNode:
                         )
                         self.order_feedback_consumer.commit()
                         continue
-
-                    event = MessageMapper.feedback_to_event(dto, order)
 
                     # 路由到对应的Portfolio
                     portfolio_id = dto.portfolio_id
@@ -1104,7 +1145,9 @@ class ExecutionNode:
                         if success:
                             # ADR-025 第②步: 注册待 feedback 的原 Order,
                             # feedback 回来按 order_id 取回注入 MessageMapper.feedback_to_event。
+                            # review #6778 问题③: 同步初始化累积计数器 (partial fill 多笔)。
                             self._pending_orders[str(event.uuid)] = event
+                            self._pending_filled[str(event.uuid)] = 0.0
                             GLOG.INFO(f"Order {event.uuid} sent to Kafka via output_queue")
                         else:
                             GLOG.ERROR(f"[ERROR] Failed to send order {event.uuid} to Kafka")

--- a/src/ginkgo/workers/execution_node/portfolio_processor.py
+++ b/src/ginkgo/workers/execution_node/portfolio_processor.py
@@ -120,14 +120,14 @@ class PortfolioProcessor(Thread):
             GLOG.WARN(f"PortfolioProcessor {self.portfolio_id} is already running")
             return
 
-        # 初始化Kafka控制命令消费者
+        # 初始化Kafka控制命令消费者 (ADR-025 第②步: GinkgoConsumer(topic=..) 构造即订阅,
+        # 签名是 (topic, group_id, offset), 无 bootstrap_servers 参数; 也无 .subscribe() 方法。
+        # 旧代码两处皆死路径。)
         try:
-            bootstrap_servers = f"{GCONF.KAFKAHOST}:{GCONF.KAFKAPORT}"
             self._control_consumer = GinkgoConsumer(
-                bootstrap_servers=bootstrap_servers,
+                topic=KafkaTopics.CONTROL_COMMANDS,
                 group_id=f"portfolio_processor_{self.portfolio_id}"
             )
-            self._control_consumer.subscribe([KafkaTopics.CONTROL_COMMANDS])
             GLOG.INFO(f"PortfolioProcessor {self.portfolio_id}: subscribed to {KafkaTopics.CONTROL_COMMANDS}")
         except Exception as e:
             GLOG.ERROR(f"PortfolioProcessor {self.portfolio_id}: failed to subscribe to control commands: {e}")
@@ -454,17 +454,18 @@ class PortfolioProcessor(Thread):
         从Kafka的ginkgo.live.control.commands topic消费控制命令，
         解析后路由到对应的处理方法。
         """
-        if not self._control_consumer:
+        consumer = self._control_consumer.consumer if self._control_consumer else None
+        if consumer is None:
             return
 
         try:
-            # 非阻塞poll，超时10ms
-            messages = self._control_consumer.poll(timeout_ms=10)
+            # ADR-025 第②步: GinkgoConsumer 无 .poll(); 底层 KafkaConsumer.poll 非阻塞轮询,
+            # 返回 {TopicPartition: [Message]}, message.value 已是 dict (json.loads 后)。
+            messages = consumer.poll(timeout_ms=10, max_records=100)
 
             for topic_partition, records in messages.items():
                 for record in records:
                     try:
-                        # 解析Kafka消息
                         self._handle_control_command(record.value)
                     except Exception as e:
                         GLOG.ERROR(f"PortfolioProcessor {self.portfolio_id}: failed to handle control command: {e}")
@@ -473,30 +474,28 @@ class PortfolioProcessor(Thread):
             # Kafka消费异常不中断主循环
             GLOG.ERROR(f"PortfolioProcessor {self.portfolio_id}: Kafka poll error: {e}")
 
-    def _handle_control_command(self, message: bytes) -> None:
+    def _handle_control_command(self, message: dict) -> None:
         """
-        处理控制命令
+        处理控制命令 (ADR-025 第②步: 经 MessageMapper.decode β 校验)
 
         T070: 恢复 trace_id 和 span_id 到 GLOG 上下文，用于分布式追踪
 
         解析Kafka消息中的ControlCommandDTO，根据命令类型路由到对应处理方法。
 
         Args:
-            message: Kafka消息（JSON字节序列）
+            message: Kafka message.value (json.loads 后的 dict)
 
         支持的命令类型：
             - update_selector: 触发selector.pick()，发布EventInterestUpdate
             - bar_snapshot: 由DataManager处理，PortfolioProcessor忽略
             - update_data: 由DataManager处理，PortfolioProcessor忽略
         """
-        try:
-            # 解析JSON
-            import json
-            message_str = message.decode('utf-8') if isinstance(message, bytes) else message
-            command_data = json.loads(message_str)
+        from ginkgo.interfaces.mappers import MessageMapper
 
-            # 使用ControlCommandDTO解析
-            command_dto = ControlCommandDTO(**command_data)
+        try:
+            # ADR-025 第②步: message 已是 dict (value_deserializer=json.loads),
+            # 经 MessageMapper.decode β 校验。消灭旧 drift: json.loads(dict) 必 TypeError。
+            command_dto = MessageMapper.decode(message, ControlCommandDTO)
 
             # T070: 恢复分布式追踪上下文到 GLOG
             if command_dto.trace_id:
@@ -520,8 +519,9 @@ class PortfolioProcessor(Thread):
             else:
                 GLOG.WARN(f"PortfolioProcessor {self.portfolio_id}: unknown command type: {command_dto.command}")
 
-        except json.JSONDecodeError as e:
-            GLOG.ERROR(f"PortfolioProcessor {self.portfolio_id}: invalid JSON in control command: {e}")
+        except ValueError as e:
+            # MessageMapper.decode β 校验失败 (字段缺失 / 类型错)
+            GLOG.ERROR(f"PortfolioProcessor {self.portfolio_id}: invalid control command payload: {e}")
         except Exception as e:
             GLOG.ERROR(f"PortfolioProcessor {self.portfolio_id}: failed to parse control command: {e}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,10 @@ except ImportError:
 # 实测 pytest_load_initial_conftests 钩子在 conftest 里注册太晚不被调用，故在 collection_modifyitems
 # （100% 触发）用 os.execvp 重启为 xdist：execvp 清空进程映像（内存归零），新进程 xdist master
 # collect 一次 + worker 进程隔离，总 RSS ~5.75GB（对比单进程 80GB）。
-SINGLE_PROCESS_TEST_THRESHOLD = 200  # 单进程允许的最多测试节点数；单文件 max ~88，余量充足
+# 单进程允许的最多测试节点数。两类合法单进程场景：(a) 单文件调试(max ~88)；
+# (b) CI smoke gate 多文件 mock/import 子集(~202 节点，轻量无 Base.metadata 累积，低 OOM 风险)。
+# 300 给 smoke 子集留余量；全量 tests/ 数千节点仍远超阈值 → 触发 xdist 隔离。
+SINGLE_PROCESS_TEST_THRESHOLD = 300
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/unit/interfaces/test_message_mapper.py
+++ b/tests/unit/interfaces/test_message_mapper.py
@@ -12,6 +12,7 @@
 """
 
 import pytest
+from pydantic import ValidationError
 
 from ginkgo.interfaces.mappers import MessageMapper
 from ginkgo.interfaces.dtos import PriceUpdateDTO, OrderFeedbackDTO, OrderSubmissionDTO
@@ -83,11 +84,28 @@ class TestSubmissionToOrder:
         assert order.volume == 100
 
     def test_direction_int_value_restored(self):
-        # listener_thread 发 event.direction.value (int); DTO str 强转; int() 还原
+        # listener_thread 显式 str(event.direction.value) 发送; int() 还原 enum value
         dto = OrderSubmissionDTO(order_id="a", portfolio_id="p", code="X",
                                  direction="2", volume=1, price="1")  # SHORT=2
         order = MessageMapper.submission_to_order(dto)
         assert order.direction == DIRECTION_TYPES.SHORT
+
+    def test_listener_thread_direction_must_coerce_str(self):
+        # 回归 (review #6778 问题①): listener_thread 发 event.direction.value (int),
+        # OrderSubmissionDTO.direction 是 str 字段, pydantic v2 拒 int → ValidationError,
+        # 构造在 send / _pending_orders 注册前崩, 使订单链路修复全空转。
+        # 生产端必须显式 str(); 此测试锁定 str() 不可被去掉。
+        # 正向: str(value) 构造 + 还原 OK
+        dto = OrderSubmissionDTO(order_id="a", portfolio_id="p", code="X",
+                                 direction=str(DIRECTION_TYPES.LONG.value),  # "1"
+                                 volume=1, price="1")
+        assert dto.direction == "1"
+        assert MessageMapper.submission_to_order(dto).direction == DIRECTION_TYPES.LONG
+        # 反向: 裸 int 必被拒 (防 str() 回退)
+        with pytest.raises(ValidationError):
+            OrderSubmissionDTO(order_id="a", portfolio_id="p", code="X",
+                               direction=DIRECTION_TYPES.LONG.value,  # int 1
+                               volume=1, price="1")
 
     def test_price_none_defaults_zero(self):
         dto = OrderSubmissionDTO(order_id="a", portfolio_id="p", code="X",

--- a/tests/unit/interfaces/test_message_mapper.py
+++ b/tests/unit/interfaces/test_message_mapper.py
@@ -113,6 +113,17 @@ class TestSubmissionToOrder:
         order = MessageMapper.submission_to_order(dto)
         assert order.limit_price == 0.0
 
+    def test_order_id_preserved_as_uuid(self):
+        # review #6778 问题②: submission_to_order 未把 dto.order_id 贯穿到 Order.uuid。
+        # 全链路: producer 发 OrderSubmissionDTO(order_id=原uuid) + _pending_orders[原uuid]=event;
+        # gateway 成交后发 OrderFeedbackDTO(order_id=Order.uuid); consumer pop(dto.order_id) 取回。
+        # 若 Order.uuid ≠ 原 order_id, consumer pop 必 None → feedback 端到端 100% drop。
+        # 修法: Order(uuid=dto.order_id) 单点贯穿。
+        dto = OrderSubmissionDTO(order_id="order-abc-123", portfolio_id="p1", code="X",
+                                 direction="1", volume=100, price="10.5")
+        order = MessageMapper.submission_to_order(dto)
+        assert order.uuid == "order-abc-123"
+
 
 class TestFeedbackToEvent:
     def test_event_from_dto_and_order(self):

--- a/tests/unit/interfaces/test_message_mapper.py
+++ b/tests/unit/interfaces/test_message_mapper.py
@@ -1,0 +1,112 @@
+# Upstream: ADR-025 第②步 MessageMapper (interfaces/mappers/message_mapper.py)
+# Role: 验证 Kafka 入站 DTO↔Event/Entity 转换 + β 运行期构造校验 (model_validate)
+
+"""ADR-025 第②步 MessageMapper 单元测试。
+
+覆盖:
+- decode: β 校验 (合法 dict → DTO; 缺字段 / 类型错 → ValueError 响亮 raise)
+- price_update_to_event: PriceUpdateDTO → EventPriceUpdate(payload=Bar), OHLC↔price 兜底
+- feedback_to_event: OrderFeedbackDTO + Order → EventOrderPartiallyFilled
+- submission_to_order: OrderSubmissionDTO → Order (limit_price←price drift 修正,
+  direction int value 还原)
+"""
+
+import pytest
+
+from ginkgo.interfaces.mappers import MessageMapper
+from ginkgo.interfaces.dtos import PriceUpdateDTO, OrderFeedbackDTO, OrderSubmissionDTO
+from ginkgo.entities import Order
+from ginkgo.enums import (
+    DIRECTION_TYPES,
+    PRICEINFO_TYPES,
+    FREQUENCY_TYPES,
+)
+
+
+class TestDecode:
+    def test_decode_valid_price_update(self):
+        raw = {"symbol": "600000.SH", "price": 10.5, "volume": 1000,
+               "amount": 10500, "timestamp": "2026-07-25T10:00:00"}
+        dto = MessageMapper.decode(raw, PriceUpdateDTO)
+        assert dto.symbol == "600000.SH"
+        assert dto.price == 10.5
+
+    def test_decode_missing_required_raises_valueerror(self):
+        # β 校验: symbol required, 缺必响亮 raise (ADR-025 §3 禁吞禁 stub)
+        with pytest.raises(ValueError):
+            MessageMapper.decode({"price": 10}, PriceUpdateDTO)
+
+    def test_decode_wrong_type_raises_valueerror(self):
+        # volume 应 float; "abc" 不可解析 → ValidationError → ValueError
+        with pytest.raises(ValueError):
+            MessageMapper.decode({"symbol": "X", "volume": "abc"}, PriceUpdateDTO)
+
+
+class TestPriceUpdateToEvent:
+    def test_bar_payload_ohlc_fallback_to_price(self):
+        dto = PriceUpdateDTO(symbol="600000.SH", price=10.5, volume=1000, amount=10500)
+        ev = MessageMapper.price_update_to_event(dto)
+        assert ev.price_type == PRICEINFO_TYPES.BAR
+        assert ev.code == "600000.SH"
+        assert float(ev.close) == 10.5
+        # OHLC 缺失 → or price 兜底 (同 PriceUpdateDTO.to_bar_dict 语义)
+        assert float(ev.open) == 10.5
+        assert float(ev.high) == 10.5
+        assert float(ev.low) == 10.5
+
+    def test_bar_keeps_explicit_ohlc(self):
+        # Bar 实体 OHLC 存 Decimal; 非二进制精确值(10.8/9.2)须 float() 归一比对
+        dto = PriceUpdateDTO(symbol="X", price=10.0, open_price=9.5,
+                             high_price=10.8, low_price=9.2)
+        ev = MessageMapper.price_update_to_event(dto)
+        assert float(ev.open) == 9.5
+        assert float(ev.high) == 10.8
+        assert float(ev.low) == 9.2
+        assert float(ev.close) == 10.0
+
+    def test_bar_frequency_day_default(self):
+        # DTO 未携带 frequency → DAY 兜底 (同 data/mappers/bar_mapper)
+        dto = PriceUpdateDTO(symbol="X", price=1.0)
+        ev = MessageMapper.price_update_to_event(dto)
+        assert ev.payload.frequency == FREQUENCY_TYPES.DAY
+
+
+class TestSubmissionToOrder:
+    def test_limit_price_from_price_field(self):
+        # drift 修正: DTO 无 limit_price, 旧代码 order_data['limit_price'] 必 KeyError;
+        # 正解 limit_price 取 dto.price (字符串 → float)
+        dto = OrderSubmissionDTO(order_id="abc", portfolio_id="p1", code="X",
+                                 direction="1", volume=100, price="10.5")
+        order = MessageMapper.submission_to_order(dto)
+        assert order.limit_price == 10.5
+        assert order.code == "X"
+        assert order.volume == 100
+
+    def test_direction_int_value_restored(self):
+        # listener_thread 发 event.direction.value (int); DTO str 强转; int() 还原
+        dto = OrderSubmissionDTO(order_id="a", portfolio_id="p", code="X",
+                                 direction="2", volume=1, price="1")  # SHORT=2
+        order = MessageMapper.submission_to_order(dto)
+        assert order.direction == DIRECTION_TYPES.SHORT
+
+    def test_price_none_defaults_zero(self):
+        dto = OrderSubmissionDTO(order_id="a", portfolio_id="p", code="X",
+                                 direction="1", volume=1)  # price None
+        order = MessageMapper.submission_to_order(dto)
+        assert order.limit_price == 0.0
+
+
+class TestFeedbackToEvent:
+    def test_event_from_dto_and_order(self):
+        src = Order(portfolio_id="p", code="X", direction=DIRECTION_TYPES.LONG,
+                    volume=100, limit_price=10.0)
+        dto = OrderFeedbackDTO(order_id="abc", portfolio_id="p", engine_id="e",
+                               task_id="t", code="X", direction="1",
+                               filled_quantity=50, fill_price=10.5,
+                               timestamp="2026-07-25T10:01:00")
+        ev = MessageMapper.feedback_to_event(dto, src)
+        assert ev.filled_quantity == 50
+        assert ev.fill_price == 10.5
+        assert ev.order is src
+        # remaining = volume - transaction_volume - filled = 100 - 0 - 50
+        assert ev.remaining_quantity == 50

--- a/tests/unit/interfaces/test_message_mapper.py
+++ b/tests/unit/interfaces/test_message_mapper.py
@@ -21,6 +21,7 @@ from ginkgo.enums import (
     DIRECTION_TYPES,
     PRICEINFO_TYPES,
     FREQUENCY_TYPES,
+    ORDERSTATUS_TYPES,
 )
 
 
@@ -139,3 +140,30 @@ class TestFeedbackToEvent:
         assert ev.order is src
         # remaining = volume - transaction_volume - filled = 100 - 0 - 50
         assert ev.remaining_quantity == 50
+
+    def test_event_carries_order_status_filled(self):
+        # review #6778 altitude: DTO.order_status (broker 终态) 透传到 event.order_status,
+        # 下游 PortfolioT1Backtest.is_final 据此判 release_frozen (#5492 闭环)。
+        # wire 格式同 direction: str(enum.value); mapper int() 还原。
+        src = Order(portfolio_id="p", code="X", direction=DIRECTION_TYPES.LONG,
+                    volume=100, limit_price=10.0)
+        dto = OrderFeedbackDTO(order_id="abc", portfolio_id="p", engine_id="e",
+                               task_id="t", code="X", direction="1",
+                               filled_quantity=50, fill_price=10.5,
+                               timestamp="2026-07-25T10:01:00",
+                               order_status=str(ORDERSTATUS_TYPES.FILLED.value))  # "4"
+        ev = MessageMapper.feedback_to_event(dto, src)
+        assert ev.order_status == ORDERSTATUS_TYPES.FILLED
+
+    def test_event_order_status_not_faked_when_dto_omits(self):
+        # DTO.order_status 缺省 None → mapper 传 None 给 event (不伪造 FILLED)。
+        # event.order_status 缺省回退 order.status (#5492 fallback 设计, 此处=NEW),
+        # 关键是 mapper 不把 None 美化成 FILLED → 下游 is_final 不会误判 release_frozen。
+        src = Order(portfolio_id="p", code="X", direction=DIRECTION_TYPES.LONG,
+                    volume=100, limit_price=10.0)
+        dto = OrderFeedbackDTO(order_id="abc", portfolio_id="p", engine_id="e",
+                               task_id="t", code="X", direction="1",
+                               filled_quantity=50, fill_price=10.5,
+                               timestamp="2026-07-25T10:01:00")  # 无 order_status
+        ev = MessageMapper.feedback_to_event(dto, src)
+        assert ev.order_status != ORDERSTATUS_TYPES.FILLED  # 不伪造终态

--- a/tests/unit/workers/test_execution_node_partial_fill.py
+++ b/tests/unit/workers/test_execution_node_partial_fill.py
@@ -8,8 +8,8 @@
 返回 None → GLOG.ERROR 丢弃 → 持仓错账。正确性被钉死在"gateway 必须一发完"。
 
 修法: 累积 filled 量, 仅最终 filled (累积 >= volume) 才 pop, 中间笔保留 entry。
-用独立 ``_pending_filled`` 字典累积, 不改原 Order (避免污染已路由 event 的
-remaining, 也避免越界碰 Order 的资金语义 settle)。
+累积计数与 Order 同存一个 dict value ``[order, cumulative]`` (避免双注册表孤儿),
+不改原 Order (避免污染已路由 event 的 remaining, 也避免越界碰 Order 的资金语义 settle)。
 """
 
 from pathlib import Path
@@ -31,8 +31,7 @@ from ginkgo.interfaces.dtos import OrderFeedbackDTO
 def _make_node_pending_only() -> ExecutionNode:
     """构造仅含 pending 注册表的 ExecutionNode (跳过 Kafka/Redis init 副作用)。"""
     node = object.__new__(ExecutionNode)
-    node._pending_orders = {}
-    node._pending_filled = {}  # review #6778 问题③: 累积 filled 判终态
+    node._pending_orders = {}  # value = [Order, cumulative_filled] (单 dict, review #6778 问题③)
     node.node_id = "test-node"
     return node
 
@@ -54,7 +53,7 @@ class TestPartialFillNoDrop:
         node = _make_node_pending_only()
         order = Order(uuid="ord-1", portfolio_id="p1", code="X",
                       direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
-        node._pending_orders["ord-1"] = order
+        node._pending_orders["ord-1"] = [order, 0.0]
 
         ev1 = node._reconcile_feedback(_dto("ord-1", 500))
         ev2 = node._reconcile_feedback(_dto("ord-1", 300))
@@ -69,7 +68,7 @@ class TestPartialFillNoDrop:
         node = _make_node_pending_only()
         order = Order(uuid="ord-1", portfolio_id="p1", code="X",
                       direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
-        node._pending_orders["ord-1"] = order
+        node._pending_orders["ord-1"] = [order, 0.0]
 
         node._reconcile_feedback(_dto("ord-1", 500))
         assert "ord-1" in node._pending_orders  # 累积 500 < 1000, 保留
@@ -79,14 +78,14 @@ class TestPartialFillNoDrop:
         assert "ord-1" not in node._pending_orders  # 累积 1000 = volume, 移除
 
     def test_cumulative_filled_cleared_after_final(self):
-        """终态 pop 后, 累积字典也清, 不留孤儿。"""
+        """终态 (累积达 volume) pop 整个 [order, cumulative] entry, 不残留。"""
         node = _make_node_pending_only()
         order = Order(uuid="ord-1", portfolio_id="p1", code="X",
                       direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
-        node._pending_orders["ord-1"] = order
+        node._pending_orders["ord-1"] = [order, 0.0]
 
         node._reconcile_feedback(_dto("ord-1", 1000))
-        assert "ord-1" not in node._pending_filled
+        assert "ord-1" not in node._pending_orders
 
     def test_no_matching_order_returns_none(self):
         """非本节点提交 / 进程重启后丢失 → None (consumer 层响亮 drop, 不伪造骨架)。"""
@@ -101,7 +100,7 @@ class TestPartialFillNoDrop:
         node = _make_node_pending_only()
         order = Order(uuid="ord-1", portfolio_id="p1", code="X",
                       direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
-        node._pending_orders["ord-1"] = order
+        node._pending_orders["ord-1"] = [order, 0.0]
 
         ev = node._reconcile_feedback(_dto("ord-1", 500))
         assert ev is not None

--- a/tests/unit/workers/test_execution_node_partial_fill.py
+++ b/tests/unit/workers/test_execution_node_partial_fill.py
@@ -1,0 +1,111 @@
+# Upstream: src/ginkgo/workers/execution_node/node.py (_consume_order_feedback)
+# Role: review #6778 问题③ — partial fill 多笔回报不能 pop 注册表
+
+"""review #6778 问题③: partial fill 多笔回报不能 pop 注册表。
+
+真实 broker 常分多笔回报 (如 1000 手拆 500+300+200)。旧代码
+``_pending_orders.pop(dto.order_id)`` 在第一笔就移除 entry → 第二笔 pop
+返回 None → GLOG.ERROR 丢弃 → 持仓错账。正确性被钉死在"gateway 必须一发完"。
+
+修法: 累积 filled 量, 仅最终 filled (累积 >= volume) 才 pop, 中间笔保留 entry。
+用独立 ``_pending_filled`` 字典累积, 不改原 Order (避免污染已路由 event 的
+remaining, 也避免越界碰 Order 的资金语义 settle)。
+"""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+project_root = Path(__file__).parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.workers.execution_node.node import ExecutionNode
+from ginkgo.entities import Order
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.interfaces.dtos import OrderFeedbackDTO
+
+
+def _make_node_pending_only() -> ExecutionNode:
+    """构造仅含 pending 注册表的 ExecutionNode (跳过 Kafka/Redis init 副作用)。"""
+    node = object.__new__(ExecutionNode)
+    node._pending_orders = {}
+    node._pending_filled = {}  # review #6778 问题③: 累积 filled 判终态
+    node.node_id = "test-node"
+    return node
+
+
+def _dto(order_id: str, filled: float, price: str = "10.0") -> OrderFeedbackDTO:
+    return OrderFeedbackDTO(
+        order_id=order_id, portfolio_id="p1", engine_id="e", task_id="t",
+        code="X", direction="1", filled_quantity=filled, fill_price=price,
+        timestamp="2026-07-26T10:00:00",
+    )
+
+
+@pytest.mark.unit
+class TestPartialFillNoDrop:
+    """review #6778 问题③: 同 order_id 多笔 partial 必须全部处理, 不 drop。"""
+
+    def test_multi_partial_fills_all_reconciled(self):
+        """1000 手拆 500+300+200: 三笔都应返回 event, 不 drop。"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = order
+
+        ev1 = node._reconcile_feedback(_dto("ord-1", 500))
+        ev2 = node._reconcile_feedback(_dto("ord-1", 300))
+        ev3 = node._reconcile_feedback(_dto("ord-1", 200))
+
+        assert ev1 is not None and ev1.filled_quantity == 500
+        assert ev2 is not None and ev2.filled_quantity == 300
+        assert ev3 is not None and ev3.filled_quantity == 200
+
+    def test_entry_retained_until_final_fill(self):
+        """前两笔 partial 保留 entry; 第三笔 (累积达 volume) 才移除。"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = order
+
+        node._reconcile_feedback(_dto("ord-1", 500))
+        assert "ord-1" in node._pending_orders  # 累积 500 < 1000, 保留
+        node._reconcile_feedback(_dto("ord-1", 300))
+        assert "ord-1" in node._pending_orders  # 累积 800 < 1000, 保留
+        node._reconcile_feedback(_dto("ord-1", 200))
+        assert "ord-1" not in node._pending_orders  # 累积 1000 = volume, 移除
+
+    def test_cumulative_filled_cleared_after_final(self):
+        """终态 pop 后, 累积字典也清, 不留孤儿。"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = order
+
+        node._reconcile_feedback(_dto("ord-1", 1000))
+        assert "ord-1" not in node._pending_filled
+
+    def test_no_matching_order_returns_none(self):
+        """非本节点提交 / 进程重启后丢失 → None (consumer 层响亮 drop, 不伪造骨架)。"""
+        node = _make_node_pending_only()
+        ev = node._reconcile_feedback(_dto("unknown", 100))
+        assert ev is None
+
+    def test_original_order_transaction_volume_not_mutated(self):
+        """不改原 Order.transaction_volume: 避免污染已路由 event 的 remaining
+        (event 持 order 引用, 改了会让下游读到的 remaining 失真), 也避免越界
+        调 Order.settle (那是资金语义, 属下游 portfolio 职责)。"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = order
+
+        ev = node._reconcile_feedback(_dto("ord-1", 500))
+        assert ev is not None
+        # event.remaining 此刻 = volume - 0 (历史) - 500 (本次) = 500, 反映"本笔后还剩"
+        assert ev.remaining_quantity == 500
+        # 原_order.transaction_volume 不被 consumer 改 (保持 0, 历史=下游职责)
+        assert order.transaction_volume == 0

--- a/tests/unit/workers/test_execution_node_partial_fill.py
+++ b/tests/unit/workers/test_execution_node_partial_fill.py
@@ -24,7 +24,7 @@ if _path not in sys.path:
 
 from ginkgo.workers.execution_node.node import ExecutionNode
 from ginkgo.entities import Order
-from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.enums import DIRECTION_TYPES, ORDERSTATUS_TYPES
 from ginkgo.interfaces.dtos import OrderFeedbackDTO
 
 
@@ -36,11 +36,12 @@ def _make_node_pending_only() -> ExecutionNode:
     return node
 
 
-def _dto(order_id: str, filled: float, price: str = "10.0") -> OrderFeedbackDTO:
+def _dto(order_id: str, filled: float, price: str = "10.0",
+         status: str = None) -> OrderFeedbackDTO:
     return OrderFeedbackDTO(
         order_id=order_id, portfolio_id="p1", engine_id="e", task_id="t",
         code="X", direction="1", filled_quantity=filled, fill_price=price,
-        timestamp="2026-07-26T10:00:00",
+        timestamp="2026-07-26T10:00:00", order_status=status,
     )
 
 
@@ -108,3 +109,44 @@ class TestPartialFillNoDrop:
         assert ev.remaining_quantity == 500
         # 原_order.transaction_volume 不被 consumer 改 (保持 0, 历史=下游职责)
         assert order.transaction_volume == 0
+
+
+@pytest.mark.unit
+class TestStatusFinalization:
+    """review #6778 altitude: dto.order_status 优先判终态 (broker 自描述),
+    缺省/解析失败回退累积量。消除"靠累积量猜终态"的 special case。"""
+
+    def test_final_status_pops_even_if_cumulative_below_volume(self):
+        """dto.order_status=FILLED → 直接判终态 pop, 不依赖累积量达 volume。
+        (broker 报 FILLED 即终态权威, 即使 filled_quantity 漏报尾笔)"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = [order, 0.0]
+        ev = node._reconcile_feedback(
+            _dto("ord-1", 800, status=str(ORDERSTATUS_TYPES.FILLED.value)))
+        assert ev is not None
+        assert "ord-1" not in node._pending_orders  # status=FILLED → pop
+
+    def test_partial_status_retained_even_if_cumulative_reaches_volume(self):
+        """dto.order_status=PARTIAL_FILLED → 中间笔保留 entry, 即使累积碰巧达 volume。
+        (broker 说 partial = 还有后续笔, 累积达 volume 是巧合不能 overrides broker 终态)"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = [order, 0.0]
+        node._reconcile_feedback(
+            _dto("ord-1", 1000, status=str(ORDERSTATUS_TYPES.PARTIAL_FILLED.value)))
+        assert "ord-1" in node._pending_orders  # broker 说 partial, 保留
+
+    def test_no_status_falls_back_to_cumulative(self):
+        """dto.order_status 缺省 None → 回退累积量判终态
+        (兼容旧 DTO / 模拟路径未填 status, 不破坏既有累积语义)。"""
+        node = _make_node_pending_only()
+        order = Order(uuid="ord-1", portfolio_id="p1", code="X",
+                      direction=DIRECTION_TYPES.LONG, volume=1000, limit_price=10.0)
+        node._pending_orders["ord-1"] = [order, 0.0]
+        node._reconcile_feedback(_dto("ord-1", 500))  # 无 status
+        assert "ord-1" in node._pending_orders  # 累积 500 < 1000, 保留
+        node._reconcile_feedback(_dto("ord-1", 500))  # 无 status
+        assert "ord-1" not in node._pending_orders  # 累积 1000, pop


### PR DESCRIPTION
## 依据 ADR-025 · 第②步实现

落地 `docs/adrs/ADR-025-dto-messenger-full-restoration.md` 的第②步:Kafka 入站侧 consumer 统一经 **MessageMapper**(四边界 Mapper 家族的 Kafka 亚型),消灭"裸 dict 直构造 Event"反模式。

### 核心机制(β 运行期构造校验)

```
raw dict ──decode──▶ DTO (pydantic model_validate) ──xxx_to_event──▶ 领域 Event/Entity
```

`decode` 走 `model_validate`,字段缺失/类型错 → `ValidationError` → 本层转 `ValueError` **响亮 raise**(禁 `except` 吞 + `return` stub,#4652 教训)。

### 新增

- `src/ginkgo/interfaces/mappers/message_mapper.py` — MessageMapper 静态工具:
  - `decode(raw, dto_cls)` β 校验
  - `price_update_to_event` — PriceUpdateDTO→EventPriceUpdate(payload=Bar),OHLC↔price 兜底
  - `feedback_to_event` — OrderFeedbackDTO+Order→EventOrderPartiallyFilled(Order 由 consumer 注册表注入,Mapper 不碰 CRUD/DB)
  - `submission_to_order` — OrderSubmissionDTO→Order(`limit_price←price` drift 修正)

### 5 处 Kafka 入站死路径/drift 修复(原均 `except` 吞后静默死)

| 文件 | 死路径 | drift |
|---|---|---|
| `workers/execution_node/node.py` | `_consume_market_data`(原 sleep 静默死) | symbol↔code + payload=Bar 签名错 |
| `workers/execution_node/node.py` | `_consume_order_feedback` | filled_volume→filled_quantity / filled_price→fill_price |
| `livecore/trade_gateway_adapter.py` | `_process_order` | DTO 无 `limit_price` 必 KeyError |
| `livecore/data_manager.py` | `_process_interest_updates` / `_process_control_commands` | `.consume()` 不存在 + `model_validate_json(dict)` 错用 + `except: pass` 静默吞 |
| `workers/execution_node/portfolio_processor.py` | 控制命令消费 | `GinkgoConsumer(bootstrap_servers=...)` 错参 + `.subscribe()/.poll()` 不存在 + `json.loads(dict)` 错用 |

`node.py` 另加 `_pending_orders` 注册表:订单提交后登记,feedback 回来时取出注入 `feedback_to_event`(不破"Mapper 不碰 DB"边界)。

### 测试

- `tests/unit/interfaces/test_message_mapper.py` — 10 cases(含 β 校验失败路径)
- 相关 5 文件回归 **29 passed**

### 范围外(留后续 PR,遵循 ADR-025 分期)

- ControlCommand 合一(dataclass 双胞胎 → DTO,触实盘部署链路)
- scheduler 裸 dict(SchedulerCommandDTO)
- 第③步 HTTP ResponseMapper、第④步 Redis CacheMapper、ADR-010 §4 DB Mapper 收尾

---

本 PR 含 ADR-025 文档(commit 1)+ 第②步实现(commit 2)。
