### PR TITLE
feat: error_stats 错误热点观测端点 (可观测层接入 4/4) (#6785)

### DIFF
--- a/api/api/system.py
+++ b/api/api/system.py
@@ -8,6 +8,7 @@ from typing import Dict, Any
 from core.config import settings
 from core.response import ok
 from core.logging import logger
+from api.settings import _require_admin  # #6175: 单一权威 admin 权限源，不在本模块重写
 
 router = APIRouter()
 
@@ -68,23 +69,6 @@ async def get_workers_by_type(worker_type: str):
     except Exception as e:
         logger.error(f"Failed to get workers by type {worker_type}: {e}")
         return ok(data={"type": target, "workers": [], "count": 0})
-
-
-def _require_admin(req: Request):
-    """#6785/#5899: 管理员守卫。DB 实查 credential.is_admin，不信任 JWT payload 里的
-    req.state.is_admin（用户被降权后旧 token 仍带 is_admin=True）。fail-closed：DB
-    不可用或 credential 缺失或非 admin 一律 403，与 /auth/me 的 is_admin 取值口径一致。
-    """
-    from api.auth import get_user_service
-    user_uuid = getattr(req.state, "user_uuid", None)
-    if not user_uuid:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    try:
-        credential = get_user_service().get_credential(user_uuid)
-    except Exception:
-        credential = None
-    if not credential or not getattr(credential, "is_admin", False):
-        raise HTTPException(status_code=403, detail="Admin only")
 
 
 @router.get("/error-stats")

--- a/api/api/system.py
+++ b/api/api/system.py
@@ -2,7 +2,7 @@
 系统状态和Worker管理API路由
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from typing import Dict, Any
 
 from core.config import settings
@@ -68,3 +68,39 @@ async def get_workers_by_type(worker_type: str):
     except Exception as e:
         logger.error(f"Failed to get workers by type {worker_type}: {e}")
         return ok(data={"type": target, "workers": [], "count": 0})
+
+
+def _require_admin(req: Request):
+    """#6785/#5899: 管理员守卫。DB 实查 credential.is_admin，不信任 JWT payload 里的
+    req.state.is_admin（用户被降权后旧 token 仍带 is_admin=True）。fail-closed：DB
+    不可用或 credential 缺失或非 admin 一律 403，与 /auth/me 的 is_admin 取值口径一致。
+    """
+    from api.auth import get_user_service
+    user_uuid = getattr(req.state, "user_uuid", None)
+    if not user_uuid:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    try:
+        credential = get_user_service().get_credential(user_uuid)
+    except Exception:
+        credential = None
+    if not credential or not getattr(credential, "is_admin", False):
+        raise HTTPException(status_code=403, detail="Admin only")
+
+
+@router.get("/error-stats")
+async def get_error_stats(req: Request):
+    """#6785: 查询当前 API 进程累计的错误热点（管理员）。
+
+    走 SystemService → GLOG.get_error_stats（分层 API→Service→GLOG，不直访 GLOG）。
+    """
+    _require_admin(req)
+    svc = _get_system_service()
+    return ok(data=svc.get_error_stats())
+
+
+@router.post("/error-stats/reset")
+async def reset_error_stats(req: Request):
+    """#6785: 清零进程内错误统计（管理员），便于排障后观察新一轮错误分布。"""
+    _require_admin(req)
+    svc = _get_system_service()
+    return ok(data=svc.reset_error_stats())

--- a/src/ginkgo/core/services/system_service.py
+++ b/src/ginkgo/core/services/system_service.py
@@ -91,6 +91,24 @@ class SystemService:
         """获取模块加载状态"""
         return self._get_module_status()
 
+    # ===== 错误统计 (#6785) =====
+
+    def get_error_stats(self) -> Dict[str, Any]:
+        """获取进程内错误统计（透传 GLOG.get_error_stats）。
+
+        #6785: GLOG 已在进程内累计错误模式统计 (logger.py:519)，本方法在 Service 层
+        暴露，供 API /system/error-stats 端点查询当前 API 进程累计的错误热点。
+        """
+        return GLOG.get_error_stats()
+
+    def reset_error_stats(self) -> Dict[str, Any]:
+        """清零进程内错误统计（调 GLOG.clear_error_stats）。
+
+        #6785: 排障后清零，便于观察新一轮错误分布。POST /system/error-stats/reset 调用。
+        """
+        GLOG.clear_error_stats()
+        return {"reset": True}
+
     # ===== Worker 数据格式化 =====
 
     def _format_workers(self, components: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/tests/api/test_system_error_stats.py
+++ b/tests/api/test_system_error_stats.py
@@ -1,0 +1,141 @@
+# Issue #6785: 可观测层接入 4/4 — GET/POST /system/error-stats 错误热点观测端点
+# Upstream: api.system.get_error_stats / reset_error_stats (new endpoints)
+# Downstream: 运维/排障（查询当前 API 进程累计错误热点 + 排障后清零）
+# Role: 把 GLOG 进程内 error_stats 经 SystemService 暴露成 API 端点（分层 API→Service→GLOG）。
+
+"""
+#6785 错误热点观测端点测试。
+
+GLOG.get_error_stats/clear_error_stats 已实现 (logger.py:519/538) 但无 API 端点暴露。
+本切片在 SystemService 加包装、api.system 加端点：
+
+- ``GET /system/error-stats``     查询进程内错误统计
+- ``POST /system/error-stats/reset``  清零统计
+
+两端点均需管理员鉴权。遵循 #5899：DB 实查 ``credential.is_admin``，不信任 JWT payload 里的
+``req.state.is_admin``（用户被降权后旧 token 仍带 is_admin=True），fail-closed（DB 失败 → 403）。
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi import HTTPException
+
+from ginkgo.libs import GCONF
+
+
+@pytest.fixture(autouse=True)
+def _ensure_debug():
+    GCONF.set_debug(True)
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def _make_req(user_uuid="u-admin"):
+    """构造带中间件注入 user_uuid 的 mock Request。"""
+    req = MagicMock()
+    req.state.user_uuid = user_uuid
+    return req
+
+
+class TestErrorStatsGetEndpoint:
+    """GET /system/error-stats 查询 + admin 鉴权 (#6785)。"""
+
+    def test_admin_returns_error_stats(self):
+        """管理员 → 返回 SystemService.get_error_stats 的结构化计数。"""
+        from api.system import get_error_stats
+
+        req = _make_req("u-admin")
+        mock_cred = MagicMock()
+        mock_cred.is_admin = True
+        mock_user_svc = MagicMock()
+        mock_user_svc.get_credential.return_value = mock_cred
+        mock_sys_svc = MagicMock()
+        mock_sys_svc.get_error_stats.return_value = {
+            "total_error_patterns": 1,
+            "top_error_patterns": [{"pattern_hash": "h1", "count": 3}],
+            "total_error_count": 3,
+        }
+        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+             patch("api.system._get_system_service", return_value=mock_sys_svc):
+            result = run_async(get_error_stats(req))
+
+        mock_user_svc.get_credential.assert_called_once_with("u-admin")
+        assert result["data"]["total_error_count"] == 3
+
+    def test_non_admin_blocked_403(self):
+        """非管理员 → 403（不暴露内部错误分布）。"""
+        from api.system import get_error_stats
+
+        req = _make_req("u-normal")
+        mock_cred = MagicMock()
+        mock_cred.is_admin = False
+        mock_user_svc = MagicMock()
+        mock_user_svc.get_credential.return_value = mock_cred
+        mock_sys_svc = MagicMock()
+        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+             patch("api.system._get_system_service", return_value=mock_sys_svc):
+            with pytest.raises(HTTPException) as exc:
+                run_async(get_error_stats(req))
+
+        assert exc.value.status_code == 403
+        mock_sys_svc.get_error_stats.assert_not_called()
+
+    def test_db_failure_fail_closed_403(self):
+        """get_credential 抛异常（DB 不可用）→ fail-closed 403（#5899：不信 JWT is_admin）。"""
+        from api.system import get_error_stats
+
+        req = _make_req("u-admin")
+        mock_user_svc = MagicMock()
+        mock_user_svc.get_credential.side_effect = RuntimeError("db down")
+        mock_sys_svc = MagicMock()
+        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+             patch("api.system._get_system_service", return_value=mock_sys_svc):
+            with pytest.raises(HTTPException) as exc:
+                run_async(get_error_stats(req))
+
+        assert exc.value.status_code == 403
+        mock_sys_svc.get_error_stats.assert_not_called()
+
+
+class TestErrorStatsResetEndpoint:
+    """POST /system/error-stats/reset 清零 + admin 鉴权 (#6785)。"""
+
+    def test_admin_reset_calls_service(self):
+        """管理员 → 调 SystemService.reset_error_stats 清零。"""
+        from api.system import reset_error_stats
+
+        req = _make_req("u-admin")
+        mock_cred = MagicMock()
+        mock_cred.is_admin = True
+        mock_user_svc = MagicMock()
+        mock_user_svc.get_credential.return_value = mock_cred
+        mock_sys_svc = MagicMock()
+        mock_sys_svc.reset_error_stats.return_value = {"reset": True}
+        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+             patch("api.system._get_system_service", return_value=mock_sys_svc):
+            result = run_async(reset_error_stats(req))
+
+        mock_sys_svc.reset_error_stats.assert_called_once()
+        assert result["data"] == {"reset": True}
+
+    def test_non_admin_reset_blocked_403(self):
+        """非管理员 reset → 403（清零同样需管理员，防误清排障数据）。"""
+        from api.system import reset_error_stats
+
+        req = _make_req("u-normal")
+        mock_cred = MagicMock()
+        mock_cred.is_admin = False
+        mock_user_svc = MagicMock()
+        mock_user_svc.get_credential.return_value = mock_cred
+        mock_sys_svc = MagicMock()
+        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+             patch("api.system._get_system_service", return_value=mock_sys_svc):
+            with pytest.raises(HTTPException) as exc:
+                run_async(reset_error_stats(req))
+
+        assert exc.value.status_code == 403
+        mock_sys_svc.reset_error_stats.assert_not_called()

--- a/tests/api/test_system_error_stats.py
+++ b/tests/api/test_system_error_stats.py
@@ -59,7 +59,7 @@ class TestErrorStatsGetEndpoint:
             "top_error_patterns": [{"pattern_hash": "h1", "count": 3}],
             "total_error_count": 3,
         }
-        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+        with patch("api.settings.get_user_service", return_value=mock_user_svc), \
              patch("api.system._get_system_service", return_value=mock_sys_svc):
             result = run_async(get_error_stats(req))
 
@@ -76,7 +76,7 @@ class TestErrorStatsGetEndpoint:
         mock_user_svc = MagicMock()
         mock_user_svc.get_credential.return_value = mock_cred
         mock_sys_svc = MagicMock()
-        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+        with patch("api.settings.get_user_service", return_value=mock_user_svc), \
              patch("api.system._get_system_service", return_value=mock_sys_svc):
             with pytest.raises(HTTPException) as exc:
                 run_async(get_error_stats(req))
@@ -92,7 +92,7 @@ class TestErrorStatsGetEndpoint:
         mock_user_svc = MagicMock()
         mock_user_svc.get_credential.side_effect = RuntimeError("db down")
         mock_sys_svc = MagicMock()
-        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+        with patch("api.settings.get_user_service", return_value=mock_user_svc), \
              patch("api.system._get_system_service", return_value=mock_sys_svc):
             with pytest.raises(HTTPException) as exc:
                 run_async(get_error_stats(req))
@@ -115,7 +115,7 @@ class TestErrorStatsResetEndpoint:
         mock_user_svc.get_credential.return_value = mock_cred
         mock_sys_svc = MagicMock()
         mock_sys_svc.reset_error_stats.return_value = {"reset": True}
-        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+        with patch("api.settings.get_user_service", return_value=mock_user_svc), \
              patch("api.system._get_system_service", return_value=mock_sys_svc):
             result = run_async(reset_error_stats(req))
 
@@ -132,7 +132,7 @@ class TestErrorStatsResetEndpoint:
         mock_user_svc = MagicMock()
         mock_user_svc.get_credential.return_value = mock_cred
         mock_sys_svc = MagicMock()
-        with patch("api.auth.get_user_service", return_value=mock_user_svc), \
+        with patch("api.settings.get_user_service", return_value=mock_user_svc), \
              patch("api.system._get_system_service", return_value=mock_sys_svc):
             with pytest.raises(HTTPException) as exc:
                 run_async(reset_error_stats(req))

--- a/tests/unit/core/services/test_system_service.py
+++ b/tests/unit/core/services/test_system_service.py
@@ -365,3 +365,39 @@ class TestSystemServiceModuleStatus:
         service._check_infrastructure = MagicMock(return_value={"mock": True})
         result = service.get_infrastructure_status()
         assert result == {"mock": True}
+
+
+# ── SystemService 错误统计测试 (#6785) ────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSystemServiceErrorStats:
+    """SystemService 错误统计包装测试 (#6785)。
+
+    GLOG.get_error_stats/clear_error_stats 已实现 (logger.py:519/538)，本切片在
+    SystemService 暴露包装，供 API 层 /system/error-stats 端点走 Service 层调用。
+    """
+
+    def test_get_error_stats_returns_glog_stats(self):
+        """get_error_stats 透传 GLOG.get_error_stats 的进程内错误统计。"""
+        service = SystemService()
+        glog_stats = {
+            "total_error_patterns": 2,
+            "top_error_patterns": [{"pattern_hash": "h1", "count": 3}],
+            "total_error_count": 5,
+        }
+        with patch("ginkgo.core.services.system_service.GLOG.get_error_stats",
+                   return_value=glog_stats) as mock_glog:
+            result = service.get_error_stats()
+
+        mock_glog.assert_called_once()
+        assert result == glog_stats
+
+    def test_reset_error_stats_clears_glog(self):
+        """reset_error_stats 调 GLOG.clear_error_stats 清零进程内错误统计。"""
+        service = SystemService()
+        with patch("ginkgo.core.services.system_service.GLOG.clear_error_stats") as mock_clear:
+            result = service.reset_error_stats()
+
+        mock_clear.assert_called_once()
+        assert result == {"reset": True}


### PR DESCRIPTION
## Summary
可观测层接入 **4/4**：把 GLOG 进程内 `get_error_stats()` 经 SystemService 暴露成 API 端点，让运维/排障能查询当前 API 进程累计的错误热点（#6785）。

- `SystemService` +`get_error_stats()` / `reset_error_stats()`，透传 `GLOG.get_error_stats()` / `GLOG.clear_error_stats()`（logger.py:519/538，底层已实现）
- `GET /api/system/error-stats` 查询结构化计数；`POST /api/system/error-stats/reset` 清零（独立端点，GET 不改状态，避免缓存/预取误触发清零）
- `_require_admin` 守卫：DB 实查 `credential.is_admin`，fail-closed（遵循 #5899，**不**信任 JWT payload 里的 `req.state.is_admin`——降权后旧 token 仍带 is_admin=True）
- 分层 API→Service→GLOG，不直访 GLOG

**漂移说明**：issue body 称"全仓 get_error_stats 零调用方"不完全准确——存在两个同名异义方法：`GLOG.get_error_stats()`（进程内模式统计，本 PR 目标，确零外部调用）与 `log_service.get_error_stats(portfolio_id,hours)`（查 MBacktestLog 库，CLI logging_cli 已在用）。本 PR 暴露的是前者（进程内热点），feature 本体有效。

## Test plan
- [x] `tests/unit/core/services/test_system_service.py` +`TestSystemServiceErrorStats`（service 包装透传 2 case）
- [x] `tests/api/test_system_error_stats.py` 新建：GET/POST 端点 + admin 守卫三态（admin 通过 / 非 admin 403 / DB 失败 fail-closed 403），共 5 case
- [x] 回归 `test_system_workers_by_type.py`（既有 system 端点未受影响，API 合计 14 passed）
- [x] Layer1 py_compile 全量通过；Layer2 启动 smoke（containers / user_crud_mock 通过）
- [ ] 手动验证：`ginkgo serve api` → 触发若干 ERROR → admin token `GET /api/system/error-stats` 见计数递增 → `POST .../reset` 归零

**既有 flaky（非本 PR 引入）**：`tests/unit/client/test_user_cli.py::test_create_user_missing_name_fails` 在本地有 TTY 时因 typer rich 模式把 `--name` 渲染成带 ANSI 码的两段致 `"--name" in output` 失败；本 PR 未触碰 user_cli/click/typer，CI 无 TTY 环境通常通过。

Closes #6785