### PR TITLE
feat: paper/live worker trace_id 经 Kafka header 传播 (#6787)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,17 @@ jobs:
             tests/unit/client/test_deploy_cli_list_smoke.py \
             tests/unit/client/test_record_cli_list_smoke.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: paper/live trace_id smoke (#6787 Kafka header 传播)
+        # deployment_service._dispatch_deploy_command 发 Kafka deploy 带 trace_id header（AC1）+
+        # paper_trading_worker._dispatch_command/_extract_trace_id 消费恢复 trace_id（AC2/AC3）
+        # 是本 PR 新增可执行行，被 containers import 链触达但 smoke 不调方法体 → diff coverage gate 红。
+        # 本 smoke mock GinkgoProducer/ControlCommand（不连 Kafka）调起两方法体补覆盖信号。
+        # 底层 send(headers=) 形参由 master 已合的 #6803 提供（本 PR 不再重复该 hunk）。
+        run: |
+          uv run python -m pytest \
+            tests/unit/trading/services/test_deployment_service_deploy_trace_id_6787.py \
+            tests/unit/workers/test_paper_trading_worker_consume_trace_id_6787.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: GCONF generate_config_file smoke (PR6686 模板源跟随包)
         # PR6686 将配置模板源从 cwd 改为跟随 ginkgo 包（__file__→src/ginkgo/config/）。
         # generate_config_file 的 origin_path 三分支（config.yml/secure.yml/task_timer.yml）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,8 @@ jobs:
             tests/unit/data/services/test_kafka_service_retired_smoke.py \
             tests/unit/data/services/test_kafka_data_commands_smoke.py \
             tests/unit/trading/services/test_deployment_list_smoke.py \
+            tests/unit/trading/services/test_deployment_service_deploy_trace_id_6787.py \
+            tests/unit/workers/test_paper_trading_worker_consume_trace_id_6787.py \
             tests/unit/client/test_deploy_cli_list_smoke.py \
             tests/unit/client/test_record_cli_list_smoke.py \
             tests/unit/libs/test_config_generate_smoke.py \

--- a/src/ginkgo/data/drivers/ginkgo_kafka.py
+++ b/src/ginkgo/data/drivers/ginkgo_kafka.py
@@ -93,9 +93,8 @@ class GinkgoProducer(object):
         Args:
             topic: Kafka topic
             msg: 消息内容
-            headers: Kafka 消息头 [(key, bytes_value)]，跨进程 trace_id 传播用
-                （#6786/#6787）。None 时不下发 header（向后兼容）。底层
-                kafka-python KafkaProducer.send 原生支持 headers 形参。
+            headers: Kafka 消息头 [(key, bytes_value)]，跨进程 trace_id 传播用（#6786）。
+                None 等价不传，向后兼容现有调用方。
 
         Returns:
             bool: 发送是否成功

--- a/src/ginkgo/data/drivers/ginkgo_kafka.py
+++ b/src/ginkgo/data/drivers/ginkgo_kafka.py
@@ -86,13 +86,16 @@ class GinkgoProducer(object):
 
     @time_logger(threshold=1.0)
     @retry(max_try=3)
-    def send(self, topic, msg):
+    def send(self, topic, msg, headers=None):
         """
         同步发送消息（等待确认）
 
         Args:
             topic: Kafka topic
             msg: 消息内容
+            headers: Kafka 消息头 [(key, bytes_value)]，跨进程 trace_id 传播用
+                （#6786/#6787）。None 时不下发 header（向后兼容）。底层
+                kafka-python KafkaProducer.send 原生支持 headers 形参。
 
         Returns:
             bool: 发送是否成功
@@ -103,7 +106,7 @@ class GinkgoProducer(object):
             return False
 
         try:
-            future = self.producer.send(topic, msg)
+            future = self.producer.send(topic, msg, headers=headers)
             result = future.get(timeout=10)
             # result 是 RecordMetadata 对象，不需要打印
             GLOG.DEBUG(f"Kafka send message. TOPIC: {topic}. {msg}")

--- a/src/ginkgo/trading/services/deployment_service.py
+++ b/src/ginkgo/trading/services/deployment_service.py
@@ -288,19 +288,9 @@ class DeploymentService(BaseService):
         except Exception as e:
             GLOG.WARN(f"更新部署记录状态失败(非致命): {e}")
 
-        # 9. 发送 Kafka deploy 命令通知 PaperTradingWorker
+        # 9. 发送 Kafka deploy 命令通知 PaperTradingWorker（#6787: 携带 trace_id header）
         try:
-            from ginkgo.messages.control_command import ControlCommand
-            from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
-            from ginkgo.interfaces.kafka_topics import KafkaTopics
-
-            cmd = ControlCommand.deploy(new_portfolio_id)
-            producer = GinkgoProducer()
-            success = producer.send(KafkaTopics.CONTROL_COMMANDS, cmd.to_dict())
-            if success:
-                GLOG.INFO(f"[DEPLOY] Kafka deploy command sent for {new_portfolio_id[:8]}")
-            else:
-                GLOG.WARN(f"[DEPLOY] Failed to send Kafka deploy command for {new_portfolio_id[:8]}")
+            self._dispatch_deploy_command(new_portfolio_id)
         except Exception as e:
             GLOG.WARN(f"[DEPLOY] Kafka notification failed (non-fatal): {e}")
 
@@ -311,6 +301,31 @@ class DeploymentService(BaseService):
             "deployment_id": deployment_id,
         }
         return result
+
+    def _dispatch_deploy_command(self, new_portfolio_id: str) -> bool:
+        """发送 Kafka deploy 命令通知 PaperTradingWorker（#6787 AC1: 携带 trace_id header）。
+
+        #6787: 从 GLOG contextvars 取 #6784 中间件注入的 trace_id 写 Kafka header，
+        使 paper/live worker 消费端恢复 trace_id（AC2/AC3），deploy 全链路日志按
+        trace_id 串联（AC4）。无 trace_id 时 headers=None（向后兼容：CLI 直接调用
+        等非 API 入口不强制注入）。异常由调用方兜底（non-fatal，不阻断 deploy 主流程）。
+        """
+        from ginkgo.messages.control_command import ControlCommand
+        from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
+        from ginkgo.interfaces.kafka_topics import KafkaTopics
+
+        cmd = ControlCommand.deploy(new_portfolio_id)
+        trace_id = GLOG.get_trace_id()
+        headers = [("trace_id", trace_id.encode())] if trace_id else None
+        producer = GinkgoProducer()
+        success = producer.send(
+            KafkaTopics.CONTROL_COMMANDS, cmd.to_dict(), headers=headers
+        )
+        if success:
+            GLOG.INFO(f"[DEPLOY] Kafka deploy command sent for {new_portfolio_id[:8]}")
+        else:
+            GLOG.WARN(f"[DEPLOY] Failed to send Kafka deploy command for {new_portfolio_id[:8]}")
+        return bool(success)
 
     def get_deployment_info(self, portfolio_id: str) -> ServiceResult:
         """获取部署信息"""

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -1163,12 +1163,13 @@ class PaperTradingWorker:
         from ginkgo.messages.control_command import ControlCommand
 
         cmd = ControlCommand.from_dict(message.value)
-        GLOG.INFO(
-            f"[PAPER-WORKER] Received command: {cmd.command}, "
-            f"params: {cmd.params}"
-        )
         tid = self._extract_trace_id(message.headers)
         with (GLOG.with_trace_id(tid) if tid else nullcontext()):
+            # 入口日志置于 trace_id 作用域内（AC4）：grep trace_id 可串联消费端入口
+            GLOG.INFO(
+                f"[PAPER-WORKER] Received command: {cmd.command}, "
+                f"params: {cmd.params}"
+            )
             success = self._handle_command(cmd.command, cmd.params)
             self._send_response(cmd.command, success, cmd.params)
 

--- a/src/ginkgo/workers/paper_trading_worker.py
+++ b/src/ginkgo/workers/paper_trading_worker.py
@@ -1130,18 +1130,8 @@ class PaperTradingWorker:
                             break
 
                         try:
-                            from ginkgo.messages.control_command import ControlCommand
-                            cmd = ControlCommand.from_dict(message.value)
-
-                            GLOG.INFO(
-                                f"[PAPER-WORKER] Received command: {cmd.command}, "
-                                f"params: {cmd.params}"
-                            )
-
-                            success = self._handle_command(cmd.command, cmd.params)
-
-                            # 发送处理结果
-                            self._send_response(cmd.command, success, cmd.params)
+                            # #6787: _dispatch_command 恢复 trace_id 到 GLOG contextvars
+                            self._dispatch_command(message)
 
                             # 成功处理后提交 offset
                             try:
@@ -1159,6 +1149,45 @@ class PaperTradingWorker:
             except Exception as e:
                 if self._running:
                     GLOG.ERROR(f"[PAPER-WORKER] Error in consume loop: {e}")
+
+    def _dispatch_command(self, message) -> None:
+        """处理单条 CONTROL_COMMANDS 消息（#6787: 恢复 trace_id 到 GLOG contextvars, AC2/AC3）。
+
+        从 message.headers 解码 trace_id，with_trace_id 包 _handle_command，使 deploy
+        全链路日志（_handle_deploy 的 GLOG.INFO/ERROR）带同一 trace_id，与 API deploy
+        端 grep 同值串联（AC4）。paper + live 均经此路径（_handle_deploy 接受 PAPER/LIVE
+        mode，仅拒 BACKTEST）。无 header / 解码失败时 graceful 降级（不注入、不阻断消费，
+        向后兼容旧消息与非 API 入口）。
+        """
+        from contextlib import nullcontext
+        from ginkgo.messages.control_command import ControlCommand
+
+        cmd = ControlCommand.from_dict(message.value)
+        GLOG.INFO(
+            f"[PAPER-WORKER] Received command: {cmd.command}, "
+            f"params: {cmd.params}"
+        )
+        tid = self._extract_trace_id(message.headers)
+        with (GLOG.with_trace_id(tid) if tid else nullcontext()):
+            success = self._handle_command(cmd.command, cmd.params)
+            self._send_response(cmd.command, success, cmd.params)
+
+    @staticmethod
+    def _extract_trace_id(headers) -> Optional[str]:
+        """从 Kafka message headers 解码 trace_id（#6787: 复用 #6786 header 传播模式）。
+
+        headers 为 kafka list[(str, bytes)]。graceful 降级：无 header / key 缺失 /
+        解码失败（非法 UTF-8 毒丸消息）时返回 None，不抛——单条畸形消息不阻断整个消费循环。
+        """
+        if not headers:
+            return None
+        try:
+            for key, value in headers:
+                if key == "trace_id" and value is not None:
+                    return value.decode("utf-8")
+        except Exception:
+            return None
+        return None
 
     def _send_response(self, command: str, success: bool, params: Dict) -> None:
         """

--- a/tests/unit/trading/services/test_deployment_service_deploy_trace_id_6787.py
+++ b/tests/unit/trading/services/test_deployment_service_deploy_trace_id_6787.py
@@ -1,0 +1,58 @@
+"""#6787: deploy 派发 Kafka 携带 trace_id header（可观测层 3/4, AC1）
+
+deploy 链路派发 ControlCommand.deploy 到 CONTROL_COMMANDS topic。
+deployment_service._dispatch_deploy_command 从 GLOG contextvars 取 #6784 中间件
+注入的 trace_id，写 Kafka header，使 paper/live worker 消费端可恢复（AC2/AC3）。
+无 trace_id 时 headers=None（向后兼容，不破坏既有派发）。
+"""
+import sys
+import os
+import pytest
+from unittest.mock import MagicMock, patch
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.trading.services.deployment_service import DeploymentService
+
+
+@pytest.fixture
+def service():
+    return DeploymentService(deployment_crud=MagicMock())
+
+
+class TestDispatchDeployCommandPropagatesTraceId:
+    """#6787 AC1: deploy 派发携带 trace_id Kafka header"""
+
+    @pytest.mark.unit
+    def test_propagates_trace_id_header(self, service):
+        """GLOG contextvars 有 trace_id 时，producer.send 收到 headers=[("trace_id", bytes)]。"""
+        from ginkgo.libs import GLOG
+
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as MockProducer, \
+                GLOG.with_trace_id("tid-deploy-6787"):
+            mock_producer = MockProducer.return_value
+            ok = service._dispatch_deploy_command("port-new-123")
+
+        assert ok is True
+        mock_producer.send.assert_called_once()
+        kwargs = mock_producer.send.call_args.kwargs
+        assert kwargs["headers"] == [("trace_id", b"tid-deploy-6787")]
+
+    @pytest.mark.unit
+    def test_no_trace_id_no_header(self, service):
+        """无 trace_id 上下文时 headers=None（向后兼容）。"""
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        token = _trace_id_ctx.set(None)
+        try:
+            with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as MockProducer:
+                mock_producer = MockProducer.return_value
+                ok = service._dispatch_deploy_command("port-new-123")
+        finally:
+            _trace_id_ctx.reset(token)
+
+        assert ok is True
+        kwargs = mock_producer.send.call_args.kwargs
+        assert kwargs.get("headers") is None

--- a/tests/unit/trading/services/test_deployment_service_deploy_trace_id_6787.py
+++ b/tests/unit/trading/services/test_deployment_service_deploy_trace_id_6787.py
@@ -30,7 +30,7 @@ class TestDispatchDeployCommandPropagatesTraceId:
         """GLOG contextvars 有 trace_id 时，producer.send 收到 headers=[("trace_id", bytes)]。"""
         from ginkgo.libs import GLOG
 
-        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as MockProducer, \
+        with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", autospec=True) as MockProducer, \
                 GLOG.with_trace_id("tid-deploy-6787"):
             mock_producer = MockProducer.return_value
             ok = service._dispatch_deploy_command("port-new-123")
@@ -47,7 +47,7 @@ class TestDispatchDeployCommandPropagatesTraceId:
 
         token = _trace_id_ctx.set(None)
         try:
-            with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer") as MockProducer:
+            with patch("ginkgo.data.drivers.ginkgo_kafka.GinkgoProducer", autospec=True) as MockProducer:
                 mock_producer = MockProducer.return_value
                 ok = service._dispatch_deploy_command("port-new-123")
         finally:

--- a/tests/unit/workers/test_paper_trading_worker_consume_trace_id_6787.py
+++ b/tests/unit/workers/test_paper_trading_worker_consume_trace_id_6787.py
@@ -1,0 +1,115 @@
+"""#6787: paper worker 消费恢复 trace_id（可观测层 3/4, AC2/AC3）
+
+_consume_loop 消费 CONTROL_COMMANDS 时，_dispatch_command 从 message.headers
+恢复 trace_id 到 GLOG contextvars，with_trace_id 包 _handle_command，使 deploy
+操作日志（_handle_deploy 的 GLOG.INFO/ERROR）带 trace_id，与 API deploy 端
+grep 同一值串联（AC4）。覆盖 paper + live（_handle_deploy 接受 PAPER/LIVE mode）。
+无 header / 解码失败时 graceful 降级（不注入，不阻断消费，向后兼容旧消息）。
+"""
+import os
+os.environ["GINKGO_SKIP_DEBUG_CHECK"] = "1"
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+def _make_worker():
+    from ginkgo.workers.paper_trading_worker import PaperTradingWorker
+    return PaperTradingWorker(worker_id="test-trace-6787")
+
+
+def _make_message(headers, command="deploy", params=None):
+    """构造 mock Kafka message: headers + value(dict)。"""
+    message = MagicMock()
+    message.headers = headers
+    message.value = {"command": command, "params": params or {"portfolio_id": "p-1"}}
+    return message
+
+
+def _mock_cmd(command="deploy", params=None):
+    c = MagicMock()
+    c.command = command
+    c.params = params or {"portfolio_id": "p-1"}
+    return c
+
+
+class TestDispatchCommandRestoresTraceId:
+    """#6787 AC2/AC3: paper worker 消费恢复 trace_id"""
+
+    def test_restores_trace_id_from_header(self):
+        """message.headers 带 trace_id 时，_handle_command 在 with_trace_id 作用域内执行。"""
+        from ginkgo.libs import GLOG
+
+        worker = _make_worker()
+        captured = {}
+
+        def fake_handle(command, params):
+            captured["trace_id"] = GLOG.get_trace_id()
+            captured["command"] = command
+            return True
+
+        worker._handle_command = fake_handle
+        worker._send_response = MagicMock()
+
+        message = _make_message([("trace_id", b"tid-paper-6787")])
+
+        with patch("ginkgo.messages.control_command.ControlCommand.from_dict",
+                   return_value=_mock_cmd()):
+            worker._dispatch_command(message)
+
+        assert captured["trace_id"] == "tid-paper-6787"
+        assert captured["command"] == "deploy"
+
+    def test_no_header_no_trace_id(self):
+        """无 header（旧消息/非 API 入口）时 _handle_command 内 trace_id 为 None（向后兼容）。"""
+        from ginkgo.libs import GLOG
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        token = _trace_id_ctx.set(None)
+        try:
+            worker = _make_worker()
+            captured = {}
+
+            def fake_handle(command, params):
+                captured["trace_id"] = GLOG.get_trace_id()
+
+            worker._handle_command = fake_handle
+            worker._send_response = MagicMock()
+
+            message = _make_message(headers=None)
+
+            with patch("ginkgo.messages.control_command.ControlCommand.from_dict",
+                       return_value=_mock_cmd()):
+                worker._dispatch_command(message)
+        finally:
+            _trace_id_ctx.reset(token)
+
+        assert captured["trace_id"] is None
+
+    def test_malformed_header_graceful(self):
+        """header trace_id 解码失败（非法 UTF-8）时 graceful 降级：不抛、不注入。"""
+        from ginkgo.libs import GLOG
+        from ginkgo.libs.core.logger import _trace_id_ctx
+
+        token = _trace_id_ctx.set(None)
+        try:
+            worker = _make_worker()
+            captured = {}
+
+            def fake_handle(command, params):
+                captured["trace_id"] = GLOG.get_trace_id()
+
+            worker._handle_command = fake_handle
+            worker._send_response = MagicMock()
+
+            # 非法 UTF-8 字节序列
+            message = _make_message([("trace_id", b"\xff\xfe\x00")])
+
+            with patch("ginkgo.messages.control_command.ControlCommand.from_dict",
+                       return_value=_mock_cmd()):
+                # 不应抛异常（毒丸消息不阻断消费）
+                worker._dispatch_command(message)
+        finally:
+            _trace_id_ctx.reset(token)
+
+        assert captured["trace_id"] is None


### PR DESCRIPTION
## Summary

可观测层接入 **3/4**：API `deploy` 端的 trace_id（#6784 中间件注入）跨 Kafka 传播到 paper/live worker，使 deploy 全链路日志 grep 同一 trace_id 串联。

承接 #6786（2/4 backtest 链路），本 PR 把同一 Kafka header 传播模式接到 paper/live deploy 链路。

### 验收标准（4 条）

| AC | 实现 |
|---|---|
| **AC1** deploy 派发携带 trace_id header | `deployment_service._dispatch_deploy_command` 从 GLOG contextvars 取 trace_id 写 `headers=[("trace_id", ...)]` |
| **AC2** paper worker 消费恢复 trace_id | `PaperTradingWorker._dispatch_command`（从 `_consume_loop` 提取）解码 `message.headers`，`with_trace_id` 包 `_handle_command` |
| **AC3** live worker 同 | `paper_trading_worker` 同时承担 PAPER + LIVE deploy（`_handle_deploy` 接受 PAPER/LIVE，仅拒 BACKTEST），AC2 恢复路径天然覆盖 live |
| **AC4** 全链路日志共享 trace_id | `with_trace_id` 作用域内 `_handle_command → _handle_deploy` 的 GLOG 日志带 trace_id，与 API deploy 端 grep 同值串联 |

### Graceful 降级（向后兼容）

无 header / key 缺失 / 解码失败（非法 UTF-8 毒丸消息）时不注入、不阻断消费，旧消息与非 API 入口不受影响。

### 不在本次范围

`execution_node/portfolio_processor` 已有独立的 T070 DTO-field trace 恢复机制（`ControlCommandDTO.trace_id` + `GLOG.set_trace_id`），与本 PR 的 Kafka-header 机制是两条正交路径，本次不动以避免 scope 膨胀。

## Test plan

TDD 垂直切片，5 个测试：

- `test_deployment_service_deploy_trace_id_6787.py`（AC1：派发 header × 2）
  - 有 trace_id 上下文 → `producer.send` 收到 `headers=[("trace_id", b"...")]`
  - 无 trace_id 上下文 → `headers=None`（向后兼容）
- `test_paper_trading_worker_consume_trace_id_6787.py`（AC2/AC3：恢复 × 3）
  - 有 header → `_handle_command` 在 `with_trace_id` 作用域内执行（捕获 `GLOG.get_trace_id()` 断言）
  - 无 header → trace_id 为 None（向后兼容）
  - 畸形 header（非法 UTF-8）→ graceful 降级，不抛、不注入

三层冒烟：
- ✅ Layer 1 `py_compile`（src + api 全量）
- ✅ Layer 2 启动路径 smoke（`user_crud_mock` / `containers` / `user_cli`，36 passed；1 既有失败 `test_create_user_missing_name_fails` 为 click rich 颜色码拆断 `--name`，stash baseline 同样失败，与本 PR 无关）
- ✅ Layer 3 变更测试（派发 2 + find 5 + 消费 3 = 10 passed）

Closes #6787

🤖 Generated with [Claude Code](https://claude.com/claude-code)