### PR TITLE
fix(backtest): 状态回写失败可见，DB 故障不再静默撒谎 (#6845)

### DIFF
--- a/src/ginkgo/data/services/backtest_task_service.py
+++ b/src/ginkgo/data/services/backtest_task_service.py
@@ -328,14 +328,14 @@ class BacktestTaskService(BaseService):
         try:
             valid_statuses = ["created", "pending", "running", "completed", "failed", "stopped"]
             if status not in valid_statuses:
-                return ServiceResult.error(f"Invalid status: {status}")
+                return ServiceResult.error(f"Invalid status: {status}", code="INVALID_STATUS")
 
             # 查找任务，支持 uuid 或 task_id
             task = self._crud_repo.get_by_uuid(uuid)
             if not task:
                 task = self._crud_repo.get_by_task_id(uuid)
             if not task:
-                return ServiceResult.error(f"Backtest task not found: {uuid}")
+                return ServiceResult.error(f"Backtest task not found: {uuid}", code="NOT_FOUND")
 
             # 使用真实的 uuid 更新
             real_uuid = task.uuid
@@ -347,7 +347,7 @@ class BacktestTaskService(BaseService):
             )
 
             if updated_count == 0:
-                return ServiceResult.error(f"Backtest task not found: {real_uuid}")
+                return ServiceResult.error(f"Backtest task not found: {real_uuid}", code="NOT_FOUND")
 
             GLOG.INFO(f"Updated task {real_uuid[:8]}... status to: {status}")
 
@@ -356,7 +356,7 @@ class BacktestTaskService(BaseService):
 
         except Exception as e:
             GLOG.ERROR(f"Failed to update task status: {e}")
-            return ServiceResult.error(f"Failed to update task status: {str(e)}")
+            return ServiceResult.error(f"Failed to update task status: {str(e)}", code="UPDATE_FAILED")
 
     @retry(max_try=3)
     def delete(self, uuid: str) -> ServiceResult:

--- a/src/ginkgo/trading/analysis/backtest_result_aggregator.py
+++ b/src/ginkgo/trading/analysis/backtest_result_aggregator.py
@@ -136,9 +136,20 @@ class BacktestResultAggregator:
                 )
 
                 if not update_result.is_success():
-                    GLOG.ERROR(f"Failed to update backtest task: {update_result.error}")
-                    # 不返回错误，允许汇总继续完成（任务可能未预先创建）
-                    GLOG.WARN(f"Backtest task may not exist. Create it before running backtest.")
+                    code = getattr(update_result, "code", None)
+                    if code == "NOT_FOUND":
+                        # task 未预建：预期容许，汇总继续（不返 error 致回测误判 FAILED）
+                        GLOG.WARN(
+                            f"Backtest task not found (may not be pre-created); "
+                            f"status write skipped, aggregation continues: {update_result.error}"
+                        )
+                    else:
+                        # #6845: 真实 DB 故障（UPDATE_FAILED/异常）——不再误导为 "task 不存在"，
+                        # 准确归因 DB 失败。返回值仍 success（避免回测成功被标 FAILED 回归，
+                        # 见切片7 分析）；ERROR 已落库可见，task_processor 路径会同步 WARN。
+                        GLOG.ERROR(
+                            f"Backtest status write to DB failed (code={code}): {update_result.error}"
+                        )
 
             # 同步绩效指标到 MPortfolio
             try:

--- a/src/ginkgo/workers/backtest_worker/progress_tracker.py
+++ b/src/ginkgo/workers/backtest_worker/progress_tracker.py
@@ -22,6 +22,7 @@ from ginkgo.libs import GLOG
 from ginkgo.workers.backtest_worker.models import BacktestTask, EngineStage
 from ginkgo.data.drivers.ginkgo_kafka import GinkgoProducer
 from ginkgo.interfaces.kafka_topics import KafkaTopics
+from ginkgo.data.services.base_service import ServiceResult
 
 
 class ProgressTracker:
@@ -116,8 +117,8 @@ class ProgressTracker:
         )
         GLOG.INFO(f"[{task.task_uuid[:8]}] Reported completion")
 
-        # 更新数据库状态为 completed
-        self._write_status_to_db(task.task_uuid, "completed", result=result)
+        # 更新数据库状态为 completed（#6845: 传播回写结果，DB 失败不再 void 撒谎）
+        return self._write_status_to_db(task.task_uuid, "completed", result=result)
 
     def report_failed(self, task: BacktestTask, error: str):
         """上报失败"""
@@ -132,8 +133,8 @@ class ProgressTracker:
         )
         GLOG.ERROR(f"[{task.task_uuid[:8]}] Reported failure: {error}")
 
-        # 更新数据库状态为 failed
-        self._write_status_to_db(task.task_uuid, "failed", error_message=error)
+        # 更新数据库状态为 failed（#6845: 传播回写结果）
+        return self._write_status_to_db(task.task_uuid, "failed", error_message=error)
 
     def report_cancelled(self, task: BacktestTask):
         """上报取消"""
@@ -147,8 +148,8 @@ class ProgressTracker:
         )
         GLOG.INFO(f"[{task.task_uuid[:8]}] Reported cancellation")
 
-        # 更新数据库状态为 stopped
-        self._write_status_to_db(task.task_uuid, "stopped")
+        # 更新数据库状态为 stopped（#6845: 传播回写结果）
+        return self._write_status_to_db(task.task_uuid, "stopped")
 
     def report_failed_by_uuid(self, task_uuid: str, error: str):
         """通过 UUID 上报失败（无需完整 BacktestTask 对象）"""
@@ -164,8 +165,8 @@ class ProgressTracker:
         )
         GLOG.ERROR(f"[{short_uuid}] Reported failure by UUID: {error}")
 
-        # 更新数据库状态为 failed
-        self._write_status_to_db(task_uuid, "failed", error_message=error)
+        # 更新数据库状态为 failed（#6845: 传播回写结果）
+        return self._write_status_to_db(task_uuid, "failed", error_message=error)
 
     def _send_to_kafka(self, message: dict):
         """发送消息到Kafka"""
@@ -250,9 +251,24 @@ class ProgressTracker:
                 uuid=task_id, status=status, error_message=error_message, **result_fields  # task_id 与 uuid 等价
             )
             if not result_obj.is_success():
+                # #6845: 区分 NOT_FOUND（task 未预建，预期容许，body: 算预期容许）与真实 DB 失败
+                if getattr(result_obj, "code", None) == "NOT_FOUND":
+                    GLOG.WARN(
+                        f"Backtest task not found, status write skipped "
+                        f"(task may not be pre-created): {result_obj.message}"
+                    )
+                    return ServiceResult.success(
+                        message="Backtest task not found; status write skipped (tolerated)"
+                    )
                 GLOG.ERROR(f"Failed to write status to DB: {result_obj.message}")
+                # #6845: 回写失败须可见——返回 error 让调用方感知，不再 void 撒谎
+                return ServiceResult.error(f"Failed to write status to DB: {result_obj.message}")
+            # #6845: 回写成功须显式返回 success，使 report_* 传播统一契约（非隐式 None）
+            return ServiceResult.success(message="Status written to DB")
         except Exception as e:
             GLOG.ERROR(f"Error writing status to DB: {e}")
+            # #6845: DB 异常（抖动/连接断）同样须传播，不再被 except 吞成 void
+            return ServiceResult.error(f"Error writing status to DB: {e}")
 
     def get_task_status(self, task_uuid: str) -> Optional[str]:
         """

--- a/src/ginkgo/workers/backtest_worker/task_processor.py
+++ b/src/ginkgo/workers/backtest_worker/task_processor.py
@@ -32,6 +32,7 @@ from ginkgo import services
 from ginkgo.libs import GLOG, GinkgoLogger
 from ginkgo.trading.time.clock import now as clock_now
 from ginkgo.libs.core.logger import _trace_id_ctx
+from ginkgo.data.services.base_service import ServiceResult
 
 
 class BacktestProcessor(Thread):
@@ -132,9 +133,8 @@ class BacktestProcessor(Thread):
             self.task.completed_at = datetime.utcnow()
             self.task.result = result.data
 
-            self.progress_tracker.report_completed(self.task, None)
-            self._ingest_task_logs()
-            GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
+            # #6845: 完成上报据回写结果分级日志，不再无条件 'completed successfully' 撒谎
+            self._report_completion()
 
         except Exception as e:
             self._exception = e
@@ -148,6 +148,24 @@ class BacktestProcessor(Thread):
             GLOG.ERROR(traceback.format_exc())
         finally:
             GLOG.clear_context()
+
+    def _report_completion(self):
+        """上报完成并据回写结果分级日志（#6845: DB 失败不再无条件 'completed successfully' 撒谎）。
+
+        report_completed 返回 ServiceResult：
+        - success / NOT_FOUND 容错（progress_tracker 已转 success）→ INFO 'completed successfully'
+        - error（DB 故障，code=UPDATE_FAILED）→ WARN 回写失败（回测本身完成，但状态卡 DB，不再静默撒谎）
+        - None（旧契约/无 task_service）→ 保持 INFO，向后兼容
+        """
+        write_result = self.progress_tracker.report_completed(self.task, None)
+        self._ingest_task_logs()
+        if isinstance(write_result, ServiceResult) and not write_result.is_success():
+            GLOG.WARN(
+                f"[{self.task.task_uuid[:8]}] Backtest completed but status write to DB failed: "
+                f"{getattr(write_result, 'message', '')}"
+            )
+        else:
+            GLOG.INFO(f"[{self.task.task_uuid[:8]}] Backtest completed successfully")
 
     def _wait_for_engine_completion(self, timeout: float = 3600.0):
         """⚠️ 死代码（#6483）：无调用点。

--- a/tests/unit/data/test_backtest_task_service_code_6845.py
+++ b/tests/unit/data/test_backtest_task_service_code_6845.py
@@ -1,0 +1,50 @@
+"""#6845: BacktestTaskService.update_status 返回 code（方案B 契约级区分）。
+
+让 progress_tracker._write_status_to_db 能据 code 区分：
+- NOT_FOUND：task 未预建，预期容许（progress_tracker 转为 success 容错，body: 算预期容许）
+- UPDATE_FAILED：真实 DB 故障（progress_tracker 传播 error，可见不撒谎）
+- INVALID_STATUS：参数非法
+
+向后兼容：调用方不读 code，新增字段不影响既有调用。
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.data.services.backtest_task_service import BacktestTaskService
+
+
+def _mk_svc(crud_mock) -> BacktestTaskService:
+    """跳过 __init__ 的容器装配，仅注入 _crud_repo（update_status 唯一依赖）。"""
+    svc = BacktestTaskService.__new__(BacktestTaskService)
+    svc._crud_repo = crud_mock
+    return svc
+
+
+@pytest.mark.tdd
+class TestUpdateStatusReturnsCode_6845:
+    def test_not_found_returns_code(self):
+        """task 不存在 → code=NOT_FOUND（供 progress_tracker 容错判定）。"""
+        crud = MagicMock()
+        crud.get_by_uuid.return_value = None
+        crud.get_by_task_id.return_value = None
+        svc = _mk_svc(crud)
+        result = svc.update_status("nonexistent-uuid", "completed")
+        assert not result.is_success()
+        assert result.code == "NOT_FOUND", f"应返 NOT_FOUND，实际 {result.code!r}"
+
+    def test_db_failure_returns_code(self):
+        """DB 异常 → code=UPDATE_FAILED（供 progress_tracker 传播 error 判定）。"""
+        crud = MagicMock()
+        crud.get_by_uuid.side_effect = Exception("OperationalError: connection lost")
+        svc = _mk_svc(crud)
+        result = svc.update_status("some-uuid", "completed")
+        assert not result.is_success()
+        assert result.code == "UPDATE_FAILED", f"应返 UPDATE_FAILED，实际 {result.code!r}"
+
+    def test_invalid_status_returns_code(self):
+        """非法 status → code=INVALID_STATUS。"""
+        svc = _mk_svc(MagicMock())
+        result = svc.update_status("some-uuid", "bogus-status")
+        assert not result.is_success()
+        assert result.code == "INVALID_STATUS", f"应返 INVALID_STATUS，实际 {result.code!r}"

--- a/tests/unit/trading/analysis/test_backtest_result_aggregator_status_write_6845.py
+++ b/tests/unit/trading/analysis/test_backtest_result_aggregator_status_write_6845.py
@@ -1,0 +1,81 @@
+"""#6845: aggregator update_status 失败日志归因准确化。
+
+原 line 138-141 对所有 update_status 失败一律 WARN "Backtest task may not exist"，
+DB 真挂（code=UPDATE_FAILED）时误导操作者查"task 是否存在"而非查 DB——这才是
+aggregator 层的"撒谎"。返回值保持 success（避免 orchestrator 透传 error 致回测
+成功被标 FAILED 的回归，见 #6845 切片7 分析）；修的是日志措辞归因准确：
+- NOT_FOUND → WARN "task 未预建，容许"
+- UPDATE_FAILED → ERROR "DB 故障"（不再误导为 task 不存在）
+
+返回值改 error 的副作用已排除：orchestrator.run:338 透传 → task_processor run:127
+raise → 回测标 FAILED（成功被标失败）。故仅修日志，不动返回值契约。
+"""
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAggregator
+
+
+def _make_aggregator(update_return=None, update_side_effect=None):
+    task_svc = MagicMock()
+    if update_side_effect is not None:
+        task_svc.update_status.side_effect = update_side_effect
+    else:
+        task_svc.update_status.return_value = update_return
+    agg = BacktestResultAggregator(analyzer_service=MagicMock(), backtest_task_service=task_svc)
+    # 绕过 analyzer 读取（ClickHouse），聚焦 update_status 失败分支
+    agg._aggregate_metrics = lambda *a, **k: {}
+    agg._aggregate_stats = lambda *a, **k: {}
+    return agg
+
+
+def _kill_portfolio_sync(monkeypatch):
+    """绕过 container.portfolio_service.update_performance（聚合副作用，与 status 无关）。"""
+    portfolio_svc = MagicMock()
+    portfolio_svc.update_performance.return_value = ServiceResult.success()
+    boom = types.SimpleNamespace(portfolio_service=lambda: portfolio_svc)
+    monkeypatch.setattr("ginkgo.data.containers.container", boom)
+
+
+@pytest.mark.tdd
+class TestAggregatorStatusWriteLogAttribution_6845:
+    def test_not_found_logs_warn_and_returns_success(self, monkeypatch):
+        """NOT_FOUND → WARN 'task 未预建'，返回 success（容许，不标回测失败）。"""
+        agg = _make_aggregator(ServiceResult.error("Backtest task not found: t1", code="NOT_FOUND"))
+        glog = MagicMock()
+        monkeypatch.setattr("ginkgo.trading.analysis.backtest_result_aggregator.GLOG", glog)
+        _kill_portfolio_sync(monkeypatch)
+
+        result = agg.aggregate_and_save(task_id="t1", portfolio_id="p1", engine_id="e1", status="completed")
+
+        assert result.is_success(), "NOT_FOUND 应容许返 success（不引回测误判回归）"
+        warns = [c.args[0] for c in glog.WARN.call_args_list]
+        assert any("not found" in w.lower() or "pre-created" in w.lower() for w in warns), (
+            f"NOT_FOUND 应 WARN task 未预建，got {warns}"
+        )
+
+    def test_update_failed_logs_db_error_not_misleading(self, monkeypatch):
+        """UPDATE_FAILED → ERROR 'DB 故障'，不再误导 WARN 'task may not exist'。"""
+        agg = _make_aggregator(
+            ServiceResult.error("OperationalError: connection lost", code="UPDATE_FAILED")
+        )
+        glog = MagicMock()
+        monkeypatch.setattr("ginkgo.trading.analysis.backtest_result_aggregator.GLOG", glog)
+        _kill_portfolio_sync(monkeypatch)
+
+        result = agg.aggregate_and_save(task_id="t1", portfolio_id="p1", engine_id="e1", status="completed")
+
+        assert result.is_success(), "返回值保持 success（避免回测成功被标 FAILED 回归）"
+        errors = [c.args[0] for c in glog.ERROR.call_args_list]
+        warns = [c.args[0] for c in glog.WARN.call_args_list]
+        # DB 故障归因到 ERROR（含 DB/status write 语义）
+        assert any("db" in e.lower() or "status write" in e.lower() for e in errors), (
+            f"UPDATE_FAILED 应 ERROR DB 故障，got errors={errors}"
+        )
+        # 不再误导为 "task may not exist"（那是 NOT_FOUND 的措辞）
+        assert not any("may not exist" in w.lower() for w in warns), (
+            f"UPDATE_FAILED 不应误导为 'task 不存在'，got warns={warns}"
+        )

--- a/tests/unit/workers/test_progress_tracker_status_write_6845.py
+++ b/tests/unit/workers/test_progress_tracker_status_write_6845.py
@@ -1,0 +1,97 @@
+"""#6845: 回测状态回写失败可见——不再撒谎。
+
+_progress_tracker._write_status_to_db_ 当前 void + 双吞，DB 写失败时
+report_completed 返回 None，调用方无法感知。本组测试要求：
+
+- _write_status_to_db 返回 ServiceResult，report_* 传播之
+- DB 异常（update_status 返 code=UPDATE_FAILED 或抛异常）→ 返回 error
+- task 不存在（code=NOT_FOUND）→ 静默容错，返回 success（body: 算预期容许）
+- 正常 success → 返回 success
+
+通过 public report_* 接口验证行为（非私有实现细节）。
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ginkgo.data.services.base_service import ServiceResult
+from ginkgo.workers.backtest_worker.models import BacktestTask
+from ginkgo.workers.backtest_worker.progress_tracker import ProgressTracker
+
+T = "8b7b8cd8d69444db9a59e01862e601d6"
+
+
+def _mk_tracker(update_return=None, update_side_effect=None) -> tuple:
+    task = BacktestTask(task_uuid=T, portfolio_uuid="P", name="n", config=None)
+    task.completed_at = None
+    svc = MagicMock()
+    if update_side_effect is not None:
+        svc.update_status.side_effect = update_side_effect
+    else:
+        svc.update_status.return_value = update_return
+    tracker = ProgressTracker(worker_id="w1", kafka_producer=MagicMock(), task_service=svc)
+    return tracker, task
+
+
+@pytest.mark.tdd
+class TestReportCompletedPropagatesStatusWrite_6845:
+    """#6845: report_completed 传播状态回写结果，不再 void 撒谎。"""
+
+    def test_db_failure_returns_error(self):
+        """DB 异常（update_status 返 code=UPDATE_FAILED）→ report_completed 返回 error。"""
+        tracker, task = _mk_tracker(
+            ServiceResult.error("Failed to update task status: boom", code="UPDATE_FAILED")
+        )
+        with patch("requests.post"):
+            result = tracker.report_completed(task, result=None)
+        assert result is not None, "应返回 ServiceResult，不再 void"
+        assert isinstance(result, ServiceResult)
+        assert not result.is_success(), "DB 失败应返回 error，而非 void 撒谎"
+
+    def test_not_found_returns_success(self):
+        """task 不存在（code=NOT_FOUND）→ 静默容错返回 success（body: 算预期容许）。"""
+        tracker, task = _mk_tracker(
+            ServiceResult.error("Backtest task not found: " + T, code="NOT_FOUND")
+        )
+        with patch("requests.post"):
+            result = tracker.report_completed(task, result=None)
+        assert result is not None, "应返回 ServiceResult"
+        assert isinstance(result, ServiceResult)
+        assert result.is_success(), "task 不存在属预期容许（未预建），应 success 非 error"
+
+    def test_success_returns_success(self):
+        """回写成功 → report_completed 返回 success。"""
+        tracker, task = _mk_tracker(ServiceResult.success(message="updated"))
+        with patch("requests.post"):
+            result = tracker.report_completed(task, result=None)
+        assert isinstance(result, ServiceResult), "应返回 ServiceResult"
+        assert result.is_success(), "回写成功应返回 success"
+
+
+@pytest.mark.tdd
+class TestReportFailedCancelledPropagate_6845:
+    """#6845: report_failed/report_cancelled 与 report_completed 对称传播回写结果。"""
+
+    def test_report_failed_propagates_db_failure(self):
+        """report_failed 的 DB 写失败须传播，不再 void（失败上报丢失致 task 卡 running）。"""
+        tracker, task = _mk_tracker(ServiceResult.error("boom", code="UPDATE_FAILED"))
+        with patch("requests.post"):
+            result = tracker.report_failed(task, "some error")
+        assert isinstance(result, ServiceResult), "应返回 ServiceResult，不再 void"
+        assert not result.is_success(), "report_failed 应传播 DB 失败"
+
+    def test_report_cancelled_propagates_db_failure(self):
+        """report_cancelled 的 DB 写失败须传播（取消上报丢失致 task 卡 running/cancelled 不一致）。"""
+        tracker, task = _mk_tracker(ServiceResult.error("boom", code="UPDATE_FAILED"))
+        with patch("requests.post"):
+            result = tracker.report_cancelled(task)
+        assert isinstance(result, ServiceResult), "应返回 ServiceResult，不再 void"
+        assert not result.is_success(), "report_cancelled 应传播 DB 失败"
+
+    def test_report_failed_by_uuid_propagates_db_failure(self):
+        """report_failed_by_uuid（node.py 畸形 payload 路径，活调用）DB 写失败须传播。"""
+        tracker, _ = _mk_tracker(ServiceResult.error("boom", code="UPDATE_FAILED"))
+        with patch("requests.post"):
+            result = tracker.report_failed_by_uuid(T, "some error")
+        assert isinstance(result, ServiceResult), "应返回 ServiceResult，不再 void"
+        assert not result.is_success(), "report_failed_by_uuid 应传播 DB 失败"

--- a/tests/unit/workers/test_task_processor_error_logging.py
+++ b/tests/unit/workers/test_task_processor_error_logging.py
@@ -17,6 +17,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from ginkgo.data.services.base_service import ServiceResult
+
 try:
     from ginkgo.workers.backtest_worker.task_processor import BacktestProcessor
     from ginkgo.workers.backtest_worker.models import BacktestTask, BacktestConfig
@@ -139,3 +141,47 @@ class TestAggregateResultsRoutesTracebackToGlog:
         assert any("Traceback" in m for m in errors), (
             f"GLOG.ERROR 未收到 traceback，收到: {errors}"
         )
+
+
+@pytest.mark.skipif(not HAS_MODULE, reason="BacktestProcessor not available")
+@pytest.mark.tdd
+class TestReportCompletionHonorsStatusWrite_6845:
+    """#6845: 完成上报据回写结果分级日志，DB 失败不再无条件 'completed successfully' 撒谎。"""
+
+    def test_logs_completed_when_write_succeeds(self, monkeypatch):
+        cfg = _full_backtest_config()
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+        proc._ingest_task_logs = MagicMock()  # 避免真实 LogIngester 灌库
+        proc.progress_tracker.report_completed.return_value = ServiceResult.success(message="ok")
+
+        infos = []
+        spy = types.SimpleNamespace(
+            WARN=lambda msg: None, ERROR=lambda msg: None,
+            INFO=lambda msg: infos.append(msg), DEBUG=lambda msg: None,
+        )
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.GLOG", spy)
+
+        proc._report_completion()
+
+        assert proc.progress_tracker.report_completed.called
+        assert any("completed successfully" in m for m in infos), f"应打 completed，got {infos}"
+
+    def test_warns_when_write_fails(self, monkeypatch):
+        cfg = _full_backtest_config()
+        task = BacktestTask.create(portfolio_uuid="ptid", name="t", config=cfg)
+        proc = _make_processor(task)
+        proc._ingest_task_logs = MagicMock()
+        proc.progress_tracker.report_completed.return_value = ServiceResult.error("boom", code="UPDATE_FAILED")
+
+        warns, infos = [], []
+        spy = types.SimpleNamespace(
+            WARN=lambda msg: warns.append(msg), ERROR=lambda msg: None,
+            INFO=lambda msg: infos.append(msg), DEBUG=lambda msg: None,
+        )
+        monkeypatch.setattr("ginkgo.workers.backtest_worker.task_processor.GLOG", spy)
+
+        proc._report_completion()
+
+        assert any("status write" in m.lower() for m in warns), f"应 WARN 回写失败，got {warns}"
+        assert not any("completed successfully" in m for m in infos), "DB 失败不应撒谎打 completed"


### PR DESCRIPTION
## 背景

回测状态回写（`update_status`）失败被三层掩盖，DB 抖动时"撒谎"——日志报成功、返回 success、状态卡 DB 无告警。本 PR 让回写失败**可见**且**不再撒谎**。

## 改动（方案B 契约级 code 区分，ADR-021）

| 层 | 原行为 | 修复 |
|---|---|---|
| `update_status` | error 仅 message | 返 `code`: NOT_FOUND / UPDATE_FAILED / INVALID_STATUS |
| `_write_status_to_db` | void（返 None） | 据 code 分流：NOT_FOUND 容许→success / UPDATE_FAILED→传播 error |
| `report_*` | void | 传播 ServiceResult |
| `task_processor` | 无视返回 + 无条件 `'completed successfully'` | `_report_completion` 分级日志（成功 INFO / 失败 WARN） |
| `aggregator` | 一律 WARN `'task may not exist'` | 据 code 归因：NOT_FOUND 容许 / UPDATE_FAILED 准确报 DB 故障 |

## 设计决策：aggregator 返回值保持 success

aggregator 的 `update_status` 失败若返 error → `orchestrator.run` 透传 → `task_processor run:127` raise → **回测成功被标 FAILED**（业务误导回归）。

故 aggregator 仅修**日志归因**（UPDATE_FAILED 不再误导为 "task 不存在"），不动返回值契约。可见性由双路保证：
- task_processor 路径（`report_completed`→WARN，DB 失败可见）
- aggregator ERROR（DB 故障准确归因）

NOT_FOUND 在两层都容许（task 未预建属预期，回测 CLI 直跑等场景）。

## 测试

7 切片 TDD，全 GREEN，18 passed：
- progress_tracker `report_*` 传播（6）
- `update_status` code（3）
- task_processor `_report_completion` 分级日志（2）
- aggregator code 归因（2）
- progress_tracker 既有回归（5）

`py_compile` + import 链 OK。

Closes #6845
