### PR TITLE
refactor(config): 收敛 #6773 机械冗余 (/simplify,无行为变更)

### DIFF
--- a/src/ginkgo/client/backtest_cli.py
+++ b/src/ginkgo/client/backtest_cli.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 from ginkgo.data.services.base_service import ServiceResult
-from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run
+from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run, reject_in_production
 
 console = Console(emoji=True, legacy_windows=False)
 app = typer.Typer(
@@ -222,11 +222,7 @@ def run_task(
     """:rocket: Run a backtest task locally."""
     # ADR-028: 回测防误连生产 —— 守卫须在 container.backtest_task_service()（DB 调用）之前
     # fail-fast，且在下方 try 之外（typer.Exit 否则被 except Exception 吞掉，#6590）。
-    from ginkgo.libs import GCONF
-    if GCONF.ENV == "PRODUCTION":
-        console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
-        console.print("[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]")
-        raise typer.Exit(1)
+    reject_in_production("回测")
 
     import json as _json
     import threading

--- a/src/ginkgo/client/cli_utils.py
+++ b/src/ginkgo/client/cli_utils.py
@@ -464,3 +464,19 @@ def build_list_result(
     if order:
         result.set_metadata("order", order)
     return result
+
+
+def reject_in_production(action: str = "回测") -> None:
+    """ADR-028: 写数据的 CLI 命令在生产集群下拒跑（防误连生产写数据）。
+
+    须在命令体 ``try`` 块之外调用——``typer.Exit`` 继承 ``Exception``，会被裸
+    ``except Exception`` 吞成 exit_code=0（见 arch_typer_exit_swallowed_by_except_exception）。
+    """
+    from ginkgo.libs import GCONF
+    if GCONF.ENV == "PRODUCTION":
+        console.print(f"[red]:x: {action}在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
+        console.print(
+            "[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；"
+            "本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]"
+        )
+        raise typer.Exit(1)

--- a/src/ginkgo/client/config_cli.py
+++ b/src/ginkgo/client/config_cli.py
@@ -147,11 +147,7 @@ def set(
             # 始终持久化：set_env 写 config.yml 的 env 字位 + 同步本进程 os.environ。
             # 本地 CLI 不读 .env，新进程经 ENV property 读 config.yml 拿到正确集群（review Q5 修复）。
             # 容器场景额外写 .env + compose 重启（下方），本地 CLI 无 compose 也已持久化。
-            try:
-                GCONF.set_env(env_value)
-            except ValueError:
-                console.print(":x: env must be PRODUCTION|DEVELOPMENT (alias: PROD|DEV)")
-                return
+            GCONF.set_env(env_value)  # env_value 上方已校验 ∈ {PRODUCTION, DEVELOPMENT}，ValueError 不可达
             console.print(f":white_check_mark: env = {env_value} ({env_label})，已写入 config.yml（本地 CLI 新进程生效）")
             # 容器部署态：写 .env（compose ${GINKGO_ENV:-DEVELOPMENT} 插值注入）+ 重启容器
             # （worker-env 烘焙不可变，改 .env 须 compose up -d 重建）。本地 CLI 无 compose 则止于此。

--- a/src/ginkgo/client/core_cli.py
+++ b/src/ginkgo/client/core_cli.py
@@ -530,12 +530,10 @@ def run(
     """
     :rocket: Run backtest (simplified from 'backtest run').
     """
-    # ADR-028: 回测防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
-    from ginkgo.libs import GCONF
-    if GCONF.ENV == "PRODUCTION":
-        console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
-        console.print("[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]")
-        raise typer.Exit(1)
+    # ADR-028: 回测防误连生产 —— 守卫须在 try 之外（typer.Exit 否则被 except Exception 吞掉，#6590）
+    from ginkgo.client.cli_utils import reject_in_production
+    from ginkgo.libs import GCONF  # 下方 try 内 set_debug 复用
+    reject_in_production("回测")
 
     try:
         console.print(f"[bold blue]:rocket: Running backtest: {engine_id}[/bold blue]")
@@ -703,12 +701,10 @@ def test(
     """
     :test_tube: Run tests (simplified from 'pytest run').
     """
-    # ADR-028: 测试防误连生产 —— 守卫须在 try 之外，否则 typer.Exit 被下方 except Exception 吞掉
-    from ginkgo.libs import GCONF
-    if GCONF.ENV == "PRODUCTION":
-        console.print("[red]:x: 测试在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
-        console.print("[dim]切研发集群：容器 `ginkgo config set env DEVELOPMENT`；本地 CLI `export GINKGO_ENV=DEVELOPMENT`[/dim]")
-        raise typer.Exit(1)
+    # ADR-028: 测试防误连生产 —— 守卫须在 try 之外（typer.Exit 否则被 except Exception 吞掉）
+    from ginkgo.client.cli_utils import reject_in_production
+    from ginkgo.libs import GCONF  # 下方 try 内 DEBUGMODE/set_debug 复用
+    reject_in_production("测试")
 
     try:
         console.print("[bold blue]:test_tube: Running tests...[/bold blue]")

--- a/src/ginkgo/client/engine_cli.py
+++ b/src/ginkgo/client/engine_cli.py
@@ -18,7 +18,7 @@ from decimal import Decimal
 import pandas as pd
 
 from ginkgo.data.services.base_service import ServiceResult
-from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run
+from ginkgo.client.cli_utils import build_list_result, format_result, announce_dry_run, reject_in_production
 
 # 导入辅助函数（从 engine_cli_helpers.py 提取）
 from ginkgo.client.engine_cli_helpers import (
@@ -487,11 +487,7 @@ def run(
 
     # ADR-028: 回测防误连生产 —— set_debug 现仅开日志不再切库，PRODUCTION env 下回测直连 master 写数据，故拒跑
     # 置于 resolve_engine_id（DB 调用）之前 fail-fast，避免生产 env 下做无谓 DB 查询
-    from ginkgo.libs import GCONF as _GCONF_ENGINE_RUN
-    if _GCONF_ENGINE_RUN.ENV == "PRODUCTION":
-        console.print("[red]:x: 回测在 PRODUCTION 集群下被拒绝（防误连生产写数据）。[/red]")
-        console.print("[dim]请先切到研发集群：ginkgo config set env DEVELOPMENT[/dim]")
-        raise typer.Exit(1)
+    reject_in_production("回测")
 
     # 如果提供了engine_id，尝试解析为UUID
     if engine_id:

--- a/src/ginkgo/libs/core/config.py
+++ b/src/ginkgo/libs/core/config.py
@@ -574,23 +574,23 @@ class GinkgoConfig(object):
             return
         GinkgoConfig._cluster_guard_done = True
         is_dev = self.IS_DEV_ENV
-        env_label, expect_suffix = ("TEST", "-test") if is_dev else ("PROD", "-master")
+        env_label = "TEST" if is_dev else "PROD"
+        expect_suffix = "-test" if is_dev else "-master"  # 期望后缀；host 落体系却不符=漂移
         hosts = {
             "MySQL": os.environ.get("GINKGO_MYSQL_HOST", ""),
             "ClickHouse": os.environ.get("GINKGO_CLICKHOUSE_HOST", ""),
         }
         if os.environ.get("GINKGO_SKIP_CLUSTER_GUARD", "") != "1":
             for name, host in hosts.items():
-                if host.endswith("-test") or host.endswith("-master"):
-                    if host.endswith("-test") != is_dev:
-                        raise RuntimeError(
-                            f"[Ginkgo Env Guard] {name} host={host!r} 与 GINKGO_ENV={self.ENV} "
-                            f"冲突：env={'DEVELOPMENT(应 -test)' if is_dev else 'PRODUCTION(应 -master)'}。"
-                            f"运行 `ginkgo config set env {'DEVELOPMENT' if is_dev else 'PRODUCTION'}` "
-                            f"重对齐 .env 后重启。"
-                        )
-        import sys
-        color = "31" if not is_dev else "32"  # PROD 红 / TEST 绿
+                # 仅当 host 落 master/test 体系时校验；localhost/外部域名跳过
+                if host.endswith(("-test", "-master")) and not host.endswith(expect_suffix):
+                    raise RuntimeError(
+                        f"[Ginkgo Env Guard] {name} host={host!r} 与 GINKGO_ENV={self.ENV} "
+                        f"冲突：env={'DEVELOPMENT(应 -test)' if is_dev else 'PRODUCTION(应 -master)'}。"
+                        f"运行 `ginkgo config set env {'DEVELOPMENT' if is_dev else 'PRODUCTION'}` "
+                        f"重对齐 .env 后重启。"
+                    )
+        color = 32 if is_dev else 31  # 绿=TEST / 红=PROD
         line = (
             f"=== [{env_label}] MySQL={hosts['MySQL']} / "
             f"ClickHouse={hosts['ClickHouse']} ==="
@@ -809,8 +809,8 @@ class GinkgoConfig(object):
             else:
                 # 迁移桥：未设 env 字段时从 DEBUGMODE 推断，保证零行为变化
                 val = "DEVELOPMENT" if self.DEBUGMODE else "PRODUCTION"
-            os.environ[key] = str(val)
-        return str(val).upper()
+            os.environ[key] = val
+        return val.upper()
 
     @property
     def IS_DEV_ENV(self) -> bool:

--- a/src/ginkgo/livecore/trade_gateway_adapter.py
+++ b/src/ginkgo/livecore/trade_gateway_adapter.py
@@ -276,6 +276,9 @@ class TradeGatewayAdapter(Thread):
         if not pending_orders:
             return
 
+        # ADR-028: 集群判据不依赖 order，上提到循环外（避免每待成交订单重复读 ENV）
+        is_production = GCONF.ENV == "PRODUCTION"
+
         # 遍历待成交订单
         for order in pending_orders:
             try:
@@ -300,7 +303,6 @@ class TradeGatewayAdapter(Thread):
                 # P3: PRODUCTION 下模拟成交被禁；非容器 paper worker(宿主直跑)若 config.yml debug=False
                 #     且未设 GINKGO_ENV → bridge 推断 PRODUCTION → 订单卡 SUBMITTED。开发场景设
                 #     GINKGO_ENV=DEVELOPMENT 即恢复模拟成交。一次性 WARN 兼顾可诊断与不刷屏。
-                is_production = GCONF.ENV == "PRODUCTION"
                 if is_production:
                     if not self._prod_mock_fill_warned:
                         GLOG.WARN("PRODUCTION env 下模拟成交已禁用，订单将保持 SUBMITTED；"


### PR DESCRIPTION
## 背景

继已合并的 #6773（GINKGO_ENV 单一旋钮 / ADR-027 启动期集群一致性护栏 / ADR-028 debug 与 DB 解耦），对其中引入的代码做 `/simplify` 机械冗余收敛。

> 本 PR 是纯机械简化，**无行为变更**。🟡 架构级提案（GCONF.bootstrap 收敛 _assert_cluster_consistency、ENV bridge 折入 _ensure_env_vars、trace_id 生成收敛、GLOG.WARN_ONCE）评估后留作后续独立 PR，不在本 PR 范围内。

## 改动（+45 / -43，7 文件）

| 文件 | 简化 |
|---|---|
| `libs/core/config.py` | 删冗余 `import sys`（顶层已 import）；`expect_suffix` 真正生效，嵌套 if 收敛为单条件 + endswith tuple；`color` 直接 `32 if is_dev else 31`；ENV setter/getter 去多余 `str()` 包装 |
| `client/config_cli.py` | 删死分支 `try/except ValueError`（env_value 上方已校验 ∈ {PRODUCTION,DEVELOPMENT}，ValueError 不可达） |
| `client/cli_utils.py` | 新增 `reject_in_production()` helper（含 typer.Exit 会被裸 except Exception 吞成 exit_code=0 的陷阱注释） |
| `client/backtest_cli.py` `engine_cli.py` | 6 行生产守卫副本 → 一行 `reject_in_production()` |
| `client/core_cli.py` | 同上收敛 run/test 两处守卫；保留 `GCONF` 函数级 import（try 内 set_debug 复用） |
| `livecore/trade_gateway_adapter.py` | `is_production = GCONF.ENV == "PRODUCTION"` 从待成交订单循环内上提到循环外（集群判据不依赖 order） |

## 验证

- `py_compile` 7 文件 ✅
- `tests/unit/libs/test_cluster_env_guard.py` 全绿 ✅
- `tests/unit/client/test_config_set_env_cli.py::TestRefuseProduction` 4 个 refuse-production + 1 个 allows-development ✅
- diff vs master 干净，无 #6773 内容复制噪音（squash-merge 后 cherry-pick 单一 commit）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
