### PR TITLE
fix(workers): 状态回写失败须可见——回写层诚实传播 ServiceResult

### DIFF
--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -335,7 +335,9 @@ class BacktestTaskService(BaseService):
             if not task:
                 task = self._crud_repo.get_by_task_id(uuid)
             if not task:
-                return ServiceResult.error(f"Backtest task not found: {uuid}")
+                # #6845: 标 code=NOT_FOUND，让下游（progress_tracker._write_status_to_db）
+                # 能区分"任务不存在"(预期容许)与"DB 写失败"(真故障)，不再一刀切告警。
+                return ServiceResult.error(f"Backtest task not found: {uuid}", code="NOT_FOUND")
 
             # 使用真实的 uuid 更新
             real_uuid = task.uuid
@@ -347,7 +349,7 @@ class BacktestTaskService(BaseService):
             )
 
             if updated_count == 0:
-                return ServiceResult.error(f"Backtest task not found: {real_uuid}")
+                return ServiceResult.error(f"Backtest task not found: {real_uuid}", code="NOT_FOUND")
 
             GLOG.INFO(f"Updated task {real_uuid[:8]}... status to: {status}")
 

--- a/src/ginkgo/trading/analysis/backtest_result_aggregator.py
+++ b/src/ginkgo/trading/analysis/backtest_result_aggregator.py
@@ -136,9 +136,15 @@ class BacktestResultAggregator:
                 )
 
                 if not update_result.is_success():
-                    GLOG.ERROR(f"Failed to update backtest task: {update_result.error}")
-                    # 不返回错误，允许汇总继续完成（任务可能未预先创建）
-                    GLOG.WARN(f"Backtest task may not exist. Create it before running backtest.")
+                    # #6845: 区分"任务不存在"(容许) vs "DB 写失败"(真故障)，不再一刀切吞掉撒谎。
+                    if update_result.code == "NOT_FOUND":
+                        # 任务可能未预先创建——容许汇总完成（保留原注释意图，仅收窄到 not-found）
+                        GLOG.INFO(f"Backtest task {task_id} not found, results not persisted (tolerable)")
+                    else:
+                        GLOG.ERROR(f"Failed to update backtest task: {update_result.error}")
+                        return ServiceResult.error(
+                            f"Failed to persist backtest status: {update_result.error}"
+                        )
 
             # 同步绩效指标到 MPortfolio
             try:

--- a/src/ginkgo/workers/backtest_worker/progress_tracker.py
+++ b/src/ginkgo/workers/backtest_worker/progress_tracker.py
@@ -22,6 +22,7 @@ from ginkgo.libs import GLOG
 from ginkgo.workers.backtest_worker.models import BacktestTask, EngineStage
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
 from ginkgo.interfaces.kafka_topics import KafkaTopics
+from ginkgo.data.services.base_service import ServiceResult
 
 
 class ProgressTracker:
@@ -103,8 +104,8 @@ class ProgressTracker:
             # 其他阶段只更新 current_stage
             self._write_progress_to_db(task.task_uuid, current_stage=stage.value)
 
-    def report_completed(self, task: BacktestTask, result: dict):
-        """上报完成"""
+    def report_completed(self, task: BacktestTask, result: dict) -> ServiceResult:
+        """上报完成。#6845: 返回状态回写结果，调用方据此 WARN 告警（不再 fire-and-forget 撒谎）。"""
         self._send_to_kafka(
             {
                 "type": "completed",
@@ -116,11 +117,11 @@ class ProgressTracker:
         )
         GLOG.INFO(f"[{task.task_uuid[:8]}] Reported completion")
 
-        # 更新数据库状态为 completed
-        self._write_status_to_db(task.task_uuid, "completed", result=result)
+        # 更新数据库状态为 completed（传播结果供调用方判定）
+        return self._write_status_to_db(task.task_uuid, "completed", result=result)
 
-    def report_failed(self, task: BacktestTask, error: str):
-        """上报失败"""
+    def report_failed(self, task: BacktestTask, error: str) -> ServiceResult:
+        """上报失败。#6845: 返回状态回写结果（DB 写失败时调用方可感知）。"""
         self._send_to_kafka(
             {
                 "type": "failed",
@@ -132,11 +133,11 @@ class ProgressTracker:
         )
         GLOG.ERROR(f"[{task.task_uuid[:8]}] Reported failure: {error}")
 
-        # 更新数据库状态为 failed
-        self._write_status_to_db(task.task_uuid, "failed", error_message=error)
+        # 更新数据库状态为 failed（传播结果供调用方判定）
+        return self._write_status_to_db(task.task_uuid, "failed", error_message=error)
 
-    def report_cancelled(self, task: BacktestTask):
-        """上报取消"""
+    def report_cancelled(self, task: BacktestTask) -> ServiceResult:
+        """上报取消。#6845: 返回状态回写结果。"""
         self._send_to_kafka(
             {
                 "type": "cancelled",
@@ -147,11 +148,11 @@ class ProgressTracker:
         )
         GLOG.INFO(f"[{task.task_uuid[:8]}] Reported cancellation")
 
-        # 更新数据库状态为 stopped
-        self._write_status_to_db(task.task_uuid, "stopped")
+        # 更新数据库状态为 stopped（传播结果供调用方判定）
+        return self._write_status_to_db(task.task_uuid, "stopped")
 
-    def report_failed_by_uuid(self, task_uuid: str, error: str):
-        """通过 UUID 上报失败（无需完整 BacktestTask 对象）"""
+    def report_failed_by_uuid(self, task_uuid: str, error: str) -> ServiceResult:
+        """通过 UUID 上报失败（无需完整 BacktestTask 对象）。#6845: 返回状态回写结果。"""
         short_uuid = task_uuid[:8] if task_uuid else "unknown"
         self._send_to_kafka(
             {
@@ -164,8 +165,8 @@ class ProgressTracker:
         )
         GLOG.ERROR(f"[{short_uuid}] Reported failure by UUID: {error}")
 
-        # 更新数据库状态为 failed
-        self._write_status_to_db(task_uuid, "failed", error_message=error)
+        # 更新数据库状态为 failed（传播结果供调用方判定）
+        return self._write_status_to_db(task_uuid, "failed", error_message=error)
 
     def _send_to_kafka(self, message: dict):
         """发送消息到Kafka"""
@@ -189,7 +190,12 @@ class ProgressTracker:
         total_orders: int = 0,
         total_signals: int = 0,
     ):
-        """写入进度到数据库（用于SSE推送）"""
+        """写入进度到数据库（用于SSE推送）。
+
+        刻意保持 fire-and-forget（与 _write_status_to_db 不同）：进度写入是瞬态
+        SSE 订阅流，丢一次只会让前端进度卡 2s，不会导致任务状态分歧（终态 status
+        写在 _write_status_to_db，那里才须诚实传播失败）。
+        """
         if self.task_service is None:
             return
 
@@ -207,10 +213,16 @@ class ProgressTracker:
 
     def _write_status_to_db(
         self, task_id: str, status: str, error_message: str = "", result: dict = None, current_stage: str = None
-    ):
-        """写入任务状态到数据库"""
+    ) -> ServiceResult:
+        """写入任务状态到数据库。
+
+        #6845: 状态回写失败必须可见——不再撒谎。返回 ServiceResult 供调用方判定：
+        - 成功：success
+        - 任务不存在（update_status code=NOT_FOUND）：success（预期容许，任务可能未预先创建）
+        - DB 写失败 / 异常：failure（真故障，调用方须 WARN 告警）
+        """
         if self.task_service is None:
-            return
+            return ServiceResult.success(message="task_service not configured, status write skipped")
 
         try:
             from datetime import datetime
@@ -250,9 +262,17 @@ class ProgressTracker:
                 uuid=task_id, status=status, error_message=error_message, **result_fields  # task_id 与 uuid 等价
             )
             if not result_obj.is_success():
+                # #6845: 区分"任务不存在"(容许) vs "DB 写失败"(真故障)。
+                # 任务可能未预先创建（aggregator 路径），not-found 不算故障，避免假告警。
+                if result_obj.code == "NOT_FOUND":
+                    GLOG.INFO(f"Task {task_id[:8]}... not found, status write skipped (tolerable)")
+                    return ServiceResult.success()
                 GLOG.ERROR(f"Failed to write status to DB: {result_obj.message}")
+                return ServiceResult.error(f"Failed to write status to DB: {result_obj.message}")
+            return ServiceResult.success(result_obj.data, f"Status {status} written for {task_id[:8]}...")
         except Exception as e:
             GLOG.ERROR(f"Error writing status to DB: {e}")
+            return ServiceResult.error(f"Error writing status to DB: {e}")
 
     def get_task_status(self, task_uuid: str) -> Optional[str]:
         """

--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -132,9 +132,7 @@ class BacktestProcessor(Thread):
             self.task.completed_at = datetime.utcnow()
             self.task.result = result.data
 
-            self.progress_tracker.report_completed(self.task, None)
-            self._ingest_task_logs()
-            GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
+            self._report_completion()
 
         except Exception as e:
             self._exception = e
@@ -148,6 +146,24 @@ class BacktestProcessor(Thread):
             GLOG.ERROR(traceback.format_exc())
         finally:
             GLOG.clear_context()
+
+    def _report_completion(self):
+        """#6845: 回测引擎成功后回写任务状态，并诚实反映写库结果。
+
+        状态写失败（DB 异常）发 WARN——不再无脑打 "Backtest completed successfully"
+        撒谎（原 fire-and-forget 丢弃返回值，写失败也声称成功）。任务不存在
+        （tolerable，update_status code=NOT_FOUND）由 progress_tracker 归一为 success，
+        仍记完成日志。report_failed 路径（except 分支）保持原样——失败已 ERROR 落库。
+        """
+        write_result = self.progress_tracker.report_completed(self.task, None)
+        self._ingest_task_logs()
+        if write_result is not None and not write_result.is_success():
+            GLOG.WARN(
+                f"[{self.task.task_uuid[:8]}] Backtest status write FAILED: "
+                f"{write_result.message} (engine finished but task status not persisted)"
+            )
+        else:
+            GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
 
     def _wait_for_engine_completion(self, timeout: float = 3600.0):
         """⚠️ 死代码（#6483）：无调用点。

--- a/tests/unit/trading/analysis/test_backtest_result_aggregator_tracer.py
+++ b/tests/unit/trading/analysis/test_backtest_result_aggregator_tracer.py
@@ -1,0 +1,74 @@
+"""Tests for BacktestResultAggregator honest return on status-write failure -- #6845.
+
+aggregate_and_save 在 backtest_task_service.update_status 失败时不能再撒谎返回 success。
+区分两类失败：
+- DB 写失败（非 NOT_FOUND）：返回 error（真故障，上层须感知）
+- 任务不存在（code=NOT_FOUND）：容许返回 success（任务可能未预先创建，原注释意图）
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAggregator
+    from ginkgo.data.services.base_service import ServiceResult
+    import ginkgo.data.containers as dc_mod
+
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+def _make_aggregator(update_status_return) -> BacktestResultAggregator:
+    """构造最小 aggregator：analyzer_service=None 跳过指标读取，backtest_task_service 受控。"""
+    task_svc = MagicMock()
+    task_svc.update_status.return_value = update_status_return
+    return BacktestResultAggregator(analyzer_service=None, backtest_task_service=task_svc)
+
+
+def _neutralize_portfolio_sync(monkeypatch):
+    """aggregate_and_save 内部会 data_container.portfolio_service().update_performance()
+    做绩效同步（重副作用）——本测试不关心，mock 成 success 隔离。"""
+    fake_svc = MagicMock()
+    fake_svc.update_performance.return_value = ServiceResult.success()
+    monkeypatch.setattr(dc_mod.container, "portfolio_service", lambda: fake_svc)
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestResultAggregator not available")
+@pytest.mark.tdd
+class TestAggregateAndSaveHonestOnStatusWriteFailure:
+    """#6845: 结果汇总在状态写失败时不再撒谎返回 success。"""
+
+    def test_db_write_failure_returns_error(self, monkeypatch):
+        """update_status 返回 failure（非 NOT_FOUND）→ aggregate_and_save 返回 error。"""
+        _neutralize_portfolio_sync(monkeypatch)
+        agg = _make_aggregator(
+            ServiceResult.error("Failed to update task status: connection lost")
+        )
+
+        result = agg.aggregate_and_save(task_id="T1", portfolio_id="P1")
+
+        assert result is not None
+        assert not result.is_success(), "DB 写失败须诚实返回 error（原 BUG：仍 return success）"
+
+    def test_task_not_found_returns_success(self, monkeypatch):
+        """任务不存在（code=NOT_FOUND）→ 容许返回 success（任务可能未预先创建）。"""
+        _neutralize_portfolio_sync(monkeypatch)
+        agg = _make_aggregator(
+            ServiceResult.error("Backtest task not found: T2", code="NOT_FOUND")
+        )
+
+        result = agg.aggregate_and_save(task_id="T2", portfolio_id="P2")
+
+        assert result is not None
+        assert result.is_success(), "任务不存在须容许为 success（非 DB 故障），否则假报错"
+
+    def test_success_returns_success(self, monkeypatch):
+        """update_status 成功 → aggregate_and_save 返回 success（回归基线）。"""
+        _neutralize_portfolio_sync(monkeypatch)
+        agg = _make_aggregator(ServiceResult.success({"uuid": "T3"}, "updated"))
+
+        result = agg.aggregate_and_save(task_id="T3", portfolio_id="P3")
+
+        assert result is not None
+        assert result.is_success()

--- a/tests/unit/workers/test_progress_tracker.py
+++ b/tests/unit/workers/test_progress_tracker.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 try:
     from ginkgo.workers.backtest_worker.progress_tracker import ProgressTracker
     from ginkgo.workers.backtest_worker.models import BacktestTask
+    from ginkgo.data.services.base_service import ServiceResult
 
     HAS_MODULE = True
 except ImportError:
@@ -80,3 +81,70 @@ class TestProgressReportNoSyncHttpNotify:
             tracker.report_completed(task, result={"total_pnl": 1.0})
 
         mock_post.assert_not_called()
+
+
+def _make_task(task_uuid: str) -> BacktestTask:
+    """最小 BacktestTask（completed_at=None 防 isoformat 报错）。"""
+    task = BacktestTask(task_uuid=task_uuid, portfolio_uuid="P", name="n", config=None)
+    task.completed_at = None
+    return task
+
+
+def _make_tracker(task_service) -> ProgressTracker:
+    """装配受控 tracker（task_service 由调用方按用例 mock 返回值/异常）。"""
+    return ProgressTracker(worker_id="w1", kafka_producer=MagicMock(), task_service=task_service)
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="ProgressTracker not available")
+@pytest.mark.tdd
+class TestReportCompletedHonestOnStatusWriteFailure:
+    """#6845: 状态回写失败必须可见——不再撒谎。
+
+    report_completed 在 DB 写失败时返回 failure（而非 void 吞异常），
+    使调用方（task_processor）能 WARN 告警而非无脑打 "completed successfully"。
+    """
+
+    def test_db_exception_propagated_as_failure(self):
+        """task_service.update_status 抛异常 → report_completed 返回 is_failure()。"""
+        task_service = MagicMock()
+        task_service.update_status.side_effect = RuntimeError("connection lost")
+
+        with patch("requests.post"):
+            result = _make_tracker(task_service).report_completed(
+                _make_task("8b7b8cd8d69444db9a59e01862e601d6"), result={"total_pnl": 1.0}
+            )
+
+        assert result is not None, "必须返回 ServiceResult，None=吞异常=撒谎"
+        assert not result.is_success(), "DB 异常须如实返回 failure"
+        # ServiceResult.error(msg) 的 message 默认 = error（base_service.py），断一处即可
+        assert "connection lost" in result.message
+
+    def test_success_path_returns_success(self):
+        """update_status 成功 → report_completed 返回 is_success()。"""
+        T = "9c8c9de9e7a555ecab6af12973f712e7"
+        task_service = MagicMock()
+        task_service.update_status.return_value = ServiceResult.success({"uuid": T}, "updated")
+
+        with patch("requests.post"):
+            result = _make_tracker(task_service).report_completed(_make_task(T), result={"total_pnl": 1.0})
+
+        assert result is not None
+        assert result.is_success(), "成功路径须返回 success"
+
+    def test_task_not_found_is_tolerable_success(self):
+        """任务不存在（code=NOT_FOUND）→ report_completed 返回 success（预期容许，非故障）。
+
+        #6845 验收：task 不存在算预期容许（任务可能未预先创建），不告警。
+        """
+        T = "ad9dae0af8b666fdbc7b023a84f823f8"
+        task_service = MagicMock()
+        # 模拟 update_status 真实返回：not-found 带 code=NOT_FOUND
+        task_service.update_status.return_value = ServiceResult.error(
+            f"Backtest task not found: {T}", code="NOT_FOUND"
+        )
+
+        with patch("requests.post"):
+            result = _make_tracker(task_service).report_completed(_make_task(T), result={"total_pnl": 1.0})
+
+        assert result is not None
+        assert result.is_success(), "任务不存在须容许为 success（非 DB 故障），否则假告警"

--- a/tests/unit/workers/test_task_processor_completion_log.py
+++ b/tests/unit/workers/test_task_processor_completion_log.py
@@ -1,0 +1,97 @@
+"""Tests for BacktestProcessor completion honest-logging -- #6845.
+
+回测引擎成功后回写任务状态：写失败（DB 异常）必须 WARN，不再无脑打
+``"Backtest completed successfully"`` 撒谎。任务不存在（tolerable）仍记成功日志。
+
+行为契约（经公开 run() 调用的 _report_completion seam）：
+- DB 写失败 → WARN（含 status write 标记），且不打 "completed successfully"
+- 写成功 / 任务不存在 → INFO "completed successfully"，无 WARN
+"""
+import types
+from threading import Event
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
+    from ginkgo.workers.backtest_worker.models import BacktestTask
+    from ginkgo.data.services.base_service import ServiceResult
+
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+def _make_processor(task_uuid: str = "8b7b8cd8d69444db9a59e01862e601d6") -> BacktestProcessor:
+    """构造最小可测处理器：跳过 __init__ 容器装配，仅设置 _report_completion 读取的属性。"""
+    proc = BacktestProcessor.__new__(BacktestProcessor)
+    proc.task = BacktestTask(task_uuid=task_uuid, portfolio_uuid="P", name="n", config=None)
+    proc.progress_tracker = MagicMock()
+    proc._ingest_task_logs = lambda: None  # 不测灌日志，隔离被测行为
+    return proc
+
+
+def _glog_spy():
+    """GLOG spy：捕获 WARN/INFO 调用文本。"""
+    captured = {"warn": [], "info": []}
+    spy = types.SimpleNamespace(
+        WARN=lambda m: captured["warn"].append(m),
+        INFO=lambda m: captured["info"].append(m),
+        ERROR=lambda m: None,
+        DEBUG=lambda m: None,
+    )
+    return spy, captured
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+@pytest.mark.tdd
+class TestCompletionLogHonestOnStatusWriteFailure:
+    """#6845: 状态写失败可见——完成日志不再撒谎。"""
+
+    def test_warns_when_status_write_failed(self, monkeypatch):
+        """report_completed 返回 failure → WARN（status write 标记），不打 completed successfully。"""
+        proc = _make_processor()
+        proc.progress_tracker.report_completed.return_value = ServiceResult.error(
+            "connection lost"
+        )
+        spy, captured = _glog_spy()
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.GLOG", spy)
+
+        proc._report_completion()
+
+        assert captured["warn"], "DB 写失败必须 WARN（不能再撒谎）"
+        assert any("status write" in m.lower() for m in captured["warn"]), \
+            "WARN 须含 status write 标记，便于 grep 诊断"
+        assert not any("completed successfully" in m for m in captured["info"]), \
+            "写失败时不应打 completed successfully（撒谎）"
+
+    def test_logs_completed_when_status_write_ok(self, monkeypatch):
+        """report_completed 返回 success → INFO completed successfully，无 WARN。"""
+        proc = _make_processor()
+        proc.progress_tracker.report_completed.return_value = ServiceResult.success(
+            {"uuid": "8b7b8cd8"}, "updated"
+        )
+        spy, captured = _glog_spy()
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.GLOG", spy)
+
+        proc._report_completion()
+
+        assert any("completed successfully" in m for m in captured["info"]), \
+            "写成功须打 completed successfully"
+        assert not captured["warn"], "写成功时不应 WARN"
+
+    def test_logs_completed_when_task_not_found(self, monkeypatch):
+        """任务不存在（tolerable）→ 视为 success，打 completed successfully，无 WARN。"""
+        proc = _make_processor()
+        proc.progress_tracker.report_completed.return_value = ServiceResult.success(
+            message="Task not found, status write skipped (tolerable): ..."
+        )
+        spy, captured = _glog_spy()
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.GLOG", spy)
+
+        proc._report_completion()
+
+        assert any("completed successfully" in m for m in captured["info"]), \
+            "任务不存在须容许为成功日志（非假告警）"
+        assert not captured["warn"], "任务不存在不应 WARN"


### PR DESCRIPTION
## 背景

回测任务状态回写原是 **fire-and-forget** 链，存在三层"撒谎"：DB 写失败被吞 → 日志/返回值谎称成功 → 任务卡 `running` 无人察觉。本 PR 是 #6845 的 tracer 切片，让状态回写失败**可见**。

## 改动（三层收窄）

| 层 | 文件 | 改动 |
|---|---|---|
| 写库层 | `progress_tracker.py` | `_write_status_to_db` 改返 `ServiceResult`；区分 **NOT_FOUND**(容许 success) vs **DB 写失败**(真 failure)；`report_completed/failed/cancelled/failed_by_uuid` 四方法非 void 传播 |
| 聚合层 | `backtest_result_aggregator.py` | `aggregate_and_save` 在 `update_status` 真失败时不再返 success（原 BUG：吞错仍 success）；NOT_FOUND 仍容许 |
| 调用层 | `task_processor.py` | `_report_completion` 据回写结果 WARN 告警，不再无脑打 "Backtest completed successfully" |
| 服务层 | `backtest_task_service.py` | not-found 两处补 `code="NOT_FOUND"`，供上层区分 |

**边界保留**：`_write_progress_to_db` 刻意保留 fire-and-forget（瞬态 SSE 进度流，丢一次只让前端卡 2s，不致任务状态分歧）——加注释说明与 status 写的差异。

## 测试

两条失败分支 × 三层，共 12 个 TDD 测试：
- DB 异常 → failure（tracker / aggregator / processor WARN）
- task-not-found → tolerable success（不假告警）

```
tests/unit/workers/test_progress_tracker.py          6 passed
tests/unit/workers/test_task_processor_completion_log.py  3 passed
tests/unit/trading/analysis/test_backtest_result_aggregator_tracer.py  3 passed
```

## 验收对照（#6845）

- [x] `_write_status_to_db` 返回 `ServiceResult`
- [x] `report_*` 传播（非 void）
- [x] `task_processor` 失败 WARN+alert（不再无脑 "completed successfully"）
- [x] `aggregate_and_save` 不再 update_status fail 仍返 success
- [x] 两测试分支（DB 异常 / task-not-found）

Fixes #6845