### PR TITLE
fix(backtest): 状态回写失败可见不再撒谎 (#6845)

### DIFF
--- a/src/ginkgo/trading/analysis/backtest_result_aggregator.py
+++ b/src/ginkgo/trading/analysis/backtest_result_aggregator.py
@@ -136,9 +136,14 @@ class BacktestResultAggregator:
                 )
 
                 if not update_result.is_success():
-                    GLOG.ERROR(f"Failed to update backtest task: {update_result.error}")
-                    # 不返回错误，允许汇总继续完成（任务可能未预先创建）
-                    GLOG.WARN(f"Backtest task may not exist. Create it before running backtest.")
+                    msg = getattr(update_result, "error", None) or getattr(update_result, "message", "") or ""
+                    # #6845: not-found 容错（任务可能未预先创建，合法场景，静默 INFO 不告警）；
+                    # DB 异常 / 写失败才是真失败，不再 return success 撒谎，让 orchestrator 据实判定。
+                    if "not found" in msg.lower():
+                        GLOG.INFO(f"Backtest task not found, status write skipped (non-fatal): {msg}")
+                    else:
+                        GLOG.ERROR(f"Failed to persist backtest status to DB: {msg}")
+                        return ServiceResult.error(f"Failed to persist backtest status: {msg}")
 
             # 同步绩效指标到 MPortfolio
             try:

--- a/src/ginkgo/workers/backtest_worker/progress_tracker.py
+++ b/src/ginkgo/workers/backtest_worker/progress_tracker.py
@@ -18,6 +18,7 @@ from threading import Lock
 from time import time
 from typing import Dict, Optional
 
+from ginkgo.data.services.base_service import ServiceResult
 from ginkgo.libs import GLOG
 from ginkgo.workers.backtest_worker.models import BacktestTask, EngineStage
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
@@ -116,8 +117,8 @@ class ProgressTracker:
         )
         GLOG.INFO(f"[{task.task_uuid[:8]}] Reported completion")
 
-        # 更新数据库状态为 completed
-        self._write_status_to_db(task.task_uuid, "completed", result=result)
+        # 更新数据库状态为 completed（#6845：返回写库结果，失败对调用方可见）
+        return self._write_status_to_db(task.task_uuid, "completed", result=result)
 
     def report_failed(self, task: BacktestTask, error: str):
         """上报失败"""
@@ -132,8 +133,8 @@ class ProgressTracker:
         )
         GLOG.ERROR(f"[{task.task_uuid[:8]}] Reported failure: {error}")
 
-        # 更新数据库状态为 failed
-        self._write_status_to_db(task.task_uuid, "failed", error_message=error)
+        # 更新数据库状态为 failed（#6845：返回写库结果，失败对调用方可见）
+        return self._write_status_to_db(task.task_uuid, "failed", error_message=error)
 
     def report_cancelled(self, task: BacktestTask):
         """上报取消"""
@@ -147,8 +148,8 @@ class ProgressTracker:
         )
         GLOG.INFO(f"[{task.task_uuid[:8]}] Reported cancellation")
 
-        # 更新数据库状态为 stopped
-        self._write_status_to_db(task.task_uuid, "stopped")
+        # 更新数据库状态为 stopped（#6845：返回写库结果，失败对调用方可见）
+        return self._write_status_to_db(task.task_uuid, "stopped")
 
     def report_failed_by_uuid(self, task_uuid: str, error: str):
         """通过 UUID 上报失败（无需完整 BacktestTask 对象）"""
@@ -164,8 +165,8 @@ class ProgressTracker:
         )
         GLOG.ERROR(f"[{short_uuid}] Reported failure by UUID: {error}")
 
-        # 更新数据库状态为 failed
-        self._write_status_to_db(task_uuid, "failed", error_message=error)
+        # 更新数据库状态为 failed（#6845：返回写库结果，失败对调用方可见）
+        return self._write_status_to_db(task_uuid, "failed", error_message=error)
 
     def _send_to_kafka(self, message: dict):
         """发送消息到Kafka"""
@@ -208,9 +209,9 @@ class ProgressTracker:
     def _write_status_to_db(
         self, task_id: str, status: str, error_message: str = "", result: dict = None, current_stage: str = None
     ):
-        """写入任务状态到数据库"""
+        """写入任务状态到数据库，返回 ServiceResult（#6845：失败可见，不再 void 吞掉）。"""
         if self.task_service is None:
-            return
+            return ServiceResult.success(None, "task_service not configured, status write skipped")
 
         try:
             from datetime import datetime
@@ -250,9 +251,22 @@ class ProgressTracker:
                 uuid=task_id, status=status, error_message=error_message, **result_fields  # task_id 与 uuid 等价
             )
             if not result_obj.is_success():
-                GLOG.ERROR(f"Failed to write status to DB: {result_obj.message}")
+                msg = result_obj.message or ""
+                # #6845: not-found 容错（任务可能未预创建，如聚合/独立运行路径），不视为致命失败；
+                # DB 异常/无效状态才是真失败。两者必须区别对待，否则状态回写永远"撒谎"。
+                if "not found" in msg.lower():
+                    GLOG.INFO(
+                        f"[{task_id[:8]}] Backtest task not found in DB, status write skipped (non-fatal): {msg}"
+                    )
+                    return ServiceResult.success(
+                        None, f"Task not found, status write skipped (non-fatal): {msg}"
+                    )
+                GLOG.ERROR(f"Failed to write status to DB: {msg}")
+                return ServiceResult.error(f"Failed to write status to DB: {msg}")
+            return ServiceResult.success({"uuid": task_id, "status": status}, "Task status written to DB")
         except Exception as e:
             GLOG.ERROR(f"Error writing status to DB: {e}")
+            return ServiceResult.error(f"Error writing status to DB: {e}")
 
     def get_task_status(self, task_uuid: str) -> Optional[str]:
         """

--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -132,9 +132,16 @@ class BacktestProcessor(Thread):
             self.task.completed_at = datetime.utcnow()
             self.task.result = result.data
 
-            self.progress_tracker.report_completed(self.task, None)
+            # #6845: 状态回写失败须可见——回测本身成功，但若终态没记上 DB 不能撒谎 "completed successfully"。
+            # not-found 已容错为 success（任务可能未预创建），只有真 DB 异常才 WARN。
+            status_result = self.progress_tracker.report_completed(self.task, None)
             self._ingest_task_logs()
-            GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
+            if status_result is not None and not status_result.is_success():
+                GLOG.WARN(
+                    f"[{self.task.task_uuid[:8]}] Backtest completed but status write failed: {status_result.message}"
+                )
+            else:
+                GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
 
         except Exception as e:
             self._exception = e

--- a/tests/unit/trading/analysis/test_backtest_result_aggregator_truthful.py
+++ b/tests/unit/trading/analysis/test_backtest_result_aggregator_truthful.py
@@ -1,0 +1,69 @@
+"""Tests for BacktestResultAggregator status-write truthfulness -- #6845.
+
+aggregate_and_save 的 update_status 失败时不再无条件 return success：
+- task 未预创建（not-found）→ 容错，return success（合法场景，无告警）
+- DB 异常 / 写失败 → return error（不再撒谎，让 orchestrator 据实判定）
+"""
+
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+try:
+    from ginkgo.data.services.base_service import ServiceResult
+    from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAggregator
+
+    HAS_MODULE = True
+except ImportError:
+    HAS_MODULE = False
+
+
+def _make_aggregator(update_behavior) -> "BacktestResultAggregator":
+    """analyzer_service=None → _aggregate_* 走默认值守卫，跳过真实查询。"""
+    agg = BacktestResultAggregator(analyzer_service=None, backtest_task_service=MagicMock())
+    agg._backtest_task_service.update_status = update_behavior
+    return agg
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestResultAggregator not available")
+@pytest.mark.tdd
+class TestAggregateSaveStatusWriteTruthful:
+    """#6845: aggregate_and_save 的 update_status 失败据实返回，不再撒谎。"""
+
+    def test_returns_error_when_db_write_fails(self, monkeypatch):
+        """DB 异常 → aggregate_and_save 不再 return success（让 orchestrator 据实判定）。"""
+        monkeypatch.setattr("ginkgo.data.containers.container", MagicMock())
+        agg = _make_aggregator(
+            MagicMock(return_value=ServiceResult.error("Failed to update task status: connection lost"))
+        )
+
+        result = agg.aggregate_and_save(
+            task_id="t1", portfolio_id="p1", engine_id="e1", status="completed"
+        )
+
+        assert not result.is_success(), "DB 异常时不应 return success（#6845 不撒谎）"
+
+    def test_silent_success_when_task_not_found(self, monkeypatch):
+        """task 未预创建（not-found）→ 容错 return success，且静默（无 WARN/ERROR 告警）。"""
+        monkeypatch.setattr("ginkgo.data.containers.container", MagicMock())
+        warned, errored = [], []
+        spy = types.SimpleNamespace(
+            WARN=lambda m: warned.append(m),
+            ERROR=lambda m: errored.append(m),
+            INFO=lambda m: None,
+            DEBUG=lambda m: None,
+        )
+        monkeypatch.setattr("ginkgo.trading.analysis.backtest_result_aggregator.GLOG", spy)
+        agg = _make_aggregator(
+            MagicMock(return_value=ServiceResult.error("Backtest task not found: t1"))
+        )
+
+        result = agg.aggregate_and_save(
+            task_id="t1", portfolio_id="p1", engine_id="e1", status="completed"
+        )
+
+        assert result.is_success(), "not-found 应容错 return success（任务可能未预创建）"
+        assert not warned and not errored, (
+            f"not-found 应静默（无 WARN/ERROR 告警），收到 warn={warned} err={errored}"
+        )

--- a/tests/unit/workers/test_progress_tracker.py
+++ b/tests/unit/workers/test_progress_tracker.py
@@ -80,3 +80,77 @@ class TestProgressReportNoSyncHttpNotify:
             tracker.report_completed(task, result={"total_pnl": 1.0})
 
         mock_post.assert_not_called()
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="ProgressTracker not available")
+@pytest.mark.tdd
+class TestStatusWriteTruthful:
+    """#6845: 状态回写失败必须可见——report_* 返回 ServiceResult，不再 void 吞掉。
+
+    区分两种失败：
+    - task 未预创建（not-found）→ 容错，返回 success（汇总/回测可继续）
+    - DB 异常 → 返回 error（调用方可 WARN/告警，不再撒谎）
+    """
+
+    def test_report_completed_returns_success_when_db_write_ok(self):
+        """DB 写成功时 report_completed 返回 is_success() 的 ServiceResult（非 None）。"""
+        task = BacktestTask(
+            task_uuid="8b7b8cd8d69444db9a59e01862e601d6",
+            portfolio_uuid="P",
+            name="n",
+            config=None,
+        )
+        task.completed_at = None
+        task_service = MagicMock()
+        task_service.update_status.return_value = MagicMock(is_success=lambda: True)
+        tracker = ProgressTracker(worker_id="w1", kafka_producer=MagicMock(), task_service=task_service)
+
+        with patch("requests.post"):
+            result = tracker.report_completed(task, result={"total_pnl": 1.0})
+
+        assert result is not None, "report_completed 不应返回 None（#6845：状态写结果须可见）"
+        assert result.is_success(), "DB 写成功应返回 success"
+
+    def test_report_completed_not_found_is_non_fatal_success(self):
+        """task 未预创建（not-found）→ 容错返回 success（汇总/回测可继续，非致命）。
+
+        区分点：update_status 返回 "Backtest task not found" 与 DB 异常 "Failed to update"
+        必须区别对待——前者是预期容错，后者是真失败。
+        """
+        from ginkgo.data.services.base_service import ServiceResult
+
+        task = BacktestTask(
+            task_uuid="8b7b8cd8d69444db9a59e01862e601d6",
+            portfolio_uuid="P",
+            name="n",
+            config=None,
+        )
+        task.completed_at = None
+        task_service = MagicMock()
+        task_service.update_status.return_value = ServiceResult.error(
+            "Backtest task not found: deadbeef"
+        )
+        tracker = ProgressTracker(worker_id="w1", kafka_producer=MagicMock(), task_service=task_service)
+
+        with patch("requests.post"):
+            result = tracker.report_completed(task, result={"total_pnl": 1.0})
+
+        assert result.is_success(), "not-found 应容错为 success（任务可能未预创建，非致命）"
+
+    def test_report_completed_db_error_returns_error(self):
+        """DB 异常（update_status 抛异常）→ 返回 error 且不抛出（失败对调用方可见，不撒谎）。"""
+        task = BacktestTask(
+            task_uuid="8b7b8cd8d69444db9a59e01862e601d6",
+            portfolio_uuid="P",
+            name="n",
+            config=None,
+        )
+        task.completed_at = None
+        task_service = MagicMock()
+        task_service.update_status.side_effect = Exception("OperationalError: connection lost")
+        tracker = ProgressTracker(worker_id="w1", kafka_producer=MagicMock(), task_service=task_service)
+
+        with patch("requests.post"):
+            result = tracker.report_completed(task, result={"total_pnl": 1.0})
+
+        assert result is not None and not result.is_success(), "DB 异常应返回 error（可见），而非 None"

--- a/tests/unit/workers/test_task_processor_error_logging.py
+++ b/tests/unit/workers/test_task_processor_error_logging.py
@@ -139,3 +139,58 @@ class TestAggregateResultsRoutesTracebackToGlog:
         assert any("Traceback" in m for m in errors), (
             f"GLOG.ERROR 未收到 traceback，收到: {errors}"
         )
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+@pytest.mark.tdd
+class TestRunStatusWriteTruthful:
+    """#6845: 回测完成时若状态回写失败，日志必须如实反映（WARN），不再无条件
+    打 "Backtest completed successfully" 撒谎。not-found 容错不算失败。"""
+
+    def test_run_warns_when_status_write_fails(self, monkeypatch):
+        from ginkgo.data.services.base_service import ServiceResult
+
+        cfg = _full_backtest_config()
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+        proc._assembly_service = MagicMock()
+        proc._portfolio_service = MagicMock()
+        proc.trace_id = None
+
+        # report_completed 返回 DB 异常 error（状态写失败，回测本身成功）
+        tracker = MagicMock()
+        tracker.report_completed.return_value = ServiceResult.error(
+            "Failed to write status to DB: connection lost"
+        )
+        proc.progress_tracker = tracker
+        proc._ingest_task_logs = MagicMock()
+
+        # orchestrator 返回成功（回测结果已算出，只是状态没记上）
+        fake_orch = MagicMock()
+        fake_orch.run.return_value = ServiceResult.success({"ok": True})
+        monkeypatch.setattr(
+            "ginkgo.trading.services.backtest_orchestrator.BacktestOrchestrator",
+            lambda **kw: fake_orch,
+        )
+        monkeypatch.setattr("ginkgo.data.containers.container", MagicMock())
+
+        warned, infoed = [], []
+        spy = types.SimpleNamespace(
+            WARN=lambda m: warned.append(m),
+            ERROR=lambda m: None,
+            INFO=lambda m: infoed.append(m),
+            DEBUG=lambda m: None,
+            clear_context=lambda: None,
+            set_log_category=lambda c: None,
+        )
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.GLOG", spy)
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.time", MagicMock())
+
+        proc.run()
+
+        assert any("status write failed" in m for m in warned), (
+            f"状态写失败应 WARN，收到 warns={warned}"
+        )
+        assert not any("completed successfully" in m for m in infoed), (
+            f"状态写失败时不应再撒谎 'completed successfully': {infoed}"
+        )


### PR DESCRIPTION
## 问题

回测任务状态回写 DB 失败时，日志、返回值、CLI **无条件报成功**——即"撒谎"：
- `progress_tracker._write_status_to_db` 是 `void`，写库失败被吞掉，调用方无从感知
- `aggregate_and_save` 的 `update_status` 失败后仍 `return ServiceResult.success`
- `task_processor.run` 终态打 "Backtest completed successfully" 不看回写结果

回测本身成功 ≠ 状态已记上 DB。状态回写静默失败会掩盖 DB 故障，运维无从定位。

## 修复

DB 写状态失败时如实反映，并区分两种失败（关键）：
- **task-not-found**：容错（任务可能未预创建，如聚合/独立运行路径）→ INFO + return success
- **DB 异常 / 写失败**：真失败 → ERROR + return error / WARN

## 变更（4 处）

| 文件 | 变更 |
|---|---|
| `progress_tracker._write_status_to_db` | 返回 ServiceResult；区分 not-found（INFO+success）与 DB 异常（ERROR+error） |
| `progress_tracker.report_*` | 4 个终态方法传播写库结果，不再 void 吞掉 |
| `task_processor.run` | 终态回写失败 WARN，不再打 "completed successfully" 撒谎 |
| `aggregate_and_save` | update_status 失败不再 return success；DB 异常 return error、not-found 容错 INFO |

区分依据：`backtest_task_service.update_status` 的错误 message——`"not found"`（任务未预创建）vs `"Failed to update task status"`/`"Invalid status"`（真失败）。

## 测试（TDD，11 passed）

- `test_progress_tracker.py::TestStatusWriteTruthful`（3）：写库成功/not-found 容错/DB 异常
- `test_task_processor_error_logging.py::TestRunStatusWriteTruthful`（1）：状态写失败 WARN、不打 "completed successfully"
- `test_backtest_result_aggregator_truthful.py`（2）：DB 异常 return error、not-found 静默 success

## 不改 Base 类

未触碰 `ServiceResult`/`BaseService`/`BaseCRUD`，仅在具体实现层（progress_tracker/aggregator/task_processor）处理。

Closes #6845

🤖 Generated with [Claude Code](https://claude.com/claude-code)