### PR TITLE
refactor(data): to_dataframe 三处去重收敛单一 helper (#6861)

### DIFF
--- a/src/ginkgo/data/models/model_base.py
+++ b/src/ginkgo/data/models/model_base.py
@@ -2,34 +2,11 @@
 # Downstream: None (基础工具类)
 # Role: MBase数据模型基类定义to_dataframe()通用方法将模型对象转换为pandas DataFrame遍历公开属性排除私有/方法/枚举
 
-
-
-
-
-
 import pandas as pd
-from types import FunctionType, MethodType
-from enum import Enum
+
+from ginkgo.libs.data.dataframe import to_dataframe as _to_dataframe
 
 
 class MBase:
     def to_dataframe(self, *args, **kwargs) -> pd.DataFrame:
-        item = {}
-        methods = ["delete", "query", "registry", "metadata", "to_dataframe"]
-        for param in self.__dir__():
-            if param in methods:
-                continue
-            if param.startswith("_"):
-                continue
-            if isinstance(self.__getattribute__(param), MethodType):
-                continue
-            if isinstance(self.__getattribute__(param), FunctionType):
-                continue
-
-            if isinstance(self.__getattribute__(param), Enum):
-                item[param] = self.__getattribute__(param).value
-            else:
-                item[param] = self.__getattribute__(param)
-
-        df = pd.DataFrame.from_dict(item, orient="index").transpose()
-        return df
+        return _to_dataframe(self)

--- a/src/ginkgo/entities/base.py
+++ b/src/ginkgo/entities/base.py
@@ -9,10 +9,8 @@
 
 import pandas as pd
 
-from types import FunctionType, MethodType
-from enum import Enum
-
 from ginkgo.enums import SOURCE_TYPES, COMPONENT_TYPES
+from ginkgo.libs.data.dataframe import to_dataframe as _to_dataframe
 from ginkgo.libs.data.number import convert_to_float as _convert_to_float_impl
 from ginkgo.libs.data.number import convert_to_int as _convert_to_int_impl
 from ginkgo.libs.data.number import convert_to_bool as _convert_to_bool_impl
@@ -104,34 +102,8 @@ class Base(object):
         self._source = source
 
     def to_dataframe(self) -> pd.DataFrame:
-        """
-        Convert Object's parameters to DataFrame.
-        Args:
-            None
-        Returns:
-            A dataframe convert from this.
-        """
-        item = {}
-        methods = ["delete", "query", "registry", "metadata", "to_dataframe"]
-        for param in self.__dir__():
-            if param in methods:
-                continue
-            if param.startswith("_"):
-                continue
-            if isinstance(self.__getattribute__(param), MethodType):
-                continue
-            if isinstance(self.__getattribute__(param), FunctionType):
-                continue
-
-            if isinstance(self.__getattribute__(param), Enum):
-                item[param] = self.__getattribute__(param).value
-            elif isinstance(self.__getattribute__(param), str):
-                item[param] = self.__getattribute__(param).strip(b"\x00".decode())
-            else:
-                item[param] = self.__getattribute__(param)
-
-        df = pd.DataFrame.from_dict(item, orient="index").transpose()
-        return df
+        """Convert Object's parameters to DataFrame."""
+        return _to_dataframe(self)
 
     def _convert_to_float(self, value, default: float = 0.0) -> float:
         """

--- a/src/ginkgo/entities/value_object.py
+++ b/src/ginkgo/entities/value_object.py
@@ -4,9 +4,8 @@
 VO 由字段值描述，不持有状态机；持久化时 uuid 由 ORM default 生成，不污染领域。
 """
 import pandas as pd
-from types import FunctionType, MethodType
-from enum import Enum
 
+from ginkgo.libs.data.dataframe import to_dataframe as _to_dataframe
 from ginkgo.libs.data.number import convert_to_float as _f
 from ginkgo.libs.data.number import convert_to_int as _i
 from ginkgo.libs.data.number import convert_to_bool as _b
@@ -16,21 +15,7 @@ class ValueObject:
     """无身份的领域值载体。"""
 
     def to_dataframe(self) -> pd.DataFrame:
-        item = {}
-        skip = {"delete", "query", "registry", "metadata", "to_dataframe"}
-        for param in self.__dir__():
-            if param in skip or param.startswith("_"):
-                continue
-            attr = self.__getattribute__(param)
-            if isinstance(attr, (MethodType, FunctionType)):
-                continue
-            if isinstance(attr, Enum):
-                item[param] = attr.value
-            elif isinstance(attr, str):
-                item[param] = attr.strip(b"\x00".decode())
-            else:
-                item[param] = attr
-        return pd.DataFrame.from_dict(item, orient="index").transpose()
+        return _to_dataframe(self)
 
     _convert_to_float = staticmethod(_f)
     _convert_to_int = staticmethod(_i)

--- a/src/ginkgo/libs/data/dataframe.py
+++ b/src/ginkgo/libs/data/dataframe.py
@@ -1,0 +1,50 @@
+# Upstream: Base / ValueObject / MBase 三根类(转发调用)
+# Downstream: pandas(DataFrame)
+# Role: 单一 to_dataframe(obj) helper —— 将任意对象的公开属性序列化为单行 DataFrame。
+#       替代三根类各自抄写的 __dir__() 迭代版 (#6861)。
+
+"""to_dataframe(obj) —— 对象公开属性 → 单行 DataFrame 的单一实现 (#6861)。
+
+此前 Base / ValueObject / MBase 各抄一份近乎相同的 __dir__() 迭代逻辑，
+跳过名单 (delete/query/registry/metadata/to_dataframe) 三处重复。本模块收敛为单一
+helper，三根类退化为单行转发；跳过名单单点归属。
+
+行为契约：
+- 排除私有属性 (``_`` 前缀)、方法 (MethodType/FunctionType)、跳过名单内的同名属性；
+- Enum 属性取 ``.value``；
+- str 属性 strip 尾随 NUL (``\\x00``，防 DB 返回的空字节填充)；对无 NUL 的正常串为 no-op。
+"""
+
+import pandas as pd
+from types import FunctionType, MethodType
+from enum import Enum
+
+# 跳过名单单点归属：与 ORM/SQLAlchemy 框架方法及本 helper 同名属性冲突，统一排除。
+_TO_DATAFRAME_SKIP = frozenset(
+    {"delete", "query", "registry", "metadata", "to_dataframe"}
+)
+
+
+def to_dataframe(obj) -> pd.DataFrame:
+    """将 ``obj`` 的公开属性序列化为单行 DataFrame。
+
+    Args:
+        obj: 任意对象（典型为 Base / ValueObject / MBase 子类实例）。
+
+    Returns:
+        pandas.DataFrame: 单行，列 = 公开属性名，值按 Enum→value / str→strip NUL 规整。
+    """
+    item = {}
+    for param in obj.__dir__():
+        if param in _TO_DATAFRAME_SKIP or param.startswith("_"):
+            continue
+        attr = obj.__getattribute__(param)
+        if isinstance(attr, (MethodType, FunctionType)):
+            continue
+        if isinstance(attr, Enum):
+            item[param] = attr.value
+        elif isinstance(attr, str):
+            item[param] = attr.strip("\x00")
+        else:
+            item[param] = attr
+    return pd.DataFrame.from_dict(item, orient="index").transpose()

--- a/tests/unit/libs/data/test_dataframe.py
+++ b/tests/unit/libs/data/test_dataframe.py
@@ -1,0 +1,54 @@
+# Upstream: 三根类 Base/ValueObject/MBase 转发调用
+# Downstream: None (helper 单测)
+# Role: 锁定单一 to_dataframe(obj) helper 契约 (#6861)，替代三份重复实现
+
+"""to_dataframe(obj) 通用序列化 helper 契约测试 (#6861)。
+
+三根类 Base / ValueObject / MBase 原各抄一份 __dir__() 迭代版 to_dataframe；
+本测试锁定单一 helper 的契约，供三根类单行转发复用。
+"""
+import pandas as pd
+from enum import Enum
+
+from ginkgo.libs.data.dataframe import to_dataframe
+
+
+class _Color(Enum):
+    RED = 1
+    GREEN = 2
+
+
+class _FakeObj:
+    """模拟根类实例：公开/私有/方法/枚举/字符串(含 NUL)属性混合。"""
+
+    def __init__(self):
+        self.code = "000001.SZ"           # 普通字符串
+        self.dirty = "ab\x00\x00"          # 含尾随 NUL，须 strip
+        self.volume = 100
+        self.color = _Color.GREEN
+        self._private = "hidden"           # 私有，排除
+        self.delete = "skip-name"          # 命中跳过名单
+        self.to_dataframe = "self-skip"    # 命中跳过名单(同名)
+
+    def calc(self):
+        return 1                           # 方法，排除
+
+
+def test_to_dataframe_serializes_public_attrs_to_single_row():
+    """单行 DataFrame；私有/方法/跳过名单排除；Enum→value；str→strip NUL。"""
+    df = to_dataframe(_FakeObj())
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 1                       # 单行
+    row = df.iloc[0]
+
+    assert row["code"] == "000001.SZ"         # 普通串原样
+    assert row["dirty"] == "ab"               # NUL 被 strip（统一契约）
+    assert row["volume"] == 100
+    assert row["color"] == 2                  # Enum → .value
+
+    # 排除项
+    assert "_private" not in df.columns       # 私有
+    assert "delete" not in df.columns         # 跳过名单
+    assert "to_dataframe" not in df.columns   # 跳过名单(同名)
+    assert "calc" not in df.columns           # 方法


### PR DESCRIPTION
## 背景 (#6861 / epic #6860 B1)

`Base` / `ValueObject` / `MBase` 三根类各抄一份近乎相同的 `__dir__()` 迭代版 `to_dataframe`,跳过名单 `{delete, query, registry, metadata, to_dataframe}` 三处重复。

## 改动

- **新** `src/ginkgo/libs/data/dataframe.py`: 单一 `to_dataframe(obj)` helper,跳过名单单点归属,行为契约(Enum→value / str→strip NUL)单点定义
- 三根类 `to_dataframe` 退化为单行转发,删重复 import(`types`/`Enum`)
- `MBase` 保留 `*args/**kwargs` 签名,零调用方回归
- 统一三根类 `str→strip NUL` 契约(`MBase` 原未 strip;仅影响 NUL 填充串,无测试覆盖,防御性收敛)

## 不在范围

- `ModelConversion.to_dataframe` / `ModelList.to_dataframe`(`crud/model_conversion.py`):CRUD-mapper / 列表→DF 转换,语义不同,非 `__dir__` dump
- `_convert_to_*` 形状统一:out of AC,deferred

## 验证

- 新契约测试 `tests/unit/libs/data/test_dataframe.py`(锁定单行/排除私有方法跳过名单/Enum→value/NUL strip)
- per-class 测试(value_object / base_model / base_model_comprehensive)+ 新测试:**68 passed**
- py_compile OK;启动链路 smoke(containers / user_cli / user_crud_mock):36 passed(1 既有失败 `test_create_user_missing_name_fails` 与本改动零相关,typer rich 单杠已知项)

Closes #6861

epic: #6860(架构冗余清理 B1,sub-PR → epic 分支)