### PR TITLE
fix(redis): function_cache 静默失效 + signal crud output_type TypeError (ADR-025 §4)

### DIFF
--- a/src/ginkgo/data/crud/signal_crud.py
+++ b/src/ginkgo/data/crud/signal_crud.py
@@ -217,7 +217,7 @@ class SignalCRUD(BaseCRUD[MSignal]):
         page: Optional[int] = None,
         page_size: Optional[int] = None,
         desc_order: bool = False,
-    ) -> List[Signal]:
+    ) -> List[MSignal]:
         """
         Business helper: Find signals by portfolio ID with date range.
         """
@@ -234,7 +234,6 @@ class SignalCRUD(BaseCRUD[MSignal]):
             page_size=page_size,
             order_by="timestamp",
             desc_order=desc_order,
-            output_type="signal"
         )
 
     def find_by_engine(
@@ -242,7 +241,7 @@ class SignalCRUD(BaseCRUD[MSignal]):
         engine_id: str,
         start_date: Optional[Any] = None,
         end_date: Optional[Any] = None,
-    ) -> List[Signal]:
+    ) -> List[MSignal]:
         """
         Business helper: Find signals by engine ID.
         """
@@ -257,7 +256,6 @@ class SignalCRUD(BaseCRUD[MSignal]):
             filters=filters,
             order_by="timestamp",
             desc_order=True,
-            output_type="signal"
         )
 
     def find_by_code_and_direction(
@@ -267,7 +265,7 @@ class SignalCRUD(BaseCRUD[MSignal]):
         portfolio_id: Optional[str] = None,
         start_date: Optional[Any] = None,
         end_date: Optional[Any] = None,
-    ) -> List[Signal]:
+    ) -> List[MSignal]:
         """
         Business helper: Find signals by code and direction.
         """
@@ -284,12 +282,11 @@ class SignalCRUD(BaseCRUD[MSignal]):
             filters=filters,
             order_by="timestamp",
             desc_order=True,
-            output_type="signal"
         )
 
     def get_latest_signals(
         self, portfolio_id: str, limit: int = 10, page: Optional[int] = None
-    ) -> List[Signal]:
+    ) -> List[MSignal]:
         """
         Business helper: Get latest signals for a portfolio with pagination support.
 

--- a/src/ginkgo/data/services/redis_service.py
+++ b/src/ginkgo/data/services/redis_service.py
@@ -1113,12 +1113,16 @@ class RedisService(BaseService):
             from ginkgo.data.redis_schema import RedisKeyBuilder
 
             full_cache_key = RedisKeyBuilder.func_cache(func_name, cache_key)
-            cache_json = self._crud_repo.get(full_cache_key)
-            
-            if cache_json:
-                cache_data = json.loads(cache_json)
+            # crud.get 已 CacheMapper.decode 还原成 dict；勿再 json.loads —
+            # dict 入 json.loads 抛 TypeError 被外层 except 吞成 return None，
+            # 致命中路径静默永 miss（修复前 get_function_cache 恒返 None）。
+            # set 侧 json.dumps(default=str) 经 crud.set 原样存（str 非dict/list
+            # 不二次 encode），round-trip 对称。
+            cache_data = self._crud_repo.get(full_cache_key)
+
+            if cache_data:
                 return cache_data.get("result")
-            
+
             return None
         except Exception as e:
             self._logger.ERROR(f"Failed to get function cache: {e}")
@@ -1193,9 +1197,8 @@ class RedisService(BaseService):
             
             for cache_key in cache_keys:
                 try:
-                    cache_json = self._crud_repo.get(cache_key)
-                    if cache_json:
-                        cache_data = json.loads(cache_json)
+                    cache_data = self._crud_repo.get(cache_key)
+                    if cache_data:
                         func_name_from_cache = cache_data.get("func_name", "unknown")
                         timestamp = cache_data.get("timestamp", current_time)
                         
@@ -1207,7 +1210,8 @@ class RedisService(BaseService):
                             }
                         
                         stats["by_function"][func_name_from_cache]["count"] += 1
-                        entry_size = len(cache_json)
+                        # crud.get 返 dict，wire 大小用 json.dumps 还原（与 set 侧 default=str 一致）
+                        entry_size = len(json.dumps(cache_data, default=str))
                         stats["by_function"][func_name_from_cache]["size_estimate"] += entry_size
                         stats["total_size_estimate"] += entry_size
                         

--- a/src/ginkgo/data/services/signal_service.py
+++ b/src/ginkgo/data/services/signal_service.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 import pandas as pd
 
 from ginkgo.data.services.base_service import BaseService, ServiceResult
+from ginkgo.data.mappers.signal_mapper import SignalMapper
 from ginkgo.libs import GLOG, datetime_normalize
 
 
@@ -81,7 +82,8 @@ class SignalService(BaseService):
                 start_date=start_date,
                 end_date=end_date,
             )
-            return ServiceResult.success(data=results)
+            signals = SignalMapper.from_models(results)
+            return ServiceResult.success(data=signals)
         except Exception as e:
             GLOG.ERROR(f"查询组合信号失败: {e}")
             return ServiceResult.error(str(e))

--- a/tests/unit/data/services/test_redis_function_cache.py
+++ b/tests/unit/data/services/test_redis_function_cache.py
@@ -1,0 +1,69 @@
+"""
+RedisService function_cache 回归测试（ADR-025 §4 Redis 收尾）。
+
+回归背景：
+  crud.get 已走 CacheMapper.decode 把 wire 还原成 dict；旧 get_function_cache /
+  get_function_cache_stats 再对该 dict 执行 json.loads → TypeError，被外层 except
+  吞成「命中路径 return None / WARN+continue」→ function_cache 命中即静默失效。
+
+本文件以纯 mock（不依赖真实 Redis 连接）验证修复后命中路径正常返回 result / 正常计数。
+
+Run: pytest tests/unit/data/services/test_redis_function_cache.py -v -o "addopts="
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.data.services.redis_service import RedisService
+
+
+def _make_service():
+    """绕 __init__（避免 Redis 连接握手），注入 mock crud_repo + logger。"""
+    svc = RedisService.__new__(RedisService)
+    svc._crud_repo = MagicMock()
+    svc._logger = MagicMock()
+    return svc
+
+
+@pytest.mark.unit
+class TestFunctionCacheDoubleJsonLoadsRegression:
+    """回归：crud.get 返 dict 后不得再 json.loads（二次解码 TypeError 静默吞）。"""
+
+    def test_get_function_cache_returns_result_when_crud_get_is_dict(self):
+        """命中路径：crud.get 返 dict（已 decode）→ 返 result，不抛 TypeError、不返 None。"""
+        svc = _make_service()
+        svc._crud_repo.get.return_value = {
+            "result": {"alpha": 1.5},
+            "func_name": "f",
+            "timestamp": 1700000000.0,
+        }
+
+        got = svc.get_function_cache("f", "k")
+
+        # 修复前恒 None：json.loads(dict) 抛 TypeError → except → return None
+        assert got == {"alpha": 1.5}
+
+    def test_get_function_cache_miss_returns_none(self):
+        """未命中：crud.get 返 None → 返 None（行为守卫，不受 bug 影响）。"""
+        svc = _make_service()
+        svc._crud_repo.get.return_value = None
+
+        assert svc.get_function_cache("f", "k") is None
+
+    def test_get_function_cache_stats_counts_when_crud_get_is_dict(self):
+        """stats 命中路径：crud.get 返 dict → 正常计数，不 WARN+continue。"""
+        svc = _make_service()
+        svc._crud_repo.keys.return_value = ["k1"]
+        svc._crud_repo.get.return_value = {
+            "result": {"x": 1},
+            "func_name": "f",
+            "timestamp": 1700000000.0,
+        }
+
+        stats = svc.get_function_cache_stats()
+
+        assert stats["total_entries"] == 1
+        assert stats["by_function"]["f"]["count"] == 1
+        assert stats["by_function"]["f"]["size_estimate"] > 0
+        # 修复前：json.loads(dict) → 内层 except WARN+continue → by_function 恒空
+        assert svc._logger.WARN.call_count == 0

--- a/tests/unit/data/services/test_signal_service.py
+++ b/tests/unit/data/services/test_signal_service.py
@@ -7,7 +7,7 @@ SignalService unit tests (#5949).
 Run: pytest tests/unit/data/services/test_signal_service.py -v -o "addopts="
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -108,8 +108,22 @@ class TestGetSignalsByPortfolioDateFilter:
         assert kwargs.get("start_date") is None
         assert kwargs.get("end_date") is None
 
-    def test_returns_crud_results_in_success(self, signal_svc, mock_crud):
-        mock_crud.find_by_portfolio.return_value = ["sig1", "sig2"]
-        result = signal_svc.get_signals_by_portfolio(portfolio_id="p1")
+    def test_maps_crud_results_via_signal_mapper(self, signal_svc, mock_crud):
+        """crud 返回的 ModelList 经 SignalMapper.from_models 映射为 Signal DTO 列表后透传进 success.data。
+
+        回归：旧实现直接透传 crud 结果（List[MSignal]）；ADR-025 后 service 走
+        SignalMapper.from_model 收敛转换，data 变 List[SignalDTO]。此处验证映射链路
+        而非 crud 透传，避免 from_model 的 isinstance 守卫对 mock 字符串抛 TypeError。
+        """
+        crud_models = ["sig1", "sig2"]  # crud 返 ModelList，占位
+        expected_signals = ["mapped-sig1", "mapped-sig2"]
+        mock_crud.find_by_portfolio.return_value = crud_models
+        with patch(
+            "ginkgo.data.services.signal_service.SignalMapper.from_models",
+            return_value=expected_signals,
+        ) as mock_map:
+            result = signal_svc.get_signals_by_portfolio(portfolio_id="p1")
+
         assert result.is_success()
-        assert result.data == ["sig1", "sig2"]
+        assert result.data == expected_signals
+        mock_map.assert_called_once_with(crud_models)


### PR DESCRIPTION
## ADR-025 §4 Redis 收尾 + signal 静默 bug

### Bug 1: function_cache 二次 json.loads 静默失效
**根因**: `redis_service.get_function_cache` / `get_function_cache_stats` 对 `crud.get` 返回值再 `json.loads`。但 `crud.get` 已走 `CacheMapper.decode` 把 wire 还原成 dict → `json.loads(dict)` 抛 TypeError → 被外层 except 吞成：
- `get_function_cache`：命中路径 `return None`（命中即永 miss）
- `get_function_cache_stats`：内层 except `WARN + continue`（by_function 恒空）

**修复**: 删 json.loads，直接用 crud.get 返值(dict)。stats 的 `entry_size` 改 `len(json.dumps(cache_data, default=str))` 还原 wire 大小（原 `len(dict)` 是键数非字节数）。

**注**: function_cache 全仓零调用（src/api/client），属死代码路径。此修是防御性 + bug 铁证回归，避免未来接线即踩坑。

### Bug 2: signal crud output_type 致 TypeError → worker 静默丢信号
**根因**: `signal_crud` 四 helper（find_by_portfolio/engine/code_and_direction/get_latest_signals）传 `output_type="signal"` 给 `base_crud.find`，但 `find` 签名无此参数 → TypeError → `signal_service` except → `ServiceResult.error` → `paper_trading_worker` `is_success()=False` 静默跳过（信号记录丢失）。

**修复**: 删 output_type（回归 ModelList 返回）；`signal_service.get_signals_by_portfolio` 加 `SignalMapper.from_models` 转 Signal DTO（ADR-025 收敛，返类型 `List[MSignal]→List[SignalDTO]` 诚实化）。

**blast radius**: signal_crud 四 helper 外部调用方仅 signal_service（已适配）。result_service/portfolio_service 用 `signal_crud.find/count` 非四 helper，不受影响。

### 测试
- `test_redis_function_cache.py`（新）：纯 mock 回归，验证命中路径返 result 不再 None、stats 正常计数不再 WARN+continue。
- `test_signal_service.py`：mapper 映射断言（crud ModelList → Signal DTO 透传）。
- 10 passed。

### 既有失败（非本 PR 引入，超出范围）
`test_signal_crud_mock.py` 4 个失败在 master 同样存在（同口径 stash 对比确认）：
- `delete_by_portfolio` / `delete_by_portfolio_and_date_range`：方法在 signal_crud 已不存在（delete 逻辑上移 service）。
- `get_latest_signals`：测试期望 `as_dataframe=False` 参数，实现无此参数（签名漂移）。

属测试与实现历史漂移，非本 PR 改动引入，不在范围内修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)