### PR TITLE
feat(#6784): API 请求 trace_id 贯穿 GLOG 日志 (可观测层 1/4)

### DIFF
--- a/api/core/logging.py
+++ b/api/core/logging.py
@@ -15,6 +15,25 @@ except ImportError:
     GINKGO_GLOG_AVAILABLE = False
 
 
+class TraceIdFilter(logging.Filter):
+    """注入 GLOG contextvar 的 trace_id 到 stdlib 日志 record (#6784)。
+
+    API 业务层用 stdlib logging (与 GINKGO 的 structlog 分离)，本 Filter 让
+    stdlib 日志也携带请求级 trace_id，与 GLOG/ecs_processor 输出对齐，
+    使一个 trace_id 能 grep 出该请求在 API 进程内的全部日志行。
+    """
+
+    def filter(self, record):
+        try:
+            from ginkgo.libs.core.logger import _trace_id_ctx
+
+            tid = _trace_id_ctx.get()
+        except ImportError:
+            tid = None
+        record.trace_id = tid or "-"
+        return True
+
+
 def setup_logging(name: str = "apiserver"):
     """设置API Server日志"""
 
@@ -26,6 +45,10 @@ def setup_logging(name: str = "apiserver"):
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
 
+    # #6784: 注入请求级 trace_id 到每条 stdlib 日志 record (TraceIdFilter 读
+    # GLOG contextvar)，使 stdlib 日志与 GLOG/ecs_processor 输出对齐
+    logger.addFilter(TraceIdFilter())
+
     # 控制台处理器（使用Rich格式）
     if sys.stdout.isatty():
         from rich.logging import RichHandler
@@ -36,12 +59,13 @@ def setup_logging(name: str = "apiserver"):
             show_time=False,
             show_path=False,
         )
-        handler.setFormatter(logging.Formatter("%(message)s"))
+        # local 模式：trace_id 行内可见
+        handler.setFormatter(logging.Formatter("trace=%(trace_id)s %(message)s"))
     else:
-        # JSON格式用于文件输出
+        # JSON格式用于文件输出 (container 模式：trace_id 平铺字段)
         handler = logging.StreamHandler()
         formatter = jsonlogger.JsonFormatter(
-            '%(asctime)s %(name)s %(levelname)s %(message)s'
+            '%(asctime)s %(name)s %(levelname)s %(message)s %(trace_id)s'
         )
         handler.setFormatter(formatter)
 

--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,7 @@ from middleware.error_handler import global_error_handler
 from middleware.rate_limit import RateLimitMiddleware
 from trailing_slash import strip_trailing_slash
 from middleware.api_stats import ApiStatsMiddleware
+from middleware.trace_id import TraceIdMiddleware
 from core.exceptions import APIError
 from websocket.manager import connection_manager
 
@@ -98,8 +99,12 @@ app.add_middleware(JWTAuthMiddleware)
 app.add_middleware(RateLimitMiddleware)
 app.add_middleware(ApiStatsMiddleware)
 # trailing slash：strip 后路由匹配，禁 307 重定向避免 POST 丢 Auth header（#5389）
-# 最后注册 → 栈顶最先执行，JWT/RateLimit 读到 strip 后 path
+# 栈顶先于 JWT/RateLimit 执行，使其读到 strip 后 path
 app.middleware("http")(strip_trailing_slash)
+# #6784: TraceIdMiddleware 最后注册 → 栈顶最外层，请求最先进入、绑定 trace_id 到
+# GLOG contextvars，包住 trailing_slash / JWT / RateLimit / ApiStats 及
+# exception_handler，使该请求的全链路日志 (router→service→crud) 同 trace_id
+app.add_middleware(TraceIdMiddleware)
 
 # 全局错误处理
 app.exception_handler(Exception)(global_error_handler)

--- a/api/middleware/error_handler.py
+++ b/api/middleware/error_handler.py
@@ -4,6 +4,7 @@
 将所有异常转换为统一的响应格式。
 """
 
+import contextlib
 import uuid
 
 from fastapi import Request, HTTPException, status
@@ -11,52 +12,85 @@ from fastapi.responses import JSONResponse
 
 from core.logging import logger
 from core.exceptions import APIError
+from middleware.trace_id import TRACE_ID_HEADER
+
+try:
+    from ginkgo.libs import GLOG
+
+    _GLOG_AVAILABLE = True
+except ImportError:
+    _GLOG_AVAILABLE = False
 
 
-def _trace_id() -> str:
-    """复用请求绑定的 trace_id (GLOG contextvar)，无则新生成。
+def _trace_id(request: Request | None = None) -> str:
+    """复用请求绑定的 trace_id，无则新生成。
 
-    TraceIdMiddleware 在请求入口已把 trace_id 注入 GLOG contextvars，此处直接
-    取用，保证错误信封与该请求的全部日志同 trace_id (不再二次生成)。
+    优先级：request.state.trace_id（TraceIdMiddleware 注入，随 scope 存活，能跨越
+    中间件异常 unwind）→ GLOG contextvar（正常路径业务层日志已绑定）→ 新生成。
+    保证错误信封、响应头与该请求全部日志同 trace_id。
+
+    对无 state 的 fake/mock request 健壮(单测直接调 handler 的场景)。
     """
-    try:
-        from ginkgo.libs import GLOG
-
+    if request is not None:
+        try:
+            tid = request.state.trace_id
+        except (AttributeError, TypeError):
+            tid = None
+        if isinstance(tid, str) and tid:
+            return tid
+    if _GLOG_AVAILABLE:
         tid = GLOG.get_trace_id()
         if tid:
             return tid
-    except ImportError:
-        pass
     return uuid.uuid4().hex[:16]
 
 
 async def global_error_handler(request: Request, exc: Exception):
-    """将所有异常转换为 {code, data, message, trace_id} 格式"""
+    """将所有异常转换为 {code, data, message, trace_id} 格式。
 
-    if isinstance(exc, APIError):
-        logger.error(f"APIError [{exc.code}] {request.url.path}: {exc.message}")
-        return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
+    中间件抛出的异常（如 JWTAuthMiddleware 的 401）会逃逸到 ServerErrorMiddleware，
+    在 TraceIdMiddleware 的 contextvar 作用域之外触发本 handler。故 trace_id 取
+    request.state（随 scope 存活），并以 with_trace_id 临时复位 contextvar，使错误
+    日志、X-Trace-Id 响应头、body trace_id 三者一致 (#6788 review 修复)。
+    """
+    trace_id = _trace_id(request)
+    headers = {TRACE_ID_HEADER: trace_id}
+    trace_cm = (
+        GLOG.with_trace_id(trace_id)
+        if _GLOG_AVAILABLE
+        else contextlib.nullcontext()
+    )
+    with trace_cm:
+        if isinstance(exc, APIError):
+            logger.error(f"APIError [{exc.code}] {request.url.path}: {exc.message}")
+            return JSONResponse(
+                status_code=exc.status_code, content=exc.to_dict(), headers=headers
+            )
 
-    if isinstance(exc, HTTPException):
-        logger.error(f"HTTPException [{exc.status_code}] {request.url.path}: {exc.detail}")
+        if isinstance(exc, HTTPException):
+            logger.error(
+                f"HTTPException [{exc.status_code}] {request.url.path}: {exc.detail}"
+            )
+            return JSONResponse(
+                status_code=exc.status_code,
+                headers=headers,
+                content={
+                    "code": exc.status_code,
+                    "data": None,
+                    "message": exc.detail,
+                    "trace_id": trace_id,
+                },
+            )
+
+        # 未捕获异常
+        logger.exception(f"Unhandled exception {request.url.path}: {exc}")
         return JSONResponse(
-            status_code=exc.status_code,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            headers=headers,
             content={
-                "code": exc.status_code,
+                "code": 500,
                 "data": None,
-                "message": exc.detail,
-                "trace_id": _trace_id(),
+                "message": "Internal Server Error",
+                "trace_id": trace_id,
             },
         )
-
-    # 未捕获异常
-    logger.exception(f"Unhandled exception {request.url.path}: {exc}")
-    return JSONResponse(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        content={
-            "code": 500,
-            "data": None,
-            "message": "Internal Server Error",
-            "trace_id": _trace_id(),
-        },
-    )

--- a/api/middleware/error_handler.py
+++ b/api/middleware/error_handler.py
@@ -14,6 +14,19 @@ from core.exceptions import APIError
 
 
 def _trace_id() -> str:
+    """复用请求绑定的 trace_id (GLOG contextvar)，无则新生成。
+
+    TraceIdMiddleware 在请求入口已把 trace_id 注入 GLOG contextvars，此处直接
+    取用，保证错误信封与该请求的全部日志同 trace_id (不再二次生成)。
+    """
+    try:
+        from ginkgo.libs import GLOG
+
+        tid = GLOG.get_trace_id()
+        if tid:
+            return tid
+    except ImportError:
+        pass
     return uuid.uuid4().hex[:16]
 
 

--- a/api/middleware/trace_id.py
+++ b/api/middleware/trace_id.py
@@ -29,6 +29,10 @@ class TraceIdMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         trace_id = request.headers.get(TRACE_ID_HEADER) or _new_trace_id()
+        # 注入 request.state：随 scope 存活，跨越中间件异常 unwind（call_next 重抛时
+        # contextvar 已随 with 块退出而 reset）。error_handler 在中间件异常路径下由
+        # ServerErrorMiddleware 在本中间件之外触发，靠 state 取回同一 trace_id (#6788)。
+        request.state.trace_id = trace_id
         with GLOG.with_trace_id(trace_id):
             response: Response = await call_next(request)
         response.headers[TRACE_ID_HEADER] = trace_id

--- a/api/middleware/trace_id.py
+++ b/api/middleware/trace_id.py
@@ -1,0 +1,35 @@
+"""请求级 trace_id 中间件 (#6784 可观测层接入 1/4)。
+
+每个 API 请求注入/透传 trace_id，绑定到 GLOG contextvars，贯穿该请求在
+API 进程内的全部日志 (router→service→crud)，并回写 X-Trace-Id 响应头，
+供客户端关联。是后续跨进程 trace_id 传播 (backtest/paper/live worker) 的前置基座。
+"""
+import uuid
+
+from ginkgo.libs import GLOG
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+TRACE_ID_HEADER = "X-Trace-Id"
+
+
+def _new_trace_id() -> str:
+    """生成 16 字符 hex trace_id (与 error_handler._trace_id() 同 scheme)。"""
+    return uuid.uuid4().hex[:16]
+
+
+class TraceIdMiddleware(BaseHTTPMiddleware):
+    """为每个请求绑定 trace_id 到 GLOG contextvars，并回写响应头。
+
+    绑定期间，该请求在 API 进程内发出的全部 GLOG 日志 (router→service→crud)
+    都携带同一 trace_id (container 模式输出为 ECS trace.id 字段)；请求结束
+    后 contextvar 自动复位，杜绝跨请求泄漏。
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        trace_id = request.headers.get(TRACE_ID_HEADER) or _new_trace_id()
+        with GLOG.with_trace_id(trace_id):
+            response: Response = await call_next(request)
+        response.headers[TRACE_ID_HEADER] = trace_id
+        return response

--- a/tests/api/test_trace_id_middleware_6784.py
+++ b/tests/api/test_trace_id_middleware_6784.py
@@ -150,3 +150,135 @@ def test_stdlib_logger_carries_trace_id(api_modules):
     out = stream.getvalue()
     assert "biz-marker" in out
     assert fixed in out  # trace_id 注入 stdlib 日志输出
+
+
+# ---------------------------------------------------------------------------
+# #6788 review: 中间件异常路径回归守护
+#
+# 缺陷：内层中间件(如 JWTAuthMiddleware 401)抛 HTTPException 时,异常逃逸 TraceIdMiddleware
+# 的 with 块 → contextvar reset + 响应头写入行被跳过;global_error_handler 由 ServerErrorMiddleware
+# 在 contextvar 作用域之外触发,trace_id 二次生成且日志显示 "-"。修复靠 request.state.trace_id
+# (随 scope 存活、跨 unwind)作跨层通道,handler 补头 + 临时复位 contextvar。
+#
+# 用忠实最小栈复现(内层 raise 中间件 + TraceId 最外层 + 同 main.py 的 handler 注册),
+# 因真实 api.main 的 lifespan 会 connection_manager.start() 拉起 DB,TestClient 集成测试不稳;
+# 本最小栈与 main.py 中间件栈序+exception_handler 注册完全等价,足以在 CI 抓回归。
+# ---------------------------------------------------------------------------
+
+
+def _build_raising_stack(api_modules, raiser):
+    """复刻 main.py 栈序:内层 raising 中间件 + TraceIdMiddleware 最外层 + 全局 handler。"""
+    from fastapi import FastAPI, HTTPException
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from middleware.trace_id import TraceIdMiddleware
+    from middleware.error_handler import global_error_handler
+
+    app = FastAPI()
+    app.add_middleware(raiser)                          # 内层(模拟 JWT)
+    app.add_middleware(TraceIdMiddleware)              # 最后注册 = 栈顶最外层(同 main.py)
+    app.exception_handler(Exception)(global_error_handler)
+    app.exception_handler(HTTPException)(global_error_handler)
+    return app
+
+
+def test_middleware_raised_exception_keeps_header_and_trace_id(api_modules):
+    """内层中间件 raise HTTPException(401) → X-Trace-Id 头不丢、body trace_id 不脱钩。
+
+    回归 #6788 问题 1:修复前 header=None、body trace_id 新生成、日志 trace_id="-"。
+    """
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class JWTLikeMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise HTTPException(status_code=401, detail="Missing authentication token")
+
+    app = _build_raising_stack(api_modules, JWTLikeMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/anything")  # 任意路径,内层中间件无条件 raise
+    assert resp.status_code == 401
+    header_tid = resp.headers.get("x-trace-id")
+    assert header_tid is not None, "中间件异常路径 X-Trace-Id 头丢失 (#6788 问题 1)"
+    body_tid = resp.json()["trace_id"]
+    assert body_tid == header_tid, (
+        f"body trace_id({body_tid})与响应头({header_tid})脱钩 — 应复用同一 trace_id"
+    )
+
+
+def test_middleware_raised_exception_passes_through_client_trace_id(api_modules):
+    """中间件异常路径下,入站 X-Trace-Id 仍正确透传到响应头/body。"""
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class JWTLikeMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+    app = _build_raising_stack(api_modules, JWTLikeMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    fixed = "1122334455667788"
+    resp = client.get("/anything", headers={"X-Trace-Id": fixed})
+    assert resp.status_code == 401
+    assert resp.headers.get("x-trace-id") == fixed, "异常路径未透传入站 trace_id"
+    assert resp.json()["trace_id"] == fixed
+
+
+def test_middleware_raised_exception_log_carries_trace_id(api_modules):
+    """中间件异常路径下,global_error_handler 的错误日志携带请求 trace_id(非 "-")。
+
+    回归 #6788:修复前 contextvar 已 reset,handler 日志输出 trace_id="-"。
+    """
+    import io
+    import logging
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class JWTLikeMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise HTTPException(status_code=401, detail="Missing authentication token")
+
+    app = _build_raising_stack(api_modules, JWTLikeMiddleware)
+
+    stream = io.StringIO()
+    h = logging.StreamHandler(stream)
+    h.setFormatter(logging.Formatter("%(trace_id)s|%(message)s"))
+
+    from core.logging import logger
+    logger.addHandler(h)
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        fixed = "9988776655443322"
+        client.get("/anything", headers={"X-Trace-Id": fixed})
+    finally:
+        logger.removeHandler(h)
+
+    out = stream.getvalue()
+    assert "Missing authentication token" in out
+    assert fixed in out, (
+        f"中间件异常路径错误日志 trace_id 未对齐请求值(期望含 {fixed}):\n{out}"
+    )
+
+
+def test_middleware_raised_unhandled_exception_returns_500_with_trace_id(api_modules):
+    """内层中间件抛非 HTTPException → 500 响应仍带 X-Trace-Id 头 + 一致 trace_id。"""
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class BombMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise RuntimeError("boom from middleware")
+
+    app = _build_raising_stack(api_modules, BombMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/anything")
+    assert resp.status_code == 500
+    header_tid = resp.headers.get("x-trace-id")
+    assert header_tid is not None, "500 异常路径 X-Trace-Id 头丢失"
+    assert resp.json()["trace_id"] == header_tid
+

--- a/tests/api/test_trace_id_middleware_6784.py
+++ b/tests/api/test_trace_id_middleware_6784.py
@@ -1,0 +1,152 @@
+"""#6784: API 请求 trace_id 贯穿 GLOG 日志 (可观测层接入 1/4)。
+
+验证 TraceIdMiddleware 行为(注入/透传/响应头/无泄漏)及 error_handler
+trace_id 复用。口径 tests/api(用 api_modules fixture 延迟 import api/)。
+"""
+# 注意：api_modules fixture 临时把 api/ 加进 sys.path，
+# 使 `from middleware.trace_id import TraceIdMiddleware` 可解析。
+
+
+def test_middleware_generates_trace_id_header_when_absent(api_modules):
+    """无入站 X-Trace-Id → 生成新 trace_id 并写入响应头(16 hex)。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from middleware.trace_id import TraceIdMiddleware
+
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert "x-trace-id" in resp.headers
+    tid = resp.headers["x-trace-id"]
+    assert len(tid) == 16
+    int(tid, 16)  # 合法 hex
+
+
+def test_middleware_passes_through_client_trace_id(api_modules):
+    """入站带 X-Trace-Id → 响应头复用该值(不重新生成)。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from middleware.trace_id import TraceIdMiddleware
+
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+
+    @app.get("/ping")
+    def ping():
+        return {"ok": True}
+
+    client = TestClient(app)
+    fixed = "abcdef0123456789"
+    resp = client.get("/ping", headers={"X-Trace-Id": fixed})
+    assert resp.headers["x-trace-id"] == fixed
+
+
+def test_middleware_binds_trace_id_to_glog_contextvar(api_modules):
+    """请求处理期间 GLOG contextvar 被设为绑定的 trace_id (贯穿 router/service/crud)。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from middleware.trace_id import TraceIdMiddleware
+
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+
+    @app.get("/whoami")
+    def whoami():
+        from ginkgo.libs import GLOG
+        return {"tid": GLOG.get_trace_id()}
+
+    client = TestClient(app)
+    fixed = "deadbeefdeadbeef"
+    resp = client.get("/whoami", headers={"X-Trace-Id": fixed})
+    assert resp.status_code == 200
+    assert resp.json()["tid"] == fixed
+
+
+def test_no_cross_request_trace_id_leakage(api_modules):
+    """连续两请求各自生成 trace_id，第二请求不继承第一的残留 (contextvar 已复位)。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from middleware.trace_id import TraceIdMiddleware
+
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+
+    @app.get("/cap")
+    def cap():
+        from ginkgo.libs import GLOG
+        return {"tid": GLOG.get_trace_id()}
+
+    client = TestClient(app)
+    r1 = client.get("/cap")
+    r2 = client.get("/cap")
+    t1, t2 = r1.json()["tid"], r2.json()["tid"]
+    assert t1 is not None and t2 is not None
+    assert t1 != t2  # 无泄漏
+
+
+def test_error_envelope_reuses_request_trace_id(api_modules):
+    """错误信封 trace_id 复用请求绑定的值，不再二次生成。"""
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+    from middleware.trace_id import TraceIdMiddleware
+    from middleware.error_handler import global_error_handler
+
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+    app.exception_handler(Exception)(global_error_handler)
+    app.exception_handler(HTTPException)(global_error_handler)
+
+    @app.get("/boom")
+    def boom():
+        raise HTTPException(status_code=404, detail="nope")
+
+    client = TestClient(app, raise_server_exceptions=False)
+    fixed = "cafecafecafecafe"
+    resp = client.get("/boom", headers={"X-Trace-Id": fixed})
+    assert resp.status_code == 404
+    assert resp.json()["trace_id"] == fixed
+
+
+def test_stdlib_logger_carries_trace_id(api_modules):
+    """API 业务层 stdlib logger 输出携带请求 trace_id (TraceIdFilter 注入)。
+
+    业务层用 `from core.logging import logger` (stdlib)，不走 GLOG structlog；
+    Filter 读 GLOG contextvar 注入 record.trace_id，使 stdlib 日志也能用
+    trace_id 检索。
+    """
+    import io
+    import logging
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from middleware.trace_id import TraceIdMiddleware
+
+    stream = io.StringIO()
+    h = logging.StreamHandler(stream)
+    h.setFormatter(logging.Formatter("%(trace_id)s|%(message)s"))
+
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+
+    @app.get("/log")
+    def log():
+        from core.logging import logger
+        logger.addHandler(h)
+        try:
+            logger.info("biz-marker")
+        finally:
+            logger.removeHandler(h)
+        return {"ok": True}
+
+    client = TestClient(app)
+    fixed = "ffeeddccbbaa9988"
+    client.get("/log", headers={"X-Trace-Id": fixed})
+    out = stream.getvalue()
+    assert "biz-marker" in out
+    assert fixed in out  # trace_id 注入 stdlib 日志输出


### PR DESCRIPTION
## Summary

可观测层接入 1/4:让每个 API 请求携带一个 trace_id,贯穿该请求在 API 进程内的全部日志(router→service→crud),并回写 `X-Trace-Id` 响应头,使任一请求的日志可按 trace_id 聚合检索。是后续跨进程 trace_id 传播(backtest/paper/live worker)的前置基座。

### 改动
- **`api/middleware/trace_id.py`(新)**:`TraceIdMiddleware`(BaseHTTPMiddleware)— 读入站 `X-Trace-Id`(透传)否则 `uuid4().hex[:16]`(复用 error_handler 同 scheme)→ `with GLOG.with_trace_id(tid)` 包 `call_next` 绑定 GLOG contextvars → 回写 `X-Trace-Id` 响应头。注册为**栈顶最外层**,包住 trailing_slash / JWT / RateLimit / ApiStats 及 exception_handler。
- **`api/core/logging.py`**:新增 `TraceIdFilter` 读 GLOG `_trace_id_ctx` contextvar,注入 `record.trace_id`,并让 RichHandler(local)/ JsonFormatter(container)输出 trace_id。**这是关键点**:API 业务层(services/crud/routers)用 stdlib logging(非 GLOG structlog),不经 `ecs_processor`;不加 Filter 则即便接了 GLOG contextvar,业务层日志仍不带 trace_id。Filter 让 stdlib 日志与 GLOG 输出对齐。
- **`api/middleware/error_handler.py`**:`_trace_id()` 优先取 `GLOG.get_trace_id()`,fallback 才新生成——错误信封不再二次生成与请求日志不一致的 trace_id。
- **`api/main.py`**:注册 TraceIdMiddleware 为最后(栈顶最外层)中间件。

### 设计决策:复用而非重写
issue brief 指出 `GLOG.with_trace_id` / `set_trace_id` / `get_trace_id`(T030–T033)与 `ecs_processor` 已实现且 worker/engine 层验证过。本 PR 全部复用:`GLOG.with_trace_id` 绑 contextvar、`_trace_id_ctx` 供 Filter 读取。唯一新增是入口 middleware + stdlib Filter 这层机械接线。

## Test plan

新增 `tests/api/test_trace_id_middleware_6784.py`(6 用例,全绿):
- 无 `X-Trace-Id` → 生成 16-hex 并写响应头
- 带 `X-Trace-Id` → 透传(响应头 == 请求头)
- GLOG contextvar 绑定(端点内 `GLOG.get_trace_id()` == 请求 trace_id)
- 无跨请求泄漏(连续两请求 trace_id 不同)
- 错误信封 `trace_id` 复用请求绑定值(不再二次生成)
- stdlib logger 输出携带 trace_id(TraceIdFilter 注入)

本地三层 smoke(对齐 ci.yml):py_compile 4 变更文件 ✅;启动路径 test_user_crud_mock + test_containers ✅。

> 注:`test_components_error_sanitization::test_500_detail_excludes_exception_internals` 与 `test_user_cli::test_create_user_missing_name_fails` 在 master 同样失败(前者 mock target `get_component_parameter_service` 缺失,后者 Rich ANSI 着色致 `--name` 字面断言失败),与本 PR 无关。

Closes #6784
