### PR TITLE
refactor(base_crud): find 默认「最新在最前」+ order_by -前缀归一

### DIFF
--- a/src/ginkgo/data/crud/base_crud.py
+++ b/src/ginkgo/data/crud/base_crud.py
@@ -260,8 +260,11 @@ class _CoreCRUD(Generic[T], ABC):
             page_size: Number of items per page;底层即 SQL LIMIT（page 缺省时
                 等价 LIMIT page_size）。优先用此参数在 DB 层截断，避免取全量后
                 Python 切片（反模式，见 issue #6572 与 PR #6561 讨论）
-            order_by: Field name to order by
-            desc_order: Whether to use descending order
+            order_by: Field name to order by；支持 ``-`` 前缀表倒序（如
+                ``"-end_time"`` 等价 ``order_by="end_time", desc_order=True``）。
+                缺省时按默认序「最新在最前」：时序模型（含 ``business_timestamp``）
+                按业务时间倒序，关系模型按 ``create_at`` 倒序（见 #6884）。
+            desc_order: Whether to use descending order（显式 order_by 时生效）
             distinct_field: Field name for DISTINCT query (returns unique values of this field)
             session: Optional SQLAlchemy session to use for the operation.
 
@@ -509,6 +512,38 @@ class _CoreCRUD(Generic[T], ABC):
         GLOG.DEBUG(f"Added {len(converted_items)} {self.model_class.__name__} items in batch")
         return result
 
+    def _resolve_order(
+        self,
+        order_by: Optional[str],
+        desc_order: bool,
+    ) -> tuple:
+        """解析排序字段与方向，返回 (字段属性 or None, 是否倒序)。
+
+        - ``order_by`` 带 ``-`` 前缀（如 ``"-end_time"``）→ 倒序，前缀剥离后须为模型字段
+          （历史 bug：``hasattr(model, "-end_time")`` 恒 False → 倒序被静默忽略，见 #6884）
+        - ``order_by`` 显式给出且为模型字段 → 按其排序，方向由 ``desc_order`` 决定
+        - ``order_by`` 缺省 → 回退默认序「最新在最前」：时序模型按 ``business_timestamp``，
+          关系模型按 ``create_at``，二者皆无则不排序（保持旧行为）
+        - 显式给出但字段不存在 → WARNING 并回退默认序（typo 的响亮报错留给 #6885）
+        """
+        # 1. 显式 order_by（含 - 前缀归一）
+        if order_by:
+            negated = order_by.startswith("-")
+            field_name = order_by[1:] if negated else order_by
+            is_desc = desc_order or negated
+            if hasattr(self.model_class, field_name):
+                return getattr(self.model_class, field_name), is_desc
+            GLOG.WARNING(
+                f"order_by field '{order_by}' not on "
+                f"{self.model_class.__name__}; falling back to default order"
+            )
+        # 2. 默认序：最新在最前（business_timestamp → create_at → 无）
+        if hasattr(self.model_class, "business_timestamp"):
+            return getattr(self.model_class, "business_timestamp"), True
+        if hasattr(self.model_class, "create_at"):
+            return getattr(self.model_class, "create_at"), True
+        return None, True
+
     def _do_find(
         self,
         filters: Optional[Dict[str, Any]] = None,
@@ -570,13 +605,12 @@ class _CoreCRUD(Generic[T], ABC):
                 if filter_conditions:
                     query = query.filter(and_(*filter_conditions))
 
-            # Apply ordering
-            if order_by and hasattr(self.model_class, order_by):
-                order_field = getattr(self.model_class, order_by)
-                if desc_order:
-                    query = query.order_by(order_field.desc())
-                else:
-                    query = query.order_by(order_field)
+            # Apply ordering（默认「最新在最前」，见 _resolve_order / #6884）
+            order_field_attr, order_desc = self._resolve_order(order_by, desc_order)
+            if order_field_attr is not None:
+                query = query.order_by(
+                    order_field_attr.desc() if order_desc else order_field_attr
+                )
 
             # Apply pagination
             if page_size is not None:

--- a/tests/unit/data/crud/test_base_crud_resolve_order.py
+++ b/tests/unit/data/crud/test_base_crud_resolve_order.py
@@ -1,0 +1,119 @@
+"""
+BaseCRUD._resolve_order 单元测试（#6884：find 默认「最新在最前」+ ``-`` 前缀归一）
+
+_resolve_order 是纯函数（仅 touch self.model_class + 模块级 GLOG），用 SimpleNamespace
+造假 self、真 Python 类造假 model（避开 MagicMock 对任意属性 hasattr 恒 True 的陷阱）。
+无需 DB。
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from unittest.mock import patch
+
+from ginkgo.data.crud.base_crud import BaseCRUD
+
+
+# 假 model：用类属性模拟 SQLAlchemy mapped_column（hasattr/getattr 语义一致）
+class _TimeSeriesModel:
+    """时序模型：含 business_timestamp（优先）+ create_at + end_time"""
+
+    business_timestamp = "BT_SENTINEL"
+    create_at = "CA_SENTINEL"
+    end_time = "ET_SENTINEL"
+
+
+class _RelationModel:
+    """关系模型：仅 create_at（无 business_timestamp）"""
+
+    create_at = "CA_SENTINEL"
+
+
+class _BareModel:
+    """既无 business_timestamp 也无 create_at（如部分 ClickHouse 时序表）"""
+
+    pass
+
+
+def _crud(model_cls):
+    return SimpleNamespace(model_class=model_cls)
+
+
+class TestResolveOrder:
+    """_resolve_order：默认序 + ``-`` 前缀 + 显式序 + 未知字段回退"""
+
+    @pytest.mark.unit
+    def test_default_timeseries_prefers_business_timestamp_desc(self):
+        """缺省 order_by + 时序模型 → business_timestamp 倒序（最新在最前）"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_TimeSeriesModel), None, False)
+        assert attr is _TimeSeriesModel.business_timestamp
+        assert desc is True
+
+    @pytest.mark.unit
+    def test_default_relation_falls_back_to_create_at_desc(self):
+        """缺省 order_by + 关系模型（无 business_timestamp）→ create_at 倒序"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_RelationModel), None, False)
+        assert attr is _RelationModel.create_at
+        assert desc is True
+
+    @pytest.mark.unit
+    def test_default_bare_model_no_order(self):
+        """缺省 order_by + 模型无任何时间戳字段 → 不排序（保持旧行为）"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_BareModel), None, False)
+        assert attr is None
+        assert desc is True
+
+    @pytest.mark.unit
+    def test_dash_prefix_recognized_as_desc(self):
+        """``order_by="-end_time"`` → 剥离 ``-``、按 end_time 倒序
+
+        历史 bug（#6884）：旧代码 ``hasattr(model, "-end_time")`` 恒 False →
+        倒序被静默忽略，``backtest_task_crud.get_completed_tasks`` 的「倒序」是假的。
+        """
+        attr, desc = BaseCRUD._resolve_order(_crud(_TimeSeriesModel), "-end_time", False)
+        assert attr is _TimeSeriesModel.end_time
+        assert desc is True
+
+    @pytest.mark.unit
+    def test_explicit_order_asc(self):
+        """显式 order_by + desc_order=False → 升序"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_TimeSeriesModel), "end_time", False)
+        assert attr is _TimeSeriesModel.end_time
+        assert desc is False
+
+    @pytest.mark.unit
+    def test_explicit_order_desc(self):
+        """显式 order_by + desc_order=True → 倒序"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_TimeSeriesModel), "end_time", True)
+        assert attr is _TimeSeriesModel.end_time
+        assert desc is True
+
+    @pytest.mark.unit
+    def test_dash_prefix_wins_when_desc_order_false(self):
+        """``-`` 前缀与 desc_order=False 冲突时，``-`` 前缀取胜（显式倒序意图）"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_TimeSeriesModel), "-end_time", False)
+        assert desc is True
+
+    @pytest.mark.unit
+    @patch("ginkgo.data.crud.base_crud.GLOG")
+    def test_unknown_field_warns_and_falls_back_to_default(self, mock_glog):
+        """显式 order_by 但字段不存在 → WARNING + 回退默认序
+
+        typo 的响亮 raise 留给 #6885（filter 字段对称收口）；此处先回退默认序，
+        避免静默无序（旧行为）也比假装排了序诚实。
+        """
+        attr, desc = BaseCRUD._resolve_order(
+            _crud(_TimeSeriesModel), "nonexistent_field", False
+        )
+        assert attr is _TimeSeriesModel.business_timestamp  # 回退默认序
+        assert desc is True
+        assert mock_glog.WARNING.called
+
+    @pytest.mark.unit
+    @patch("ginkgo.data.crud.base_crud.GLOG")
+    def test_unknown_field_on_bare_model_no_order(self, mock_glog):
+        """显式未知字段 + 模型无默认序字段 → 仍 WARNING，返回 (None, True)"""
+        attr, desc = BaseCRUD._resolve_order(_crud(_BareModel), "nonexistent", False)
+        assert attr is None
+        assert desc is True
+        assert mock_glog.WARNING.called


### PR DESCRIPTION
Closes #6884 ｜ Epic #6849（BaseCRUD interface 诚实收口，方向 1）

## 改动

`BaseCRUD._do_find` 缺省 `order_by` 时不再无序（静默取最旧），改为默认「最新在最前」：
- 时序模型（含 `business_timestamp`）→ 按业务时间倒序
- 关系模型 → 按 `create_at` 倒序
- 二者皆无 → 不排序（保持旧行为）

`order_by` 带 `-` 前缀（如 `"-end_time"`）现正确识别为倒序——此前 `hasattr(model, "-end_time")` 恒 `False`，倒序被静默忽略（`backtest_task_crud.get_completed_tasks` 的「倒序」是假的）。

抽出 `_resolve_order` 收口排序解析：显式序 / `-` 前缀 / 默认序 / 未知字段 WARNING 回退。

## 授权

用户明确授权「直接改 BaseCRUD」（解除 CLAUDE.md「禁改 Base 类」对本条适用，先例 ADR-031）。ADR 记录留 #6883。

## 爆炸半径评估

401 个 `find()` 调用点；行为变更仅影响「依赖取最旧 / 对序无感」的调用方。审计 `find()[0]` 调用点：绝大多数是唯一键查找（uuid/code/task_id，`[0]` 与序无关，安全）；`backtest_task get_by_task_id/get_by_uuid` 唯一匹配不受影响；本改动把「隐式取最新」的语义 bug 修正（这些调用方本就想要最新）。

## 验证

- 新增 `_resolve_order` 单测 9 项全过（默认序/`-`前缀/显式序/未知字段回退）
- `tests/unit/data/crud/` 633 passed；10 failed 经 stash 比对**全部既有**（零回归）
- CI smoke 三件套（user_crud_mock + containers import + user_cli）37 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)