### PR TITLE
feat(observability): API 请求 trace_id 全量注入贯穿 GLOG 日志

### DIFF
--- a/api/core/logging.py
+++ b/api/core/logging.py
@@ -15,6 +15,24 @@ except ImportError:
     GINKGO_GLOG_AVAILABLE = False
 
 
+class TraceIdFilter(logging.Filter):
+    """从 GLOG _trace_id_ctx 读 trace_id 注入 LogRecord，让 api 层标准 logging 也带 trace_id。
+
+    与 src 层 GLOG ecs_processor 共享同一 _trace_id_ctx 源头（#6784 可观测层接入 1/4）。
+    TraceIdMiddleware 在请求入口 set _trace_id_ctx，本 filter 让 api 层 logger 输出同步可见。
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if GINKGO_GLOG_AVAILABLE:
+            try:
+                record.trace_id = GLOG.get_trace_id() or "-"
+            except Exception:
+                record.trace_id = "-"
+        else:
+            record.trace_id = "-"
+        return True
+
+
 def setup_logging(name: str = "apiserver"):
     """设置API Server日志"""
 
@@ -23,8 +41,9 @@ def setup_logging(name: str = "apiserver"):
 
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.INFO)
+
+    # trace_id 注入（#6784）：logger 级 filter，所有 handler 输出经 %(trace_id)s 可见
+    logger.addFilter(TraceIdFilter())
 
     # 控制台处理器（使用Rich格式）
     if sys.stdout.isatty():
@@ -36,12 +55,12 @@ def setup_logging(name: str = "apiserver"):
             show_time=False,
             show_path=False,
         )
-        handler.setFormatter(logging.Formatter("%(message)s"))
+        handler.setFormatter(logging.Formatter("[trace_id=%(trace_id)s] %(message)s"))
     else:
         # JSON格式用于文件输出
         handler = logging.StreamHandler()
         formatter = jsonlogger.JsonFormatter(
-            '%(asctime)s %(name)s %(levelname)s %(message)s'
+            '%(asctime)s %(name)s %(levelname)s %(trace_id)s %(message)s'
         )
         handler.setFormatter(formatter)
 

--- a/api/main.py
+++ b/api/main.py
@@ -15,6 +15,7 @@ from middleware.error_handler import global_error_handler
 from middleware.rate_limit import RateLimitMiddleware
 from trailing_slash import strip_trailing_slash
 from middleware.api_stats import ApiStatsMiddleware
+from middleware.trace_id import TraceIdMiddleware
 from core.exceptions import APIError
 from websocket.manager import connection_manager
 
@@ -100,6 +101,9 @@ app.add_middleware(ApiStatsMiddleware)
 # trailing slash：strip 后路由匹配，禁 307 重定向避免 POST 丢 Auth header（#5389）
 # 最后注册 → 栈顶最先执行，JWT/RateLimit 读到 strip 后 path
 app.middleware("http")(strip_trailing_slash)
+# trace_id 全量注入（#6784）：最后注册 → 栈顶最先执行，trace_id 覆盖所有后续
+# middleware 与路由；GLOG.with_trace_id 注入 contextvars，贯穿 api+src 层日志
+app.add_middleware(TraceIdMiddleware)
 
 # 全局错误处理
 app.exception_handler(Exception)(global_error_handler)

--- a/api/middleware/error_handler.py
+++ b/api/middleware/error_handler.py
@@ -14,7 +14,16 @@ from core.exceptions import APIError
 
 
 def _trace_id() -> str:
-    return uuid.uuid4().hex[:16]
+    """错误响应 trace_id：优先取请求已注入的（与日志一致），fallback 生成。
+
+    TraceIdMiddleware 在请求入口 set GLOG contextvars，exception_handler 在 middleware
+    内层执行，此时 trace_id 仍在作用域内 → 错误信封 trace_id 与该请求日志同源（#6784）。
+    """
+    try:
+        from ginkgo.libs import GLOG
+        return GLOG.get_trace_id() or uuid.uuid4().hex[:16]
+    except ImportError:
+        return uuid.uuid4().hex[:16]
 
 
 async def global_error_handler(request: Request, exc: Exception):

--- a/api/middleware/error_handler.py
+++ b/api/middleware/error_handler.py
@@ -63,8 +63,13 @@ async def global_error_handler(request: Request, exc: Exception):
     with trace_cm:
         if isinstance(exc, APIError):
             logger.error(f"APIError [{exc.code}] {request.url.path}: {exc.message}")
+            # exc.to_dict() 带 APIError 构造时自生的随机 trace_id（exceptions.py），
+            # 与本请求 X-Trace-Id 头/日志脱钩；override 为请求 trace_id，与下方
+            # HTTPException/500 分支对称，兑现 docstring「三者一致」契约。
             return JSONResponse(
-                status_code=exc.status_code, content=exc.to_dict(), headers=headers
+                status_code=exc.status_code,
+                content={**exc.to_dict(), "trace_id": trace_id},
+                headers=headers,
             )
 
         if isinstance(exc, HTTPException):

--- a/api/middleware/error_handler.py
+++ b/api/middleware/error_handler.py
@@ -4,6 +4,7 @@
 将所有异常转换为统一的响应格式。
 """
 
+import contextlib
 import uuid
 
 from fastapi import Request, HTTPException, status
@@ -11,48 +12,85 @@ from fastapi.responses import JSONResponse
 
 from core.logging import logger
 from core.exceptions import APIError
+from middleware.trace_id import TRACE_ID_HEADER
+
+try:
+    from ginkgo.libs import GLOG
+
+    _GLOG_AVAILABLE = True
+except ImportError:
+    _GLOG_AVAILABLE = False
 
 
-def _trace_id() -> str:
-    """错误响应 trace_id：优先取请求已注入的（与日志一致），fallback 生成。
+def _trace_id(request: Request | None = None) -> str:
+    """复用请求绑定的 trace_id，无则新生成。
 
-    TraceIdMiddleware 在请求入口 set GLOG contextvars，exception_handler 在 middleware
-    内层执行，此时 trace_id 仍在作用域内 → 错误信封 trace_id 与该请求日志同源（#6784）。
+    优先级：request.state.trace_id（TraceIdMiddleware 注入，随 scope 存活，能跨越
+    中间件异常 unwind）→ GLOG contextvar（正常路径业务层日志已绑定）→ 新生成。
+    保证错误信封、响应头与该请求全部日志同 trace_id。
+
+    对无 state 的 fake/mock request 健壮(单测直接调 handler 的场景)。
     """
-    try:
-        from ginkgo.libs import GLOG
-        return GLOG.get_trace_id() or uuid.uuid4().hex[:16]
-    except ImportError:
-        return uuid.uuid4().hex[:16]
+    if request is not None:
+        try:
+            tid = request.state.trace_id
+        except (AttributeError, TypeError):
+            tid = None
+        if isinstance(tid, str) and tid:
+            return tid
+    if _GLOG_AVAILABLE:
+        tid = GLOG.get_trace_id()
+        if tid:
+            return tid
+    return uuid.uuid4().hex[:16]
 
 
 async def global_error_handler(request: Request, exc: Exception):
-    """将所有异常转换为 {code, data, message, trace_id} 格式"""
+    """将所有异常转换为 {code, data, message, trace_id} 格式。
 
-    if isinstance(exc, APIError):
-        logger.error(f"APIError [{exc.code}] {request.url.path}: {exc.message}")
-        return JSONResponse(status_code=exc.status_code, content=exc.to_dict())
+    中间件抛出的异常（如 JWTAuthMiddleware 的 401）会逃逸到 ServerErrorMiddleware，
+    在 TraceIdMiddleware 的 contextvar 作用域之外触发本 handler。故 trace_id 取
+    request.state（随 scope 存活），并以 with_trace_id 临时复位 contextvar，使错误
+    日志、X-Trace-Id 响应头、body trace_id 三者一致 (#6788 review 修复)。
+    """
+    trace_id = _trace_id(request)
+    headers = {TRACE_ID_HEADER: trace_id}
+    trace_cm = (
+        GLOG.with_trace_id(trace_id)
+        if _GLOG_AVAILABLE
+        else contextlib.nullcontext()
+    )
+    with trace_cm:
+        if isinstance(exc, APIError):
+            logger.error(f"APIError [{exc.code}] {request.url.path}: {exc.message}")
+            return JSONResponse(
+                status_code=exc.status_code, content=exc.to_dict(), headers=headers
+            )
 
-    if isinstance(exc, HTTPException):
-        logger.error(f"HTTPException [{exc.status_code}] {request.url.path}: {exc.detail}")
+        if isinstance(exc, HTTPException):
+            logger.error(
+                f"HTTPException [{exc.status_code}] {request.url.path}: {exc.detail}"
+            )
+            return JSONResponse(
+                status_code=exc.status_code,
+                headers=headers,
+                content={
+                    "code": exc.status_code,
+                    "data": None,
+                    "message": exc.detail,
+                    "trace_id": trace_id,
+                },
+            )
+
+        # 未捕获异常
+        logger.exception(f"Unhandled exception {request.url.path}: {exc}")
         return JSONResponse(
-            status_code=exc.status_code,
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            headers=headers,
             content={
-                "code": exc.status_code,
+                "code": 500,
                 "data": None,
-                "message": exc.detail,
-                "trace_id": _trace_id(),
+                "message": "Internal Server Error",
+                "trace_id": trace_id,
             },
         )
-
-    # 未捕获异常
-    logger.exception(f"Unhandled exception {request.url.path}: {exc}")
-    return JSONResponse(
-        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-        content={
-            "code": 500,
-            "data": None,
-            "message": "Internal Server Error",
-            "trace_id": _trace_id(),
-        },
-    )

--- a/api/middleware/trace_id.py
+++ b/api/middleware/trace_id.py
@@ -1,0 +1,45 @@
+"""
+Trace ID 中间件（全量注入）
+
+每个请求注入一个 trace_id 到 GLOG contextvars，贯穿该请求在 API 进程内的全部日志：
+- src 层（service/crud/engine）走 GLOG structlog，ecs_processor 读 _trace_id_ctx 输出 trace.id
+- api 层（router/middleware）走 core.logging 标准 logging，TraceIdFilter 同源读 _trace_id_ctx
+两层共享同一 _trace_id_ctx 源头，单 trace_id 即可聚合一个请求全链路日志。
+
+透传客户端 X-Trace-Id（若有），否则生成；所有响应回写 X-Trace-Id。
+
+#6784 可观测层接入 1/4
+"""
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from ginkgo.libs import GLOG
+
+# 与 error_handler._trace_id 一致的格式（uuid4 hex 前 16 位）
+TRACE_ID_HEADER = "X-Trace-Id"
+
+
+def _new_trace_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+class TraceIdMiddleware(BaseHTTPMiddleware):
+    """
+    全量注入 trace_id（每个请求都注入，不采样）。
+
+    - 透传客户端 X-Trace-Id（若有），否则生成
+    - GLOG.with_trace_id 注入 contextvars，同请求所有日志（api+src 层）共享
+    - 响应回写 X-Trace-Id，便于客户端关联
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        trace_id = request.headers.get(TRACE_ID_HEADER) or _new_trace_id()
+        # sync contextmanager 包 await call_next: contextvars 在同 task 贯穿该请求所有
+        # 后续 await（service/crud 同 task 读到），请求结束 finally 自动 reset 不泄漏
+        with GLOG.with_trace_id(trace_id):
+            response: Response = await call_next(request)
+        response.headers[TRACE_ID_HEADER] = trace_id
+        return response

--- a/api/middleware/trace_id.py
+++ b/api/middleware/trace_id.py
@@ -37,6 +37,11 @@ class TraceIdMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         trace_id = request.headers.get(TRACE_ID_HEADER) or _new_trace_id()
+        # 注入 request.state：随 scope 存活，跨越中间件异常 unwind。内层中间件(如
+        # JWTAuthMiddleware 401)抛 HTTPException 时 call_next re-raise，本 with 块退出
+        # 致 contextvar reset、且下方响应头写入行被跳过；error_handler 由外层
+        # ServerErrorMiddleware 在本 with 作用域之外触发，靠 state 取回同一 trace_id 补头。
+        request.state.trace_id = trace_id
         # sync contextmanager 包 await call_next: contextvars 在同 task 贯穿该请求所有
         # 后续 await（service/crud 同 task 读到），请求结束 finally 自动 reset 不泄漏
         with GLOG.with_trace_id(trace_id):

--- a/tests/unit/api/middleware/conftest.py
+++ b/tests/unit/api/middleware/conftest.py
@@ -1,0 +1,6 @@
+import os
+
+# #5464/#6784: api.core import 链触发 config.py 全局 Settings()，需合法 SECRET_KEY。
+# conftest 在测试模块 import 前加载，此处 setdefault 先于 middleware.error_handler →
+# core.logging → core/__init__ → config.Settings() 生效。
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-jwt-security-tests")

--- a/tests/unit/api/middleware/test_trace_id.py
+++ b/tests/unit/api/middleware/test_trace_id.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport, AsyncClient
 
 from middleware.trace_id import TRACE_ID_HEADER, TraceIdMiddleware
 from middleware.error_handler import global_error_handler
+from core.exceptions import APIError, NotFoundError
 
 
 @pytest.fixture
@@ -19,7 +20,10 @@ def app():
     """最小 app:只挂 TraceIdMiddleware + 错误处理,避免拉起完整 Ginkgo 服务。"""
     app = FastAPI()
     app.add_middleware(TraceIdMiddleware)
+    # 复刻 main.py 的三层注册(Exception/APIError/HTTPException);漏 APIError 会致
+    # NotFoundError 冒泡到 ServerErrorMiddleware 而非 ExceptionMiddleware
     app.exception_handler(Exception)(global_error_handler)
+    app.exception_handler(APIError)(global_error_handler)
     app.exception_handler(HTTPException)(global_error_handler)
 
     @app.get("/probe")
@@ -31,6 +35,12 @@ def app():
     @app.get("/boom")
     async def boom():
         raise HTTPException(status_code=400, detail="test error")
+
+    @app.get("/apierror")
+    async def apierror():
+        # APIError 子类:构造时自生随机 trace_id(exceptions.py),用于验证 error_handler
+        # override body.trace_id 为请求 trace_id(否则与 X-Trace-Id 头脱钩)
+        raise NotFoundError("user", "123")
 
     return app
 
@@ -85,6 +95,35 @@ async def test_error_passthrough_consistency(app):
     client_tid = uuid.uuid4().hex[:16]
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         r = await c.get("/boom", headers={TRACE_ID_HEADER: client_tid})
+    assert r.json()["trace_id"] == client_tid
+    assert r.headers[TRACE_ID_HEADER] == client_tid
+
+
+@pytest.mark.asyncio
+async def test_apierror_response_trace_id_consistency(app):
+    """APIError 响应 body.trace_id 必须等于请求 X-Trace-Id 头,而非 exc 自生随机值。
+
+    回归 #6797 review:exc.to_dict() 带 APIError 构造时自生的随机 trace_id,修复前
+    error_handler 直接 content=exc.to_dict() 致 body 与响应头脱钩(同一响应两个 trace_id)。
+    """
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/apierror")
+    assert r.status_code == 404
+    body = r.json()
+    header_tid = r.headers[TRACE_ID_HEADER]
+    assert body["trace_id"] == header_tid, (
+        f"APIError body trace_id({body['trace_id']})与响应头({header_tid})脱钩 — "
+        "应 override 为请求 trace_id,而非 exc 自生随机值"
+    )
+
+
+@pytest.mark.asyncio
+async def test_apierror_passthrough_consistency(app):
+    """APIError 路径下,入站 X-Trace-Id 贯穿到 body.trace_id(非 exc 随机值)。"""
+    client_tid = uuid.uuid4().hex[:16]
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/apierror", headers={TRACE_ID_HEADER: client_tid})
+    assert r.status_code == 404
     assert r.json()["trace_id"] == client_tid
     assert r.headers[TRACE_ID_HEADER] == client_tid
 

--- a/tests/unit/api/middleware/test_trace_id.py
+++ b/tests/unit/api/middleware/test_trace_id.py
@@ -1,0 +1,89 @@
+"""
+TraceIdMiddleware 单元测试（#6784 可观测层接入 1/4）
+
+覆盖:全量注入、客户端透传、响应头回写、错误响应 trace_id 一致性、贯穿 api+src 层。
+用最小 FastAPI app + TraceIdMiddleware + global_error_handler 隔离测试,不引入完整 Ginkgo app。
+"""
+import uuid
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from middleware.trace_id import TRACE_ID_HEADER, TraceIdMiddleware
+from middleware.error_handler import global_error_handler
+
+
+@pytest.fixture
+def app():
+    """最小 app:只挂 TraceIdMiddleware + 错误处理,避免拉起完整 Ginkgo 服务。"""
+    app = FastAPI()
+    app.add_middleware(TraceIdMiddleware)
+    app.exception_handler(Exception)(global_error_handler)
+    app.exception_handler(HTTPException)(global_error_handler)
+
+    @app.get("/probe")
+    async def probe():
+        # 端点内读 GLOG contextvars,验证 src 层贯穿
+        from ginkgo.libs import GLOG
+        return {"trace_id": GLOG.get_trace_id()}
+
+    @app.get("/boom")
+    async def boom():
+        raise HTTPException(status_code=400, detail="test error")
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_inject_trace_id_every_request(app):
+    """全量注入:无客户端头时,响应回写 X-Trace-Id,且贯穿到端点内 GLOG。"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/probe")
+    assert r.status_code == 200
+    assert TRACE_ID_HEADER in r.headers
+    # 贯穿:端点读到的 GLOG trace_id == 响应头
+    assert r.json()["trace_id"] == r.headers[TRACE_ID_HEADER]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_client_header(app):
+    """透传:客户端带 X-Trace-Id 时复用,不重新生成。"""
+    client_tid = uuid.uuid4().hex[:16]
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/probe", headers={TRACE_ID_HEADER: client_tid})
+    assert r.headers[TRACE_ID_HEADER] == client_tid
+    assert r.json()["trace_id"] == client_tid
+
+
+@pytest.mark.asyncio
+async def test_unique_trace_id_per_request(app):
+    """隔离:不同请求 trace_id 不同(contextvars 不泄漏)。"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r1 = await c.get("/probe")
+        r2 = await c.get("/probe")
+    t1 = r1.headers[TRACE_ID_HEADER]
+    t2 = r2.headers[TRACE_ID_HEADER]
+    assert t1 != t2
+    assert len(t1) == 16 and len(t2) == 16
+
+
+@pytest.mark.asyncio
+async def test_error_response_trace_id_consistency(app):
+    """错误响应 trace_id 与响应头一致(error_handler 读 GLOG.get_trace_id,非随机重生成)。"""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/boom")
+    assert r.status_code == 400
+    body = r.json()
+    # 错误信封 trace_id == 响应头(同一请求 trace_id 贯穿到异常处理)
+    assert body["trace_id"] == r.headers[TRACE_ID_HEADER]
+
+
+@pytest.mark.asyncio
+async def test_error_passthrough_consistency(app):
+    """透传 + 错误:客户端 trace_id 贯穿到错误响应信封。"""
+    client_tid = uuid.uuid4().hex[:16]
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        r = await c.get("/boom", headers={TRACE_ID_HEADER: client_tid})
+    assert r.json()["trace_id"] == client_tid
+    assert r.headers[TRACE_ID_HEADER] == client_tid

--- a/tests/unit/api/middleware/test_trace_id.py
+++ b/tests/unit/api/middleware/test_trace_id.py
@@ -87,3 +87,113 @@ async def test_error_passthrough_consistency(app):
         r = await c.get("/boom", headers={TRACE_ID_HEADER: client_tid})
     assert r.json()["trace_id"] == client_tid
     assert r.headers[TRACE_ID_HEADER] == client_tid
+
+
+# ---------------------------------------------------------------------------
+# 中间件异常路径回归守护 (port 自 #6788 review 问题 1)
+#
+# 缺陷:内层中间件(如 JWTAuthMiddleware 401)抛 HTTPException 时,异常逃逸
+# TraceIdMiddleware 的 with 块 → contextvar reset + 响应头写入行被跳过;
+# global_error_handler 由外层 ServerErrorMiddleware 在 contextvar 作用域之外触发,
+# trace_id 二次生成且日志显示 "-"。修复靠 request.state.trace_id (随 scope 存活、跨 unwind)
+# 作跨层通道,handler 补头 + 临时复位 contextvar。
+# 用忠实最小栈复现(内层 raise 中间件 + TraceId 最外层 + 同 main.py 的 handler 注册)。
+# ---------------------------------------------------------------------------
+
+
+def _build_raising_stack(raiser):
+    """复刻 main.py 栈序:内层 raising 中间件 + TraceIdMiddleware 最外层 + 全局 handler。"""
+    from fastapi import FastAPI, HTTPException
+    from middleware.trace_id import TraceIdMiddleware
+    from middleware.error_handler import global_error_handler
+
+    app = FastAPI()
+    app.add_middleware(raiser)  # 内层(模拟 JWT)
+    app.add_middleware(TraceIdMiddleware)  # 最后注册 = 栈顶最外层(同 main.py)
+    app.exception_handler(Exception)(global_error_handler)
+    app.exception_handler(HTTPException)(global_error_handler)
+    return app
+
+
+def test_middleware_raised_exception_keeps_header_and_trace_id():
+    """内层中间件 raise HTTPException(401) → X-Trace-Id 头不丢、body trace_id 不脱钩。
+
+    回归 #6788 问题 1:修复前 header=None、body trace_id 新生成。
+    """
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class JWTLikeMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise HTTPException(status_code=401, detail="Missing authentication token")
+
+    app = _build_raising_stack(JWTLikeMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    resp = client.get("/anything")  # 任意路径,内层中间件无条件 raise
+    assert resp.status_code == 401
+    header_tid = resp.headers.get("x-trace-id")
+    assert header_tid is not None, "中间件异常路径 X-Trace-Id 头丢失 (#6788 问题 1)"
+    body_tid = resp.json()["trace_id"]
+    assert body_tid == header_tid, (
+        f"body trace_id({body_tid})与响应头({header_tid})脱钩 — 应复用同一 trace_id"
+    )
+
+
+def test_middleware_raised_exception_passes_through_client_trace_id():
+    """中间件异常路径下,入站 X-Trace-Id 仍正确透传到响应头/body。"""
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+
+    class JWTLikeMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+    app = _build_raising_stack(JWTLikeMiddleware)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    fixed = "1122334455667788"
+    resp = client.get("/anything", headers={"X-Trace-Id": fixed})
+    assert resp.status_code == 401
+    assert resp.headers.get("x-trace-id") == fixed, "异常路径未透传入站 trace_id"
+    assert resp.json()["trace_id"] == fixed
+
+
+def test_middleware_raised_exception_log_carries_trace_id():
+    """中间件异常路径下,global_error_handler 的错误日志携带请求 trace_id(非 "-")。
+
+    回归 #6788:修复前 contextvar 已 reset,handler 日志输出 trace_id="-"。
+    """
+    import io
+    import logging
+    from fastapi import HTTPException
+    from fastapi.testclient import TestClient
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from core.logging import logger as api_logger, TraceIdFilter
+
+    class JWTLikeMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            raise HTTPException(status_code=401, detail="Missing authentication token")
+
+    app = _build_raising_stack(JWTLikeMiddleware)
+    # 最小 app 不走 setup_logging,手动确保捕获 logger 带 TraceIdFilter(幂等)
+    if not any(isinstance(f, TraceIdFilter) for f in api_logger.filters):
+        api_logger.addFilter(TraceIdFilter())
+
+    stream = io.StringIO()
+    h = logging.StreamHandler(stream)
+    h.setFormatter(logging.Formatter("%(trace_id)s|%(message)s"))
+    api_logger.addHandler(h)
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        fixed = "9988776655443322"
+        client.get("/anything", headers={"X-Trace-Id": fixed})
+    finally:
+        api_logger.removeHandler(h)
+
+    out = stream.getvalue()
+    assert fixed in out, (
+        f"错误日志未携带请求 trace_id(应为 {fixed}),输出: {out!r} — contextvar 未复位 (#6788)"
+    )


### PR DESCRIPTION
## Implements

#6784（可观测层接入 1/4：API 请求 trace_id 全量注入贯穿 GLOG 日志）

## What

每个 API 请求注入一个 trace_id 到 GLOG contextvars，贯穿该请求在 API 进程内全部日志：
- **src 层**（service/crud/engine，GLOG structlog）：`ecs_processor` 读 `_trace_id_ctx` 输出 `trace.id`
- **api 层**（router/middleware，`core.logging` 标准 logging）：新增 `TraceIdFilter` 同源读 `_trace_id_ctx`

两层共享单一 `_trace_id_ctx` 源头，一个 trace_id 即可聚合一个请求全链路日志。透传客户端 `X-Trace-Id`；所有响应回写 `X-Trace-Id`。

## Changes

- `api/middleware/trace_id.py`（新）：`TraceIdMiddleware` 全量注入，透传 `X-Trace-Id`，响应回写 `X-Trace-Id`
- `api/core/logging.py`：`TraceIdFilter` 接 GLOG `_trace_id_ctx`，JSON/Rich formatter 输出 `trace_id`
- `api/middleware/error_handler.py`：`_trace_id()` 优先 `GLOG.get_trace_id()`（错误信封 trace_id 与请求同源，不再随机重生成），fallback 生成
- `api/main.py`：注册 `TraceIdMiddleware`（最后注册 = 最外层，trace_id 覆盖全栈）
- `tests/unit/api/middleware/test_trace_id.py`（新）：5 用例 + conftest

## 决策点（issue HITL）

用户拍板：**全量注入**（不采样，每请求都注入）。container ECS 模式开关沿用 `LogMode.AUTO` 现有默认，未改全局行为。

## 验证

- 新增 5 用例全绿：`pytest tests/unit/api/middleware/test_trace_id.py` ✅
- 回归守护 4 用例全绿（含 #5405 HTTPException trace_id 契约 + main.py 注册链 import smoke）：`pytest tests/api/test_error_handler_5405.py tests/api/test_http_exception_unified_response.py` ✅
- `py_compile` main.py / core/logging.py / error_handler.py / trace_id.py ✅

## 后续

本切片是跨进程 trace_id 传播的前置基座：
- #6786 Backtest 跨进程 trace_id（经 Kafka header）阻塞于此
- #6787 Paper/Live worker trace_id 阻塞于此

🤖 Generated with [Claude Code](https://claude.com/claude-code)