### PR TITLE
docs(adr): 归位 ADR-038/039 草稿（日志 TTL / LiveEngine 移除）

### DIFF
--- a/docs/adrs/ADR-038-log-table-ttl-cleanup.md
+++ b/docs/adrs/ADR-038-log-table-ttl-cleanup.md
@@ -1,0 +1,82 @@
+# ADR-038: 日志表 TTL 自动清理（ginkgo_logs_* 三表 TTL 接线 + 存量 drop/reseed）
+
+**Status:** Accepted
+**Date:** 2026-07-29
+**Related:** ADR-007（model 驱动禁 ALTER / create_all 不补已有表）、ADR-023（时间 seam：Infra Time 墙钟 vs Business Time）、ADR-032（CH 时序审计层）、spec 015（分布式日志）
+
+## Context
+
+Vector 采集链路（`.conf/vector.toml`）把应用 JSON 日志路由写入 ClickHouse 三表 `ginkgo_logs_backtest` / `ginkgo_logs_component` / `ginkgo_logs_performance`（`docker-compose.yml:428` vector 服务 → 三 sink）。**落库后无任何清理策略,三表只增不减,磁盘无限增长。**
+
+spec 015（`specs/015-distributed-logging-vector/data-model.md`）设计了 TTL（backtest 180 天 / component 90 天 / performance 30 天）,但实现层全漏,经 spike 核实（锚点如下）:
+
+### 双层断裂（非 #4652 式误判,均有实测锚点）
+
+- **model 建表无 TTL**:`src/ginkgo/data/models/model_logs.py:34/185/235` 三表 `engines.ReplacingMergeTree / MergeTree(order_by=...)` 均**无 `ttl=`** 子句。
+- **GCONF 配置是死参数**:`src/ginkgo/libs/core/config.py:1320/1339/1357` 的 `LOGGING_TTL_BACKTEST/COMPONENT/PERFORMANCE`（默认 180/90/30）全仓**零消费方**（grep 仅定义点,无任何读取）——与 ADR-037 `--slippage` 死参数同型。
+
+### 源头已有兜底,问题集中在库侧
+
+- 文件侧:`logger.py:422` `max_file_bytes=2GB / backup_count=3`,RotatingFileHandler 已轮转（3 处 handler）。文件源头不无限增长。
+- 库侧:三表零 TTL、零清理 CLI、零 `MODIFY TTL`/`OPTIMIZE` 定时任务（grep 全仓无）。
+
+### 叠加 create_all 铁律
+
+ADR-007 / `arch_ch_create_all_no_alter_drift`:`create_all` 只建表,不给**已有表**补列/补 TTL。即使改 model 让新建表带 TTL,master/test **存量已建表**仍无 TTL,需独立迁移。
+
+判定三条全中（drop 存量日志难逆转 / `timestamp` 做 TTL 反直觉易踩坑 / drop vs ALTER 真实权衡）,立本 ADR。
+
+## Decision
+
+### D1 起算字段:`timestamp`（非 `business_timestamp`）
+
+三表统一 `TTL timestamp + INTERVAL N DAY`。
+
+- `timestamp` = **Infra Time 墙钟写入时间**,`logger.py:134` `event_dict["@timestamp"] = ... datetime.utcnow().isoformat()`,经 `vector.toml:46` 映射入 CH `timestamp` 列。
+- `business_timestamp` = **Business Time 回测业务历史时间**,`logger.py:193` 取自 `engine_ctx.business_timestamp`（TimeProvider,ADR-023）,回测 2024 年数据时即 2024-xx。
+
+**反直觉点**（立 ADR 主因）:`timestamp` 名字像"事件时间",极易误选 `business_timestamp` 做 TTL——后者会让回测历史日志**一写入即过期**。本决策是 ADR-023 时间 seam（Infra Time vs Business Time）在日志 TTL 场景的直接应用。
+
+### D2 三表 model 注入 TTL + 统一单一保留期（默认 6 个月）
+
+`model_logs.py` 三表 `engines.*MergeTree(order_by=..., ttl=<读 GCONF 的表达式>)`,TTL 天数**统一读单一配置** `GCONF.LOGGING_TTL_DAYS`（默认 **180 天 ≈ 6 个月**）,三表同值。废弃 spec 015 原设计的 backtest/component/performance 分级（180/90/30）——三个分级 `@property`（`config.py:1320/1339/1357`）当前均为零消费死参数,直接以单一 `LOGGING_TTL_DAYS` 替换,无运行时兼容负担。值经 `config.yaml` 的 `logging.ttl.days` 或 `GINKGO_LOGGING_TTL_DAYS` 环境变量覆盖。
+
+**生效路径约束**（承 D3 drop/reseed 与 ADR-007）:`logging.ttl.days` 在 **model 建表期**（`ginkgo init` create_all）注入 TTL;改 config.yaml 后**存量已建表不会自动跟随**（create_all 不 ALTER 已有表）,需 drop 三表 + `ginkgo init` 重建才套用新值。日志 TTL 通常设一次长期不变,一次性重建可接受;若未来要"改值即时生效不丢数据",需另开 `ALTER TABLE ... MODIFY TTL` 路径（本 ADR 不含）。
+
+### D3 存量库:drop + `ginkgo init` 重建（非 ALTER MODIFY TTL）
+
+master/test 已有无 TTL 表,`create_all` 不补（ADR-007）。存量迁移走 **drop 三张日志表 + `ginkgo init`（create_all 带新 model 重建）**,而非 `ALTER TABLE ... MODIFY TTL`。
+
+## Considered Options
+
+- **起算字段**:
+  - A `business_timestamp`:否决——回测业务历史时间,历史回测日志一写入即过期。
+  - B `ingested_at`:否决——`vector.toml` 未填充该列,`model_logs.py:157` `default=None`,NULL 导致 TTL 不触发;且需同步改 vector。
+  - **C `timestamp`（本 ADR）**:墙钟写入时间,非空实时,安全;无需改 vector。
+  - D 分表策略（backtest 用 ingested_at / component+performance 用 timestamp）:否决——引入字段不一致 + 仍需 vector 填 ingested_at,复杂度高于 C 且收益不抵。
+
+- **存量迁移**:
+  - P `ALTER TABLE ... MODIFY TTL`:否决——保留历史,但需独立迁移工具/CLI 长期维护,且 ADR-007 精神是"model 驱动、禁手动 ALTER"。
+  - **Q drop + reseed（本 ADR）**:简单,create_all 重建即带新 TTL;代价是丢存量历史日志。
+  - R 只管新建、存量不迁:否决——不解决用户原诉求（存量库继续无限增长）。
+
+## Rationale
+
+- **`timestamp` 是唯一安全且零改动的起算字段**:墙钟时间天然单调递增、非空,与回测业务时间解耦（ADR-023）。误用 `business_timestamp` 是该领域最可能的事故,故显式立 ADR 防后续 agent/人踩坑。
+- **drop + reseed 与 ADR-007 一致**:model 驱动建表是正解,存量漂移靠重建非 ALTER（与 `arch_ch_create_all_no_alter_drift`、`arch_master_mysql_never_migrated` 同源处置）。自用项目历史日志无强审计需求,drop 可接受。
+- **GCONF 接线而非硬编码**:TTL 天数因表而异（180/90/30）且可能调整,配置化优于魔法值;同时消除 ADR-037 型死参数。
+
+## Consequences
+
+- **正**:三表靠 CH 原生 TTL 后台 merge 自动清理,磁盘不再无限增长;`LOGGING_TTL_*` 活化为可调配置。
+- **负**:
+  - drop 丢失存量历史日志（不可逆,本 ADR 接受）。
+  - **TTL 天数变更需再次 drop**:因 create_all 不改已有表,运行时改 GCONF 不会作用到已建表的 TTL。若未来需"热调 TTL 不丢数据",须另开 `ALTER TABLE ... MODIFY TTL` 路径（本 ADR 不含,留后续 ADR）。
+  - CH TTL 是**真后台自动删除**（非"仅标记靠外部清"）:过期行在 background merge 期间被物理删除,无需外部 cron/DELETE。但**非插入即删**——受 `merge_with_ttl_timeout` 节流,**默认 14400s ≈ 4 小时**,过期行最多滞留约 4h 才清（设很小也不保证立即,merge 需调度+资源）。日常无需手动。
+  - 手动立即触发（逃生口,不等 4h）:`ALTER TABLE ... MATERIALIZE TTL`（轻,重应用 TTL 于存量 parts）/ `OPTIMIZE TABLE ... FINAL`（重,全表 merge 副带清,IO 与临时空间翻倍）。#6859 `cleanup --force` 实现时据此择优。
+- **关联约束**:受 ADR-007（禁 ALTER）、ADR-023（时间 seam）、ADR-032（CH 时序审计层定位）约束。
+
+## Sub-issues
+
+- **S1** 三表 model 注入 TTL（读 GCONF）+ 存量 drop/`ginkgo init` 重建 + 测试（`SHOW CREATE` 验 TTL 子句）
+- **S2** 清理可观测 + 手动触发 CLI（`ttl-status` 查三表 TTL/行数/最老记录、`cleanup --force` 跑 `OPTIMIZE` 触发后台清）+ quickstart 文档

--- a/docs/adrs/ADR-039-liveengine-removal-distributed-live.md
+++ b/docs/adrs/ADR-039-liveengine-removal-distributed-live.md
@@ -1,0 +1,43 @@
+# ADR-039: 实盘走 ExecutionNode 分布式,移除 LiveEngine 迁移孤儿
+
+**Status:** Accepted
+**Date:** 2026-07-29
+**Related:** ADR-003（引擎二态统一,其"mode=LIVE 接管"目标在此降级）、[Epic #6875 移除 LiveEngine 迁移孤儿](https://github.com/Kaoruha/GinkGO/issues/6875)（由 issue 跟踪实现）
+
+## Context
+
+2026-07-29 spike 考古结论：LiveEngine 是**引擎统一迁移（ADR-003）+ 实盘分布式转向**两条线夹缝中的孤儿。
+
+历史脉络：
+- LiveEngine 原与按 mode 分态的旧引擎族同级（`ENGINE_TYPES.LIVE=4` 是独立引擎类型；ADR-003:8「引擎层曾遍布 `if mode==` 三态分支」）。
+- ADR-003（2026-03-28）二态统一，声称「旧 LiveEngine 废弃，统一为 `TimeControlledEventEngine(mode=LIVE)`」。
+
+但两条后续迁移线都没真正接管实盘：
+1. **统一引擎线没落地**：`TimeControlledEventEngine(mode=LIVE)` 从未实例化。grep 确认 `time_controlled_engine.py` 全是 `if mode==BACKTEST / else`，实际只服务 BACKTEST/PAPER。
+2. **分布式新线绕开引擎**：实盘改走 ExecutionNode 双平面（Control/Data），`PortfolioProcessor` 裸线程消费 Kafka 事件裸驱动 `PortfolioLive`，`node.py` 零 `EventEngine`/`engine.start`。
+
+→ LiveEngine 被两条线同时抛弃，成夹缝孤儿：既没被统一引擎取代，也没被分布式架构容纳。叠加下单链路断（`TradeGateway` 全仓仅 3 处构造且实盘路径零实例化、`OKXBroker` 无 Kafka 订单入口只有入站 WS、`PortfolioLive` 不持 broker），它「活」的只剩连接 / WS 数据同步（入站），策略→下单→交易所闭环从未闭合。
+
+相邻死代码 / 画饼枚举：
+- `broker_manager.startup_create_all_brokers`（扫 `mode=LIVE` 建 broker，src/ 零调用方）——与 `LiveEngine.initialize` 重复的死方法。
+- `TradeGatewayAdapter` 占位符（`main.py:396 _trade_gateway_placeholder`，「Phase 4 集成代码」在注释里未挂载）。
+- `ENGINE_ARCHITECTURE.MATRIX`（矩阵/向量化架构）枚举值——即历史「向量计算引擎」设想，src/ 零分支实现、`engines/` 全事件驱动系，从未有对应引擎类。
+
+## Decision
+
+1. **正式承认实盘 = ExecutionNode 分布式路径**（Control/Data 双平面 + PortfolioProcessor 裸线程 + Kafka/Redis 总线）。这是现状，ADR 予以追认。不再追求「实盘收敛回 `TimeControlledEventEngine(mode=LIVE)`」——那是 ADR-003 的未完成目标，正式放弃。
+2. **移除 LiveEngine 迁移孤儿**，连同其独有但无人使用的编排重复。具体清理项与顺序由关联 Epic 跟踪。
+3. **下单闭环补焊另立 Epic**（不在本 ADR 决策范围）：移除 LiveEngine 既不修、也不恶化「实盘不能下单」——它本来就断。补焊是独立的实盘落地工作，涉资金安全需单独 gate。
+
+## Rationale
+
+- **Deletion test**：LiveEngine 是浅模块 + 重复——核心编排与 `startup_create_all_brokers` 重复（且后者已死），独有增量仅「进程胶水」（心跳 / 数据同步 / 恢复 / 信号处理），独立层无 leverage 只增 indirection。删它复杂度不重新散落到 N 个调用方。
+- **架构叙事失真**：实盘现状就是 ExecutionNode 分布式。保留一个从不接管实盘的旧引擎类，会让 CLAUDE.md「实盘端到端待验证」被误读为「快好了」，而实则是闭环从未焊。移除孤儿让叙事归真。
+- **scope 分离**：清理孤儿（可逆、低风险、纯删除）与补焊实盘下单（不可逆、高资金风险）是两种性质的工作。混 scope 会把删除的安全可逆性嫁接给下单接线的风险。
+
+## Consequences
+
+- `serve livecore --live-engine` / `live start` 等启用 LiveEngine 的入口需一并清理或重定向（ExecutionNode 已是正路）。
+- `ENGINE_ARCHITECTURE.MATRIX` 等未实现枚举值的处置：移除或显式标注 `planned, not built`——防 grep 误判「已实现」（参因子子系统休眠 75% 教训）。
+- 实盘下单闭环仍断（维持现状），由后续「实盘下单接线」Epic 解决——本 ADR 明确不覆盖。
+- **与 ADR-003 的关系**：ADR-003 的「mode=LIVE 接管」目标降级为「仅引擎层行为语义（LIVE 与 PAPER 在引擎层等价）」，不再承诺实盘跑在事件引擎上。ADR-003 文本需补一条「见 ADR-039」的指针。

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -47,6 +47,8 @@
 | ADR-034 | [signal 跨库同名陷阱（CH 事件流 vs MySQL tracker）](ADR-034-signal-cross-store-namesake.md) | Accepted（含现状偏离） | 2026-07-28 |
 | ADR-035 | [回测应用用例层（BacktestUseCase Protocol）](ADR-035-backtest-use-case-layer.md) | Accepted | 2026-07-05 |
 | ADR-036 | [回测 fill 时序无后视（T+1 延迟队列 + 两阶段推进）](ADR-036-backtest-fill-no-lookahead.md) | Accepted | 2026-07-28 |
+| ADR-038 | [日志表 TTL 自动清理（ginkgo_logs_* 三表 TTL 接线 + 存量 drop/reseed）](ADR-038-log-table-ttl-cleanup.md) | Accepted | 2026-07-29 |
+| ADR-039 | [实盘走 ExecutionNode 分布式，移除 LiveEngine 迁移孤儿](ADR-039-liveengine-removal-distributed-live.md) | Accepted | 2026-07-29 |
 
 ### 缺号说明
 


### PR DESCRIPTION
## 归位 ADR-038 / ADR-039 草稿

两份决策草稿原随 epic-6851（slippage）工作区携带，与 slippage 主题无关，现归位至独立 docs 分支。

### ADR-038：日志表 TTL 自动清理
`ginkgo_logs_*` 三表 TTL 接线 + 存量 drop/reseed。关联实现 issue #6858（待实现）。

### ADR-039：实盘走 ExecutionNode 分布式，移除 LiveEngine 迁移孤儿
关联 Epic #6875（待实现）。

### README 编号说明
ADR-038/039 暂插 ADR-036 后。ADR-037 由 slippage epic（PR #6857）引入，合并后经 conflict 解析归位 036→037→038→039。

> 仅落档决策记录，不关闭关联实现 issue（均为 docs 类）。