### PR TITLE
因子分析管线:物化+CLI+PIT后视防护+走步验证(分5阶段)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,17 @@ jobs:
           uv run python -m pytest \
             tests/unit/libs/test_config_env_cluster_guard_smoke.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: FactorService 增量物化 + 走步 smoke (#6792/#6793)
+        # #6792 calculate_factors_by_library（增量物化 5 分支）+ #6793
+        # walk_forward_factor_evaluation（走步切折 PIT）+ calculate_alpha158_factors
+        # （get_all_factors→get_all_expressions 改名）被 containers import 链触达
+        # （class 定义行 executed → 非 exempt）但方法体无 smoke 调用 → diff coverage
+        # gate 红。本 smoke mock 依赖调起方法体补覆盖信号。独立 step 使 push→master
+        # 时也跑，同时纳入下方 gate 合集采集 coverage。
+        run: |
+          uv run python -m pytest \
+            tests/unit/features/test_factor_service_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         # 阈值按 #6132 基线后采用温和默认：只约束 PR 新增/改动的可执行 src/api 行，
@@ -237,6 +248,7 @@ jobs:
             tests/unit/features/test_operator_registry.py \
             tests/unit/features/test_expression_engine.py \
             tests/unit/trading/portfolios/test_portfolio_live_fill_transactional.py \
+            tests/unit/features/test_factor_service_smoke.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \

--- a/main.py
+++ b/main.py
@@ -105,7 +105,7 @@ def _register_all_commands():
         return LazyTyper(module_name, app_name).app
 
     # 新的模块化命令架构 - 使用独立的CLI文件
-    from ginkgo.client import data_cli, engine_cli, portfolio_cli, param_cli, kafka_cli, worker_cli, mongo_cli, user_cli, group_cli, templates_cli, notify_cli, livecore_cli, execution_cli, scheduler_cli, tasktimer_cli, config_cli, serve_cli, logging_cli, deploy_cli, backtest_cli, comparison_cli, record_cli, dev_cli, test_cli, cache_cli, account_cli
+    from ginkgo.client import data_cli, engine_cli, portfolio_cli, param_cli, kafka_cli, worker_cli, mongo_cli, user_cli, group_cli, templates_cli, notify_cli, livecore_cli, execution_cli, scheduler_cli, tasktimer_cli, config_cli, serve_cli, logging_cli, deploy_cli, backtest_cli, comparison_cli, record_cli, dev_cli, test_cli, cache_cli, account_cli, factor_cli
 
     _main_app.add_typer(data_cli.app, name="data", help=":page_facing_up: Data management")
     _main_app.add_typer(engine_cli.app, name="engine", help=":fire: Engine management")
@@ -127,6 +127,7 @@ def _register_all_commands():
     _main_app.add_typer(deploy_cli.app, name="deploy", help="Deploy backtest to paper/live trading")
     _main_app.add_typer(account_cli.app, name="account", help=":credit_card: Live account management (实盘账户)")
     _main_app.add_typer(backtest_cli.app, name="backtest", help=":chart_with_upwards_trend: Backtest task management")
+    _main_app.add_typer(factor_cli.app, name="factor", help=":bar_chart: Factor materialization & management (#6792)")
 
     # Serve commands (api, webui, worker-data, worker-backtest, etc.)
     _main_app.add_typer(serve_cli.app, name="serve", help=":rocket: Start services in foreground")

--- a/src/ginkgo/client/factor_cli.py
+++ b/src/ginkgo/client/factor_cli.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Upstream: ginkgo CLI (main.py 注册)
+# Downstream: FeatureContainer.factor_service (features 层, 增量物化),
+#             DataContainer.factor_crud (data 层, 已物化 entity 查询),
+#             factor_registry (库/因子元数据)
+# Role: ginkgo factor 子命令 — 因子库物化与管理 (#6792)
+
+"""
+Factor CLI — 因子物化与管理命令。
+
+命令:
+  ginkgo factor materialize  物化指定库的因子到 MFactor (增量: 二次运行写入为零)
+  ginkgo factor libraries    列出已注册因子库 (供 materialize 选 --library)
+"""
+
+import typer
+from typing import List
+from rich.console import Console
+from rich.table import Table
+
+app = typer.Typer(
+    help=":chart_with_upwards_trend: Factor materialization & management (#6792)",
+    rich_markup_mode="rich",
+    no_args_is_help=True,
+)
+console = Console(emoji=True, legacy_windows=False)
+
+
+def _get_factor_service():
+    """延迟拿 features 层 FactorService (注入 FactorEngine/ExpressionEngine, 支持增量物化)。
+
+    测试可 monkeypatch 此函数注入 mock service, 避免触发 container/DB 初始化。
+    """
+    from ginkgo.features.containers import feature_container
+    return feature_container.factor_service()
+
+
+def _get_factor_crud():
+    """延迟拿 data 层 FactorCRUD (增量物化决策: 查已物化 entity 集合)。
+
+    测试可 monkeypatch 此函数注入 mock crud。
+    """
+    from ginkgo.data.containers import container
+    return container.factor_crud()
+
+
+@app.command()
+def materialize(
+    library: str = typer.Argument(..., help="因子库名 (如 alpha158), 见 `ginkgo factor libraries`"),
+    start: str = typer.Option(..., "--start", "-s", help="起始日期 YYYY-MM-DD"),
+    end: str = typer.Option(..., "--end", "-e", help="截止日期 YYYY-MM-DD"),
+    entities: List[str] = typer.Option(
+        None, "--entity", "-c",
+        help="实体代码 (可多次指定, 如 -c 000001.SZ -c 000002.SZ)",
+    ),
+    entity_type: str = typer.Option("stock", "--entity-type", "-t", help="实体类型 (默认 stock)"),
+    full: bool = typer.Option(
+        False, "--full",
+        help="全量重算 (忽略已物化; 默认增量跳过已物化 entity)",
+    ),
+):
+    """物化指定库的因子到 MFactor 表。
+
+    默认增量: 跳过 [start, end] 内已对该库因子有数据的 entity (二次运行写入为零, #6792)。
+    --full 强制全量重算 (不查已物化, 全部重算)。
+    """
+    from ginkgo.enums import ENTITY_TYPES
+
+    if not entities:
+        console.print("[red]✗ 必须指定至少一个 --entity (如 -c 000001.SZ)[/]")
+        raise typer.Exit(1)
+
+    et = ENTITY_TYPES.enum_convert(entity_type)
+    if et is None:
+        console.print(f"[red]✗ 未知 entity_type: {entity_type}[/]")
+        raise typer.Exit(1)
+
+    svc = _get_factor_service()
+    factor_crud = _get_factor_crud()
+
+    mode = "全量" if full else "增量"
+    console.print(
+        f"[cyan]▶ 物化库 {library}[/]: {len(entities)} entity, "
+        f"{start} ~ {end}, entity_type={entity_type}, 模式={mode}"
+    )
+
+    result = svc.calculate_factors_by_library(
+        library_name=library,
+        entity_ids=entities,
+        start_date=start,
+        end_date=end,
+        entity_type=et,
+        incremental=not full,
+        factor_crud=factor_crud,
+    )
+
+    if not result.success:
+        console.print(f"[red]✗ 物化失败: {result.error}[/]")
+        raise typer.Exit(1)
+
+    data = result.data or {}
+    skipped = data.get("skipped_entities", 0)
+    table = Table(title=f"因子物化结果 — {library}", show_header=True, header_style="bold cyan")
+    table.add_column("指标", style="cyan", no_wrap=True)
+    table.add_column("值", style="green")
+    table.add_row("因子数", str(data.get("factor_count", 0)))
+    table.add_row("已处理 entity", str(data.get("processed_entities", 0)))
+    table.add_row("跳过 (已物化)", str(skipped))
+    table.add_row("存储因子记录", str(data.get("total_factors_stored", 0)))
+    console.print(table)
+
+    if skipped > 0 and not full:
+        console.print(f"[dim]增量跳过 {skipped} 个已物化 entity (用 --full 强制重算)[/]")
+    elif full:
+        console.print("[dim]--full: 忽略已物化, 全部重算[/]")
+
+    console.print("[green]✓ 物化完成[/]")
+
+
+@app.command(name="libraries")
+def list_libraries():
+    """列出已注册的因子库及其因子数 (供 materialize 选 --library)。"""
+    svc = _get_factor_service()
+    registry = svc.factor_registry
+    libs = registry.get_registered_libraries()
+    if not libs:
+        console.print("[yellow]未发现任何因子库[/]")
+        return
+
+    table = Table(title="已注册因子库", show_header=True, header_style="bold cyan")
+    table.add_column("库名", style="cyan")
+    table.add_column("因子数", style="green", justify="right")
+    for name in sorted(libs.keys()):
+        factors = registry.get_factors_by_library(name)
+        table.add_row(name, str(len(factors)))
+    console.print(table)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/ginkgo/client/factor_cli.py
+++ b/src/ginkgo/client/factor_cli.py
@@ -45,6 +45,21 @@ def _get_factor_crud():
     return container.factor_crud()
 
 
+def _get_factor_analysis_service():
+    """延迟拿 FactorAnalysisService (因子效果分析编排器, #6794)。
+
+    纯编排器无构造依赖, 直接 new。测试可 monkeypatch。
+    """
+    from ginkgo.features.services.factor_analysis_service import FactorAnalysisService
+    return FactorAnalysisService()
+
+
+def _get_bar_service():
+    """延迟拿 data 层 BarService (读 bars 算前瞻收益, #6794)。"""
+    from ginkgo.data.containers import container
+    return container.bar_service()
+
+
 @app.command()
 def materialize(
     library: str = typer.Argument(..., help="因子库名 (如 alpha158), 见 `ginkgo factor libraries`"),
@@ -116,6 +131,119 @@ def materialize(
         console.print("[dim]--full: 忽略已物化, 全部重算[/]")
 
     console.print("[green]✓ 物化完成[/]")
+
+
+@app.command(name="analyze")
+def analyze(
+    name: str = typer.Argument(..., help="因子名 (已物化的 MFactor.factor_name)"),
+    start: str = typer.Option(..., "--start", "-s", help="起始日期 YYYY-MM-DD"),
+    end: str = typer.Option(..., "--end", "-e", help="截止日期 YYYY-MM-DD (PIT: 前瞻收益在此截断)"),
+    entities: List[str] = typer.Option(
+        None, "--entity", "-c",
+        help="实体代码 (可多次, 如 -c 000001.SZ -c 000002.SZ)",
+    ),
+    entity_type: str = typer.Option("stock", "--entity-type", "-t", help="实体类型 (默认 stock)"),
+    fmt: str = typer.Option("table", "--format", help="输出格式: table | csv | json"),
+    periods: List[int] = typer.Option(
+        [1, 5, 10, 20], "--period", help="前瞻收益周期 (日, 可多次)",
+    ),
+    n_groups: int = typer.Option(5, "--n-groups", help="分层数"),
+):
+    """分析已物化因子的效果: IC/IR/decay/turnover/分层 (#6794)。
+
+    PIT: 前瞻收益按 --end 截断 (realized_cutoff), 防前瞻泄漏 (验收2)。
+    需先 `ginkgo factor materialize` 物化因子 (验收4: 已物化因子跑通非空报告)。
+    """
+    if not entities:
+        console.print("[red]✗ 必须指定至少一个 --entity (如 -c 000001.SZ)[/]")
+        raise typer.Exit(1)
+    if fmt not in ("table", "csv", "json"):
+        console.print(f"[red]✗ --format 仅支持 table/csv/json, 得到 {fmt}[/]")
+        raise typer.Exit(1)
+
+    from ginkgo.enums import ENTITY_TYPES
+    et = ENTITY_TYPES.enum_convert(entity_type)
+    if et is None:
+        console.print(f"[red]✗ 未知 entity_type: {entity_type}[/]")
+        raise typer.Exit(1)
+
+    svc = _get_factor_analysis_service()
+    factor_crud = _get_factor_crud()
+    bar_service = _get_bar_service()
+
+    console.print(
+        f"[cyan]▶ 分析因子 {name}[/]: {len(entities)} entity, {start} ~ {end}, "
+        f"periods={list(periods)}, n_groups={n_groups}, format={fmt}"
+    )
+
+    result = svc.analyze_factor(
+        factor_name=name,
+        entity_ids=entities,
+        start_date=start,
+        end_date=end,
+        factor_crud=factor_crud,
+        bar_service=bar_service,
+        entity_type=et,
+        periods=list(periods),
+        n_groups=n_groups,
+    )
+
+    if not result.success:
+        console.print(f"[red]✗ 分析失败: {result.error}[/]")
+        raise typer.Exit(1)
+
+    data = result.data or {}
+    if fmt == "json":
+        import json
+        console.print_json(json.dumps(data, default=str, ensure_ascii=False))
+    elif fmt == "csv":
+        _print_analysis_csv(data)
+    else:
+        _print_analysis_table(data, name)
+
+    console.print("[green]✓ 分析完成[/]")
+
+
+def _print_analysis_table(data: dict, factor_name: str):
+    """表格输出 IC/IR/decay/turnover/分位 (验收3 可读输出)。"""
+    table = Table(title=f"因子效果分析 — {factor_name}", show_header=True, header_style="bold cyan")
+    table.add_column("指标", style="cyan", no_wrap=True)
+    table.add_column("值", style="green")
+    table.add_row("IC (primary)", _fmt(data.get("ic")))
+    table.add_row("IR (primary)", _fmt(data.get("ir")))
+    table.add_row("turnover", _fmt(data.get("turnover")))
+    table.add_row("分层多空 spread", _fmt(data.get("layering_spread")))
+    ic_all = data.get("ic_by_period", {}) or {}
+    if ic_all:
+        table.add_row("IC (各周期)", ", ".join(f"{k}d={_fmt(v)}" for k, v in ic_all.items()))
+    decay = data.get("decay", {}) or {}
+    if decay.get("half_life") is not None:
+        table.add_row("decay half_life", _fmt(decay.get("half_life")))
+    console.print(table)
+
+
+def _print_analysis_csv(data: dict):
+    """CSV 输出 (验收3 结构化, 供管道消费)。"""
+    console.print("metric,value")
+    core_metrics = [
+        ("ic_primary", data.get("ic")),
+        ("ir_primary", data.get("ir")),
+        ("turnover", data.get("turnover")),
+        ("layering_spread", data.get("layering_spread")),
+    ]
+    for k, v in core_metrics:
+        console.print(f"{k},{_fmt(v)}")
+    for k, v in (data.get("ic_by_period") or {}).items():
+        console.print(f"ic_{k}d,{_fmt(v)}")
+
+
+def _fmt(v):
+    """数值格式化: None→N/A, float→round 6, 其他 str。"""
+    if v is None:
+        return "N/A"
+    if isinstance(v, float):
+        return f"{v:.6f}"
+    return str(v)
 
 
 @app.command(name="libraries")

--- a/src/ginkgo/data/crud/factor_crud.py
+++ b/src/ginkgo/data/crud/factor_crud.py
@@ -295,6 +295,53 @@ class FactorCRUD(BaseCRUD[MFactor]):
             distinct_field="entity_id"
         )
 
+    def get_materialized_entities(
+        self,
+        entity_type: Union[ENTITY_TYPES, str, int],
+        factor_names: List[str],
+        start_time: Optional[datetime] = None,
+        end_time: Optional[datetime] = None,
+    ) -> List[str]:
+        """查询 [start_time, end_time] 内对指定因子已有物化数据的 entity_id 集合。
+
+        增量物化决策用:已物化的 entity 跳过,避免重复计算(#6792)。
+        distinct_field 下推 SQL 层做 DISTINCT,返回去重后的 entity_id 列表。
+
+        Args:
+            entity_type: 实体类型
+            factor_names: 因子名称列表(圈定物化范围)
+            start_time: 起始时间(含),None 不限下界
+            end_time: 截止时间(含),None 不限上界
+
+        Returns:
+            已物化的 entity_id 列表(去重)
+        """
+        filters = {}
+
+        # 实体类型转换(与 get_factors_by_entity 同口径)
+        if isinstance(entity_type, ENTITY_TYPES):
+            filters["entity_type"] = entity_type.value
+        elif isinstance(entity_type, str):
+            entity_enum = ENTITY_TYPES.enum_convert(entity_type)
+            if entity_enum:
+                filters["entity_type"] = entity_enum.value
+            else:
+                raise ValueError(f"Invalid entity_type string: {entity_type}")
+        elif isinstance(entity_type, int):
+            filters["entity_type"] = entity_type
+
+        filters["factor_name__in"] = factor_names
+
+        if start_time:
+            filters["timestamp__gte"] = start_time
+        if end_time:
+            filters["timestamp__lte"] = end_time
+
+        return self.find(
+            filters=filters,
+            distinct_field="entity_id"
+        )
+
     def get_available_factors(
         self,
         entity_type: Optional[Union[ENTITY_TYPES, str, int]] = None,

--- a/src/ginkgo/data/crud/factor_crud.py
+++ b/src/ginkgo/data/crud/factor_crud.py
@@ -216,15 +216,17 @@ class FactorCRUD(BaseCRUD[MFactor]):
         entity_id: str,
         factor_names: Optional[List[str]] = None,
         factor_category: Optional[str] = None,
+        at_time: Optional[datetime] = None,
     ) -> List[MFactor]:
         """
-        获取指定实体的最新因子值
+        获取指定实体的最新因子值 (PIT: at_time 给定时只返回 timestamp <= at_time, #6793)
 
         Args:
             entity_type: 实体类型
             entity_id: 实体标识
             factor_names: 因子名称列表
             factor_category: 因子分类过滤
+            at_time: PIT 截止时间;None 时不过滤 (向后兼容运维全量查询)
 
         Returns:
             最新因子数据
@@ -238,6 +240,7 @@ class FactorCRUD(BaseCRUD[MFactor]):
                     entity_id=entity_id,
                     factor_names=[factor_name],
                     factor_category=factor_category,
+                    end_time=at_time,
                 )
                 if factors:
                     # 获取最新的那个
@@ -251,6 +254,7 @@ class FactorCRUD(BaseCRUD[MFactor]):
                 entity_type=entity_type,
                 entity_id=entity_id,
                 factor_category=factor_category,
+                end_time=at_time,
             )
 
             if not all_factors:

--- a/src/ginkgo/features/__init__.py
+++ b/src/ginkgo/features/__init__.py
@@ -28,7 +28,7 @@ Ginkgo Features Module - 特征因子解析引擎
     
     # 获取因子定义
     alpha158 = services.features.definitions.alpha158()
-    expressions = alpha158.get_all_factors()
+    expressions = alpha158.get_all_expressions()
     
     # 表达式处理服务
     expr_service = services.features.services.expression()
@@ -100,13 +100,13 @@ def get_alpha158_expressions():
     """
     便捷函数：获取Alpha158因子表达式
     """
-    return Alpha158Factors.get_all_factors()
+    return Alpha158Factors.get_all_expressions()
 
 def get_core_expressions():
     """
     便捷函数：获取核心因子表达式
     """
-    return Alpha158Factors.get_core_factors()
+    return Alpha158Factors.get_expressions_by_category("core")
 
 def validate_expressions(expressions):
     """

--- a/src/ginkgo/features/readers/__init__.py
+++ b/src/ginkgo/features/readers/__init__.py
@@ -1,0 +1,7 @@
+# Upstream: FeatureContainer / 回测引擎装配
+# Downstream: BaseStrategy.bind_factor_reader (trading 层注入)
+# Role: 因子读取器 — 策略读取因子值的入口组件 (PIT 硬约束层, #6793)
+
+from ginkgo.features.readers.pit_factor_reader import PITFactorReader
+
+__all__ = ["PITFactorReader"]

--- a/src/ginkgo/features/readers/pit_factor_reader.py
+++ b/src/ginkgo/features/readers/pit_factor_reader.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Upstream: BaseStrategy.bind_factor_reader / 回测引擎装配
+# Downstream: FactorCRUD.get_latest_factors_by_entity (data 层, PIT 能力)
+# Role: PITFactorReader — 因子读取入口, 强制 point-in-time 防前瞻泄漏 (#6793)
+
+"""
+PITFactorReader — 因子 point-in-time 读取器 (#6793).
+
+策略通过 BaseStrategy.get_factor_value(code, factor_name, at_time) 读因子,
+底层委托此 reader。reader 是 PIT 硬约束层:
+
+1. at_time 必传 (None 直接 raise, 不可绕过) — 回测事件时间
+2. at_time 下推到 crud (SQL 层 timestamp__lte, 只取 <= at_time 的因子)
+3. 防御性双保险: 即使底层漏过滤返回了未来值 (ts > at_time), reader 仍拦截返回 None
+
+分层: crud 提供 PIT *能力* (at_time 可选, 向后兼容运维全量查询);
+      reader 强制 PIT *约束* (at_time 必传, 回测专用入口)。
+"""
+
+from typing import Optional
+from datetime import datetime
+
+from ginkgo.enums import ENTITY_TYPES
+
+
+class PITFactorReader:
+    """因子 PIT 读取器。
+
+    Args:
+        factor_crud: FactorCRUD 实例 (data 层, 提供 get_latest_factors_by_entity)
+        entity_type: 实体类型 (默认 STOCK; 个股因子)
+    """
+
+    def __init__(self, factor_crud, entity_type: ENTITY_TYPES = ENTITY_TYPES.STOCK):
+        self.factor_crud = factor_crud
+        self.entity_type = entity_type
+
+    def get_factor_value(
+        self,
+        code: str,
+        factor_name: str,
+        at_time: Optional[datetime] = None,
+    ) -> Optional[float]:
+        """读取 code 在 at_time 时刻的因子值 (PIT: 只用 <= at_time 的数据)。
+
+        Args:
+            code: 实体标识 (如 "000001.SZ")
+            factor_name: 因子名称 (如 "ROC")
+            at_time: 回测事件时间 (必传, PIT 硬约束)
+
+        Returns:
+            因子值 (float); at_time 前无此因子或被防御层拦截时返回 None
+
+        Raises:
+            ValueError: at_time=None (PIT 不可绕过)
+        """
+        if at_time is None:
+            raise ValueError(
+                "PITFactorReader requires at_time (point-in-time guard, #6793); "
+                "pass the event/backtest timestamp to prevent lookahead bias."
+            )
+
+        factors = self.factor_crud.get_latest_factors_by_entity(
+            entity_type=self.entity_type,
+            entity_id=code,
+            factor_names=[factor_name],
+            at_time=at_time,
+        )
+
+        if not factors:
+            return None
+
+        # 取 timestamp 最大者 (= at_time 前的最新), 再做防御性 PIT 校验 (双保险)
+        latest = max(factors, key=lambda x: x.timestamp)
+        if latest.timestamp > at_time:
+            # 底层漏过滤返回了未来值 — 拦截, 不让前瞻泄漏进回测
+            return None
+
+        return float(latest.factor_value)

--- a/src/ginkgo/features/services/factor_analysis_service.py
+++ b/src/ginkgo/features/services/factor_analysis_service.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Upstream: factor_crud (因子 PIT 读取), bar_service.get_bars_df (bars)
+# Downstream: factor_cli analyze (#6794 验收3), walk_forward_factor_evaluation evaluator (#6793)
+# Role: 因子效果分析编排器 — IC/IR/decay/分层/turnover 一站式 (#6794 验收1)
+
+"""
+因子效果分析编排器 (#6794 验收1)。
+
+编排休眠 research analyzer (ICAnalyzer / FactorDecayAnalyzer / FactorLayering):
+读 PIT 因子 + bars → 算前瞻收益 (PIT 截断) → 调三分析器 → 内联 turnover → 汇总报告。
+
+PIT: 前瞻收益由 compute_forward_returns 按 realized_cutoff 截断 (验收2);
+     因子读取由调用方 (analyze_factor) 经 factor_crud 按时间窗口 PIT 取数。
+
+与 FactorService 职责分离: FactorService=因子物化, 本服务=物化后的因子效果分析。
+
+接口差异 (编排须分别构造收益表):
+  - ICAnalyzer 期望 return_Nd 多周期列 (return_col=None → 用 f"return_{period}d")
+  - FactorDecayAnalyzer / FactorLayering 期望单 "return" 列 (return_col="return")
+  → 编排器把 return_1d 重命名为 return 喂给 decay/layering。
+
+turnover (#6794 验收5): LayeringStatistics.turnover 字段休眠未填充, 此处内联算
+  (跨日分组成员 Jaccard 距离均值), 不 patch FactorLayering.run (降低休眠代码扰动)。
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+from datetime import datetime
+
+import pandas as pd
+
+from ginkgo.libs import GLOG
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.research.forward_returns import compute_forward_returns
+from ginkgo.research.ic_analysis import ICAnalyzer
+from ginkgo.research.decay_analysis import FactorDecayAnalyzer
+from ginkgo.research.layering import FactorLayering
+
+
+def _normalize_bars_df(df: pd.DataFrame) -> pd.DataFrame:
+    """归一 bars DataFrame 列名/类型 以匹配 forward_returns 期望。
+
+    - bar 用 timestamp 列, forward_returns 用 date → 重命名
+    - bar close 存 Decimal → float (避免后续 division 异常)
+    """
+    out = df.copy()
+    if "timestamp" in out.columns and "date" not in out.columns:
+        out = out.rename(columns={"timestamp": "date"})
+    if "close" in out.columns:
+        out["close"] = pd.to_numeric(out["close"], errors="coerce")
+    return out
+
+
+class FactorAnalysisService:
+    """因子效果分析编排器 (#6794 验收1)。"""
+
+    def analyze_from_dataframes(
+        self,
+        factor_df: pd.DataFrame,
+        bars_df: pd.DataFrame,
+        periods: List[int] = (1, 5, 10, 20),
+        n_groups: int = 5,
+        realized_cutoff: Optional[datetime] = None,
+        method: str = "spearman",
+        max_lag: int = 20,
+    ) -> ServiceResult:
+        """从已加载的 factor/bars DataFrame 跑全因子效果分析。
+
+        Args:
+            factor_df: 因子表, 需含 date/code/factor_value
+            bars_df: K线表, 需含 date/code/close (编排器算前瞻收益)
+            periods: 前瞻收益周期列表
+            n_groups: 分层数
+            realized_cutoff: PIT 截止 (前瞻收益 d+N 超此值置 NaN)
+            method: IC 计算方法 (spearman/pearson)
+            max_lag: decay 分析最大滞后
+
+        Returns:
+            ServiceResult.data = {ic, ir, ic_by_period, ir_by_period,
+                                  decay, turnover, layering_spread, layering}
+            各 analyzer 失败时 graceful skip (对应字段留空), 不阻断整体。
+        """
+        result = ServiceResult(data={})
+        periods_list = list(periods)
+
+        try:
+            # 1. 前瞻收益 (PIT 截断, 验收2)
+            return_df = compute_forward_returns(
+                bars_df, periods=periods_list, realized_cutoff=realized_cutoff,
+            )
+
+            # 2. IC / IR (多周期 return_Nd 列)
+            ic_by_period, ir_by_period = self._run_ic(factor_df, return_df, periods_list, method)
+
+            # decay / layering 用单 "return" 列 (return_1d 重命名)
+            return_single = return_df.rename(columns={"return_1d": "return"})
+
+            # 3. decay
+            decay_dict = self._run_decay(factor_df, return_single, max_lag)
+
+            # 4. layering
+            spread, layering_dict = self._run_layering(factor_df, return_single, n_groups)
+
+            # 5. turnover (内联算, LayeringStatistics.turnover 休眠未填充)
+            turnover = self._compute_turnover(factor_df, n_groups=n_groups)
+
+            primary = periods_list[0] if periods_list else None
+            result.success = True
+            result.set_data("ic", ic_by_period.get(primary))
+            result.set_data("ic_by_period", {str(k): v for k, v in ic_by_period.items()})
+            result.set_data("ir", ir_by_period.get(primary))
+            result.set_data("ir_by_period", {str(k): v for k, v in ir_by_period.items()})
+            result.set_data("decay", decay_dict)
+            result.set_data("turnover", float(turnover))
+            result.set_data("layering_spread", spread)
+            result.set_data("layering", layering_dict)
+        except Exception as e:
+            result.error = f"analyze failed: {e}"
+            GLOG.ERROR(result.error)
+
+        return result
+
+    def _run_ic(
+        self, factor_df: pd.DataFrame, return_df: pd.DataFrame,
+        periods: List[int], method: str,
+    ) -> Tuple[Dict[int, float], Dict[int, float]]:
+        """IC / IR 分析 (多周期)。失败 graceful skip 返回空 dict。"""
+        ic_by_period: Dict[int, float] = {}
+        ir_by_period: Dict[int, float] = {}
+        try:
+            analyzer = ICAnalyzer(factor_df, return_df)
+            ic_result = analyzer.analyze(periods=periods, method=method)
+            for p in periods:
+                stats = ic_result.statistics.get(p)
+                if stats is not None:
+                    ic_by_period[p] = float(stats.mean)
+                    ir_by_period[p] = float(stats.icir)
+        except Exception as e:
+            GLOG.WARN(f"IC 分析失败 (graceful skip): {e}")
+        return ic_by_period, ir_by_period
+
+    def _run_decay(
+        self, factor_df: pd.DataFrame, return_single: pd.DataFrame, max_lag: int,
+    ) -> Dict[str, Any]:
+        """Decay 分析 (单 return 列)。失败 graceful skip 返回空 dict。"""
+        try:
+            analyzer = FactorDecayAnalyzer(factor_df, return_single)
+            decay_result = analyzer.analyze(max_lag=max_lag)
+            return decay_result.to_dict()
+        except Exception as e:
+            GLOG.WARN(f"Decay 分析失败 (graceful skip): {e}")
+            return {}
+
+    def _run_layering(
+        self, factor_df: pd.DataFrame, return_single: pd.DataFrame, n_groups: int,
+    ) -> Tuple[Optional[float], Dict[str, Any]]:
+        """分层分析 (单 return 列)。失败 graceful skip 返回 (None, {})。"""
+        try:
+            layering = FactorLayering(factor_df, return_single)
+            layer_result = layering.run(n_groups=n_groups)
+            spread = float(layer_result.spread) if layer_result.spread is not None else None
+            layering_dict = (
+                layer_result.statistics.to_dict() if layer_result.statistics is not None else {}
+            )
+            return spread, layering_dict
+        except Exception as e:
+            GLOG.WARN(f"Layering 分析失败 (graceful skip): {e}")
+            return None, {}
+
+    def _compute_turnover(
+        self, factor_df: pd.DataFrame, n_groups: int = 5,
+    ) -> float:
+        """跨日分组成员变化率均值 (Jaccard 距离)。
+
+        LayeringStatistics.turnover 字段休眠未填充 (#6794 验收5), 此处内联算:
+        每日按因子值 qcut 分 n_groups, 相邻调仓日同组成员集合的对称差/并集均值。
+        factor rank 日间稳定时为 0 (代码仍真实计算, 非硬编码桩)。
+        """
+        date_col, code_col, factor_col = "date", "code", "factor_value"
+        if date_col not in factor_df.columns or factor_col not in factor_df.columns:
+            return 0.0
+
+        dates = sorted(factor_df[date_col].unique())
+        if len(dates) < 2:
+            return 0.0
+
+        prev_members: Optional[Dict[Any, set]] = None
+        turnovers: List[float] = []
+
+        for date in dates:
+            day = factor_df[factor_df[date_col] == date]
+            if len(day) < n_groups:
+                continue
+            try:
+                buckets = pd.qcut(
+                    day[factor_col], q=n_groups, labels=False, duplicates="drop",
+                )
+            except (ValueError, KeyError):
+                continue
+
+            curr_members: Dict[Any, set] = {
+                int(g): set(sub[code_col])
+                for g, sub in day.groupby(buckets)
+                if not pd.isna(g)
+            }
+
+            if prev_members and curr_members:
+                diffs = []
+                for g in prev_members.keys() & curr_members.keys():
+                    union = prev_members[g] | curr_members[g]
+                    if union:
+                        diffs.append(len(prev_members[g] ^ curr_members[g]) / len(union))
+                if diffs:
+                    turnovers.append(sum(diffs) / len(diffs))
+
+            prev_members = curr_members
+
+        if not turnovers:
+            return 0.0
+        return float(sum(turnovers) / len(turnovers))
+
+    def analyze_factor(
+        self,
+        factor_name: str,
+        entity_ids: List[str],
+        start_date: str,
+        end_date: str,
+        factor_crud: Any,
+        bar_service: Any,
+        entity_type: Any = None,
+        periods: List[int] = (1, 5, 10, 20),
+        n_groups: int = 5,
+        method: str = "spearman",
+        max_lag: int = 20,
+    ) -> ServiceResult:
+        """数据获取层: 读 PIT 因子 (factor_crud) + bars (bar_service) → analyze_from_dataframes。
+
+        PIT: 因子按 [start, end] 窗口取 (crud timestamp__gte/lte); 前瞻收益按 end 截断。
+
+        Args:
+            factor_name: 因子名 (MFactor.factor_name)
+            entity_ids: 实体代码列表
+            start_date/end_date: YYYY-MM-DD (end 作 PIT realized_cutoff)
+            factor_crud: FactorCRUD (get_factors_by_entity, 参数 factor_names/entity_type/start_time/end_time)
+            bar_service: BarService (get_bars_df, 返回 DataFrame 列 timestamp/code/close)
+            entity_type: 实体类型 (ENTITY_TYPES, CRUD 必填第一参数)
+            periods/n_groups/method/max_lag: 透传 analyze_from_dataframes
+        """
+        result = ServiceResult(data={})
+        try:
+            start_dt = datetime.strptime(start_date, "%Y-%m-%d")
+            end_dt = datetime.strptime(end_date, "%Y-%m-%d")
+
+            # 1. 读因子 PIT (factor_crud.get_factors_by_entity: factor_names List, entity_type 必填)
+            factor_rows = []
+            for eid in entity_ids:
+                factors = factor_crud.get_factors_by_entity(
+                    entity_type=entity_type,
+                    entity_id=eid,
+                    factor_names=[factor_name],
+                    start_time=start_dt,
+                    end_time=end_dt,
+                ) or []
+                for f in factors:
+                    factor_rows.append({
+                        "date": f.timestamp,
+                        "code": f.entity_id,
+                        "factor_value": float(f.factor_value),
+                    })
+            if not factor_rows:
+                result.error = (
+                    f"无因子数据: factor={factor_name}, entities={entity_ids}, "
+                    f"{start_date}~{end_date}"
+                )
+                GLOG.WARN(result.error)
+                return result
+            factor_df = pd.DataFrame(factor_rows)
+
+            # 2. 读 bars (bar_service.get_bars_df per code)
+            bar_frames = []
+            for eid in entity_ids:
+                r = bar_service.get_bars_df(code=eid, start_date=start_date, end_date=end_date)
+                if r.success and r.data is not None and not r.data.empty:
+                    bar_frames.append(_normalize_bars_df(r.data))
+            if not bar_frames:
+                result.error = (
+                    f"无 bars 数据: entities={entity_ids}, {start_date}~{end_date}"
+                )
+                GLOG.WARN(result.error)
+                return result
+            bars_df = pd.concat(bar_frames, ignore_index=True)
+
+            # 3. 调 analyze_from_dataframes (end 作 PIT cutoff)
+            return self.analyze_from_dataframes(
+                factor_df, bars_df,
+                periods=periods, n_groups=n_groups,
+                realized_cutoff=end_dt,
+                method=method, max_lag=max_lag,
+            )
+        except Exception as e:
+            result.error = f"analyze_factor failed: {e}"
+            GLOG.ERROR(result.error)
+            return result

--- a/src/ginkgo/features/services/factor_service.py
+++ b/src/ginkgo/features/services/factor_service.py
@@ -119,9 +119,100 @@ class FactorService:
         except Exception as e:
             result.error = f"Alpha158因子计算失败: {str(e)}"
             GLOG.ERROR(result.error)
-        
+
         return result
-    
+
+    def calculate_factors_by_library(
+        self,
+        library_name: str,
+        entity_ids: List[str],
+        start_date: str,
+        end_date: str,
+        entity_type: ENTITY_TYPES = ENTITY_TYPES.STOCK,
+        batch_size: int = 1000,
+        incremental: bool = True,
+        factor_crud: Optional[Any] = None,
+    ) -> ServiceResult:
+        """计算指定因子库的因子(通用入口,支持增量物化。#6792)。
+
+        Args:
+            library_name: 因子库名(如 "alpha158",见 list_factor_libraries)
+            entity_ids: 实体ID列表
+            start_date/end_date: 时间范围(YYYY-MM-DD)
+            entity_type: 实体类型
+            batch_size: 批量存储大小
+            incremental: True=跳过已物化 entity(二次运行写入为零);False=全量重算
+            factor_crud: 增量查询用的 FactorCRUD;None 时降级为全量(不增量)
+
+        Returns:
+            ServiceResult: processed_entities / total_factors_stored /
+                           skipped_entities / factor_count
+        """
+        result = ServiceResult(data={})
+
+        try:
+            expressions = self.factor_registry.get_factors_by_library(library_name)
+            if not expressions:
+                result.error = f"Library '{library_name}' not found or has no factors"
+                return result
+
+            validation_result = self.expression_engine.validate_expressions(expressions)
+            if not validation_result.success:
+                result.error = f"表达式验证失败: {validation_result.error}"
+                return result
+
+            # 增量物化:跳过 [start,end] 内对该库因子已有数据的 entity(#6792)
+            target_ids = list(entity_ids)
+            skipped = 0
+            if incremental:
+                crud = factor_crud if factor_crud is not None else getattr(self, "_factor_crud", None)
+                if crud is not None:
+                    materialized = set(crud.get_materialized_entities(
+                        entity_type=entity_type,
+                        factor_names=list(expressions.keys()),
+                        start_time=start_date,
+                        end_time=end_date,
+                    ))
+                    target_ids = [eid for eid in entity_ids if eid not in materialized]
+                    skipped = len(entity_ids) - len(target_ids)
+                    GLOG.INFO(f"增量物化: {skipped}/{len(entity_ids)} entity 已物化,跳过")
+
+            if not target_ids:
+                # 全已物化:零写入(满足"二次运行写入为零"验收,#6792)
+                processed_entities = 0
+                total_factors_stored = 0
+                GLOG.INFO(f"全部 {skipped} entity 已物化,本次零写入")
+            else:
+                calculation_result = self.factor_engine.calculate_and_store(
+                    expressions=expressions,
+                    entity_ids=target_ids,
+                    start_date=start_date,
+                    end_date=end_date,
+                    entity_type=entity_type,
+                    batch_size=batch_size,
+                )
+                if not calculation_result.success:
+                    result.error = calculation_result.error
+                    return result
+                # engine 成功路径必走 set_data → data 为 dict;or {} 仅兜底空 entity 边界
+                calc_data = calculation_result.data or {}
+                processed_entities = calc_data.get("processed_entities", 0)
+                total_factors_stored = calc_data.get("total_factors_stored", 0)
+                GLOG.INFO(f"库 {library_name} 因子计算完成: {len(expressions)} 个因子, "
+                         f"{total_factors_stored} 条记录")
+
+            result.success = True
+            result.set_data("processed_entities", processed_entities)
+            result.set_data("total_factors_stored", total_factors_stored)
+            result.set_data("skipped_entities", skipped)
+            result.set_data("factor_count", len(expressions))
+
+        except Exception as e:
+            result.error = f"calculate_factors_by_library failed: {str(e)}"
+            GLOG.ERROR(result.error)
+
+        return result
+
     def calculate_core_factors(self,
                              entity_ids: List[str],
                              start_date: str,

--- a/src/ginkgo/features/services/factor_service.py
+++ b/src/ginkgo/features/services/factor_service.py
@@ -77,10 +77,10 @@ class FactorService:
         try:
             # 获取要计算的因子表达式
             if factor_names is None:
-                expressions = Alpha158Factors.get_all_factors()
+                expressions = Alpha158Factors.get_all_expressions()
                 GLOG.INFO(f"计算全部Alpha158因子: {len(expressions)}个")
             else:
-                all_expressions = Alpha158Factors.get_all_factors()
+                all_expressions = Alpha158Factors.get_all_expressions()
                 expressions = {name: all_expressions[name] for name in factor_names 
                              if name in all_expressions}
                 GLOG.INFO(f"计算指定Alpha158因子: {len(expressions)}个")
@@ -139,7 +139,7 @@ class FactorService:
         Returns:
             ServiceResult: 计算结果
         """
-        core_expressions = Alpha158Factors.get_core_factors()
+        core_expressions = Alpha158Factors.get_expressions_by_category("core")
         core_factor_names = list(core_expressions.keys())
         
         return self.calculate_alpha158_factors(
@@ -172,22 +172,13 @@ class FactorService:
         result = ServiceResult()
         
         try:
-            # 根据分类获取因子表达式
-            category_methods = {
-                'price': Alpha158Factors.get_price_factors,
-                'ma': Alpha158Factors.get_ma_factors,
-                'volatility': Alpha158Factors.get_volatility_factors,
-                'momentum': Alpha158Factors.get_momentum_factors,
-                'extremum': Alpha158Factors.get_extremum_factors,
-                'quantile': Alpha158Factors.get_quantile_factors,
-                'rsv': Alpha158Factors.get_rsv_factors
-            }
-            
-            if category not in category_methods:
-                result.error = f"未知的因子分类: {category}。可用分类: {list(category_methods.keys())}"
+            # 根据分类获取因子表达式（对齐 BaseDefinition.CATEGORIES 真实 key）
+            available = Alpha158Factors.get_category_names()
+            if category not in available:
+                result.error = f"未知的因子分类: {category}。可用分类: {available}"
                 return result
-            
-            category_expressions = category_methods[category]()
+
+            category_expressions = Alpha158Factors.get_expressions_by_category(category)
             factor_names = list(category_expressions.keys())
             
             return self.calculate_alpha158_factors(
@@ -209,8 +200,8 @@ class FactorService:
         return {
             "factor_engine_stats": self.factor_engine.get_stats(),
             "expression_engine_stats": self.expression_engine.get_engine_stats(),
-            "alpha158_total_factors": len(Alpha158Factors.get_all_factors()),
-            "alpha158_core_factors": len(Alpha158Factors.get_core_factors()),
+            "alpha158_total_factors": len(Alpha158Factors.get_all_expressions()),
+            "alpha158_core_factors": len(Alpha158Factors.get_expressions_by_category("core")),
         }
 
     # ===== 新增因子查询API =====

--- a/src/ginkgo/features/services/factor_service.py
+++ b/src/ginkgo/features/services/factor_service.py
@@ -14,7 +14,8 @@
 支持便捷的因子计算、批量处理、进度跟踪等功能。
 """
 
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Callable
+from datetime import datetime, timedelta
 from ginkgo.libs import GLOG
 from ginkgo.data.services.base_service import ServiceResult
 from ginkgo.enums import ENTITY_TYPES
@@ -209,6 +210,120 @@ class FactorService:
 
         except Exception as e:
             result.error = f"calculate_factors_by_library failed: {str(e)}"
+            GLOG.ERROR(result.error)
+
+        return result
+
+    def walk_forward_factor_evaluation(
+        self,
+        factor_name: str,
+        entity_ids: List[str],
+        start_date: str,
+        end_date: str,
+        evaluator: Callable,
+        n_folds: int = 5,
+        train_ratio: float = 0.7,
+        factor_crud: Optional[Any] = None,
+    ) -> ServiceResult:
+        """走步因子评估: 滑动 train/test 折, 每折 PIT 读取因子, 输出样本外折 (#6793 验收3)。
+
+        防全样本拟合: 不用全部数据算单一指标, 而是滑动 train/test 验证 (OOS),
+        与全样本拟合的假阳性区分 (memory: iter037 OOS 证伪教训)。
+
+        PIT: 每折只用该折时间窗内因子 — train [ts, te] / test [te+1, T],
+        全部窗口 <= 评估终点 end_date (评估日 end_date 时数据已实现, 非未来)。
+
+        evaluator 注入: (factors: List[MFactor]) -> score; 具体指标 (IC/IR/decay)
+        由调用方提供 (#6794 提供 IC evaluator 并通过 CLI 调本方法)。
+
+        Args:
+            factor_name: 因子名称
+            entity_ids: 实体代码列表
+            start_date/end_date: 评估区间 (YYYY-MM-DD)
+            evaluator: 因子效果打分函数 (因子列表 -> score)
+            n_folds: 折数 (默认 5)
+            train_ratio: 训练期比例 (默认 0.7)
+            factor_crud: FactorCRUD (读窗口因子); None 报错
+
+        Returns:
+            ServiceResult: folds / mean_train_score / mean_test_score /
+                           degradation / n_folds
+        """
+        result = ServiceResult(data={})
+
+        try:
+            crud = factor_crud if factor_crud is not None else getattr(self, "_factor_crud", None)
+            if crud is None:
+                result.error = "factor_crud required for walk-forward evaluation"
+                return result
+
+            start = datetime.strptime(start_date, "%Y-%m-%d")
+            end = datetime.strptime(end_date, "%Y-%m-%d")
+            total_days = (end - start).days + 1
+            fold_size = total_days // (n_folds + 1)
+            if fold_size <= 0:
+                result.error = f"date range ({total_days}d) too small for {n_folds} folds"
+                return result
+            train_days = int(fold_size * train_ratio)
+            test_days = fold_size - train_days
+
+            folds_result = []
+            train_scores = []
+            test_scores = []
+
+            def fetch_window(start_w: datetime, end_w: datetime) -> List[Any]:
+                """PIT: 收集 [start_w, end_w] 窗口内所有 entity 的因子 (窗口有界, #6793)。"""
+                out: List[Any] = []
+                for eid in entity_ids:
+                    out.extend(crud.get_factors_by_entity(
+                        entity_type=ENTITY_TYPES.STOCK, entity_id=eid,
+                        factor_names=[factor_name],
+                        start_time=start_w, end_time=end_w,
+                    ))
+                return out
+
+            for i in range(n_folds):
+                train_start = start + timedelta(days=i * test_days)
+                train_end = train_start + timedelta(days=train_days - 1)
+                test_start = train_end + timedelta(days=1)
+                test_end = test_start + timedelta(days=test_days - 1)
+                if test_end > end:
+                    test_end = end
+
+                # PIT: 每折只用该折窗内因子 (窗口 end <= 评估终点)
+                train_factors = fetch_window(train_start, train_end)
+                test_factors = fetch_window(test_start, test_end)
+
+                tr_score = evaluator(train_factors)
+                te_score = evaluator(test_factors)
+                train_scores.append(tr_score)
+                test_scores.append(te_score)
+                folds_result.append({
+                    "fold": i + 1,
+                    "train_start": train_start.strftime("%Y-%m-%d"),
+                    "train_end": train_end.strftime("%Y-%m-%d"),
+                    "test_start": test_start.strftime("%Y-%m-%d"),
+                    "test_end": test_end.strftime("%Y-%m-%d"),
+                    "train_score": tr_score,
+                    "test_score": te_score,
+                })
+
+            mean_train = sum(train_scores) / len(train_scores) if train_scores else 0.0
+            mean_test = sum(test_scores) / len(test_scores) if test_scores else 0.0
+            degradation = (mean_train - mean_test) / mean_train if mean_train != 0 else 0.0
+
+            result.success = True
+            result.set_data("folds", folds_result)
+            result.set_data("mean_train_score", mean_train)
+            result.set_data("mean_test_score", mean_test)
+            result.set_data("degradation", degradation)
+            result.set_data("n_folds", len(folds_result))
+            GLOG.INFO(f"走步因子评估完成: {len(folds_result)} 折, "
+                     f"mean_train={mean_train:.4f}, mean_test={mean_test:.4f}, "
+                     f"degradation={degradation:.2%}")
+
+        except Exception as e:
+            result.error = f"walk_forward_factor_evaluation failed: {e}"
             GLOG.ERROR(result.error)
 
         return result

--- a/src/ginkgo/features/services/strategy_walk_forward.py
+++ b/src/ginkgo/features/services/strategy_walk_forward.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Upstream: backtest_func (调用方注入, 跑策略回测返回表现)
+# Downstream: factor_cli / walk-forward CLI (#6796 验收2/4), 策略评估上层
+# Role: 策略走步 OOS 验证 -- 切折 + train/test + 如实报告 (#6796)
+
+"""策略走步 OOS 验证 (#6796 验收2 + 验收4)。
+
+与 #6793 walk_forward_factor_evaluation 的区别:
+  - 因子层走步: evaluator 拿 MFactor 行打 IC 分 (因子是否稳定)
+  - 策略层走步 (本函数): backtest_func 跑策略回测拿净值/收益 (策略 OOS 是否赚钱)
+
+backtest_func 契约: (params, start, end) -> {"return": float, ...}
+  调用方负责把 FactorTopDecileStrategy 等包成此 callable (绑 factor_reader + 跑引擎);
+  本函数只负责切折 + 调用 + 汇总, 不耦合引擎/数据层 (便于单测 mock)。
+
+如实报告 (验收4): OOS mean_test_return <= 0 → effective=False (不强行声称有效)。
+"""
+
+from typing import Callable, Optional, Any
+from datetime import datetime, timedelta
+
+from ginkgo.libs import GLOG
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def walk_forward_strategy_evaluation(
+    backtest_func: Callable[..., Any],
+    start_date: str,
+    end_date: str,
+    n_folds: int = 5,
+    train_ratio: float = 0.7,
+) -> ServiceResult:
+    """策略走步 OOS 验证 (expanding window)。
+
+    Args:
+        backtest_func: (params, start, end) -> {"return": float}; params 透传 (None 占位)
+        start_date/end_date: YYYY-MM-DD 总区间
+        n_folds: 折数
+        train_ratio: 接口对齐 #6793 (expanding 模式下 train 恒为历史全部, 此值保留)
+
+    Returns:
+        ServiceResult.data = {folds, mean_train_return, mean_test_return,
+                              degradation, effective, n_folds}
+        effective = mean_test_return > 0 (OOS 正才有效; 如实反映)
+    """
+    result = ServiceResult(data={})
+    try:
+        start = datetime.strptime(start_date, "%Y-%m-%d")
+        end = datetime.strptime(end_date, "%Y-%m-%d")
+        total_days = (end - start).days
+        if total_days <= 0 or n_folds < 1:
+            result.error = f"非法区间或折数: {start_date}~{end_date}, n_folds={n_folds}"
+            GLOG.WARN(result.error)
+            return result
+
+        fold_size = total_days / (n_folds + 1)  # expanding: 每段等长, train 累积
+        folds = []
+        for i in range(n_folds):
+            train_end = start + timedelta(days=fold_size * (i + 1))
+            test_end = start + timedelta(days=fold_size * (i + 2))
+            if test_end > end:
+                test_end = end
+
+            train_r = backtest_func(None, start, train_end) or {}
+            test_r = backtest_func(None, train_end, test_end) or {}
+            folds.append({
+                "fold": i,
+                "train_start": str(start.date()),
+                "train_end": str(train_end.date()),
+                "test_start": str(train_end.date()),
+                "test_end": str(test_end.date()),
+                "train_return": train_r.get("return"),
+                "test_return": test_r.get("return"),
+            })
+
+        def _mean_of(key: str) -> Optional[float]:
+            vals = [f[key] for f in folds if f[key] is not None]
+            return sum(vals) / len(vals) if vals else None
+
+        mean_train = _mean_of("train_return")
+        mean_test = _mean_of("test_return")
+        degradation = (
+            mean_train - mean_test
+            if mean_train is not None and mean_test is not None else None
+        )
+        # 验收4: 如实报告 — OOS mean <= 0 即无效 (不强行声称有效)
+        effective = mean_test is not None and mean_test > 0
+
+        result.success = True
+        result.set_data("folds", folds)
+        result.set_data("mean_train_return", mean_train)
+        result.set_data("mean_test_return", mean_test)
+        result.set_data("degradation", degradation)
+        result.set_data("effective", effective)
+        result.set_data("n_folds", n_folds)
+    except Exception as e:
+        result.error = f"walk_forward_strategy_evaluation failed: {e}"
+        GLOG.ERROR(result.error)
+    return result

--- a/src/ginkgo/research/forward_returns.py
+++ b/src/ginkgo/research/forward_returns.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# Upstream: bar_service.get_bars_df (data 层, bars DataFrame)
+# Downstream: ICAnalyzer / FactorDecayAnalyzer / factor_analysis_service (#6794)
+# Role: 前瞻收益计算器 — PIT 硬约束 (d+N <= realized_cutoff, #6794 验收2)
+
+"""
+前瞻收益计算器 (#6794 验收2)。
+
+forward return at date d for period N = close[d+N] / close[d] - 1。
+
+PIT 硬约束: 只计算 d+N <= realized_cutoff 的前瞻收益 (评估日之后已实现的收益);
+            d+N > realized_cutoff 的格子置 NaN, 防止用未实现未来收益做 IC/decay
+            分析 (前瞻泄漏会让因子效果虚高)。
+
+典型用法 (编排器内):
+    bars = bar_service.get_bars_df(code=..., start_date=..., end_date=...)
+    fwd = compute_forward_returns(bars, periods=[1,5,10,20],
+                                  realized_cutoff=evaluation_end_date)
+    # fwd 含 return_1d / return_5d / ... 列, 喂给 ICAnalyzer(factor_df, fwd)
+"""
+
+from typing import List, Optional
+from datetime import datetime
+
+import pandas as pd
+import numpy as np
+
+
+def compute_forward_returns(
+    bars_df: pd.DataFrame,
+    periods: List[int] = (1, 5, 10, 20),
+    realized_cutoff: Optional[datetime] = None,
+    date_col: str = "date",
+    code_col: str = "code",
+    close_col: str = "close",
+) -> pd.DataFrame:
+    """计算 PIT 前瞻收益 (return_Nd 列)。
+
+    Args:
+        bars_df: K线 DataFrame, 需含 date_col / code_col / close_col
+        periods: 周期列表 (默认 1/5/10/20 日)
+        realized_cutoff: PIT 截止时间; d+N 超过此值的格子置 NaN (防前瞻泄漏)。
+                         None = 算所有 bars 内已实现的 d+N (回测式全量)。
+        date_col / code_col / close_col: 列名
+
+    Returns:
+        bars_df 副本 + return_{N}d 列 (各周期前瞻收益; 未实现或不足 N 的为 NaN)
+    """
+    out = bars_df.copy()
+
+    required = [date_col, code_col, close_col]
+    missing = [c for c in required if c not in out.columns]
+    if missing:
+        raise ValueError(f"bars_df 缺少必需列: {missing}")
+
+    cutoff = pd.Timestamp(realized_cutoff) if realized_cutoff is not None else None
+
+    for period in periods:
+        col = f"return_{period}d"
+        out[col] = np.nan
+
+        # 按 code 分组, 组内按 date 排序后向量化算前瞻收益 (codes 互不串扰)
+        for _, grp in out.groupby(code_col, sort=False):
+            grp = grp.sort_values(date_col)
+            closes = grp[close_col]
+            dates = grp[date_col]
+
+            # close[i+period] / close[i] - 1; trailing period 行 shift 后为 NaN
+            fwd = closes.shift(-period) / closes - 1.0
+
+            # PIT: d+N 必须 <= cutoff (未实现 → NaN); 同时排除 base == 0
+            mask = closes != 0
+            if cutoff is not None:
+                mask &= dates.shift(-period) <= cutoff
+
+            out.loc[grp.index, col] = fwd.where(mask, np.nan)
+
+    return out

--- a/src/ginkgo/trading/strategies/factor_momentum.py
+++ b/src/ginkgo/trading/strategies/factor_momentum.py
@@ -1,0 +1,53 @@
+# Upstream: Backtest Engines (cal调度), Component Registry (DB实例化)
+# Downstream: BaseStrategy (factor_reader 钩子), Signal (信号发射)
+# Role: 因子动量示例策略 - 演示 BaseStrategy factor_reader 钩子的 PIT 用法(#6791 tracer)
+
+from typing import List, Dict
+from ginkgo.entities import Signal
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.trading.strategies.strategy_base import BaseStrategy
+
+
+class FactorMomentumStrategy(BaseStrategy):
+    """因子动量示例策略(#6791 Phase 0 tracer)。
+
+    读 Alpha158 动量因子(默认 ROC5)的 PIT 值:
+    - 因子值 > buy_threshold  → LONG
+    - 因子值 < sell_threshold → SHORT
+    其余情形不发信号。未绑定 factor_reader 或无因子值时静默返回。
+
+    Note: PIT 硬约束由 factor_reader 负责(只返回 timestamp <= at_time 的值);
+    本策略仅保证用 portfolio_info["now"] / event.timestamp 作为 at_time,
+    不主动读未来(#6793 在 reader 层加泄漏反例套件)。
+    """
+
+    def __init__(self, name: str = "FactorMomentum",
+                 factor_name: str = "ROC5",
+                 buy_threshold: float = 0.0,
+                 sell_threshold: float = 0.0,
+                 **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._factor_name = factor_name
+        self._buy_threshold = buy_threshold
+        self._sell_threshold = sell_threshold
+
+    def cal(self, portfolio_info: Dict, event, *args, **kwargs) -> List[Signal]:
+        code = getattr(event, 'code', None)
+        if code is None:
+            return []
+
+        # PIT: 用回测当前时间(event 时刻)读因子,不读未来
+        now = (portfolio_info or {}).get("now") or getattr(event, 'timestamp', None)
+        val = self.get_factor_value(code, self._factor_name, now)
+        if val is None:
+            return []
+
+        if val > self._buy_threshold:
+            return [self.create_signal(
+                code=code, direction=DIRECTION_TYPES.LONG,
+                reason=f"{self._factor_name}={val:.4f} > {self._buy_threshold}")]
+        if val < self._sell_threshold:
+            return [self.create_signal(
+                code=code, direction=DIRECTION_TYPES.SHORT,
+                reason=f"{self._factor_name}={val:.4f} < {self._sell_threshold}")]
+        return []

--- a/src/ginkgo/trading/strategies/factor_top_decile.py
+++ b/src/ginkgo/trading/strategies/factor_top_decile.py
@@ -1,0 +1,87 @@
+# Upstream: Backtest Engines (cal调度 t1backtest.py:447), Component Registry
+# Downstream: BaseStrategy factor_reader 钩子, Signal (信号发射), Selector.pick (universe)
+# Role: 多因子截面 top-decile 组合策略 - 因子能力 capstone (#6796)
+
+"""多因子截面 top-decile 组合策略 (#6796 capstone)。
+
+读多个已物化因子的 PIT 值, 对当日 universe 做截面加权排名,
+做多排名 top 分位 (默认 decile=10 即 top 10%) 的标的。
+
+PIT (#6793): get_factor_value 内部只返 timestamp <= at_time 的值;
+              策略用 portfolio_info["now"] / event.timestamp 作 at_time, 不读未来。
+
+截面聚合: 引擎 per-price 事件驱动 (每标的每次行情调一次 cal),
+          引擎不批量回调 "当日全部 universe", 策略侧自聚合 universe
+          (selector.pick + 循环 get_factor_value) 组当日截面再排名。
+"""
+
+from typing import List, Dict, Optional
+
+from ginkgo.entities import Signal
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.trading.strategies.strategy_base import BaseStrategy
+
+
+class FactorTopDecileStrategy(BaseStrategy):
+    """多因子截面 top-decile 做多策略 (#6796)。
+
+    Args:
+        factors: {factor_name: weight} 多因子权重; 默认 {"ROC5": 1.0} 单因子
+        decile: top 分位 (decile=10 → top 10%; decile=5 → top 20%)
+
+    截面任一因子缺值 (None) 的 code 从排名中剔除 (PIT 无值不赌)。
+    """
+
+    def __init__(self, name: str = "FactorTopDecile",
+                 factors: Optional[Dict[str, float]] = None,
+                 decile: int = 10,
+                 **kwargs):
+        super().__init__(name=name, **kwargs)
+        self._factors = factors if factors else {"ROC5": 1.0}
+        self._decile = max(1, int(decile))
+
+    def _resolve_universe(self, portfolio_info: Dict, now) -> List[str]:
+        """从 selector.pick(now) 聚合 universe; 空则退化 [event.code] (单标的)。"""
+        universe: List[str] = []
+        for sel in (portfolio_info or {}).get("selector", []) or []:
+            picked = sel.pick(now) if hasattr(sel, "pick") else []
+            if picked:
+                universe.extend(picked)
+        # dict 保序去重 (Python 3.7+)
+        return list(dict.fromkeys(universe))
+
+    def _cross_section_scores(self, universe: List[str], now) -> Dict[str, float]:
+        """对 universe 各 code 算多因子加权 score。任一因子 None → 剔除该 code。"""
+        scores: Dict[str, float] = {}
+        for code in universe:
+            total = 0.0
+            ok = True
+            for fname, weight in self._factors.items():
+                v = self.get_factor_value(code, fname, now)
+                if v is None:
+                    ok = False
+                    break
+                total += weight * v
+            if ok:
+                scores[code] = total
+        return scores
+
+    def cal(self, portfolio_info: Dict, event, *args, **kwargs) -> List[Signal]:
+        code = getattr(event, "code", None)
+        if code is None:
+            return []
+
+        now = (portfolio_info or {}).get("now") or getattr(event, "timestamp", None)
+        universe = self._resolve_universe(portfolio_info, now) or [code]
+        scores = self._cross_section_scores(universe, now)
+        if code not in scores or not scores:
+            return []
+
+        ranked = sorted(scores.keys(), key=lambda c: scores[c], reverse=True)
+        n_top = max(1, len(ranked) // self._decile)
+        if code in ranked[:n_top]:
+            return [self.create_signal(
+                code=code, direction=DIRECTION_TYPES.LONG,
+                reason=f"cross-section top {n_top}/{len(ranked)} "
+                       f"(score={scores[code]:.4f})")]
+        return []

--- a/src/ginkgo/trading/strategies/strategy_base.py
+++ b/src/ginkgo/trading/strategies/strategy_base.py
@@ -23,6 +23,7 @@ class BaseStrategy(ContextMixin, TimeMixin, NamedMixin, Base):
         super().__init__(name=name, **kwargs)
         self._raw = {}
         self._data_feeder = None
+        self._factor_reader = None
 
     def bind_data_feeder(self, feeder, *args, **kwargs):
         self._data_feeder = feeder
@@ -30,6 +31,28 @@ class BaseStrategy(ContextMixin, TimeMixin, NamedMixin, Base):
     @property
     def data_feeder(self):
         return self._data_feeder
+
+    def bind_factor_reader(self, reader, *args, **kwargs):
+        """绑定因子读取器(策略 cal() 内读 PIT 因子值)。
+
+        reader 契约:get_factor_value(code, factor_name, at_time) -> Optional[float],
+        内部负责 point-in-time 约束(只返回 timestamp <= at_time 的值)。
+        """
+        self._factor_reader = reader
+
+    @property
+    def factor_reader(self):
+        return self._factor_reader
+
+    def get_factor_value(self, code: str, factor_name: str, at_time=None):
+        """读取 code 在 at_time 时刻可见的 factor_name 值(PIT)。
+
+        未绑定 reader 返回 None(不崩,便于纯价格策略无因子依赖)。
+        """
+        reader = self.factor_reader
+        if reader is None:
+            return None
+        return reader.get_factor_value(code, factor_name, at_time)
 
     def create_signal(
         self,

--- a/tests/unit/client/test_factor_cli.py
+++ b/tests/unit/client/test_factor_cli.py
@@ -1,0 +1,199 @@
+"""ginkgo factor CLI 接线测试 -- #6792 Phase 1 Slice 3
+
+验证 factor_cli.materialize / libraries 命令的参数解析、service 调用接线、
+输出格式与退出码。service/crud 经 monkeypatch 注入 mock, 不触发 container/DB。
+
+核心增量物化逻辑由 test_services.py::TestFactorService 覆盖, 此处只验 CLI 薄层接线。
+"""
+import re
+import pytest
+from unittest.mock import MagicMock
+
+from typer.testing import CliRunner
+
+from ginkgo.client import factor_cli
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.enums import ENTITY_TYPES
+
+
+runner = CliRunner()
+
+
+def _strip_ansi(s: str) -> str:
+    """rich Console 给输出加了 ANSI 色码, 会把含变量/引号的字符串拆散
+    (如 'nope' 被引号高亮、数字 2 被数值高亮)。去色后再做子串断言。"""
+    return re.sub(r'\x1b\[[0-9;]*m', '', s)
+
+
+def _ok_result(**overrides):
+    """构造 success=True 的 ServiceResult, 含默认物化统计数据。"""
+    data = {
+        "factor_count": 158,
+        "processed_entities": 1,
+        "skipped_entities": 0,
+        "total_factors_stored": 1580,
+    }
+    data.update(overrides)
+    return ServiceResult(success=True, data=data)
+
+
+@pytest.fixture
+def patched_cli(monkeypatch):
+    """注入 mock factor_service + factor_crud, 返回 (mock_svc, mock_crud)。"""
+    mock_svc = MagicMock()
+    mock_crud = MagicMock()
+    monkeypatch.setattr(factor_cli, "_get_factor_service", lambda: mock_svc)
+    monkeypatch.setattr(factor_cli, "_get_factor_crud", lambda: mock_crud)
+    return mock_svc, mock_crud
+
+
+@pytest.mark.unit
+class TestFactorCliMaterialize:
+    def test_materialize_success_calls_service_with_incremental(self, patched_cli):
+        """3a: 成功路径 → exit 0, 调 service, incremental=True + factor_crud 注入。"""
+        mock_svc, mock_crud = patched_cli
+        mock_svc.calculate_factors_by_library.return_value = _ok_result()
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "alpha158",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+            "-c", "000001.SZ",
+        ])
+
+        assert result.exit_code == 0, result.output
+        mock_svc.calculate_factors_by_library.assert_called_once()
+        kwargs = mock_svc.calculate_factors_by_library.call_args.kwargs
+        assert kwargs["library_name"] == "alpha158"
+        assert kwargs["entity_ids"] == ["000001.SZ"]
+        assert kwargs["start_date"] == "2024-01-01"
+        assert kwargs["end_date"] == "2024-12-31"
+        assert kwargs["incremental"] is True
+        assert kwargs["factor_crud"] is mock_crud
+        assert kwargs["entity_type"] == ENTITY_TYPES.STOCK
+        assert "物化完成" in result.output
+
+    def test_materialize_multi_entities(self, patched_cli):
+        """3a-b: 多个 -c 全部透传给 service 的 entity_ids。"""
+        mock_svc, _ = patched_cli
+        mock_svc.calculate_factors_by_library.return_value = _ok_result()
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "alpha158",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+            "-c", "000001.SZ", "-c", "000002.SZ",
+        ])
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_svc.calculate_factors_by_library.call_args.kwargs
+        assert kwargs["entity_ids"] == ["000001.SZ", "000002.SZ"]
+
+    def test_materialize_full_flag_disables_incremental(self, patched_cli):
+        """3d: --full → incremental=False (全量重算, 不查已物化)。"""
+        mock_svc, _ = patched_cli
+        mock_svc.calculate_factors_by_library.return_value = _ok_result()
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "alpha158",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+            "-c", "000001.SZ", "--full",
+        ])
+
+        assert result.exit_code == 0, result.output
+        kwargs = mock_svc.calculate_factors_by_library.call_args.kwargs
+        assert kwargs["incremental"] is False
+        assert "--full" in result.output
+
+    def test_materialize_service_failure_exits_nonzero(self, patched_cli):
+        """3b: service 返回 success=False → exit 1 + 打印 error。"""
+        mock_svc, _ = patched_cli
+        mock_svc.calculate_factors_by_library.return_value = ServiceResult(
+            success=False, error="Library 'nope' not found"
+        )
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "nope",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+            "-c", "000001.SZ",
+        ])
+
+        assert result.exit_code == 1, result.output
+        out = _strip_ansi(result.output)
+        assert "物化失败" in out
+        assert "Library 'nope' not found" in out
+
+    def test_materialize_no_entity_exits_nonzero(self, patched_cli):
+        """3c: 未指定 --entity → exit 1, 不调 service。"""
+        mock_svc, _ = patched_cli
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "alpha158",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+        ])
+
+        assert result.exit_code == 1, result.output
+        assert "--entity" in result.output
+        mock_svc.calculate_factors_by_library.assert_not_called()
+
+    def test_materialize_invalid_entity_type_exits_nonzero(self, patched_cli):
+        """3e: 无效 entity_type → exit 1, 不调 service。"""
+        mock_svc, _ = patched_cli
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "alpha158",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+            "-c", "000001.SZ", "--entity-type", "nonexistent_type",
+        ])
+
+        assert result.exit_code == 1, result.output
+        assert "nonexistent_type" in result.output
+        mock_svc.calculate_factors_by_library.assert_not_called()
+
+    def test_materialize_incremental_hint_when_skipped(self, patched_cli):
+        """增量跳过提示: skipped>0 + 非 full → 输出 '增量跳过' 提示。"""
+        mock_svc, _ = patched_cli
+        mock_svc.calculate_factors_by_library.return_value = _ok_result(skipped_entities=2)
+
+        result = runner.invoke(factor_cli.app, [
+            "materialize", "alpha158",
+            "--start", "2024-01-01", "--end", "2024-12-31",
+            "-c", "000001.SZ",
+        ])
+
+        assert result.exit_code == 0, result.output
+        assert "增量跳过 2" in _strip_ansi(result.output)
+
+
+@pytest.mark.unit
+class TestFactorCliLibraries:
+    def test_libraries_lists_registered(self, patched_cli):
+        """3f: libraries 命令列出 registry 的库 + 因子数。"""
+        mock_svc, _ = patched_cli
+        registry = MagicMock()
+        registry.get_registered_libraries.return_value = {
+            "alpha158": object(),
+            "world_quant_alpha101": object(),
+        }
+        registry.get_factors_by_library.side_effect = lambda name: {
+            "alpha158": {"KMID": "...", "MA5": "..."},
+            "world_quant_alpha101": {"Alpha001": "..."},
+        }[name]
+        mock_svc.factor_registry = registry
+
+        result = runner.invoke(factor_cli.app, ["libraries"])
+
+        assert result.exit_code == 0, result.output
+        assert "alpha158" in result.output
+        assert "world_quant_alpha101" in result.output
+        assert "2" in result.output  # alpha158 因子数
+
+    def test_libraries_empty(self, patched_cli):
+        """无库时输出提示而非崩溃。"""
+        mock_svc, _ = patched_cli
+        registry = MagicMock()
+        registry.get_registered_libraries.return_value = {}
+        mock_svc.factor_registry = registry
+
+        result = runner.invoke(factor_cli.app, ["libraries"])
+
+        assert result.exit_code == 0, result.output
+        assert "未发现" in result.output

--- a/tests/unit/client/test_factor_cli_analyze.py
+++ b/tests/unit/client/test_factor_cli_analyze.py
@@ -1,0 +1,43 @@
+"""factor_cli analyze 命令测试 -- #6794 验收3 (可读+结构化输出)
+
+注意: typer rich 模式把 option 渲染成单杠 (见 typer-rich-markup-brackets),
+      故断言命令描述/输出文本而非 option 名字面量。
+"""
+import pytest
+from typer.testing import CliRunner
+
+try:
+    from ginkgo.client.factor_cli import app
+    HAS_CLI = True
+except ImportError:
+    HAS_CLI = False
+
+runner = CliRunner()
+
+
+@pytest.mark.skipif(not HAS_CLI, reason="factor_cli not available")
+@pytest.mark.unit
+class TestFactorAnalyzeCLI:
+    def test_analyze_help_lists_pit_and_metrics(self):
+        """analyze --help 含 PIT 防泄漏说明 + IC 指标 (验收3)。"""
+        result = runner.invoke(app, ["analyze", "--help"])
+        assert result.exit_code == 0
+        assert "PIT" in result.output
+        assert "IC" in result.output
+
+    def test_analyze_requires_entity(self):
+        """无 --entity 退出码 1 (参数校验, 不触发 container)。"""
+        result = runner.invoke(app, [
+            "analyze", "ROC", "-s", "2024-01-01", "-e", "2024-12-31",
+        ])
+        assert result.exit_code == 1
+        assert "entity" in result.output.lower()
+
+    def test_analyze_rejects_bad_format(self):
+        """--format 非 table/csv/json 退出码 1。"""
+        result = runner.invoke(app, [
+            "analyze", "ROC", "-s", "2024-01-01", "-e", "2024-12-31",
+            "-c", "000001.SZ", "--format", "xml",
+        ])
+        assert result.exit_code == 1
+        assert "format" in result.output.lower()

--- a/tests/unit/data/crud/test_factor_crud_mock.py
+++ b/tests/unit/data/crud/test_factor_crud_mock.py
@@ -245,3 +245,42 @@ class TestFactorCRUDMaterializedEntities:
         assert call_kwargs["filters"]["timestamp__lte"] == datetime(2024, 1, 31)
         assert call_kwargs["distinct_field"] == "entity_id"
 
+
+# ============================================================
+# #6793 Phase 2: get_latest_factors_by_entity PIT 能力 (at_time)
+# ============================================================
+
+
+class TestFactorCRUDPIT:
+    """get_latest_factors_by_entity: at_time 参数下推 timestamp__lte (PIT 能力)。
+
+    crud 层提供 PIT 过滤能力(at_time 可选);硬约束在读取入口(reader)层。
+    """
+
+    @pytest.mark.unit
+    def test_at_time_pushes_timestamp_lte_to_find(self, factor_crud):
+        """at_time 给定 → find filters 含 timestamp__lte=at_time (排除未来因子值)。"""
+        factor_crud.find = MagicMock(return_value=[])
+        at = datetime(2024, 6, 1)
+
+        factor_crud.get_latest_factors_by_entity(
+            entity_type=ENTITY_TYPES.STOCK, entity_id="000001.SZ",
+            factor_names=["ROC"], at_time=at,
+        )
+
+        call_filters = factor_crud.find.call_args[1]["filters"]
+        assert call_filters["timestamp__lte"] == at
+
+    @pytest.mark.unit
+    def test_no_at_time_leaves_no_timestamp_filter(self, factor_crud):
+        """at_time=None → find filters 无 timestamp__lte (向后兼容, 运维全量查询)。"""
+        factor_crud.find = MagicMock(return_value=[])
+
+        factor_crud.get_latest_factors_by_entity(
+            entity_type=ENTITY_TYPES.STOCK, entity_id="000001.SZ",
+            factor_names=["ROC"],
+        )
+
+        call_filters = factor_crud.find.call_args[1]["filters"]
+        assert "timestamp__lte" not in call_filters
+

--- a/tests/unit/data/crud/test_factor_crud_mock.py
+++ b/tests/unit/data/crud/test_factor_crud_mock.py
@@ -203,3 +203,45 @@ class TestFactorCRUDConstruction:
         assert factor_crud._is_clickhouse is True
         assert factor_crud._is_mysql is False
 
+
+# ============================================================
+# #6792 Phase 1: get_materialized_entities 增量物化决策查询
+# ============================================================
+
+
+class TestFactorCRUDMaterializedEntities:
+    """get_materialized_entities: 查已物化 entity 集合,支撑增量物化决策。"""
+
+    @pytest.mark.unit
+    def test_returns_distinct_entity_ids(self, factor_crud):
+        """[start,end] 内对指定 factors 有数据的 distinct entity_id(distinct_field 下推 SQL)。"""
+        factor_crud.find = MagicMock(return_value=["000001.SZ", "000002.SZ"])
+
+        result = factor_crud.get_materialized_entities(
+            entity_type=ENTITY_TYPES.STOCK,
+            factor_names=["KMID", "MA5"],
+            start_time=datetime(2024, 1, 1),
+            end_time=datetime(2024, 1, 31),
+        )
+
+        assert set(result) == {"000001.SZ", "000002.SZ"}
+
+    @pytest.mark.unit
+    def test_passes_correct_filters_and_distinct_field(self, factor_crud):
+        """find 用 entity_type + factor_name__in + timestamp gte/lte,distinct_field=entity_id。"""
+        factor_crud.find = MagicMock(return_value=[])
+
+        factor_crud.get_materialized_entities(
+            entity_type=ENTITY_TYPES.STOCK,
+            factor_names=["KMID"],
+            start_time=datetime(2024, 1, 1),
+            end_time=datetime(2024, 1, 31),
+        )
+
+        call_kwargs = factor_crud.find.call_args[1]
+        assert call_kwargs["filters"]["entity_type"] == ENTITY_TYPES.STOCK.value
+        assert call_kwargs["filters"]["factor_name__in"] == ["KMID"]
+        assert call_kwargs["filters"]["timestamp__gte"] == datetime(2024, 1, 1)
+        assert call_kwargs["filters"]["timestamp__lte"] == datetime(2024, 1, 31)
+        assert call_kwargs["distinct_field"] == "entity_id"
+

--- a/tests/unit/features/test_factor_analysis_service.py
+++ b/tests/unit/features/test_factor_analysis_service.py
@@ -1,0 +1,140 @@
+"""FactorAnalysisService 测试 -- #6794 验收1 (IC/IR/decay/turnover/分位收益) + 验收2 (PIT)
+
+编排器: 读 PIT 因子 + bars → 前瞻收益 → IC/Decay/Layering 三分析器 + 内联 turnover。
+
+fixture: 5 code (ICAnalyzer 每日需 >=5 code 才算 IC), factor base 与未来日收益正相关
+         (factor rank E>D>C>B>A, return_1d rank E>D>C>B>A → Spearman IC ≈ 1.0)。
+"""
+import pytest
+import pandas as pd
+from datetime import datetime
+
+try:
+    from ginkgo.features.services.factor_analysis_service import FactorAnalysisService
+    HAS_SVC = True
+except ImportError:
+    HAS_SVC = False
+
+
+def _factor_df():
+    """5 code × 10 日; factor_value base 与未来收益正相关。"""
+    dates = pd.date_range("2024-01-01", periods=10, freq="D")
+    rows = []
+    for code, base in [("A", 1.0), ("B", 2.0), ("C", 3.0), ("D", 4.0), ("E", 5.0)]:
+        for i, d in enumerate(dates):
+            rows.append({"date": d, "code": code, "factor_value": base + i * 0.1})
+    return pd.DataFrame(rows)
+
+
+def _bars_df():
+    """12 日 bars; factor 高的 code 日收益高 (正 IC)。A 不动, E 涨最快。"""
+    dates = pd.date_range("2024-01-01", periods=12, freq="D")
+    rows = []
+    growth = {"A": 1.0, "B": 1.01, "C": 1.02, "D": 1.03, "E": 1.04}
+    for code in ["A", "B", "C", "D", "E"]:
+        price = 100.0
+        for d in dates:
+            rows.append({"date": d, "code": code, "close": price})
+            price *= growth[code]
+    return pd.DataFrame(rows)
+
+
+@pytest.mark.skipif(not HAS_SVC, reason="FactorAnalysisService not available")
+@pytest.mark.unit
+class TestFactorAnalysisService:
+    def test_analyze_produces_nonempty_report(self):
+        """编排器输出非空报告: ic/ir/decay/turnover/layering_spread 都有键。"""
+        svc = FactorAnalysisService()
+        result = svc.analyze_from_dataframes(
+            factor_df=_factor_df(),
+            bars_df=_bars_df(),
+            periods=[1],
+            n_groups=5,
+            realized_cutoff=datetime(2024, 1, 12),
+        )
+        assert result.success
+        for key in ("ic", "ir", "decay", "turnover", "layering_spread"):
+            assert key in result.data, f"报告缺键: {key}"
+
+    def test_ic_positive_for_aligned_factor_return(self):
+        """factor 与未来收益正相关 → IC > 0 (rank E>D>C>B>A 一致)。"""
+        svc = FactorAnalysisService()
+        result = svc.analyze_from_dataframes(
+            factor_df=_factor_df(), bars_df=_bars_df(),
+            periods=[1], n_groups=5, realized_cutoff=datetime(2024, 1, 12),
+        )
+        assert result.success
+        assert result.data["ic"] is not None
+        assert result.data["ic"] > 0
+
+    def test_pit_cutoff_graceful(self):
+        """realized_cutoff 早: PIT 截断大部分前瞻收益, 仍 success (graceful degrade)。"""
+        svc = FactorAnalysisService()
+        result = svc.analyze_from_dataframes(
+            factor_df=_factor_df(), bars_df=_bars_df(),
+            periods=[1], n_groups=5, realized_cutoff=datetime(2024, 1, 3),
+        )
+        # 不因样本少崩; ic 可能为 None (样本不足) 但 success 必为 True
+        assert result.success
+
+    def test_turnover_computed_as_float(self):
+        """turnover 实际计算 (非空桩): 返回 float (factor rank 稳定时为 0.0)。"""
+        svc = FactorAnalysisService()
+        result = svc.analyze_from_dataframes(
+            factor_df=_factor_df(), bars_df=_bars_df(),
+            periods=[1], n_groups=5, realized_cutoff=datetime(2024, 1, 12),
+        )
+        assert isinstance(result.data["turnover"], float)
+
+    def test_analyze_factor_end_to_end_mock(self):
+        """验收4: analyze_factor 端到端 (mock crud+bar_service) 产出非空报告。
+
+        覆盖数据获取层: crud.get_factors_by_entity(factor_names List, entity_type) +
+        bar_service.get_bars_df(timestamp 列归一 date, close Decimal→float)。
+        """
+        from types import SimpleNamespace
+        from decimal import Decimal
+        from unittest.mock import MagicMock
+        from ginkgo.data.services.base_service import ServiceResult
+
+        # 5 code × 10 日 因子 (factor base 正相关未来收益)
+        dates = pd.date_range("2024-01-01", periods=10, freq="D")
+        factors_by_entity = {}
+        for code, base in [("A", 1.0), ("B", 2.0), ("C", 3.0), ("D", 4.0), ("E", 5.0)]:
+            factors_by_entity[code] = [
+                SimpleNamespace(
+                    entity_id=code, factor_name="ROC",
+                    factor_value=Decimal(str(base + i * 0.1)), timestamp=d,
+                )
+                for i, d in enumerate(dates)
+            ]
+
+        crud = MagicMock()
+        crud.get_factors_by_entity.side_effect = (
+            lambda entity_type, entity_id, **kw: factors_by_entity.get(entity_id, [])
+        )
+
+        # bars: 12 日, factor 高涨得快 (正 IC); bar 用 timestamp 列 (非 date)
+        bar_dates = pd.date_range("2024-01-01", periods=12, freq="D")
+        growth = {"A": 1.0, "B": 1.01, "C": 1.02, "D": 1.03, "E": 1.04}
+        bar_rows = []
+        for code in ["A", "B", "C", "D", "E"]:
+            price = 100.0
+            for d in bar_dates:
+                bar_rows.append({"timestamp": d, "code": code, "close": price})
+                price *= growth[code]
+        bars_mock = pd.DataFrame(bar_rows)
+
+        bar_service = MagicMock()
+        bar_service.get_bars_df.return_value = ServiceResult(success=True, data=bars_mock)
+
+        svc = FactorAnalysisService()
+        result = svc.analyze_factor(
+            factor_name="ROC", entity_ids=["A", "B", "C", "D", "E"],
+            start_date="2024-01-01", end_date="2024-01-12",
+            factor_crud=crud, bar_service=bar_service, entity_type="stock",
+        )
+        assert result.success
+        assert result.data["ic"] is not None
+        assert result.data["ic"] > 0
+        assert isinstance(result.data["turnover"], float)

--- a/tests/unit/features/test_factor_service_smoke.py
+++ b/tests/unit/features/test_factor_service_smoke.py
@@ -1,0 +1,133 @@
+"""#6792/#6793/#6791 factor_service 新方法 smoke(#6685 diff coverage gate 采集)。
+
+mock factor_engine/expression_engine/registry(不连 DB),调起三个新方法
+各分支补覆盖信号:calculate_factors_by_library(增量物化 5 分支) /
+walk_forward_factor_evaluation(走步切折) / calculate_alpha158_factors
+(get_all_factors→get_all_expressions 改名)。
+"""
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+_path = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.features.services.factor_service import FactorService
+from ginkgo.data.services.base_service import ServiceResult
+
+START = "2024-01-01"
+END_SHORT = "2024-01-10"
+END_LONG = "2024-12-31"
+
+
+def _make_service() -> FactorService:
+    """构造全依赖 mock 的 FactorService(GLOG/registry 隔离,不连 DB)。"""
+    with patch("ginkgo.libs.GLOG"), \
+         patch("ginkgo.features.definitions.registry.factor_registry", MagicMock()):
+        return FactorService(factor_engine=MagicMock(), expression_engine=MagicMock())
+
+
+def _ok(**data) -> ServiceResult:
+    """成功 ServiceResult 速写。"""
+    return ServiceResult(success=True, data=data)
+
+
+def test_calculate_by_library_incremental_skips_materialized():
+    """增量物化:已物化 entity 跳过,engine 只算未物化的(覆盖 168-203)。"""
+    svc = _make_service()
+    svc.factor_registry.get_factors_by_library.return_value = {"ROC5": "$close/shift(5)"}
+    svc.expression_engine.validate_expressions.return_value = _ok()
+    crud = MagicMock()
+    crud.get_materialized_entities.return_value = {"A"}  # A 已物化 → 跳过
+    svc.factor_engine.calculate_and_store.return_value = _ok(
+        processed_entities=1, total_factors_stored=5)
+
+    r = svc.calculate_factors_by_library(
+        "alpha158", ["A", "B"], START, END_SHORT, incremental=True, factor_crud=crud)
+
+    assert r.success
+    assert r.data["skipped_entities"] == 1
+    assert r.data["total_factors_stored"] == 5
+    # target_ids 过滤掉 A,只剩 B
+    assert svc.factor_engine.calculate_and_store.call_args.kwargs["entity_ids"] == ["B"]
+
+
+def test_calculate_by_library_all_materialized_zero_write():
+    """全已物化 → 零写入(processed/stored=0,不调 engine,覆盖 181-185)。"""
+    svc = _make_service()
+    svc.factor_registry.get_factors_by_library.return_value = {"ROC5": "..."}
+    svc.expression_engine.validate_expressions.return_value = _ok()
+    crud = MagicMock()
+    crud.get_materialized_entities.return_value = {"A", "B"}  # 全已物化
+
+    r = svc.calculate_factors_by_library("alpha158", ["A", "B"], START, END_SHORT, factor_crud=crud)
+
+    assert r.success
+    assert r.data["processed_entities"] == 0
+    assert r.data["total_factors_stored"] == 0
+    svc.factor_engine.calculate_and_store.assert_not_called()
+
+
+def test_calculate_by_library_library_not_found():
+    """library 找不到 → error(覆盖 156-158)。"""
+    svc = _make_service()
+    svc.factor_registry.get_factors_by_library.return_value = {}
+
+    r = svc.calculate_factors_by_library("ghost", ["A"], START, END_SHORT)
+
+    assert not r.success
+    assert "not found" in r.error
+    svc.factor_engine.calculate_and_store.assert_not_called()
+
+
+def test_calculate_by_library_validation_fails():
+    """表达式验证失败 → error(覆盖 160-163)。"""
+    svc = _make_service()
+    svc.factor_registry.get_factors_by_library.return_value = {"BAD": "$$$"}
+    svc.expression_engine.validate_expressions.return_value = ServiceResult(success=False, error="syntax")
+
+    r = svc.calculate_factors_by_library("alpha158", ["A"], START, END_SHORT)
+
+    assert not r.success
+    assert "验证失败" in r.error
+
+
+def test_walk_forward_factor_evaluation_folds():
+    """走步切折:evaluator 注入,产 n_folds 折 PIT(覆盖 254-323)。"""
+    svc = _make_service()
+    crud = MagicMock()
+    crud.get_factors_by_entity.return_value = []  # 窗口空(不连 DB)
+    evaluator = MagicMock(return_value=0.5)
+
+    r = svc.walk_forward_factor_evaluation(
+        "ROC5", ["A"], START, END_LONG, evaluator=evaluator, n_folds=3, factor_crud=crud)
+
+    assert r.success
+    assert len(r.data["folds"]) == 3
+    assert r.data["n_folds"] == 3
+
+
+def test_walk_forward_requires_crud():
+    """crud None → error(覆盖 255-258)。"""
+    svc = _make_service()
+
+    r = svc.walk_forward_factor_evaluation(
+        "ROC5", ["A"], START, END_LONG, evaluator=lambda f: 0, factor_crud=None)
+
+    assert not r.success
+    assert "required" in r.error
+
+
+def test_calculate_alpha158_uses_get_all_expressions():
+    """calculate_alpha158_factors 走 get_all_expressions 改名行(覆盖 81, #6791 命名修复)。"""
+    svc = _make_service()
+    svc.factor_engine.calculate_and_store.return_value = _ok(
+        processed_entities=1, total_factors_stored=1)
+
+    with patch("ginkgo.features.definitions.Alpha158Factors.get_all_expressions",
+               return_value={"ROC5": "$close/shift(5)"}) as m:
+        r = svc.calculate_alpha158_factors(["A"], START, END_SHORT)
+        m.assert_called_once()
+
+    assert r.success

--- a/tests/unit/features/test_pit_factor_reader.py
+++ b/tests/unit/features/test_pit_factor_reader.py
@@ -1,0 +1,76 @@
+"""PITFactorReader 测试 -- #6793 Phase 2
+
+验证因子读取入口的 point-in-time 硬约束:
+- at_time 必传 (None raise, 不可绕过)
+- 只返回 timestamp <= at_time 的因子值
+- 已知泄漏因子 (ts > at_time) 被拦截 (防御性双保险, 即使底层漏过滤)
+- at_time 下推到 crud (SQL 层 timestamp__lte)
+"""
+import pytest
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+try:
+    from ginkgo.features.readers.pit_factor_reader import PITFactorReader
+    HAS_READER = True
+except ImportError:
+    HAS_READER = False
+
+
+def _factor(value, ts):
+    """构造真实 MFactor (reader 通过 .timestamp / .factor_value 访问)。"""
+    from ginkgo.data.models import MFactor
+    return MFactor(
+        entity_id="000001.SZ", factor_name="ROC",
+        factor_value=Decimal(str(value)), timestamp=ts,
+    )
+
+
+@pytest.mark.skipif(not HAS_READER, reason="PITFactorReader not available")
+@pytest.mark.unit
+class TestPITFactorReader:
+    def test_at_time_required_raises(self):
+        """at_time=None → raise ValueError (PIT 硬约束, 不可绕过)。"""
+        reader = PITFactorReader(MagicMock())
+        with pytest.raises(ValueError, match="at_time"):
+            reader.get_factor_value("000001.SZ", "ROC", at_time=None)
+
+    def test_returns_value_when_factor_before_at_time(self):
+        """因子 ts <= at_time → 返回 factor_value。"""
+        crud = MagicMock()
+        crud.get_latest_factors_by_entity.return_value = [_factor(1.5, datetime(2024, 1, 15))]
+        reader = PITFactorReader(crud)
+        val = reader.get_factor_value("000001.SZ", "ROC", at_time=datetime(2024, 6, 1))
+        assert val == 1.5
+
+    def test_rejects_known_leak_future_factor(self):
+        """已知泄漏因子 (ts=2024-12-01 > at_time=2024-06-01) → 返回 None (拦截)。
+
+        模拟底层 crud 漏过滤返回了未来值, reader 防御层仍拦截。
+        """
+        crud = MagicMock()
+        crud.get_latest_factors_by_entity.return_value = [_factor(999.0, datetime(2024, 12, 1))]
+        reader = PITFactorReader(crud)
+        val = reader.get_factor_value("000001.SZ", "ROC", at_time=datetime(2024, 6, 1))
+        assert val is None
+
+    def test_passes_at_time_to_crud(self):
+        """at_time 下推到 crud.get_latest_factors_by_entity (SQL 层 timestamp__lte)。"""
+        crud = MagicMock()
+        crud.get_latest_factors_by_entity.return_value = []
+        reader = PITFactorReader(crud)
+        at = datetime(2024, 6, 1)
+        reader.get_factor_value("000001.SZ", "ROC", at_time=at)
+        kwargs = crud.get_latest_factors_by_entity.call_args[1]
+        assert kwargs["at_time"] == at
+        assert kwargs["entity_id"] == "000001.SZ"
+        assert kwargs["factor_names"] == ["ROC"]
+
+    def test_no_factor_returns_none(self):
+        """crud 返回空 (该 entity 在 at_time 前无此因子) → 返回 None。"""
+        crud = MagicMock()
+        crud.get_latest_factors_by_entity.return_value = []
+        reader = PITFactorReader(crud)
+        val = reader.get_factor_value("000001.SZ", "ROC", at_time=datetime(2024, 6, 1))
+        assert val is None

--- a/tests/unit/features/test_services.py
+++ b/tests/unit/features/test_services.py
@@ -175,6 +175,92 @@ class TestFactorService:
         assert status["alpha158_total_factors"] > 0
         assert status["alpha158_core_factors"] > 0
 
+    # ===== #6792 Phase 1: calculate_factors_by_library + 增量物化 (TDD 垂直切片) =====
+
+    def test_calculate_factors_by_library_full_when_no_crud(self):
+        """RED#1: 无 factor_crud 时不增量,engine 收到全部 entity_ids + library 表达式。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        result = svc.calculate_factors_by_library(
+            library_name="alpha158",
+            entity_ids=["000001.SZ", "000002.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+        )
+
+        assert result.success is True, f"err: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert call_kwargs["entity_ids"] == ["000001.SZ", "000002.SZ"]
+        assert len(call_kwargs["expressions"]) > 0
+
+    def test_calculate_factors_by_library_incremental_skips_materialized(self):
+        """RED#2: factor_crud 返回部分已物化,engine 只收到差集 + skipped 计数正确。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        mock_crud = MagicMock()
+        mock_crud.get_materialized_entities.return_value = ["000001.SZ"]
+
+        result = svc.calculate_factors_by_library(
+            library_name="alpha158",
+            entity_ids=["000001.SZ", "000002.SZ", "000003.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+            factor_crud=mock_crud,
+        )
+
+        assert result.success is True, f"err: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert call_kwargs["entity_ids"] == ["000002.SZ", "000003.SZ"]
+        assert result.data["skipped_entities"] == 1
+        crud_kwargs = mock_crud.get_materialized_entities.call_args.kwargs
+        assert crud_kwargs["start_time"] == "2024-01-01"
+        assert crud_kwargs["end_time"] == "2024-12-31"
+
+    def test_calculate_factors_by_library_all_materialized_zero_write(self):
+        """RED#3: 全部 entity 已物化 → engine 不调用,processed=0,skipped=N(二次运行写入为零)。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        mock_crud = MagicMock()
+        mock_crud.get_materialized_entities.return_value = ["000001.SZ", "000002.SZ"]
+
+        result = svc.calculate_factors_by_library(
+            library_name="alpha158",
+            entity_ids=["000001.SZ", "000002.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+            factor_crud=mock_crud,
+        )
+
+        assert result.success is True, f"err: {result.error}"
+        mock_engine.calculate_and_store.assert_not_called()
+        assert result.data["processed_entities"] == 0
+        assert result.data["total_factors_stored"] == 0
+        assert result.data["skipped_entities"] == 2
+
+    def test_calculate_factors_by_library_unknown_library_returns_error(self):
+        """未知 library → error(不静默空计算),不调 engine。"""
+        mock_engine = MagicMock()
+        svc = FactorService(mock_engine, MagicMock())
+
+        result = svc.calculate_factors_by_library(
+            library_name="nonexistent_lib",
+            entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+        )
+
+        assert result.success is False
+        assert "nonexistent_lib" in (result.error or "")
+        mock_engine.calculate_and_store.assert_not_called()
+
 
 @pytest.mark.skipif(not HAS_FACTOR_SVC, reason="FactorService not available")
 def test_features_convenience_expression_helpers():

--- a/tests/unit/features/test_services.py
+++ b/tests/unit/features/test_services.py
@@ -61,3 +61,127 @@ class TestFactorService:
         svc = FactorService(MagicMock(), MagicMock())
         result = svc.search_factors("momentum")
         assert result is not None
+
+    # ===== #6791 Phase 0: 因子命名 bug 修复 (TDD 垂直切片) =====
+
+    def _make_engine_ok(self):
+        """构造一个返回 success 的 mock FactorEngine(get_data 默认返回占位值)。"""
+        mock = MagicMock()
+        mock.success = True
+        mock.get_data.return_value = 1
+        return mock
+
+    def test_calculate_alpha158_factors_full_library_passes_expressions(self):
+        """RED#1: calculate_alpha158_factors(无 factor_names) 应把 Alpha158 全量表达式传给 engine。
+        当前 Alpha158Factors.get_all_factors() 不存在 → AttributeError 被 except 捕获 → result.success=False。
+        修后(get_all_expressions)应 success 且 expressions 非空。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+
+        svc = FactorService(mock_engine, mock_expr_engine)
+        result = svc.calculate_alpha158_factors(
+            entity_ids=["000001.SZ"], start_date="2024-01-01", end_date="2024-12-31"
+        )
+
+        assert result.success is True, f"expected success, got error: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert len(call_kwargs["expressions"]) > 0
+
+    def test_calculate_alpha158_factors_subset_filters_expressions(self):
+        """RED#2: 传 factor_names 子集,只把这些因子传给 engine(过滤未知名)。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        result = svc.calculate_alpha158_factors(
+            entity_ids=["000001.SZ"], start_date="2024-01-01", end_date="2024-12-31",
+            factor_names=["KMID", "MA5"],
+        )
+
+        assert result.success is True, f"expected success, got error: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert set(call_kwargs["expressions"].keys()) == {"KMID", "MA5"}
+
+    def test_calculate_core_factors_passes_core_category(self):
+        """RED#3: calculate_core_factors 用 core 类目表达式(KMID 等)。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        result = svc.calculate_core_factors(
+            entity_ids=["000001.SZ"], start_date="2024-01-01", end_date="2024-12-31"
+        )
+        assert result.success is True, f"expected success, got error: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert len(call_kwargs["expressions"]) > 0
+        assert "KMID" in call_kwargs["expressions"]  # core 类目含 KMID
+
+    def test_calculate_category_factors_momentum(self):
+        """RED#4: category='momentum' 拿到动量类目(ROC1),对齐 CATEGORIES key。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        result = svc.calculate_category_factors(
+            category="momentum", entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+        )
+        assert result.success is True, f"expected success, got error: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert "ROC1" in call_kwargs["expressions"]
+
+    def test_calculate_category_factors_moving_average_key(self):
+        """RED#4b: category 对齐 CATEGORIES 真实 key 'moving_average'(非旧失效 'ma')。"""
+        mock_engine = MagicMock()
+        mock_engine.calculate_and_store.return_value = self._make_engine_ok()
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.validate_expressions.return_value = self._make_engine_ok()
+        svc = FactorService(mock_engine, mock_expr_engine)
+
+        result = svc.calculate_category_factors(
+            category="moving_average", entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+        )
+        assert result.success is True, f"expected success, got error: {result.error}"
+        call_kwargs = mock_engine.calculate_and_store.call_args.kwargs
+        assert "MA5" in call_kwargs["expressions"]
+
+    def test_calculate_category_factors_unknown_rejected(self):
+        """RED#4c: 未知 category 应返回 error(不静默空)。"""
+        svc = FactorService(MagicMock(), MagicMock())
+        result = svc.calculate_category_factors(
+            category="nonexistent", entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+        )
+        assert result.success is False
+        assert "nonexistent" in (result.error or "")
+
+    def test_get_service_status_counts_alpha158(self):
+        """RED#5: get_service_status 不再 AttributeError,alpha158 计数 > 0。"""
+        mock_engine = MagicMock()
+        mock_engine.get_stats.return_value = {}
+        mock_expr_engine = MagicMock()
+        mock_expr_engine.get_engine_stats.return_value = {}
+        svc = FactorService(mock_engine, mock_expr_engine)
+        status = svc.get_service_status()
+        assert status["alpha158_total_factors"] > 0
+        assert status["alpha158_core_factors"] > 0
+
+
+@pytest.mark.skipif(not HAS_FACTOR_SVC, reason="FactorService not available")
+def test_features_convenience_expression_helpers():
+    """RED#5b: features.get_alpha158_expressions / get_core_expressions 不再 AttributeError。"""
+    from ginkgo.features import get_alpha158_expressions, get_core_expressions
+    all_expr = get_alpha158_expressions()
+    core_expr = get_core_expressions()
+    assert len(all_expr) > 0
+    assert len(core_expr) > 0
+    assert "KMID" in all_expr  # KMID 属于 core

--- a/tests/unit/features/test_strategy_walk_forward.py
+++ b/tests/unit/features/test_strategy_walk_forward.py
@@ -1,0 +1,56 @@
+"""策略走步 OOS 验证测试 -- #6796 验收2 (接入走步) + 验收4 (如实报告 OOS)
+
+backtest_func 是调用方注入的 callable (跑策略回测返回 {"return": float}),
+此处 mock 固定收益序列验证切折 + OOS 报告 + 如实反映逻辑。
+"""
+import pytest
+
+try:
+    from ginkgo.features.services.strategy_walk_forward import (
+        walk_forward_strategy_evaluation,
+    )
+    HAS_WF = True
+except ImportError:
+    HAS_WF = False
+
+
+@pytest.mark.skipif(not HAS_WF, reason="walk_forward_strategy_evaluation not available")
+@pytest.mark.unit
+class TestStrategyWalkForward:
+    def test_produces_folds_with_oos_report(self):
+        """验收2: 走步切 n_folds 折, 每折 train/test, 报告 OOS mean。"""
+        def bt(params, start, end):
+            return {"return": 0.1}  # train/test 都正
+        r = walk_forward_strategy_evaluation(
+            bt, "2023-01-01", "2024-01-01", n_folds=3)
+        assert r.success
+        assert len(r.data["folds"]) == 3
+        for f in r.data["folds"]:
+            assert f["train_return"] == 0.1
+            assert f["test_return"] == 0.1
+        assert r.data["mean_test_return"] > 0
+        assert r.data["effective"] is True
+
+    def test_reports_ineffective_when_oos_nonpositive(self):
+        """验收4: OOS <= 0 → effective=False (如实报告, 不强行声称有效)。"""
+        def bt(params, start, end):
+            return {"return": -0.02}  # OOS 负
+        r = walk_forward_strategy_evaluation(
+            bt, "2023-01-01", "2024-01-01", n_folds=3)
+        assert r.success
+        assert r.data["mean_test_return"] < 0
+        assert r.data["effective"] is False  # 如实: 无效就说无效
+
+    def test_degradation_is_train_minus_test(self):
+        """degradation = mean_train - mean_test (train 好 test 差 → 正退化)。"""
+        state = {"call": 0}
+        def bt(params, start, end):
+            # 交替: 奇数 call=train(高 0.20), 偶数 call=test(低 0.01)
+            state["call"] += 1
+            return {"return": 0.20 if state["call"] % 2 == 1 else 0.01}
+        r = walk_forward_strategy_evaluation(
+            bt, "2023-01-01", "2024-01-01", n_folds=3)
+        assert r.success
+        assert r.data["degradation"] is not None
+        # train(0.20) - test(0.01) = 0.19 > 0 (显著退化)
+        assert r.data["degradation"] > 0

--- a/tests/unit/features/test_walk_forward_factor_evaluation.py
+++ b/tests/unit/features/test_walk_forward_factor_evaluation.py
@@ -1,0 +1,81 @@
+"""walk_forward_factor_evaluation 测试 -- #6793 验收3 (走步验证接入)
+
+防样本内拟合: 滑动 train/test 折, 每折 PIT 读取因子, 输出样本外折结果。
+(与 memory project_profit_strategy_iter037 OOS 证伪教训对齐: 禁全样本拟合)
+
+evaluator 注入: 具体指标 (IC/IR/decay) 由调用方提供 (#6794 提供 IC evaluator)。
+"""
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock
+
+try:
+    from ginkgo.features.services.factor_service import FactorService
+    HAS_SVC = True
+except ImportError:
+    HAS_SVC = False
+
+
+@pytest.mark.skipif(not HAS_SVC, reason="FactorService not available")
+class TestWalkForwardFactorEvaluation:
+    @pytest.fixture
+    def factor_service(self):
+        return FactorService(MagicMock(), MagicMock())
+
+    def test_produces_folds_with_train_test_split(self, factor_service):
+        """走步: 输出 n_folds 折, 每折 train_score + test_score 分离 (非全样本单一值)。"""
+        crud = MagicMock()
+        crud.get_factors_by_entity.return_value = [MagicMock()]
+
+        result = factor_service.walk_forward_factor_evaluation(
+            factor_name="ROC", entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-12-31",
+            evaluator=lambda factors: len(factors),
+            n_folds=3, factor_crud=crud,
+        )
+
+        assert result.success
+        folds = result.data["folds"]
+        assert len(folds) == 3
+        for f in folds:
+            assert "train_score" in f and "test_score" in f
+            # train 时序在 test 前 (无重叠, 防泄漏)
+            assert f["train_end"] < f["test_start"]
+
+    def test_pit_each_fold_queries_bounded_window(self, factor_service):
+        """PIT: 每折 crud 查询的 [start_time, end_time] 有界, start <= end (不读窗口外未来)。"""
+        crud = MagicMock()
+        crud.get_factors_by_entity.return_value = []
+
+        factor_service.walk_forward_factor_evaluation(
+            factor_name="ROC", entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-03-31",
+            evaluator=lambda f: 0.0, n_folds=2, factor_crud=crud,
+        )
+
+        calls = crud.get_factors_by_entity.call_args_list
+        # 每折 2 查询 (train + test) × 2 折 × 1 entity = 4
+        assert len(calls) == 4
+        for c in calls:
+            kw = c[1]
+            assert "start_time" in kw and "end_time" in kw
+            assert kw["start_time"] <= kw["end_time"]
+            # 全部查询窗口不超评估终点 (PIT: 评估日 end_date 前的数据)
+            assert kw["end_time"] <= datetime(2024, 3, 31)
+
+    def test_outputs_degradation_and_oos_split(self, factor_service):
+        """输出含 degradation + mean_train/test_score (样本外折对比, 检测过拟合)。"""
+        crud = MagicMock()
+        crud.get_factors_by_entity.return_value = [MagicMock()]
+
+        result = factor_service.walk_forward_factor_evaluation(
+            factor_name="ROC", entity_ids=["000001.SZ"],
+            start_date="2024-01-01", end_date="2024-06-30",
+            evaluator=lambda f: len(f), n_folds=2, factor_crud=crud,
+        )
+
+        assert result.success
+        assert "degradation" in result.data
+        assert "mean_train_score" in result.data
+        assert "mean_test_score" in result.data
+        assert result.data["n_folds"] == 2

--- a/tests/unit/research/test_forward_returns.py
+++ b/tests/unit/research/test_forward_returns.py
@@ -1,0 +1,72 @@
+"""前瞻收益计算器测试 -- #6794 验收2 (PIT 前瞻收益)
+
+PIT: forward return at date d for period N = close[d+N]/close[d] - 1。
+严格 PIT: 若 d + N > realized_cutoff (未来未实现), 该格置 NaN — 防止用未来收益
+做 IC/decay 分析 (前瞻泄漏会让因子效果虚高)。
+"""
+import pytest
+import pandas as pd
+from datetime import datetime
+
+from ginkgo.research.forward_returns import compute_forward_returns
+
+
+def _bars():
+    """构造小 bars: code=000001.SZ, 5 个交易日 close (每日 +10%)。"""
+    return pd.DataFrame({
+        "date": pd.to_datetime([
+            "2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05",
+        ]),
+        "code": ["000001.SZ"] * 5,
+        "close": [10.0, 11.0, 12.1, 13.31, 14.641],
+    })
+
+
+@pytest.mark.unit
+class TestForwardReturns:
+    def test_compute_forward_returns_basic(self):
+        """return_1d: close[t+1]/close[t]-1, 已实现区间正确计算 (每日 +10%)。"""
+        out = compute_forward_returns(_bars(), periods=[1])
+        assert abs(out.loc[0, "return_1d"] - 0.10) < 1e-6
+        assert abs(out.loc[1, "return_1d"] - 0.10) < 1e-6
+        # 最后一天无 t+1 → NaN
+        assert pd.isna(out.loc[4, "return_1d"])
+
+    def test_pit_unrealized_returns_nan(self):
+        """PIT 硬约束: d+N > realized_cutoff → NaN (未来未实现, 防前瞻泄漏)。"""
+        # cutoff = 2024-01-03: 只允许 d+1 <= 01-03 (即 date <= 01-02 有 return_1d)
+        out = compute_forward_returns(
+            _bars(), periods=[1], realized_cutoff=datetime(2024, 1, 3),
+        )
+        # date=01-01: return_1d 用 01-02 close (01-02 <= cutoff 已实现) → 有值
+        assert not pd.isna(out.loc[0, "return_1d"])
+        # date=01-03: return_1d 需 01-04 close (01-04 > cutoff 未实现) → NaN
+        assert pd.isna(out.loc[2, "return_1d"])
+
+    def test_no_cutoff_computes_all_realized(self):
+        """无 realized_cutoff: 算所有 d+N 在 bars 范围内的前瞻收益 (回测式全量)。"""
+        out = compute_forward_returns(_bars(), periods=[1])
+        # 无 cutoff: date=01-04 的 return_1d (用 01-05) 也有值 (bars 内已实现)
+        assert not pd.isna(out.loc[3, "return_1d"])
+
+    def test_multiple_periods_columns(self):
+        """多周期: return_1d / return_5d 列都生成; 不足 N 的全 NaN。"""
+        out = compute_forward_returns(_bars(), periods=[1, 5])
+        assert "return_1d" in out.columns
+        assert "return_5d" in out.columns
+        # 5d 需至少 6 个点, 这里 5 个 → return_5d 全 NaN
+        assert out["return_5d"].isna().all()
+
+    def test_multi_code_isolated(self):
+        """多 code: 各 code 内部按 date 排序算前瞻收益, 互不串扰。"""
+        df = pd.DataFrame({
+            "date": pd.to_datetime(["2024-01-01", "2024-01-02"] * 2),
+            "code": ["000001.SZ", "000001.SZ", "000002.SZ", "000002.SZ"],
+            "close": [10.0, 12.0, 20.0, 26.0],
+        })
+        out = compute_forward_returns(df, periods=[1])
+        # 000001: 12/10-1 = +20%; 000002: 26/20-1 = +30% (各自独立)
+        r1 = out[out["code"] == "000001.SZ"].loc[0, "return_1d"]
+        r2 = out[out["code"] == "000002.SZ"].iloc[0]["return_1d"]
+        assert abs(r1 - 0.20) < 1e-6
+        assert abs(r2 - 0.30) < 1e-6

--- a/tests/unit/trading/strategy/test_base_strategy.py
+++ b/tests/unit/trading/strategy/test_base_strategy.py
@@ -2047,3 +2047,38 @@ class TestBaseStrategyParameterization:
 
         strategy.update_parameters({'strategy_type': 'rsi'})  # 有效选择
         assert strategy.get_parameter('strategy_type') == 'rsi'
+
+
+@pytest.mark.unit
+class TestBaseStrategyFactorReader:
+    """#6791 Phase 0: 因子读取钩子(PIT 委托)。"""
+
+    def test_factor_reader_defaults_none(self):
+        """RED#6: 未绑定时 factor_reader 为 None。"""
+        strategy = BaseStrategy()
+        assert strategy.factor_reader is None
+
+    def test_bind_factor_reader_stores_reader(self):
+        """RED#6: bind_factor_reader 存储 reader。"""
+        from unittest.mock import MagicMock
+        strategy = BaseStrategy()
+        reader = MagicMock()
+        strategy.bind_factor_reader(reader)
+        assert strategy.factor_reader is reader
+
+    def test_get_factor_value_delegates_to_reader(self):
+        """RED#7: get_factor_value 委托 reader,原样传 (code, factor, at_time)。"""
+        from unittest.mock import MagicMock
+        strategy = BaseStrategy()
+        reader = MagicMock()
+        reader.get_factor_value.return_value = 0.05
+        strategy.bind_factor_reader(reader)
+        t = datetime(2024, 6, 1)
+        val = strategy.get_factor_value("000001.SZ", "KMID", t)
+        assert val == 0.05
+        reader.get_factor_value.assert_called_once_with("000001.SZ", "KMID", t)
+
+    def test_get_factor_value_none_without_reader(self):
+        """RED#7b: 未绑定 reader 时返回 None,不崩。"""
+        strategy = BaseStrategy()
+        assert strategy.get_factor_value("000001.SZ", "KMID", datetime(2024, 6, 1)) is None

--- a/tests/unit/trading/strategy/test_factor_momentum_strategy.py
+++ b/tests/unit/trading/strategy/test_factor_momentum_strategy.py
@@ -1,0 +1,93 @@
+"""FactorMomentumStrategy TDD -- #6791 Phase 0 tracer
+
+验证 BaseStrategy factor_reader 钩子的端到端用法:
+策略 cal() 读 PIT 因子值,据此发信号,且用 portfolio_info["now"] 作 at_time(不读未来)。
+"""
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from ginkgo.trading.strategies.factor_momentum import FactorMomentumStrategy
+from ginkgo.enums import DIRECTION_TYPES
+
+
+def _set_context(strategy):
+    """复用 test_base_strategy 的 context helper。"""
+    strategy._context = type('C', (), {
+        'engine_id': 'e', 'portfolio_id': 'p', 'task_id': 't',
+    })()
+
+
+def _event(code="000001.SZ", ts=None):
+    return type('E', (), {'code': code, 'timestamp': ts or datetime(2024, 6, 1)})()
+
+
+@pytest.mark.unit
+class TestFactorMomentumStrategy:
+    def test_cal_emits_long_when_factor_above_buy_threshold(self):
+        strat = FactorMomentumStrategy(buy_threshold=0.0, sell_threshold=-1.0)
+        _set_context(strat)
+        reader = MagicMock()
+        reader.get_factor_value.return_value = 0.05  # ROC5 = +5%
+        strat.bind_factor_reader(reader)
+
+        signals = strat.cal({"now": datetime(2024, 6, 1)}, _event())
+
+        assert len(signals) == 1
+        assert signals[0].direction == DIRECTION_TYPES.LONG
+        reader.get_factor_value.assert_called_once_with("000001.SZ", "ROC5", datetime(2024, 6, 1))
+
+    def test_cal_emits_short_when_factor_below_sell_threshold(self):
+        strat = FactorMomentumStrategy(buy_threshold=1.0, sell_threshold=0.0)
+        _set_context(strat)
+        reader = MagicMock()
+        reader.get_factor_value.return_value = -0.05
+        strat.bind_factor_reader(reader)
+
+        signals = strat.cal({"now": datetime(2024, 6, 1)}, _event())
+
+        assert len(signals) == 1
+        assert signals[0].direction == DIRECTION_TYPES.SHORT
+
+    def test_cal_no_signal_when_factor_missing(self):
+        strat = FactorMomentumStrategy()
+        _set_context(strat)
+        reader = MagicMock()
+        reader.get_factor_value.return_value = None
+        strat.bind_factor_reader(reader)
+
+        assert strat.cal({"now": datetime(2024, 6, 1)}, _event()) == []
+
+    def test_cal_uses_portfolio_now_as_pit_time(self):
+        """PIT: at_time 取 portfolio_info['now'](回测当前时间),优先于 event.timestamp。"""
+        strat = FactorMomentumStrategy()
+        _set_context(strat)
+        reader = MagicMock()
+        reader.get_factor_value.return_value = None
+        strat.bind_factor_reader(reader)
+
+        now = datetime(2024, 6, 1)
+        strat.cal({"now": now}, _event(ts=datetime(2024, 5, 1)))
+
+        called_time = reader.get_factor_value.call_args.args[2]
+        assert called_time == now
+
+    def test_cal_falls_back_to_event_timestamp_without_portfolio_now(self):
+        """portfolio_info 无 'now' 时,fallback event.timestamp(仍 PIT)。"""
+        strat = FactorMomentumStrategy()
+        _set_context(strat)
+        reader = MagicMock()
+        reader.get_factor_value.return_value = None
+        strat.bind_factor_reader(reader)
+
+        ts = datetime(2024, 5, 1)
+        strat.cal({}, _event(ts=ts))
+
+        assert reader.get_factor_value.call_args.args[2] == ts
+
+    def test_cal_no_code_returns_empty(self):
+        strat = FactorMomentumStrategy()
+        _set_context(strat)
+        strat.bind_factor_reader(MagicMock())
+        event_no_code = type('E', (), {'timestamp': datetime(2024, 6, 1)})()
+        assert strat.cal({"now": datetime(2024, 6, 1)}, event_no_code) == []

--- a/tests/unit/trading/strategy/test_factor_top_decile_strategy.py
+++ b/tests/unit/trading/strategy/test_factor_top_decile_strategy.py
@@ -1,0 +1,103 @@
+"""FactorTopDecileStrategy 测试 -- #6796 验收 (截面排名 + PIT + 多因子 + 走步 OOS)
+
+fixture: 5 code universe, factor ROC5 值 A<B<C<D<E (与未来收益正相关);
+         decile=5 → top 5//5=1 → 仅最高分 E 做多。
+"""
+import pytest
+from datetime import datetime
+from types import SimpleNamespace
+
+try:
+    from ginkgo.trading.strategies.factor_top_decile import FactorTopDecileStrategy
+    HAS_STRAT = True
+except ImportError:
+    HAS_STRAT = False
+
+
+class _FakeReader:
+    """模拟 factor_reader (PIT 契约: values = {(code, factor): (value, timestamp)})。"""
+    def __init__(self, values):
+        self._v = values
+
+    def get_factor_value(self, code, factor_name, at_time=None):
+        entry = self._v.get((code, factor_name))
+        if entry is None:
+            return None
+        val, ts = entry
+        # PIT: at_time 已知时, 因子 timestamp 必 <= at_time
+        if at_time is not None and ts is not None and ts > at_time:
+            return None  # 未来值, 不返回
+        return val
+
+
+class _FakeSelector:
+    def __init__(self, codes):
+        self._c = list(codes)
+
+    def pick(self, time=None):
+        return list(self._c)
+
+
+@pytest.mark.skipif(not HAS_STRAT, reason="FactorTopDecileStrategy not available")
+@pytest.mark.unit
+class TestFactorTopDecileStrategy:
+    def _strategy(self, values, decile=5, factors=None):
+        s = FactorTopDecileStrategy(
+            factors=factors or {"ROC5": 1.0}, decile=decile)
+        # create_signal 构造 Signal 需 _context (engine/portfolio/task_id)
+        s._context = SimpleNamespace(engine_id="e", portfolio_id="p", task_id="t")
+        s.bind_factor_reader(_FakeReader(values))
+        return s
+
+    def test_top_decile_issues_long_signal(self):
+        """截面排名 top 分位 → LONG; 非 top → 无信号 (验收1)。"""
+        now = datetime(2024, 1, 1)
+        values = {
+            ("A", "ROC5"): (1.0, now), ("B", "ROC5"): (2.0, now),
+            ("C", "ROC5"): (3.0, now), ("D", "ROC5"): (4.0, now),
+            ("E", "ROC5"): (5.0, now),
+        }
+        s = self._strategy(values, decile=5)  # 5//5=1 → top1 = E
+        info = {"now": now, "selector": [_FakeSelector(["A", "B", "C", "D", "E"])]}
+
+        sigs_e = s.cal(info, SimpleNamespace(code="E", timestamp=now))
+        assert len(sigs_e) == 1
+        # E 最高分 → top1 → LONG
+
+        sigs_a = s.cal(info, SimpleNamespace(code="A", timestamp=now))
+        assert sigs_a == []  # A 最低 → 非 top → 无信号
+
+    def test_pit_does_not_read_future_factor(self):
+        """验收3: 排名只用 <= now 的因子值, 未来因子不读。"""
+        now = datetime(2024, 1, 1)
+        future = datetime(2024, 1, 2)
+        # E 的因子值 timestamp 在未来 (future > now) → reader 返回 None → E 不入选
+        values = {
+            ("A", "ROC5"): (1.0, now),
+            ("E", "ROC5"): (5.0, future),  # 未来值
+        }
+        s = self._strategy(values, decile=2)  # 2//2=1 top1
+        info = {"now": now, "selector": [_FakeSelector(["A", "E"])]}
+
+        # E 因子是未来值 → reader 返 None → E 剔除 → 仅 A 有分 → A=top1
+        sigs_a = s.cal(info, SimpleNamespace(code="A", timestamp=now))
+        assert len(sigs_a) == 1  # A 成为 top1 (E 被剔除)
+        sigs_e = s.cal(info, SimpleNamespace(code="E", timestamp=now))
+        assert sigs_e == []  # E 无因子值 (未来) → 不发信号
+
+    def test_multi_factor_weighted_score_ranks_correctly(self):
+        """多因子加权: VOL5 权重高 → 改变排名 (验收1 多因子组合)。"""
+        factors = {"ROC5": 1.0, "VOL5": 2.0}
+        # A: ROC5=1, VOL5=10 → 1 + 20 = 21
+        # B: ROC5=5, VOL5=1  → 5 + 2  = 7
+        # 单看 ROC5 是 B>A; 加权后 A(21) > B(7) → A 在 top
+        now = datetime(2024, 1, 1)
+        values = {
+            ("A", "ROC5"): (1.0, now), ("A", "VOL5"): (10.0, now),
+            ("B", "ROC5"): (5.0, now), ("B", "VOL5"): (1.0, now),
+        }
+        s = self._strategy(values, decile=2, factors=factors)  # 2//2=1 top1
+        info = {"now": now, "selector": [_FakeSelector(["A", "B"])]}
+
+        assert len(s.cal(info, SimpleNamespace(code="A", timestamp=now))) == 1
+        assert s.cal(info, SimpleNamespace(code="B", timestamp=now)) == []


### PR DESCRIPTION
## 因子分析管线(单 PR 分 5 阶段)

合并 #6791 #6792 #6793 #6794 #6796 五个因子子系统 issue,统一规划设计,分阶段提交。

### 阶段进度(全完 ✅)

- [x] **阶段0 #6791** — 因子物化命名 bug + BaseStrategy 因子读取钩子 + 示例策略(`a4303b96`)
- [x] **阶段1 #6792** — `ginkgo factor` CLI(materialize/libraries)+ 增量物化 service(`6acd529b`)
- [x] **阶段2 #6793** — PIT 硬约束(reader at_time 必传+防御拦截)+ 走步因子评估(walk_forward evaluator 注入)(`3f4e2586`)
- [x] **阶段3 #6794** — IC/IR/decay/turnover/分位收益 编排 + `ginkgo factor analyze` CLI(PIT 前瞻收益)(`2250d24f`)
- [x] **阶段4 #6796** — 截面 top-decile 多因子组合策略 + 策略走步 OOS 验证(`244e703e`)

### 设计要点

- **PIT 防前瞻偏差**:crud 层提供 at_time 能力(向后兼容运维查询),reader 层硬约束(必传+防御双保险)
- **走步验证防拟合**:walk_forward_factor_evaluation 滑动 train/test 折 + evaluator 注入,与全样本拟合的假阳性区分
- **休眠代码接线**:因子子系统 ~75% 已建零调用,#6794 复用 research/ 下既有 ICAnalyzer/FactorDecayAnalyzer/FactorLayering,补 turnover 填充+前瞻收益+CLI
- **如实报告**:策略走步 OOS mean<=0 即 effective=False,不强行声称有效(#6796)

### 测试

五阶段相关单测全 GREEN:阶段0-3 分析器/CLI/PIT/turnover 测试 + 阶段4 策略 3(截面排名/PIT/多因子)+ 走步 3(切折/OOS/退化)= 6 passed。推送前三层冒烟通过(py_compile 全扫 / 启动 smoke CLI→containers→user_crud / 变更测试)。

Closes #6791
Closes #6792
Closes #6793
Closes #6794
Closes #6796