### PR TITLE
fix(backtest): running 任务孤儿治理改心跳持有判定 (#6846)

### DIFF
--- a/src/ginkgo/data/redis_schema.py
+++ b/src/ginkgo/data/redis_schema.py
@@ -13,8 +13,8 @@ Redis Schema - 统一管理 Redis 键命名和数据结构
 4. 所有 Redis 键的集中管理
 """
 
-from dataclasses import dataclass, asdict
-from typing import Optional, Dict, Any
+from dataclasses import dataclass, asdict, field
+from typing import Optional, Dict, Any, List
 from datetime import datetime
 from enum import Enum
 import json
@@ -246,11 +246,15 @@ class BacktestWorkerHeartbeat(BaseHeartbeat):
     max_tasks: int
     started_at: str
     last_heartbeat: str
+    # #6846: 当前持有的 task_uuid 集合。此前仅 running_tasks 计数，无法判定
+    # "某 running 任务是否被活跃 worker 持有"；孤儿治理改心跳判定后需 union 此字段。
+    task_uuids: List[str] = field(default_factory=list)
 
     @classmethod
     def create(cls, worker_id: str, status: WorkerStatus,
                running_tasks: int = 0, max_tasks: int = 5,
-               started_at: str = None) -> "BacktestWorkerHeartbeat":
+               started_at: str = None,
+               task_uuids: List[str] = None) -> "BacktestWorkerHeartbeat":
         """创建心跳数据"""
         now = datetime.now().isoformat()
         return cls(
@@ -260,7 +264,8 @@ class BacktestWorkerHeartbeat(BaseHeartbeat):
             running_tasks=running_tasks,
             max_tasks=max_tasks,
             started_at=started_at or now,
-            last_heartbeat=now
+            last_heartbeat=now,
+            task_uuids=task_uuids or [],
         )
 
     def update_heartbeat(self, running_tasks: int = None) -> "BacktestWorkerHeartbeat":

--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -16,9 +16,8 @@ import time
 import json
 from typing import List, Union, Any, Optional, Dict
 import pandas as pd
-from datetime import datetime, timedelta, timezone
 
-from ginkgo.libs import cache_with_expiration, retry, GLOG
+from ginkgo.libs import cache_with_expiration, retry, GLOG, datetime_normalize
 from ginkgo.libs.data.number import convert_to_float
 from ginkgo.data.crud.model_conversion import ModelList
 from ginkgo.data.services.base_service import BaseService, ServiceResult
@@ -386,53 +385,68 @@ class BacktestTaskService(BaseService):
             GLOG.ERROR(f"Failed to delete backtest task {uuid[:8]}...: {e}")
             return ServiceResult.error(f"Failed to delete backtest task: {str(e)}")
 
-    def cleanup_orphan_tasks(self, timeout_minutes: int = 30) -> ServiceResult:
+    def cleanup_orphan_tasks(self) -> ServiceResult:
         """
-        清理孤儿回测任务（#4853）。
+        清理孤儿回测任务（#6846）。
 
-        扫描 status=running 但 start_time 早于 timeout_minutes 的任务，标记为 failed。
-        处理两类孤儿：
-        - Worker 重启期间 Kafka 消息丢失（派发成功但 Worker 未消费）
-        - 派发期未被 send 返回值检查拦截的历史残留（本方法上线前的存量）
+        判定：running 任务不被任何活跃 worker 心跳持有 → 孤儿 → 标 failed。
+        心跳 TTL 30s，worker crash / 丢 Kafka 消息后心跳过期即不再声明持有该 task，
+        遂被判定孤儿，兜底状态机防永久 running。
 
-        与 portfolio_service.reset_stale_running() 同构：状态机兜底，防永久 running。
+        相比 #4853 旧的 start_time 超时判定，心跳持有集才是"有 worker 在管这事"
+        的真实信号：worker 正常在跑 → 心跳声明持有 → 不动；worker 死了 → 心跳过期
+        → 持有集不含该 task → 标 failed。start_time 无法区分"真在跑"与"已丢"，
+        且 naive/UTC 语态漂移让 30min 阈值形同虚设。
 
-        Args:
-            timeout_minutes: running 状态超时阈值（分钟），默认 30。
+        告警消息含 business_timestamp（worker 上报 current_date 时同步写入，①），
+        便于运维定位最后业务推进点。
 
         Returns:
-            ServiceResult: data 含 cleaned（标记 failed 数量）与 total_running（扫描时 running 总数）。
+            ServiceResult: data 含 cleaned（标记 failed 数量）、total_running（扫描时
+            running 总数）；Redis 不可达时 skipped=True 且 cleaned=0（防基础设施抖动误杀全量）。
         """
         try:
             running = self._crud_repo.get_running_tasks()
-            # 阈值语态绑死 worker 写入端：progress_tracker.py:218 写 naive local
-            # datetime.now()（宿主 Asia/Shanghai UTC+8）。两端必须同语态比较，
-            # 否则 naive 北京时间被 replace(tzinfo=utc) 当 UTC 解释会看起来年轻 8h，
-            # 30min timeout 实际变 ~8h30min（#4853 PR #6565 review 抓的 bug）。
-            # 治本（worker 改 aware UTC）属全仓 naive→UTC 迁移，超出本 PR 范围，
-            # 迁移完成时同步此行回 datetime.now(timezone.utc)。
-            threshold = datetime.now() - timedelta(minutes=timeout_minutes)
+            if not running:
+                return ServiceResult.success(
+                    {"cleaned": 0, "total_running": 0},
+                    "无 running 任务",
+                )
+
+            held = self._get_held_task_uuids()
+            # Redis 不可达：无法区分"真孤儿"与"基础设施抖动"，本轮跳过防误杀全量。
+            if held is None:
+                GLOG.WARN("跳过本轮孤儿清理：无法读取活跃 worker 心跳（Redis 不可达）")
+                return ServiceResult.success(
+                    {"cleaned": 0, "total_running": len(running), "skipped": True},
+                    "Redis 不可达，跳过孤儿清理",
+                )
+
             cleaned = 0
-
             for task in running:
-                st = task.start_time
-                if st is None:
-                    # start_time 残缺无法判定，跳过（不崩，留给下次或人工）。
+                if task.uuid in held:
                     continue
-
-                if st < threshold:
-                    self.update_status(
-                        task.uuid, status="failed",
-                        error_message=(
-                            f"Orphan task: running > {timeout_minutes}min without progress "
-                            "(worker lost Kafka message or crashed)"
-                        ),
-                    )
-                    cleaned += 1
-                    GLOG.INFO(f"Marked orphan backtest task {task.uuid[:8]}... as failed")
+                bt = getattr(task, "business_timestamp", None)
+                bt_str = bt.strftime("%Y-%m-%d %H:%M:%S") if bt else "N/A"
+                self.update_status(
+                    task.uuid, status="failed",
+                    error_message=(
+                        f"Orphan task: no active worker holds it "
+                        f"(worker crashed or lost Kafka message). "
+                        f"last business_timestamp={bt_str}"
+                    ),
+                )
+                cleaned += 1
+                GLOG.INFO(
+                    f"Marked orphan backtest task {task.uuid[:8]}... as failed "
+                    f"(not held by any active worker)"
+                )
 
             if cleaned > 0:
-                GLOG.INFO(f"Cleaned {cleaned}/{len(running)} orphan running backtest tasks")
+                GLOG.INFO(
+                    f"Cleaned {cleaned}/{len(running)} orphan running backtest tasks "
+                    f"(held by active workers: {len(held)})"
+                )
 
             return ServiceResult.success(
                 {"cleaned": cleaned, "total_running": len(running)},
@@ -441,6 +455,43 @@ class BacktestTaskService(BaseService):
         except Exception as e:
             GLOG.ERROR(f"Failed to cleanup orphan backtest tasks: {e}")
             return ServiceResult.error(f"Failed to cleanup orphan backtest tasks: {str(e)}")
+
+    def _get_held_task_uuids(self):
+        """
+        读取所有活跃 backtest worker 心跳，union 出被持有的 task_uuid 集合（#6846）。
+
+        SCAN 枚举 backtest:worker:* 心跳键（TTL 30s，过期即视为该 worker 已死），
+        解析每条心跳的 task_uuids 字段取并集。
+
+        Returns:
+            set: 被持有的 task_uuid 集合（无活跃 worker 时为空集）。
+            None: Redis 不可达 / 读取异常，无法判定。调用方据此跳过本轮，防误杀全量。
+        """
+        try:
+            from ginkgo.data.redis_schema import (
+                RedisKeyPrefix, BacktestWorkerHeartbeat,
+            )
+            from ginkgo.data.drivers import create_redis_connection
+
+            redis = create_redis_connection()
+            held = set()
+            pattern = f"{RedisKeyPrefix.BACKTEST_WORKER_HEARTBEAT}:*"
+            for key in redis.scan_iter(match=pattern, count=100):
+                raw = redis.get(key)
+                if not raw:
+                    continue
+                if isinstance(raw, bytes):
+                    raw = raw.decode("utf-8", errors="ignore")
+                try:
+                    hb = BacktestWorkerHeartbeat.from_json(raw)
+                    held.update(hb.task_uuids)
+                except Exception:
+                    # 单条心跳解析失败不拖垮整轮；坏数据留给下次或人工。
+                    continue
+            return held
+        except Exception as e:
+            GLOG.WARN(f"读取 worker 心跳失败，跳过本轮孤儿清理: {e}")
+            return None
 
     def get_statistics(self) -> ServiceResult:
         """
@@ -585,6 +636,10 @@ class BacktestTaskService(BaseService):
                 updates["current_stage"] = current_stage
             if current_date is not None:
                 updates["current_date"] = current_date
+                # #6846: business_timestamp 此前恒 None——worker 每次上报 current_date
+                # （回测当前处理的业务日期）却未落库，使其无法作"业务推进"信号。
+                # 同步写入，供孤儿判定告警与运维定位（与 current_date 同源同值）。
+                updates["business_timestamp"] = datetime_normalize(current_date)
 
             if not updates:
                 return ServiceResult.error("No progress fields to update")

--- a/src/ginkgo/workers/backtest_worker/node.py
+++ b/src/ginkgo/workers/backtest_worker/node.py
@@ -102,6 +102,24 @@ class BacktestWorker:
         from ginkgo import services
         task_service = services.data.backtest_task_service()
 
+        # #6846: 启动期兜底清理上次异常退出残留的 running 孤儿（心跳判定：不被任何
+        # 活跃 worker 持有的 running task → 标 failed）。对称 paper_trading_worker
+        # 启动期调 portfolio_service.reset_stale_running()。清理失败非致命，不阻断启动。
+        try:
+            result = task_service.cleanup_orphan_tasks()
+            if result.is_success():
+                data = result.data or {}
+                cleaned = data.get("cleaned", 0)
+                if cleaned:
+                    GLOG.WARN(
+                        f"Startup cleanup: marked {cleaned} orphan task(s) failed "
+                        f"(total running scanned: {data.get('total_running', 0)})"
+                    )
+            else:
+                GLOG.WARN(f"Startup orphan cleanup returned non-success: {result.error}")
+        except Exception as e:
+            GLOG.WARN(f"Startup orphan cleanup failed (non-fatal, worker continues): {e}")
+
         # 初始化Kafka Producer（进度上报）
         self.progress_producer = GinkgoProducer()
         self.progress_tracker = ProgressTracker(
@@ -490,7 +508,8 @@ class BacktestWorker:
                 status=WorkerStatus.RUNNING if self.is_running else WorkerStatus.STOPPED,
                 running_tasks=len(self.tasks),
                 max_tasks=self.max_backtests,
-                started_at=self.started_at
+                started_at=self.started_at,
+                task_uuids=list(self.tasks.keys()),
             )
 
             redis.setex(key, RedisTTL.BACKTEST_WORKER_HEARTBEAT, heartbeat.to_json())

--- a/tests/unit/data/services/test_backtest_task_orphan.py
+++ b/tests/unit/data/services/test_backtest_task_orphan.py
@@ -4,8 +4,10 @@
 两层防御：
 1. 派发期（防新增）：producer.send 返回 False → start_task 标 task failed 并报错，
    不再 fire-and-forget 留下永久 running 孤儿。
-2. 兜底（清存量）：cleanup_orphan_tasks 扫描 running 超 N 分钟无进展的任务标 failed，
-   处理历史孤儿与 Worker 重启丢消息场景。
+2. 兜底（清存量）：cleanup_orphan_tasks 判定改为"running 任务不被任何活跃 worker
+   心跳持有 → 孤儿 → 标 failed"（#6846）。不再用 start_time 超时（worker crash/
+   丢消息场景下 start_time 无法区分"真在跑"与"已丢"）；心跳持有集才是"有 worker
+   在管这事"的真实信号。Redis 不可达时跳过本轮，防基础设施抖动误杀全量。
 
 参考既有 mock 模式：test_backtest_task_assignment_payload.py。
 """
@@ -102,82 +104,82 @@ class TestStartDispatchFailure:
 # ---------- 兜底：清存量孤儿 ----------
 
 class TestCleanupOrphanTasks:
-    """cleanup_orphan_tasks 扫描 running 超 N 分钟无进展的任务标 failed。"""
+    """cleanup_orphan_tasks: running 任务不被任何活跃 worker 心跳持有 → 孤儿 → 标 failed。"""
+
+    def _set_held(self, service, held):
+        """注入 _get_held_task_uuids 返回值（set=被持有集，None=Redis 不可达）。"""
+        service._get_held_task_uuids = MagicMock(return_value=held)
 
     @pytest.mark.unit
-    def test_stale_running_marked_failed(self, service):
-        """running + start_time 早于阈值 → 标 failed。"""
-        # naive local，与 worker progress_tracker.py 写入语态一致（#4853 review 契约）。
-        now = datetime.now()
-        stale = _make_task(
-            status="running",
-            start_time=now - timedelta(minutes=60),
-        )
-        stale.uuid = "stale-uuid"
-        service._crud_repo.get_running_tasks.return_value = [stale]
+    def test_orphan_not_held_marked_failed(self, service):
+        """running + 不被任何活跃 worker 持有 → 标 failed。"""
+        orphan = _make_task(status="running")
+        orphan.uuid = "orphan-1"
+        service._crud_repo.get_running_tasks.return_value = [orphan]
+        self._set_held(service, set())
         service.update_status = MagicMock(return_value=ServiceResult.success({}, "ok"))
 
-        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+        result = service.cleanup_orphan_tasks()
 
         assert result.is_success()
         service.update_status.assert_called_once()
         assert service.update_status.call_args.kwargs.get("status") == "failed"
-        assert "stale-uuid" == service.update_status.call_args.args[0]
+        assert service.update_status.call_args.args[0] == "orphan-1"
 
     @pytest.mark.unit
-    def test_fresh_running_not_touched(self, service):
-        """running + start_time 新鲜 → 不动。"""
-        # naive local，与 worker progress_tracker.py 写入语态一致（#4853 review 契约）。
-        now = datetime.now()
-        fresh = _make_task(
-            status="running",
-            start_time=now - timedelta(minutes=5),
-        )
-        service._crud_repo.get_running_tasks.return_value = [fresh]
+    def test_held_running_not_touched(self, service):
+        """running + 被活跃 worker 持有 → 不动。"""
+        held_task = _make_task(status="running")
+        held_task.uuid = "held-1"
+        service._crud_repo.get_running_tasks.return_value = [held_task]
+        self._set_held(service, {"held-1"})
         service.update_status = MagicMock()
 
-        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+        result = service.cleanup_orphan_tasks()
 
         assert result.is_success()
         service.update_status.assert_not_called()
 
     @pytest.mark.unit
-    def test_running_without_start_time_skipped(self, service):
-        """running 但 start_time=None（数据残缺）→ 跳过不崩。"""
-        no_time = _make_task(status="running", start_time=None)
-        service._crud_repo.get_running_tasks.return_value = [no_time]
+    def test_mixed_only_orphans_marked(self, service):
+        """held 与 orphan 混合 → 仅 orphan 被标 failed。"""
+        held = _make_task(status="running"); held.uuid = "held"
+        orphan = _make_task(status="running"); orphan.uuid = "orphan"
+        service._crud_repo.get_running_tasks.return_value = [held, orphan]
+        self._set_held(service, {"held"})
+        service.update_status = MagicMock(return_value=ServiceResult.success({}, "ok"))
+
+        service.cleanup_orphan_tasks()
+
+        marked = [c.args[0] for c in service.update_status.call_args_list]
+        assert marked == ["orphan"]
+
+    @pytest.mark.unit
+    def test_redis_down_skips_cleanup(self, service):
+        """_get_held_task_uuids 返回 None（Redis 不可达）→ 跳过本轮，不误杀。"""
+        orphan = _make_task(status="running"); orphan.uuid = "orphan-x"
+        service._crud_repo.get_running_tasks.return_value = [orphan]
+        self._set_held(service, None)
         service.update_status = MagicMock()
 
-        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+        result = service.cleanup_orphan_tasks()
 
         assert result.is_success()
         service.update_status.assert_not_called()
 
     @pytest.mark.unit
-    def test_naive_local_start_time_cleaned_within_real_timeout(self, service):
-        """回归守护（#4853 PR #6565 review 抓的 bug）。
-
-        worker progress_tracker.py 写 start_time=datetime.now() 是 naive local
-        （宿主 Asia/Shanghai UTC+8）。cleanup 阈值必须与 worker 写入同语态
-        （naive local），否则 naive 北京时间被 replace(tzinfo=utc) 当 UTC 解释，
-        task 看起来比实际年轻 8 小时，声明的 30min timeout 实际变 ~8h30min，
-        孤儿永久不被清理 —— issue #4853 痛点未被有效兜底。
-
-        构造 naive local start_time = now-35min（与 worker 写入语态一致），
-        timeout=30min → 必须触发 failed。
-        """
-        naive_local_now = datetime.now()  # 无 tzinfo，模拟 worker 写入
-        stale = _make_task(
+    def test_failure_message_includes_business_timestamp(self, service):
+        """告警消息含 business_timestamp，便于运维定位最后业务推进点。"""
+        orphan = _make_task(
             status="running",
-            start_time=naive_local_now - timedelta(minutes=35),
+            business_timestamp=datetime(2026, 7, 28, 12, 0, 0),
         )
-        stale.uuid = "stale-naive-local"
-        service._crud_repo.get_running_tasks.return_value = [stale]
+        orphan.uuid = "orphan-ts"
+        service._crud_repo.get_running_tasks.return_value = [orphan]
+        self._set_held(service, set())
         service.update_status = MagicMock(return_value=ServiceResult.success({}, "ok"))
 
-        result = service.cleanup_orphan_tasks(timeout_minutes=30)
+        service.cleanup_orphan_tasks()
 
-        assert result.is_success()
-        service.update_status.assert_called_once()
-        assert service.update_status.call_args.kwargs.get("status") == "failed"
-        assert service.update_status.call_args.args[0] == "stale-naive-local"
+        msg = service.update_status.call_args.kwargs.get("error_message", "")
+        assert "2026-07-28" in msg

--- a/tests/unit/data/services/test_backtest_task_progress.py
+++ b/tests/unit/data/services/test_backtest_task_progress.py
@@ -1,0 +1,78 @@
+"""
+#6846：回测任务 business_timestamp 写入。
+
+worker progress_tracker 每次上报 current_date（回测当前处理的业务日期），
+但 update_progress 从未把该日期落到 task.business_timestamp —— 字段恒 None，
+无法用作"业务推进"信号（issue #6846 前提之一）。
+
+修复：update_progress(current_date=X) 同步写 business_timestamp=datetime_normalize(X)。
+
+参考既有 mock 模式：test_backtest_task_orphan.py。
+"""
+import sys
+import os
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+from ginkgo.libs import datetime_normalize
+
+
+def _make_task(**overrides):
+    task = MagicMock()
+    task.uuid = "uuid-1234-5678"
+    task.task_id = "task-abc"
+    task.portfolio_id = "portfolio-001"
+    task.name = "test_backtest"
+    task.status = "running"
+    task.start_time = None
+    task.business_timestamp = None
+    for k, v in overrides.items():
+        setattr(task, k, v)
+    return task
+
+
+@pytest.fixture
+def service():
+    crud = MagicMock()
+    return BacktestTaskService(crud_repo=crud)
+
+
+class TestUpdateProgressBusinessTimestamp:
+    """update_progress 须把 current_date 落到 business_timestamp。"""
+
+    @pytest.mark.unit
+    def test_current_date_written_as_business_timestamp(self, service):
+        """上报 current_date → modify 的 updates 含 business_timestamp = datetime_normalize(current_date)。"""
+        task = _make_task()
+        service._crud_repo.get_by_uuid.return_value = task
+        service._crud_repo.modify.return_value = 1
+
+        result = service.update_progress(
+            uuid="uuid-1234-5678", current_date="2025-06-01"
+        )
+
+        assert result.is_success()
+        call = service._crud_repo.modify.call_args
+        updates = call.kwargs.get("updates")
+        assert updates is not None
+        assert "business_timestamp" in updates
+        assert updates["business_timestamp"] == datetime_normalize("2025-06-01")
+
+    @pytest.mark.unit
+    def test_no_current_date_leaves_business_timestamp_absent(self, service):
+        """回归：未传 current_date → 不动 business_timestamp（不强制清空）。"""
+        task = _make_task()
+        service._crud_repo.get_by_uuid.return_value = task
+        service._crud_repo.modify.return_value = 1
+
+        service.update_progress(uuid="uuid-1234-5678", progress=42.0)
+
+        updates = service._crud_repo.modify.call_args.kwargs.get("updates")
+        assert "business_timestamp" not in updates

--- a/tests/unit/data/test_backtest_worker_heartbeat.py
+++ b/tests/unit/data/test_backtest_worker_heartbeat.py
@@ -1,0 +1,72 @@
+"""
+#6846：BacktestWorker 心跳须携带当前持有的 task_uuids。
+
+此前心跳只有 running_tasks 计数（int），无法判定"某个 running 任务是否被某
+活跃 worker 持有"。孤儿治理（cleanup_orphan_tasks）改心跳判定后，需要从
+心跳 union 出"活跃 worker 持有的 task 集合"，故心跳结构须带上 task_uuids。
+
+向后兼容：旧心跳 JSON（无 task_uuids）反序列化不崩，默认空列表。
+"""
+import sys
+import os
+import json
+
+import pytest
+
+_path = os.path.join(os.path.dirname(__file__), '..', '..', '..')
+if _path not in sys.path:
+    sys.path.insert(0, _path)
+
+from ginkgo.data.redis_schema import BacktestWorkerHeartbeat, WorkerStatus
+
+
+class TestHeartbeatCarriesTaskUuids:
+    """create 携带 task_uuids，to_json 落盘，from_json 可还原。"""
+
+    @pytest.mark.unit
+    def test_create_carries_task_uuids(self):
+        hb = BacktestWorkerHeartbeat.create(
+            worker_id="bw-1", status=WorkerStatus.RUNNING,
+            running_tasks=2, task_uuids=["task-a", "task-b"],
+        )
+        assert hb.task_uuids == ["task-a", "task-b"]
+
+    @pytest.mark.unit
+    def test_to_json_contains_task_uuids(self):
+        hb = BacktestWorkerHeartbeat.create(
+            worker_id="bw-1", status=WorkerStatus.RUNNING,
+            task_uuids=["task-a"],
+        )
+        payload = json.loads(hb.to_json())
+        assert payload["task_uuids"] == ["task-a"]
+
+    @pytest.mark.unit
+    def test_from_json_roundtrip(self):
+        hb = BacktestWorkerHeartbeat.create(
+            worker_id="bw-1", status=WorkerStatus.RUNNING,
+            running_tasks=1, task_uuids=["task-x"],
+        )
+        restored = BacktestWorkerHeartbeat.from_json(hb.to_json())
+        assert restored.task_uuids == ["task-x"]
+
+    @pytest.mark.unit
+    def test_from_json_legacy_payload_without_task_uuids(self):
+        """旧心跳（无 task_uuids 字段）反序列化默认 []，不崩。"""
+        legacy = {
+            "worker_id": "bw-1",
+            "status": "running",
+            "timestamp": "2026-07-29T00:00:00",
+            "running_tasks": 1,
+            "max_tasks": 5,
+            "started_at": "2026-07-29T00:00:00",
+            "last_heartbeat": "2026-07-29T00:00:00",
+        }
+        restored = BacktestWorkerHeartbeat.from_json(json.dumps(legacy))
+        assert restored.task_uuids == []
+
+    @pytest.mark.unit
+    def test_create_default_empty_task_uuids(self):
+        hb = BacktestWorkerHeartbeat.create(
+            worker_id="bw-1", status=WorkerStatus.RUNNING,
+        )
+        assert hb.task_uuids == []

--- a/tests/unit/workers/test_backtest_worker_node.py
+++ b/tests/unit/workers/test_backtest_worker_node.py
@@ -9,6 +9,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from pathlib import Path
 import sys
+import json
 
 project_root = Path(__file__).parent.parent.parent
 _path = str(project_root / "src")
@@ -137,3 +138,101 @@ class TestStartTaskSkipStopped:
         # stopped 应被 skip：不创建 processor，不重置状态
         assert MockProc.call_count == 0, "stopped 任务不应创建 processor（应 skip）"
         worker.progress_tracker.task_service.update_status.assert_not_called()
+
+
+@pytest.mark.unit
+class TestSendHeartbeatCarriesTaskUuids:
+    """#6846: _send_heartbeat 须把 self.tasks 的 uuid 集合写入心跳。
+
+    孤儿治理（cleanup_orphan_tasks）改心跳判定后，需从活跃 worker 心跳 union
+    出"被持有的 task 集合"。worker 必须在心跳里声明自己持有哪些 task。
+    """
+
+    def test_heartbeat_records_held_task_uuids(self):
+        """self.tasks 中的 task uuid 写入心跳 task_uuids。"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+
+        worker = BacktestWorker("test-hb-uuids")
+        worker.is_running = True
+        worker.tasks = {"task-held-aaa": MagicMock(), "task-held-bbb": MagicMock()}
+        redis = MagicMock()
+        worker._get_redis = MagicMock(return_value=redis)
+
+        worker._send_heartbeat()
+
+        redis.setex.assert_called_once()
+        payload = json.loads(redis.setex.call_args.args[2])
+        assert set(payload["task_uuids"]) == {"task-held-aaa", "task-held-bbb"}
+
+    def test_heartbeat_empty_when_no_tasks(self):
+        """无在跑任务时心跳 task_uuids 为空列表。"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+
+        worker = BacktestWorker("test-hb-empty")
+        worker.is_running = True
+        worker.tasks = {}
+        redis = MagicMock()
+        worker._get_redis = MagicMock(return_value=redis)
+
+        worker._send_heartbeat()
+
+        payload = json.loads(redis.setex.call_args.args[2])
+        assert payload["task_uuids"] == []
+
+
+@pytest.mark.unit
+class TestStartCallsCleanup:
+    """#6846: BacktestWorker.start() 启动时调 cleanup_orphan_tasks。
+
+    对称 portfolio_service.reset_stale_running()（paper_trading_worker 启动期调用）：
+    worker 重启时兜底清理上次异常退出残留的 running 孤儿。清理失败须非致命
+    （不应阻断 worker 启动）。
+    """
+
+    def _stub_start_io(self, worker):
+        """屏蔽 start() 的 Redis/Kafka/线程 IO，仅保留 services + cleanup 路径。"""
+        worker._is_worker_id_in_use = MagicMock(return_value=False)
+        worker._cleanup_old_heartbeat_data = MagicMock()
+        worker._send_heartbeat = MagicMock()
+        worker._start_heartbeat_thread = MagicMock()
+        worker._start_task_consumer_thread = MagicMock()
+        worker._start_cleanup_thread = MagicMock()
+
+    def test_start_invokes_cleanup_orphan_tasks(self):
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+        from ginkgo.data.services.base_service import ServiceResult
+
+        worker = BacktestWorker("test-start-cleanup")
+        self._stub_start_io(worker)
+        task_service = MagicMock()
+        task_service.cleanup_orphan_tasks.return_value = ServiceResult.success(
+            {"cleaned": 0, "total_running": 0}, "ok"
+        )
+        fake_services = MagicMock()
+        fake_services.data.backtest_task_service.return_value = task_service
+
+        with patch("ginkgo.workers.backtest_worker.node.GinkgoProducer"), \
+             patch("ginkgo.workers.backtest_worker.node.ProgressTracker"), \
+             patch("ginkgo.services", fake_services):
+            worker.start()
+
+        task_service.cleanup_orphan_tasks.assert_called_once()
+
+    def test_start_survives_cleanup_exception(self):
+        """cleanup 抛异常时 start 不应阻断（非致命），worker 仍进入 running。"""
+        from ginkgo.workers.backtest_worker.node import BacktestWorker
+
+        worker = BacktestWorker("test-start-cleanup-err")
+        self._stub_start_io(worker)
+        task_service = MagicMock()
+        task_service.cleanup_orphan_tasks.side_effect = RuntimeError("cleanup boom")
+        fake_services = MagicMock()
+        fake_services.data.backtest_task_service.return_value = task_service
+
+        with patch("ginkgo.workers.backtest_worker.node.GinkgoProducer"), \
+             patch("ginkgo.workers.backtest_worker.node.ProgressTracker"), \
+             patch("ginkgo.services", fake_services):
+            worker.start()  # 不应抛
+
+        assert worker.is_running is True
+        task_service.cleanup_orphan_tasks.assert_called_once()


### PR DESCRIPTION
## 问题 (#6846)

回测 task 卡在 `running` 状态永久不收敛。`cleanup_orphan_tasks` 虽存在却是**死方法**（零调用方），即所谓"补偿扫描"从未接线——状态机缺兜底。

此外旧实现的判定逻辑（`start_time` 超 30min）本身不可用：
- worker 正常长跑回测（>30min）会被误判超时
- 反之 worker crash / 丢 Kafka 消息后，`start_time` 不再更新也无法区分"真在跑"与"已丢"
- `start_time` naive/UTC 语态漂移，30min 阈值形同虚设

## 根因

孤儿判定应基于"**有没有活跃 worker 在管这个 task**"，而非墙上时钟超时。worker 心跳（Redis，TTL 30s）才是"有 worker 在管"的真实信号——worker 死了心跳过期即不再声明持有该 task。

## 方案（心跳持有判定）

1. **`update_progress` 落 `business_timestamp`**：此前恒 `None`（worker 上报 `current_date` 却未落库）。映射为 `current_date`，作"业务推进"信号。
2. **worker 心跳新增 `task_uuids`**：worker 在心跳里声明当前持有哪些 task（向后兼容：`field(default_factory=list)`，旧 JSON 反序列化默认空）。
3. **`cleanup_orphan_tasks` 改心跳判定**：`running` 任务**不被任何活跃 worker 心跳持有** → 孤儿 → 标 `failed`（告警消息含 `business_timestamp` 便于定位）。
   - Redis 不可达 → 跳过本轮（返 `skipped=True`），防基础设施抖动误杀全量。
4. **`node.start` 启动期调 cleanup**：worker 重启时兜底清理上次异常退出残留的 running 孤儿。对称 `paper_trading_worker` 启动期调 `portfolio_service.reset_stale_running()`。清理失败**非致命**，不阻断启动。

## 测试（TDD，4 vertical slices，22 用例全过）

- `test_backtest_task_progress.py`：`business_timestamp` 写入（2）
- `test_backtest_worker_heartbeat.py`：`task_uuids` 序列化/旧 JSON 兼容（5）
- `test_backtest_worker_node.py`：心跳携带 task_uuids + `start()` 调 cleanup + 异常非致命（原有 +4 新增）
- `test_backtest_task_orphan.py`：心跳判定 5 场景（孤儿标 failed / 持有不改 / 混合仅标孤儿 / Redis 不可达跳过 / 告警含 business_timestamp）

三层冒烟：py_compile 3 源文件 + services provider 解析 + 22/22 touched-file 单测。

Closes #6846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
