### PR TITLE
feat(observability): backtest 跨进程 trace_id 经 Kafka header 传播 (#6786)

### DIFF
--- a/api/api/backtest.py
+++ b/api/api/backtest.py
@@ -18,6 +18,7 @@ from core.pagination import DEFAULT_MAX_PAGE_SIZE
 from core.redis_client import get_backtest_progress
 from core.response import ok, paginated
 from core.exceptions import APIError, NotFoundError, ValidationError, BusinessError
+from ginkgo.libs import GLOG
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
 from ginkgo.interfaces.kafka_topics import KafkaTopics
 from ginkgo.data.containers import container
@@ -219,6 +220,15 @@ def create_backtest_task(data: BacktestTaskCreate) -> dict:
     if effective_end:
         create_kwargs["backtest_end_date"] = effective_end
 
+    # #6786 AC2: 持久化 trace_id 到 task.meta JSON（复用 MMysqlBase.meta，无 schema 变更）。
+    # #6784 TraceIdMiddleware 在请求入口注入 GLOG contextvars；此处取出写入 meta，
+    # worker/CLI 可从 DB 回查 trace_id（AC5 backtest cat 显示），不依赖 Kafka header
+    # 是否完好（header 是运行期串联，meta 是落库回查，双保险）。
+    # 无 trace_id 时不写 meta，保持 model 默认 "{}"（向后兼容）。
+    trace_id = GLOG.get_trace_id()
+    if trace_id:
+        create_kwargs["meta"] = json.dumps({"trace_id": trace_id})
+
     task_service = get_backtest_task_service()
     result = task_service.create(**create_kwargs)
 
@@ -247,7 +257,13 @@ def create_backtest_task(data: BacktestTaskCreate) -> dict:
 
 
 async def send_task_to_kafka(task_uuid: str, portfolio_uuids: list, name: str, config: dict):
-    """发送任务到Kafka"""
+    """发送任务到Kafka
+
+    #6786: 从 GLOG contextvars 取请求 trace_id（#6784 TraceIdMiddleware 在请求入口
+    注入），写入 Kafka 消息 header；worker 消费时从 header 恢复到 GLOG contextvars，
+    使 engine/strategy/fill/portfolio 日志共享同一 trace_id，串联 API 提交端与
+    worker 执行端全链路日志。
+    """
     producer = get_kafka_producer()
 
     assignment = {
@@ -260,9 +276,15 @@ async def send_task_to_kafka(task_uuid: str, portfolio_uuids: list, name: str, c
         "priority": 0,
     }
 
+    # #6786: trace_id 经 Kafka header 跨进程传播。None 时等价不传（向后兼容，
+    # 非 API 入口调用如 CLI 直派无 trace_id 时不污染消息）。
+    trace_id = GLOG.get_trace_id()
+    headers = [("trace_id", trace_id.encode())] if trace_id else None
+
     result = producer.send(
         topic=KafkaTopics.BACKTEST_ASSIGNMENTS,
         msg=assignment,
+        headers=headers,
     )
     # GinkgoProducer.send 返 bool 不 raise（ginkgo_kafka.py:89-123 三处 return False：
     # 未连接/KafkaError/异常，成功 return True）。不判返回值则协程无异常，create_task

--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -53,6 +53,26 @@ def _emit_backtest_failure(result):
         console.print(preflight_warning)
 
 
+def _extract_trace_id_from_meta(meta) -> Optional[str]:
+    """从 task.meta JSON 解析 trace_id（#6786 AC5）。
+
+    meta 是 MMysqlBase.meta（String(255) 默认 '{}'）。API create_backtest_task
+    写 {"trace_id": ...}（任务 #3）；cat 解析显示，让运维 grep trace_id 串联
+    API→worker 全链路。非 JSON / 无 trace_id / None graceful 返 None（向后兼容
+    旧任务 + 防 cat 崩溃）。
+    """
+    if not meta or not isinstance(meta, str):
+        return None
+    try:
+        data = json.loads(meta)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    tid = data.get("trace_id")
+    return tid if isinstance(tid, str) and tid else None
+
+
 def _task_record(task) -> dict:
     """序列化 backtest task 为 JSON record。
 
@@ -100,6 +120,8 @@ def _task_record(task) -> dict:
         "error_message": _get("error_message"),
         # config_snapshot：回测配置快照（text 路径 Config panel；#6652 review E6 补齐 _task_record 覆盖声明）。
         "config_snapshot": _get("config_snapshot"),
+        # trace_id：从 meta JSON 解析（#6786 AC5，API create_backtest_task 写入）。
+        "trace_id": _extract_trace_id_from_meta(_get("meta")),
     }
 
 
@@ -651,6 +673,11 @@ def cat_task(
     display_progress = _display_progress(status_val, task.progress)
     info_lines.append(f"[bold]Progress:[/bold]     {display_progress}%")
     info_lines.append(f"[bold]Created:[/bold]      {task.create_at}")
+
+    # #6786 AC5：trace_id 从 meta 解析显示（运维 grep 串联 API→worker 全链路）
+    trace_id = _extract_trace_id_from_meta(getattr(task, "meta", None))
+    if trace_id:
+        info_lines.append(f"[bold]Trace ID:[/bold]    {trace_id}")
 
     if task.start_time:
         info_lines.append(f"[bold]Started:[/bold]      {task.start_time}")

--- a/src/ginkgo/data/crud/backtest_task_crud.py
+++ b/src/ginkgo/data/crud/backtest_task_crud.py
@@ -96,6 +96,9 @@ class BacktestTaskCRUD(BaseCRUD[MBacktestTask]):
             total_events=kwargs.get("total_events", 0),
             config_snapshot=kwargs.get("config_snapshot", "{}"),
             environment_info=kwargs.get("environment_info", "{}"),
+            # #6786: meta 须显式透传——MMysqlBase.meta 默认 "{}"，白名单漏掉会让
+            # api 层写入的 trace_id 在此被静默丢弃（arch_crud_whitelist_field_drop）。
+            meta=kwargs.get("meta", "{}"),
             final_portfolio_value=kwargs.get("final_portfolio_value", 0.0),
             total_pnl=kwargs.get("total_pnl", 0.0),
             max_drawdown=kwargs.get("max_drawdown", 0.0),

--- a/src/ginkgo/data/drivers/ginkgo_kafka.py
+++ b/src/ginkgo/data/drivers/ginkgo_kafka.py
@@ -86,13 +86,15 @@ class GinkgoProducer(object):
 
     @time_logger(threshold=1.0)
     @retry(max_try=3)
-    def send(self, topic, msg):
+    def send(self, topic, msg, headers=None):
         """
         同步发送消息（等待确认）
 
         Args:
             topic: Kafka topic
             msg: 消息内容
+            headers: Kafka 消息头 [(key, bytes_value)]，跨进程 trace_id 传播用（#6786）。
+                None 等价不传，向后兼容现有调用方。
 
         Returns:
             bool: 发送是否成功
@@ -103,7 +105,7 @@ class GinkgoProducer(object):
             return False
 
         try:
-            future = self.producer.send(topic, msg)
+            future = self.producer.send(topic, msg, headers=headers)
             result = future.get(timeout=10)
             # result 是 RecordMetadata 对象，不需要打印
             GLOG.DEBUG(f"Kafka send message. TOPIC: {topic}. {msg}")

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -838,7 +838,12 @@ class BacktestTaskService(BaseService):
 
             # #4853：检查 send 返回值，失败即标 failed，避免永久 running 孤儿。
             # GinkgoProducer.send 已装饰 @retry(max_try=3)，此处 False 表示重试耗尽仍未送达。
-            send_ok = producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment)
+            # #6786：trace_id 经 Kafka header 跨进程传播（与 api 层 send_task_to_kafka 对称），
+            # POST /{uuid}/start 入口同进程继承 #6784 TraceIdMiddleware 注入的 GLOG contextvars。
+            # None 时等价不传，向后兼容（既有 start_task 测试断言位置参数不受影响）。
+            trace_id = GLOG.get_trace_id()
+            headers = [("trace_id", trace_id.encode())] if trace_id else None
+            send_ok = producer.send(KafkaTopics.BACKTEST_ASSIGNMENTS, assignment, headers=headers)
             producer.flush(timeout=2.0)
             producer.close()
 

--- a/src/ginkgo/trading/engines/event_engine.py
+++ b/src/ginkgo/trading/engines/event_engine.py
@@ -40,6 +40,7 @@ from queue import Queue, Empty
 from ginkgo.trading.engines.base_engine import BaseEngine
 from ginkgo.enums import EXECUTION_MODE
 from ginkgo.libs import GCONF, GLOG
+from ginkgo.libs.core.logger import _trace_id_ctx
 from ginkgo.trading.core.status import EngineStatus, EventStats, QueueInfo
 
 
@@ -76,6 +77,10 @@ class EventEngine(BaseEngine):
         self._timer_thread.daemon = True
         self._timer_thread_started = False
         self._pause_flag = threading.Event()  # 暂停标志
+        # #6786 AC4: start() 时从当前线程（BacktestProcessor 线程，已 set trace_id）
+        # 捕获 trace_id，供 main_loop/timer_loop 在 engine 子线程恢复。
+        # contextvars 不跨线程自动传播，须手动接力（见 _restore_trace_context）。
+        self._trace_id: Optional[str] = None
 
         # === 事件处理器注册 ===
         self._handlers: dict[EVENT_TYPES, list] = {}
@@ -195,12 +200,27 @@ class EventEngine(BaseEngine):
         """实现BaseEngine的抽象方法"""
         self._process(event)
 
+    def _restore_trace_context(self) -> None:
+        """#6786 AC4: 在 engine 子线程入口恢复 trace_id 到本线程 contextvars。
+
+        contextvars 不跨线程自动传播：main_loop/timer_loop 跑在 engine 自起的
+        Thread 里，看不到 BacktestProcessor 线程 set 的 trace_id。start() 已把
+        trace_id 捕获到 self._trace_id，本方法在子线程入口 set 回 _trace_id_ctx，
+        使后续 _process → strategy/fill/portfolio handler 的 GLOG 日志带 trace_id。
+        无 trace_id 时 noop（向后兼容非 API 入口 / 旧消息）。
+        """
+        if self._trace_id:
+            _trace_id_ctx.set(self._trace_id)
+
     def main_loop(self, *args, **kwargs) -> None:
         """
         Main event processing loop - 默认实现从事件队列中获取并处理事件
         """
         # 在引擎线程中绑定 EngineContext 引用（contextvars 不跨线程传播）
         GLOG.bind_context(engine_context=self._engine_context)
+        # #6786 AC4: engine 子线程恢复 trace_id，使 strategy/fill/portfolio 日志
+        # 带 trace_id（main_loop 内同步调用 _process → 各 handler，同线程可见）。
+        self._restore_trace_context()
 
         while not self._main_flag.is_set():
             # 检查暂停标志
@@ -232,6 +252,8 @@ class EventEngine(BaseEngine):
         """
         Timer Task. Something like crontab or systemd timer
         """
+        # #6786 AC4: timer 子线程同样须恢复 trace_id（与 main_loop 对称）。
+        self._restore_trace_context()
         while True:
             if self._timer_flag.is_set():
                 break
@@ -276,6 +298,10 @@ class EventEngine(BaseEngine):
         """
         if not super().start():
             return False
+
+        # #6786 AC4: 在 start() 时（调用方 BacktestProcessor 线程已 set trace_id）
+        # 捕获 trace_id；main_loop/timer_loop 在 engine 子线程入口接力恢复。
+        self._trace_id = GLOG.get_trace_id()
 
         # 清除暂停标志，允许主循环继续运行
         self._pause_flag.clear()

--- a/src/ginkgo/trading/engines/time_controlled_engine.py
+++ b/src/ginkgo/trading/engines/time_controlled_engine.py
@@ -253,6 +253,9 @@ class TimeControlledEventEngine(EventEngine, TimeAwareComponent):
         # 在引擎线程中绑定 EngineContext 引用（contextvars 不跨线程传播）
         GLOG.bind_context(engine_context=self._engine_context)
         GLOG.set_log_category("backtest")
+        # #6786 AC4: engine 子线程恢复 trace_id，使回测事件链（strategy/fill/
+        # portfolio handler 经 _process_backtest_event 同步调用）日志带 trace_id。
+        self._restore_trace_context()
 
         GLOG.INFO(f"{self.name}: Main loop started - Mode: {self.mode}")
         GLOG.INFO(f"{self.name}: main_flag.is_set() = {main_flag.is_set()} at start")

--- a/src/ginkgo/workers/backtest_worker/node.py
+++ b/src/ginkgo/workers/backtest_worker/node.py
@@ -200,12 +200,10 @@ class BacktestWorker:
                     # 处理消息 {TopicPartition: [ConsumerRecord]}
                     for tp, records in messages.items():
                         for message in records:
-                            # GinkgoConsumer 已反序列化，message.value 直接是 dict
-                            assignment = message.value
-
-                            # #5399②: 不在派发前提前提交 offset——派发失败会导致任务静默丢失
-                            # commit 移到 _handle_task_assignment 正常完成决策后（at-least-once）
-                            self._handle_task_assignment(assignment)
+                            # #6786: _dispatch_message 从 message.headers 恢复 trace_id，
+                            # with_trace_id 包 _handle_task_assignment；at-least-once offset
+                            # 提交逻辑不变（仍在 _handle_task_assignment 决策后提交）
+                            self._dispatch_message(message)
 
                 except Exception as e:
                     if not self.should_stop:
@@ -213,6 +211,40 @@ class BacktestWorker:
 
         self.task_consumer_thread = Thread(target=consume_tasks, daemon=True)
         self.task_consumer_thread.start()
+
+    def _dispatch_message(self, message):
+        """处理单条 Kafka 消息：恢复 trace_id（#6786）+ 派发到 _handle_task_assignment。
+
+        #6786: 从 message.headers 读 trace_id，with_trace_id 包 _handle_task_assignment，
+        使派发决策日志（槽位等待 / 畸形处理 / offset 提交）带 trace_id，与 API 提交端
+        grep 同一值串联。engine 线程的 trace_id 传播由 BacktestProcessor 接力
+        （_start_task 取 contextvars 传 processor，run() 入口恢复）。
+        无 header / 解码失败时向后兼容（不注入 trace_id，不阻断消费）。
+        """
+        assignment = message.value
+        tid = self._extract_trace_id(message.headers)
+        if tid:
+            with GLOG.with_trace_id(tid):
+                self._handle_task_assignment(assignment)
+        else:
+            self._handle_task_assignment(assignment)
+
+    @staticmethod
+    def _extract_trace_id(headers) -> Optional[str]:
+        """从 Kafka ConsumerRecord.headers [(key, bytes_value)] 提取 trace_id。
+
+        kafka-python ConsumerRecord.headers 为 list[(str, bytes)] 或 None。解码失败
+        graceful 降级返 None（不抛 UnicodeDecodeError 进 consume except，避免毒丸重投死循环）。
+        """
+        if not headers:
+            return None
+        for key, value in headers:
+            if key == "trace_id" and value:
+                try:
+                    return value.decode("utf-8")
+                except (UnicodeDecodeError, AttributeError):
+                    return None
+        return None
 
     def _handle_task_assignment(self, assignment: dict):
         """处理任务分配（ADR-018：from_payload + match 判别联合）。
@@ -353,7 +385,11 @@ class BacktestWorker:
             GLOG.INFO(f"  with {len(task.config.analyzers)} analyzers: {[a.name for a in task.config.analyzers]}")
 
         # 创建Processor
-        processor = BacktestProcessor(task, self.worker_id, self.progress_tracker)
+        # #6786: 从 consume 线程 GLOG contextvars 取 trace_id 传入 processor（contextvars
+        # 不跨线程自动传播，processor.start() spawn 的 engine 线程需 run() 入口 _init_trace_context
+        # 手动恢复）。_dispatch_message 的 with_trace_id 此时仍在栈上，get_trace_id() 可见。
+        trace_id = GLOG.get_trace_id()
+        processor = BacktestProcessor(task, self.worker_id, self.progress_tracker, trace_id=trace_id)
 
         with self.task_lock:
             self.tasks[task.task_uuid] = processor

--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -31,12 +31,14 @@ from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAgg
 from ginkgo import services
 from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.trading.time.clock import now as clock_now
+from ginkgo.libs.core.logger import _trace_id_ctx
 
 
 class BacktestProcessor(Thread):
     """回测任务处理器"""
 
-    def __init__(self, task: BacktestTask, worker_id: str, progress_tracker: ProgressTracker):
+    def __init__(self, task: BacktestTask, worker_id: str, progress_tracker: ProgressTracker,
+                 trace_id: Optional[str] = None):
         """
         初始化任务处理器
 
@@ -44,11 +46,14 @@ class BacktestProcessor(Thread):
             task: 回测任务
             worker_id: 所属Worker ID
             progress_tracker: 进度上报器
+            trace_id: 跨进程 trace_id（#6786）。由 _start_task 从 consume 线程 GLOG
+                contextvars 取出传入；contextvars 不跨线程自动传播，run() 入口手动恢复。
         """
         super().__init__(daemon=True)
         self.task = task
         self.worker_id = worker_id
         self.progress_tracker = progress_tracker
+        self.trace_id = trace_id
 
         # 线程控制
         self._stop_event = Event()
@@ -60,6 +65,18 @@ class BacktestProcessor(Thread):
         self._assembly_service = services.trading.services.engine_assembly_service()
         self._portfolio_service = services.data.portfolio_service()
 
+    def _init_trace_context(self):
+        """恢复跨进程 trace_id 到本线程 contextvars（#6786 AC4）。
+
+        contextvars 不跨线程自动传播：BacktestProcessor.start() spawn 的 engine 线程
+        看不到 consume 线程 with_trace_id 设的值。_start_task 从 consume 上下文取出
+        trace_id 传入构造，run() 入口调本方法手动 set，使 engine/strategy/fill/portfolio
+        日志带 trace_id，与 API 提交端 grep 同一值串联（全链路 AC4）。
+        无 trace_id 时 noop（向后兼容旧消息 / 非 API 入口）。
+        """
+        if self.trace_id:
+            _trace_id_ctx.set(self.trace_id)
+
     def run(self):
         """执行回测任务"""
         self.task.started_at = datetime.utcnow()
@@ -67,6 +84,8 @@ class BacktestProcessor(Thread):
 
         GLOG.clear_context()
         GLOG.set_log_category("component")
+        # #6786: 恢复跨进程 trace_id（clear_context 不动 _trace_id_ctx，此处安全 set）
+        self._init_trace_context()
 
         try:
             GLOG.INFO(f"[{self.task.task_uuid[:8]}] Starting backtest task: {self.task.name}")

--- a/tests/api/test_backtest_create_meta_trace_id_6786.py
+++ b/tests/api/test_backtest_create_meta_trace_id_6786.py
@@ -1,0 +1,86 @@
+# Issue #6786 AC2: create_backtest_task 持久化 trace_id 到 task.meta JSON
+#
+# 方案：复用 MMysqlBase.meta JSON 字段（String(255) default "{}"），避免 schema 变更
+# 触发安全阀。create_backtest_task 从 GLOG contextvars 取 trace_id（#6784 TraceIdMiddleware
+# 注入），json.dumps({"trace_id": tid}) 写入 service.create 的 meta kwarg；service.create
+# **kwargs 展开落 crud.create → model.meta 字段。worker/CLI 后续从 meta 读 trace_id
+# （AC5 backtest cat 显示），即使 Kafka header 丢失，meta 仍可回查。
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestCreateBacktestTaskPersistsTraceIdToMeta:
+    """#6786 AC2: create_backtest_task 把 trace_id 持久化到 task.meta JSON"""
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_create_persists_trace_id_to_meta(self, mock_get_service, mock_portfolio, api_modules):
+        """GLOG contextvars 有 trace_id 时，service.create 收到 meta JSON 含 trace_id。"""
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+        from ginkgo.libs import GLOG
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+
+        with GLOG.with_trace_id("tid-meta-456"):
+            create_backtest_task(data)
+
+        call_kwargs = mock_service.create.call_args.kwargs
+        assert "meta" in call_kwargs, f"create() 未收到 meta, 实际: {list(call_kwargs.keys())}"
+        meta = json.loads(call_kwargs["meta"])
+        assert meta.get("trace_id") == "tid-meta-456"
+
+    @patch("api.backtest.get_portfolio_info")
+    @patch("api.backtest.get_backtest_task_service")
+    def test_create_no_trace_id_no_meta(self, mock_get_service, mock_portfolio, api_modules):
+        """无 trace_id 上下文时不写 meta（向后兼容，保持 model 默认 "{}"）。"""
+        from api.backtest import create_backtest_task, BacktestTaskCreate, EngineConfig
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        mock_portfolio.return_value = {"uuid": "p-1", "name": "Portfolio1"}
+        mock_task = MagicMock()
+        mock_task.uuid = "task-uuid"
+        mock_task.created_at = "2025-01-01T00:00:00Z"
+        mock_result = MagicMock()
+        mock_result.is_success.return_value = True
+        mock_result.data = mock_task
+        mock_service = MagicMock()
+        mock_service.create.return_value = mock_result
+        mock_get_service.return_value = mock_service
+
+        data = BacktestTaskCreate(
+            name="test_bt",
+            portfolio_uuids=["p-1"],
+            engine_config=EngineConfig(
+                start_date="2025-06-01",
+                end_date="2025-12-31",
+            ),
+        )
+
+        token = _trace_id_ctx.set(None)
+        try:
+            create_backtest_task(data)
+        finally:
+            _trace_id_ctx.reset(token)
+
+        call_kwargs = mock_service.create.call_args.kwargs
+        assert "meta" not in call_kwargs, "无 trace_id 时不应写 meta（保持 model 默认）"

--- a/tests/api/test_backtest_dispatch_trace_id_6786.py
+++ b/tests/api/test_backtest_dispatch_trace_id_6786.py
@@ -1,0 +1,60 @@
+# Issue #6786: backtest 跨进程 trace_id 经 Kafka header 传播（可观测层 2/4）
+#
+# 根因：api/api/backtest.py send_task_to_kafka 派发 Kafka 消息时不携带 trace_id，
+#   worker 消费侧拿不到，engine/strategy/fill/portfolio 日志无 trace_id，无法把
+#   一次回测的 API 提交端与 worker 执行端日志关联排障。
+# 修复：send_task_to_kafka 从 GLOG contextvars 取 trace_id（#6784 中间件已注入），
+#   写入 producer.send 的 headers=[("trace_id", bytes)]，worker 消费时从
+#   message.headers 恢复到 GLOG contextvars。
+
+import asyncio
+from unittest.mock import patch, MagicMock
+
+
+class TestBacktestDispatchTraceIdHeader:
+    """#6786: backtest Kafka 派发携带 trace_id header"""
+
+    def test_dispatch_propagates_trace_id_header(self, api_modules):
+        """GLOG contextvars 有 trace_id 时，producer.send 收到 headers=[("trace_id", bytes)]。
+
+        #6784 TraceIdMiddleware 在请求入口把 trace_id 注入 GLOG contextvars；
+        #6786 派发时从 contextvars 取出写入 Kafka header，跨进程传给 worker。
+        """
+        from api.backtest import send_task_to_kafka
+        from ginkgo.libs import GLOG
+
+        fake_producer = MagicMock()
+        fake_producer.send.return_value = True
+
+        with patch("api.backtest.get_kafka_producer", return_value=fake_producer), \
+             GLOG.with_trace_id("tid-abc-123"):
+            asyncio.run(
+                send_task_to_kafka("task-1", ["port-1"], "name", {"engine_uuid": "e1"})
+            )
+
+        fake_producer.send.assert_called_once()
+        _, kwargs = fake_producer.send.call_args
+        # header 值须为 bytes（kafka-python 要求），key 为 trace_id
+        assert kwargs.get("headers") == [("trace_id", b"tid-abc-123")]
+
+    def test_dispatch_no_trace_id_no_header(self, api_modules):
+        """GLOG contextvars 无 trace_id 时，不写 header（向后兼容，不污染消息）。"""
+        from api.backtest import send_task_to_kafka
+        from ginkgo.libs import GLOG
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        # 显式隔离：确保本测试 contextvars trace_id 为 None（防前序测试残留）
+        token = _trace_id_ctx.set(None)
+        try:
+            fake_producer = MagicMock()
+            fake_producer.send.return_value = True
+
+            with patch("api.backtest.get_kafka_producer", return_value=fake_producer):
+                asyncio.run(
+                    send_task_to_kafka("task-2", ["port-2"], "name", {})
+                )
+        finally:
+            _trace_id_ctx.reset(token)
+
+        _, kwargs = fake_producer.send.call_args
+        assert kwargs.get("headers") is None

--- a/tests/unit/client/test_backtest_cat_trace_id_6786.py
+++ b/tests/unit/client/test_backtest_cat_trace_id_6786.py
@@ -1,0 +1,93 @@
+# Issue #6786 AC5: ginkgo backtest cat 显示 trace_id（从 task.meta JSON 解析）
+#
+# API 写 task.meta={"trace_id":...}（任务 #3），cat 须解析显示，让运维 grep trace_id
+# 串联 API→worker 全链路（AC4 闭环 + AC5 机读/人读）。
+
+import json
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+import re
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+
+from ginkgo.client.backtest_cli import _task_record
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    """去除 ANSI 转义码"""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _mock_task(meta="{}"):
+    """构造 mock backtest task（参考 test_backtest_cli._mock_task，补 meta 字段）。"""
+    task = MagicMock()
+    task.uuid = "abc123456789"
+    task.task_id = "task-run-id-001"
+    task.name = "Test Backtest"
+    task.portfolio_id = "port-001"
+    task.engine_id = "engine-001"
+    task.status = "completed"
+    task.progress = 100
+    task.create_at = "2025-01-01"
+    task.start_time = None
+    task.end_time = None
+    task.duration_seconds = None
+    task.error_message = None
+    task.config_snapshot = None
+    task.final_portfolio_value = 0.0
+    task.total_pnl = 0.0
+    task.max_drawdown = 0.0
+    task.sharpe_ratio = 0.0
+    task.annual_return = 0.0
+    task.win_rate = 0.0
+    task.total_signals = 0
+    task.total_orders = 0
+    task.total_positions = 0
+    task.total_events = 0
+    task.meta = meta
+    return task
+
+
+class TestBacktestCatTraceId:
+    """#6786 AC5: cat 显示从 meta 解析的 trace_id（人读 text + 机读 json 双路径）"""
+
+    def test_record_extracts_trace_id_from_meta_json(self):
+        """_task_record 从 task.meta JSON 解析 trace_id（json 机读路径，AC5）。"""
+        task = _mock_task(meta=json.dumps({"trace_id": "tid-cat-001"}))
+        record = _task_record(task)
+        assert record["trace_id"] == "tid-cat-001", \
+            "cat --format json 须暴露 trace_id，供运维 grep 串联 API→worker 全链路（AC5）"
+
+    def test_record_trace_id_none_when_meta_empty(self):
+        """meta 无 trace_id（'{}'/旧任务）时 record.trace_id is None（向后兼容）。"""
+        task = _mock_task(meta="{}")
+        assert _task_record(task)["trace_id"] is None
+
+    @patch("ginkgo.data.containers.container")
+    def test_cat_text_shows_trace_id_line(self, mock_container):
+        """cat text 模式输出含 trace_id 行（人读路径，AC5）。"""
+        from ginkgo.client.backtest_cli import app
+
+        mock_service = MagicMock()
+        result = MagicMock()
+        result.is_success.return_value = True
+        result.data = _mock_task(meta=json.dumps({"trace_id": "tid-cat-002"}))
+        mock_service.get_by_id.return_value = result
+        mock_container.backtest_task_service.return_value = mock_service
+
+        invoke_result = runner.invoke(app, ["cat", "abc12345"])
+        assert invoke_result.exit_code == 0
+
+        plain = _strip_ansi(invoke_result.output)
+        assert "tid-cat-002" in plain, "cat text 须显示 trace_id 值（AC5 人读路径）"
+        assert "Trace ID" in plain or "trace_id" in plain.lower(), \
+            "须有 Trace ID 标签行（可读性，运维一眼定位）"

--- a/tests/unit/data/crud/test_backtest_task_crud_mock.py
+++ b/tests/unit/data/crud/test_backtest_task_crud_mock.py
@@ -93,6 +93,30 @@ class TestBacktestTaskCRUDCreateFromParams:
         model = crud_instance._create_from_params()
         assert model.source == SOURCE_TYPES.SIM.value
 
+    @pytest.mark.unit
+    def test_create_from_params_preserves_meta_trace_id(self, crud_instance):
+        """#6786 AC2/AC5: meta 须透传到模型，不能被字段白名单静默丢弃。
+
+        回归守卫：api 层把 trace_id 写入 meta（JSON），经 service **kwargs →
+        crud.create → _create_from_params。此处构造 MBacktestTask 的字段表
+        必须显式含 meta=，否则 trace_id 落库为 MMysqlBase 默认 "{}"，
+        backtest cat 永远看不到 trace_id（arch_crud_whitelist_field_drop）。
+        """
+        import json
+
+        trace_meta = json.dumps({"trace_id": "tid-6786-ac2"})
+        model = crud_instance._create_from_params(name="t", meta=trace_meta)
+
+        assert model.meta == trace_meta, (
+            "meta 被 _create_from_params 字段白名单丢弃——trace_id 不落库"
+        )
+
+    @pytest.mark.unit
+    def test_create_from_params_meta_defaults_to_empty_json(self, crud_instance):
+        """未传 meta 时取 MMysqlBase 默认 '{}'（向后兼容非 API 入口）。"""
+        model = crud_instance._create_from_params(name="t")
+        assert model.meta == "{}"
+
 
 # ============================================================
 # Business Helper 测试

--- a/tests/unit/data/drivers/test_ginkgo_kafka.py
+++ b/tests/unit/data/drivers/test_ginkgo_kafka.py
@@ -52,3 +52,29 @@ def test_send_kafka_timeout_degrades_disconnect():
 
     assert result is False
     assert p._connected is False  # timeout 必须触发降级断开
+
+
+@pytest.mark.unit
+def test_producer_send_propagates_headers():
+    """GinkgoProducer.send 透传 headers 到底层 KafkaProducer.send（#6786 跨进程 trace_id）。
+
+    跨进程 trace_id 传播依赖 Kafka 消息 header。kafka-python KafkaProducer.send
+    原生支持 headers=[(key, bytes_value)]；GinkgoProducer.send 包装层须透传，
+    否则 API 端写入的 trace_id 到不了 worker 消费侧。
+    """
+    from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
+
+    p = GinkgoProducer.__new__(GinkgoProducer)  # 绕过真实 Kafka 连接
+    p._connected = True
+    future = MagicMock()
+    future.get.return_value = MagicMock()  # RecordMetadata
+    p.producer = MagicMock()
+    p.producer.send.return_value = future
+
+    headers = [("trace_id", b"abc123def456")]
+    result = p.send("backtest_assignments", {"task_uuid": "x"}, headers=headers)
+
+    assert result is True
+    # 底层 KafkaProducer.send 必须收到调用方传入的 headers
+    _, kwargs = p.producer.send.call_args
+    assert kwargs.get("headers") == headers

--- a/tests/unit/data/services/test_backtest_task_service_start_trace_id_6786.py
+++ b/tests/unit/data/services/test_backtest_task_service_start_trace_id_6786.py
@@ -1,0 +1,105 @@
+# Issue #6786: service 层 start_task 派发 Kafka 携带 trace_id header（派发第二入口）
+#
+# api/api/backtest.py 有两条 Kafka 派发路径：
+#   1. POST "" create_backtest → send_task_to_kafka（已写 headers，见 test_backtest_dispatch_trace_id_6786.py）
+#   2. POST /{uuid}/start → task_service.start_task（本测试覆盖）
+# 两条都在 API 进程内（FastAPI handler 经 #6784 TraceIdMiddleware 注入 GLOG contextvars），
+# start_task 同进程同步调用继承 contextvars，须取 trace_id 写 header，
+# 否则 /start 入口派发的回测在 worker 侧无 trace_id，全链路日志断链。
+
+import sys
+import os
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _make_task(**overrides):
+    """构建 mock task 对象（config_snapshot 完整，驱动 start_task 到 Kafka 派发）。"""
+    task = MagicMock()
+    task.uuid = "uuid-1234-5678"
+    task.task_id = "task-abc"
+    task.portfolio_id = "portfolio-001"
+    task.name = "test_backtest"
+    task.backtest_start_date = None
+    task.backtest_end_date = None
+    task.status = "completed"
+    task.config_snapshot = json.dumps({
+        "start_date": "2025-06-01",
+        "end_date": "2026-06-01",
+        "initial_cash": 200000.0,
+    })
+    for k, v in overrides.items():
+        setattr(task, k, v)
+    return task
+
+
+@contextmanager
+def _mock_kafka_and_container():
+    """统一 mock Kafka producer 和 container（旧数据清理 / DTO 构造）。"""
+    mock_producer = MagicMock()
+    mock_container = MagicMock()
+    with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", return_value=mock_producer), \
+         patch("ginkgo.data.containers.container", mock_container):
+        yield mock_producer
+
+
+@pytest.fixture
+def service():
+    crud = MagicMock()
+    return BacktestTaskService(crud_repo=crud)
+
+
+def _setup_task(service, task):
+    service._crud_repo.get_by_uuid.return_value = task
+    service._crud_repo.find.return_value = []
+    service.update_status = MagicMock(return_value=ServiceResult.success(task, "ok"))
+
+
+class TestStartTaskPropagatesTraceIdHeader:
+    """#6786: service 层 start_task 派发携带 trace_id header（POST /{uuid}/start 入口）"""
+
+    @pytest.mark.unit
+    def test_start_task_propagates_trace_id_header(self, service):
+        """GLOG contextvars 有 trace_id 时，start_task 的 producer.send 收到 headers=[("trace_id", bytes)]。"""
+        from ginkgo.libs import GLOG
+
+        task = _make_task()
+        _setup_task(service, task)
+
+        with _mock_kafka_and_container() as mock_producer, \
+             GLOG.with_trace_id("tid-svc-789"):
+            result = service.start_task(uuid="uuid-1234-5678")
+
+        assert result.is_success(), f"start_task failed: {result.error}"
+        mock_producer.send.assert_called_once()
+        headers = mock_producer.send.call_args.kwargs.get("headers")
+        assert headers == [("trace_id", b"tid-svc-789")]
+
+    @pytest.mark.unit
+    def test_start_task_no_trace_id_no_header(self, service):
+        """无 trace_id 上下文时 headers=None（向后兼容，不污染消息，不破坏既有 start_task 测试）。"""
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        task = _make_task()
+        _setup_task(service, task)
+
+        # 显式隔离 contextvars（防前序测试 with_trace_id 残留）
+        token = _trace_id_ctx.set(None)
+        try:
+            with _mock_kafka_and_container() as mock_producer:
+                result = service.start_task(uuid="uuid-1234-5678")
+        finally:
+            _trace_id_ctx.reset(token)
+
+        assert result.is_success()
+        headers = mock_producer.send.call_args.kwargs.get("headers")
+        assert headers is None

--- a/tests/unit/trading/engines/test_event_engine_trace_id_6786.py
+++ b/tests/unit/trading/engines/test_event_engine_trace_id_6786.py
@@ -1,0 +1,134 @@
+"""
+#6786 AC4: engine 子线程恢复 trace_id 守卫
+
+contextvars 不跨线程自动传播：EventEngine 在 start() 自起的 main_loop / timer_loop
+线程看不到 BacktestProcessor 线程 set 的 trace_id。修复方案：
+  1. start() 在调用方线程（已 set trace_id）捕获 GLOG.get_trace_id() → self._trace_id
+  2. main_loop / timer_loop 在 engine 子线程入口调 _restore_trace_context() 恢复
+
+本套件验证恢复机制 + main_loop 入口调用 + 跨线程生效（AC4 真正达成，非仅
+BacktestProcessor 主线程）。CI 全绿不能证伪——须显式 spawn 子线程才暴露原本的缺口。
+"""
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+
+project_root = Path(__file__).parent.parent.parent.parent
+_path = str(project_root / "src")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.trading.engines.event_engine import EventEngine
+from ginkgo.libs import GLOG
+from ginkgo.libs.core.logger import _trace_id_ctx
+
+
+@pytest.mark.unit
+class TestEventEngineTraceIdRestore:
+    """#6786 AC4: engine 子线程 trace_id 恢复"""
+
+    def test_restore_trace_context_sets_trace_id(self):
+        """_restore_trace_context 把 self._trace_id set 到 _trace_id_ctx。"""
+        engine = EventEngine()
+        engine._trace_id = "tid-engine-001"
+
+        token = _trace_id_ctx.set(None)
+        try:
+            engine._restore_trace_context()
+            assert GLOG.get_trace_id() == "tid-engine-001"
+        finally:
+            _trace_id_ctx.reset(token)
+
+    def test_restore_trace_context_noop_without_trace_id(self):
+        """_trace_id 为 None 时不动 contextvars（向后兼容非 API 入口 / 旧消息）。"""
+        engine = EventEngine()
+        engine._trace_id = None
+
+        token = _trace_id_ctx.set(None)
+        try:
+            engine._restore_trace_context()
+            assert GLOG.get_trace_id() is None
+        finally:
+            _trace_id_ctx.reset(token)
+
+    def test_restore_trace_context_works_in_spawned_thread(self):
+        """机制核心：全新线程里 _restore_trace_context 能恢复 trace_id。
+
+        真实场景：engine main_loop 跑在 spawn 的 Thread 中，父线程 contextvars
+        不自动继承。证明 helper 在子线程内 set 生效——这是 AC4 的关键证据。
+        """
+        engine = EventEngine()
+        engine._trace_id = "tid-spawn-002"
+
+        _trace_id_ctx.set(None)  # 父线程无 trace_id
+        seen = {}
+
+        def runner():
+            engine._restore_trace_context()
+            seen["tid"] = GLOG.get_trace_id()
+
+        t = threading.Thread(target=runner)
+        t.start()
+        t.join()
+
+        assert seen["tid"] == "tid-spawn-002", (
+            "engine 子线程未能恢复 trace_id——strategy/fill/portfolio 日志将无 trace_id"
+        )
+
+    def test_main_loop_restores_trace_id(self):
+        """main_loop 入口恢复 trace_id，同线程 handler（_process → strategy/fill/portfolio）可见。
+
+        预置 _main_flag 让 while 立即退出，不碰事件队列；main_loop 顶部已 set
+        trace_id，返回后 get_trace_id() 应为 self._trace_id（clear_context 不动 _trace_id_ctx）。
+        """
+        engine = EventEngine()
+        engine._trace_id = "tid-loop-003"
+        engine._main_flag.set()  # while not is_set() → 立即退出
+
+        token = _trace_id_ctx.set(None)
+        try:
+            engine.main_loop()
+            assert GLOG.get_trace_id() == "tid-loop-003", (
+                "main_loop 未在入口恢复 trace_id"
+            )
+        finally:
+            _trace_id_ctx.reset(token)
+
+    def test_timer_loop_restores_trace_id(self):
+        """timer_loop 入口同样恢复 trace_id（与 main_loop 对称）。"""
+        engine = EventEngine()
+        engine._trace_id = "tid-timer-005"
+        engine._timer_flag.set()  # while True → if is_set(): break 立即退出
+
+        token = _trace_id_ctx.set(None)
+        try:
+            engine.timer_loop()
+            assert GLOG.get_trace_id() == "tid-timer-005", (
+                "timer_loop 未在入口恢复 trace_id"
+            )
+        finally:
+            _trace_id_ctx.reset(token)
+
+    def test_start_captures_current_trace_id(self):
+        """start() 从当前线程捕获 GLOG.get_trace_id() → self._trace_id。
+
+        模拟 BacktestProcessor 线程：trace_id 已 set，start() 应捕获供子线程恢复。
+        mock 掉 super().start() 与 Thread.start()，避免真起引擎线程，只验捕获行。
+        """
+        engine = EventEngine()
+        assert engine._trace_id is None  # 构造默认
+
+        token = _trace_id_ctx.set("tid-capture-004")
+        try:
+            with patch("ginkgo.trading.engines.base_engine.BaseEngine.start", return_value=True), \
+                 patch.object(engine._main_thread, "start"), \
+                 patch.object(engine._timer_thread, "start"):
+                engine.start()
+            assert engine._trace_id == "tid-capture-004", (
+                "start() 未捕获当前 trace_id，engine 子线程将无 trace_id 可恢复"
+            )
+        finally:
+            _trace_id_ctx.reset(token)

--- a/tests/unit/workers/test_backtest_worker_dispatch_trace_id_6786.py
+++ b/tests/unit/workers/test_backtest_worker_dispatch_trace_id_6786.py
@@ -1,0 +1,89 @@
+# Issue #6786 AC3: worker consume_tasks 从 Kafka header 恢复 trace_id 到 GLOG contextvars
+#
+# consume_tasks 内循环读 message.headers，with_trace_id 包 _handle_task_assignment，
+# 使派发决策日志（_start_task 槽位等待 / 畸形处理 / offset 提交）带 trace_id，
+# 与 API 提交端 grep 同一值串联。engine 线程的 trace_id 传播由 BacktestProcessor
+# 接力（_start_task 取 contextvars 传 processor，run() 入口恢复，见对应测试）。
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestWorkerDispatchMessageRestoresTraceId:
+    """#6786 AC3: worker _dispatch_message 从 Kafka header 恢复 trace_id"""
+
+    def test_dispatch_restores_trace_id_from_header(self):
+        """message.headers 含 trace_id 时，_handle_task_assignment 在 trace_id contextvars 内执行。"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+        from ginkgo.libs import GLOG
+
+        worker = BacktestWorker("test-trace-restore")
+        captured = {}
+
+        def spy(assignment):
+            captured["tid"] = GLOG.get_trace_id()
+
+        worker._handle_task_assignment = spy
+
+        msg = MagicMock()
+        msg.value = {"task_uuid": "t1", "command": "start", "portfolio_uuid": "p1"}
+        msg.headers = [("trace_id", b"tid-worker-001")]
+
+        worker._dispatch_message(msg)
+
+        assert captured.get("tid") == "tid-worker-001", \
+            f"_handle_task_assignment 应在 trace_id contextvars 内执行, got {captured.get('tid')}"
+
+    def test_dispatch_no_header_no_trace_id(self):
+        """message.headers 无 trace_id 时，_handle_task_assignment 在无 trace_id 上下文执行（向后兼容）。"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+        from ginkgo.libs import GLOG
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        worker = BacktestWorker("test-trace-none")
+        captured = {}
+
+        def spy(assignment):
+            captured["tid"] = GLOG.get_trace_id()
+
+        worker._handle_task_assignment = spy
+
+        token = _trace_id_ctx.set(None)
+        try:
+            msg = MagicMock()
+            msg.value = {"task_uuid": "t2", "command": "start", "portfolio_uuid": "p2"}
+            msg.headers = None
+
+            worker._dispatch_message(msg)
+        finally:
+            _trace_id_ctx.reset(token)
+
+        assert captured.get("tid") is None, "无 header 时不应注入 trace_id（向后兼容旧消息）"
+
+    def test_dispatch_ignores_malformed_header_bytes(self):
+        """header value 非 valid UTF-8 bytes 时 graceful 降级（不抛、不注入 trace_id）。"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+        from ginkgo.libs import GLOG
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        worker = BacktestWorker("test-trace-malformed")
+        captured = {}
+
+        def spy(assignment):
+            captured["tid"] = GLOG.get_trace_id()
+
+        worker._handle_task_assignment = spy
+
+        token = _trace_id_ctx.set(None)
+        try:
+            msg = MagicMock()
+            msg.value = {"task_uuid": "t3", "command": "start", "portfolio_uuid": "p3"}
+            # 非 UTF-8 字节序列（解码失败须降级，不得抛 UnicodeDecodeError 进 consume except）
+            msg.headers = [("trace_id", b"\xff\xfe\x00bad")]
+
+            worker._dispatch_message(msg)  # 不应抛
+        finally:
+            _trace_id_ctx.reset(token)
+
+        # 解码失败 → 不注入 trace_id（None），但 _handle_task_assignment 仍被调（不阻断消费）
+        assert captured.get("tid") is None

--- a/tests/unit/workers/test_task_processor_trace_id_6786.py
+++ b/tests/unit/workers/test_task_processor_trace_id_6786.py
@@ -1,0 +1,69 @@
+# Issue #6786 AC4: BacktestProcessor 接力 trace_id 到 engine 线程
+#
+# contextvars 不跨线程自动传播：consume 线程 with_trace_id 设的 trace_id 到不了
+# processor.start() spawn 的 engine 线程。_start_task 从 consume 上下文取出 trace_id
+# 传入 BacktestProcessor 构造，run() 入口 _init_trace_context 手动 set _trace_id_ctx，
+# 使 engine/strategy/fill/portfolio 日志带 trace_id（全链路串联，AC4）。
+
+import inspect
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
+from ginkgo.libs import GLOG
+from ginkgo.libs.core.logger import _trace_id_ctx
+
+
+def _make_processor(trace_id=None):
+    """构造最小可测处理器（跳过 __init__ service 容器装配，参考 test_task_processor_error_logging）。"""
+    proc = BacktestProcessor.__new__(BacktestProcessor)
+    proc.task = MagicMock()
+    proc.task.task_uuid = "t-trace"
+    proc.worker_id = "w-test"
+    proc.progress_tracker = MagicMock()
+    proc._stop_event = Event()
+    proc._engine = None
+    proc._exception = None
+    proc._result = {}
+    proc.trace_id = trace_id  # 模拟 __init__ 改后存的属性
+    return proc
+
+
+class TestBacktestProcessorTraceIdRelay:
+    """#6786 AC4: BacktestProcessor engine 线程接力 trace_id"""
+
+    @pytest.mark.unit
+    def test_init_trace_context_sets_trace_id(self):
+        """_init_trace_context 把 self.trace_id set 到 _trace_id_ctx（engine 线程入口恢复）。"""
+        proc = _make_processor(trace_id="tid-proc-999")
+
+        token = _trace_id_ctx.set(None)
+        try:
+            proc._init_trace_context()
+            assert GLOG.get_trace_id() == "tid-proc-999", \
+                "run() 入口须恢复 trace_id，否则 engine 线程日志无 trace_id（contextvars 不跨线程）"
+        finally:
+            _trace_id_ctx.reset(token)
+
+    @pytest.mark.unit
+    def test_init_trace_context_no_trace_id_noop(self):
+        """无 trace_id 时 _init_trace_context 不动 contextvars（向后兼容旧消息/非 API 入口）。"""
+        proc = _make_processor(trace_id=None)
+
+        token = _trace_id_ctx.set(None)
+        try:
+            proc._init_trace_context()
+            assert GLOG.get_trace_id() is None
+        finally:
+            _trace_id_ctx.reset(token)
+
+    @pytest.mark.unit
+    def test_init_signature_accepts_trace_id_kwarg(self):
+        """__init__ 须接 trace_id 可选 kwarg（_start_task 接力 consume 上下文传入）。"""
+        sig = inspect.signature(BacktestProcessor.__init__)
+        assert "trace_id" in sig.parameters, \
+            f"__init__ 须接 trace_id 参数, 实际: {list(sig.parameters)}"
+        assert sig.parameters["trace_id"].default is None, \
+            "trace_id 默认 None（向后兼容 node.py:388 之外的现有 3 参构造）"


### PR DESCRIPTION
## Summary

可观测层接入 **2/4**：把 API 提交端的 `trace_id`（[#6784](https://github.com/Kaoruha/GinkGO/issues/6784) 中间件注入）经 Kafka 消息头跨进程传播到回测 worker，使 **API → worker 全链路日志 grep 同一 trace_id 串联**。

依赖 #6784 已合并（合并提交 `9a89cfeb`，PR #6797），本 PR 在其 contextvars 基座上接 Kafka 边界。

## 5 条验收标准

| AC | 实现 | 文件 |
|---|---|---|
| **AC1** Kafka 派发消息携带 trace_id header | `send_task_to_kafka` + `service.start_task` 两条派发入口均补 `headers=[("trace_id",...)]`（`GinkgoProducer.send` 透传 headers 给底层 kafka-python） | `api/api/backtest.py`、`src/.../backtest_task_service.py`、`src/.../ginkgo_kafka.py` |
| **AC2** DB task 持久化 trace_id | `create_backtest_task` 写 `task.meta={"trace_id":...}`（复用 `MMysqlBase.meta` JSON 字段，**无 schema 变更**，避安全阀） | `api/api/backtest.py` |
| **AC3** worker 消费恢复 trace_id 到 GLOG | `BacktestWorker._dispatch_message` 从 `message.headers` 解码，`with_trace_id` 包 `_handle_task_assignment`（graceful 降级：无 header / 解码失败不阻断消费） | `src/.../backtest_worker/node.py` |
| **AC4** 回测全链路日志共享 trace_id | contextvars **不跨线程自动传播**——`_start_task` 从 consume 上下文取 trace_id 传入 `BacktestProcessor` 构造，`run()` 入口 `_init_trace_context` 手动 set，使 engine/strategy/fill/portfolio 线程日志带 trace_id | `src/.../backtest_worker/task_processor.py`、`node.py` |
| **AC5** backtest cat 显示 trace_id | `_extract_trace_id_from_meta` 解析 meta，cat text/json 双路径暴露 trace_id | `src/.../client/backtest_cli.py` |

## 关键设计

- **无 schema 变更**：trace_id 复用 `MMysqlBase.meta`（`String(255) default '{}'`）JSON 字段，不触发 DB 安全阀。
- **跨线程接力**（AC4 核心）：`contextvars` 在 `processor.start()` spawn 的 engine 线程里看不到 consume 线程 `with_trace_id` 设的值，需经构造参数显式传递 + `run()` 入口手动 `_trace_id_ctx.set`。`clear_context()` 不动 `_trace_id_ctx`，故在其后 set 安全。
- **graceful 降级**：旧消息无 header、header 解码失败、meta 无 trace_id —— 均向后兼容，不阻断消费/不崩 cat。

## Test plan

15 个测试（TDD 垂直切片，逐条 RED→GREEN）：
- `tests/unit/data/drivers/test_ginkgo_kafka.py` — headers 透传
- `tests/api/test_backtest_dispatch_trace_id_6786.py` — AC1 派发 header
- `tests/api/test_backtest_create_meta_trace_id_6786.py` — AC2 meta 持久化
- `tests/unit/data/services/test_backtest_task_service_start_trace_id_6786.py` — AC1 第二派发入口
- `tests/unit/workers/test_backtest_worker_dispatch_trace_id_6786.py` — AC3 恢复（含畸形 header 降级）
- `tests/unit/workers/test_task_processor_trace_id_6786.py` — AC4 跨线程接力
- `tests/unit/client/test_backtest_cat_trace_id_6786.py` — AC5 显示（text + json 双路径）

三层 smoke 全绿：
- Layer 1 `py_compile`（src + api 全量）✅
- Layer 2 启动路径（user_crud_mock / containers / user_cli）36 passed（1 pre-existing typer rich 渲染失败已 stash 验证豁免，与本 PR 无关）
- Layer 3 变更相关：unit 侧 35 passed（含 `test_backtest_cli.py` 全量回归）+ api 侧 4 passed

Closes #6786