### PR TITLE
fix(paper): position 持久化改 Position 实体契约(各层原生类型,修持仓静默丢失)

### DIFF
--- a/src/ginkgo/data/services/portfolio_service.py
+++ b/src/ginkgo/data/services/portfolio_service.py
@@ -371,19 +371,19 @@ class PortfolioService(BaseService):
 
         Args:
             portfolio_id: 投资组合UUID
-            state: snapshot_state() 返回的状态字典
+            state: snapshot_state() 返回的状态字典（positions 为 Position 实体列表）
 
         Returns:
             ServiceResult
         """
         try:
             from decimal import Decimal
+            from ginkgo.data.mappers import PositionMapper
 
             # 1. 更新 portfolio 表的运行时字段
             positions = state.get("positions", [])
             position_value = sum(
-                Decimal(p.get("price", 0)) * int(p.get("volume", 0))
-                for p in positions
+                Decimal(p.price) * int(p.volume) for p in positions
             )
             current_capital = Decimal(state["cash"]) + Decimal(state["frozen"]) + position_value
 
@@ -397,11 +397,12 @@ class PortfolioService(BaseService):
             }
             self._crud_repo.modify(filters={"uuid": portfolio_id}, updates=portfolio_updates)
 
-            # 2. 全量替换 position 表（通过 CRUD 层 batch_create）
+            # 2. 全量替换 position 表：Position 实体 → MPosition（DB 边界转换，ADR-010）
             if positions:
+                m_positions = [PositionMapper.entity_to_model(p) for p in positions]
                 position_crud = self._get_position_crud()
                 position_crud.delete_by_portfolio(portfolio_id)
-                position_crud.batch_create(positions)
+                position_crud.batch_create(m_positions)
 
             GLOG.INFO(
                 f"Persisted state for portfolio {portfolio_id[:8]}: "
@@ -423,9 +424,11 @@ class PortfolioService(BaseService):
             portfolio_id: 投资组合UUID
 
         Returns:
-            ServiceResult: data 为 state dict（兼容 restore_state()）
+            ServiceResult: data 为 state dict（兼容 restore_state()，positions 为 Position 实体列表）
         """
         try:
+            from ginkgo.data.mappers import PositionMapper
+
             # 1. 读取 portfolio 表的运行时字段
             portfolios = self._crud_repo.find(filters={"uuid": portfolio_id})
             if not portfolios:
@@ -433,37 +436,19 @@ class PortfolioService(BaseService):
 
             p = portfolios[0]
 
-            # 2. 读取 position 表的持仓快照
+            # 2. 读取 position 表的持仓快照 → Position 实体（DB 边界转换，ADR-010）
             position_crud = self._get_position_crud()
             m_positions = position_crud.find(filters={"portfolio_id": portfolio_id})
+            positions = PositionMapper.models_to_entities(m_positions)
 
-            positions_data = []
-            for m_pos in m_positions:
-                positions_data.append({
-                    "portfolio_id": m_pos.portfolio_id,
-                    "engine_id": m_pos.engine_id,
-                    "task_id": m_pos.task_id,
-                    "code": m_pos.code,
-                    "cost": str(m_pos.cost),
-                    "volume": m_pos.volume,
-                    "frozen_volume": m_pos.frozen_volume,
-                    "settlement_frozen_volume": m_pos.settlement_frozen_volume,
-                    "settlement_days": m_pos.settlement_days,
-                    "settlement_queue_json": m_pos.settlement_queue_json,
-                    "frozen_money": str(m_pos.frozen_money),
-                    "price": str(m_pos.price),
-                    "fee": str(m_pos.fee),
-                    "uuid": m_pos.uuid,
-                })
-
-            has_state = float(p.cash) > 0 or len(positions_data) > 0
+            has_state = float(p.cash) > 0 or len(positions) > 0
 
             et = p.engine_current_time
             return ServiceResult.success({
                 "cash": str(p.cash),
                 "frozen": str(p.frozen),
                 "fee": str(p.total_fee),
-                "positions": positions_data,
+                "positions": positions,
                 "has_state": has_state,
                 # #6159: 返回引擎时间，worker 据此判定是否进入 REPLAY 快进历史
                 "engine_current_time": et.isoformat() if et else None,
@@ -478,15 +463,16 @@ class PortfolioService(BaseService):
         获取 Portfolio 的当前持仓快照（#5783 验收2）。
 
         数据层 PositionCRUD.find_by_portfolio / get_active_positions 早已存在，
-        本方法在 service 层接线并按 load_persisted_state 既有形状序列化，
-        供 GET /portfolios/{uuid}/positions 端点使用。
+        本方法在 service 层接线为 WebUI 序列化（GET /portfolios/{uuid}/positions）。
+        此处 dict 形状为本端点自有契约，与 persist/load 路径（DB 边界走 Position
+        实体，见 ADR-010）相互独立。
 
         Args:
             portfolio_id: 投资组合UUID
             active_only: True 仅返回 volume>0 的活跃持仓
 
         Returns:
-            ServiceResult: data 为持仓 dict 列表（字段对齐 load_persisted_state:425-440）
+            ServiceResult: data 为持仓 dict 列表（WebUI 端点 JSON 契约）
         """
         try:
             position_crud = self._get_position_crud()

--- a/src/ginkgo/trading/bases/portfolio_base.py
+++ b/src/ginkgo/trading/bases/portfolio_base.py
@@ -834,74 +834,40 @@ class PortfolioBase(TimeMixin, ContextMixin, EngineBindableMixin, SubscribableMi
 
     def snapshot_state(self) -> dict:
         """
-        序列化运行时状态，用于持久化到数据库。
+        序列化运行时状态（进程内 handoff，供 worker→service 持久化）。
+
+        positions 直接携带 Position 实体（trading 层原生类型），由 service 层在
+        DB 边界用 PositionMapper.entity_to_model 转 MPosition——不在此处构造 ORM、
+        不展开 dict key（ADR-010 entity/model 分层，避免 dict key 漂移导致持仓静默丢失）。
+        外层 cash/frozen/fee 走 str(Decimal) 便于日志可读。
 
         Returns:
-            dict: 包含 cash, frozen, fee, positions 的状态字典
+            dict: cash/frozen/fee 标量 + positions: List[Position]
         """
-        positions_data = []
-        for code, pos in self._positions.items():
-            from ginkgo.data.mappers import PositionMapper
-            model = PositionMapper.entity_to_model(pos)
-            positions_data.append({
-                "portfolio_id": model.portfolio_id,
-                "engine_id": model.engine_id,
-                "task_id": model.task_id,
-                "code": model.code,
-                "cost": model.cost,
-                "volume": model.volume,
-                "frozen_volume": model.frozen_volume,
-                "settlement_frozen_volume": model.settlement_frozen_volume,
-                "settlement_days": model.settlement_days,
-                "settlement_queue_json": model.settlement_queue_json,
-                "frozen_money": model.frozen_money,
-                "price": model.price,
-                "fee": model.fee,
-                "uuid": model.uuid,
-            })
-
         return {
             "cash": str(self._cash),
             "frozen": str(self._frozen),
             "fee": str(self._fee),
-            "positions": positions_data,
+            "positions": list(self._positions.values()),
         }
 
     def restore_state(self, state: dict) -> None:
         """
         从快照恢复运行时状态（直接设内部字段，不发事件，不写 DB）。
 
+        positions 已是 Position 实体（load_persisted_state 在 DB 边界用
+        PositionMapper.model_to_entity 还原），直接装回 self._positions。
+
         Args:
-            state: snapshot_state() 返回的状态字典
+            state: load_persisted_state 返回的状态字典（兼容 snapshot_state 形状）
         """
         self._cash = Decimal(state["cash"])
         self._frozen = Decimal(state["frozen"])
         self._fee = Decimal(state["fee"])
-        self._positions = {}
 
-        for p_dict in state.get("positions", []):
-            # 利用 MPosition 的 update 方法，再通过 PositionMapper.model_to_entity 转换
-            from ginkgo.data.models import MPosition
-            from ginkgo.data.mappers import PositionMapper
-            m_pos = MPosition()
-            m_pos.update(
-                p_dict["portfolio_id"],
-                p_dict["engine_id"],
-                p_dict.get("task_id", ""),
-                code=p_dict["code"],
-                cost=p_dict["cost"],
-                volume=p_dict["volume"],
-                frozen_volume=p_dict["frozen_volume"],
-                settlement_frozen_volume=p_dict["settlement_frozen_volume"],
-                settlement_days=p_dict["settlement_days"],
-                settlement_queue_json=p_dict["settlement_queue_json"],
-                frozen_money=p_dict["frozen_money"],
-                price=p_dict["price"],
-                fee=p_dict["fee"],
-            )
-            m_pos.uuid = p_dict.get("uuid", "")
-            pos = PositionMapper.model_to_entity(m_pos)
-            self._positions[p_dict["code"]] = pos
+        self._positions = {}
+        for pos in state.get("positions", []):
+            self._positions[pos.code] = pos
 
         self.update_worth()
         self.update_profit()

--- a/tests/unit/data/services/test_portfolio_service_mock.py
+++ b/tests/unit/data/services/test_portfolio_service_mock.py
@@ -542,41 +542,30 @@ class TestPersistState:
     """persist_state 应通过 position_crud.add_batch 替代手动 MPosition 构造"""
 
     def _make_state(self):
+        # G：snapshot 的 positions 携带 Position 实体（trading 层原生类型），
+        # service 在 DB 边界用 entity_to_model 转 MPosition——不再用 dict key 契约。
+        from decimal import Decimal
+        from ginkgo.entities import Position
+
+        def _pos(code, cost, volume, price, fee, task_id="task-001"):
+            return Position(
+                portfolio_id="port-001",
+                engine_id="eng-001",
+                task_id=task_id,
+                code=code,
+                cost=Decimal(cost),
+                volume=volume,
+                price=Decimal(price),
+                fee=Decimal(fee),
+            )
+
         return {
             "cash": "500000",
             "frozen": "0",
             "fee": "100",
             "positions": [
-                {
-                    "portfolio_id": "port-001",
-                    "engine_id": "eng-001",
-                    "task_id": "task-001",
-                    "code": "000001.SZ",
-                    "cost": "10.50",
-                    "volume": 100,
-                    "frozen_volume": 0,
-                    "settlement_frozen_volume": 0,
-                    "settlement_days": 0,
-                    "settlement_queue_json": "[]",
-                    "frozen_money": "0",
-                    "price": "11.00",
-                    "fee": "5.25",
-                },
-                {
-                    "portfolio_id": "port-001",
-                    "engine_id": "eng-001",
-                    "task_id": "",
-                    "code": "600000.SH",
-                    "cost": "20.00",
-                    "volume": 50,
-                    "frozen_volume": 0,
-                    "settlement_frozen_volume": 0,
-                    "settlement_days": 0,
-                    "settlement_queue_json": "[]",
-                    "frozen_money": "0",
-                    "price": "21.00",
-                    "fee": "10.50",
-                },
+                _pos("000001.SZ", "10.50", 100, "11.00", "5.25"),
+                _pos("600000.SH", "20.00", 50, "21.00", "10.50"),
             ],
         }
 
@@ -686,6 +675,44 @@ class TestPersistState:
 
         assert result.is_success()
         assert result.data.get("engine_current_time") is None
+
+    @pytest.mark.unit
+    def test_load_returns_position_entities(self, service, mock_deps):
+        """load 须在 DB 边界把 MPosition 还原为 Position 实体（G：snapshot 携带 Position）。
+
+        restore_state 期望 positions 为 Position 实体（直接装回 self._positions，
+        取 pos.code 作 key），故 load 端须用 PositionMapper.model_to_entity 还原；
+        返 dict 则 restore_state 取 pos.code 崩。回归 #6890 持仓持久化丢失。
+        """
+        from decimal import Decimal
+        from ginkgo.entities import Position
+        mock_portfolio = MagicMock()
+        mock_portfolio.cash = "500000"
+        mock_portfolio.frozen = "0"
+        mock_portfolio.total_fee = "100"
+        mock_portfolio.engine_current_time = None
+        mock_deps["crud_repo"].find.return_value = [mock_portfolio]
+
+        from ginkgo.data.models import MPosition
+        m_pos = MPosition()
+        m_pos.update(
+            "port-001", "eng-001", "task-001",
+            code="000001.SZ", cost=Decimal("10.50"), volume=100,
+            price=Decimal("11.00"), fee=Decimal("5"),
+        )
+        m_pos.uuid = "u1"
+        mock_position_crud = MagicMock()
+        mock_position_crud.find.return_value = [m_pos]
+
+        with patch.object(service, "_get_position_crud", return_value=mock_position_crud):
+            result = service.load_persisted_state("port-001")
+
+        assert result.is_success()
+        positions = result.data["positions"]
+        assert len(positions) == 1
+        assert isinstance(positions[0], Position), "load 须还原 Position 实体供 restore_state"
+        assert positions[0].code == "000001.SZ"
+        assert positions[0].volume == 100
 
 
 # ============================================================


### PR DESCRIPTION
## 问题

`PortfolioService.persist_portfolio_state` 收 `PortfolioBase.snapshot_state()` 的 state。旧 dict 契约下,`snapshot_state` 把每个 Position 展成 14-key dict,`persist_portfolio_state` 把 **dict 列表直传** `position_crud.batch_create(positions)`——而 CRUD `_convert_input_item` 只认 Model 实例(model_class),**dict 被静默丢弃**:

- → position 表 **恒空**(persist 后无任何持仓行)
- → 重启 `load_persisted_state` 读不到持仓 → `restore_state` 装空 → **重启丢持仓**
- → WebUI `GET /portfolios/{uuid}/positions` 走独立 `get_positions`(直读 DB),DB 空 → **WebUI 无持仓**

bug 自 #3890 / c7c566e6 引入 dict 契约起即存在(持仓持久化自出生即坏)。`/review 6890`(ADR-029)评审暴露。

## 修复(Option G — ADR-010 分层,各层原生类型)

每层说自己的原生类型,service 在 DB 边界做 Position↔MPosition 转换,dict 从持久化路径彻底消失:

```python
# snapshot_state (trading 层):直接携带 Position 实体,不展 dict
"positions": list(self._positions.values())

# persist_portfolio_state (service,DB 边界):Position→MPosition
m_positions = [PositionMapper.entity_to_model(p) for p in positions]
position_crud.batch_create(m_positions)   # CRUD 收 MPosition = happy path

# load_persisted_state (service,DB 边界):MPosition→Position
positions = PositionMapper.models_to_entities(m_positions)

# restore_state (trading 层):Position 实体直装
self._positions[pos.code] = pos
```

消除 14-key dict 漂移隐患——dict 无 schema 约束,缺键/错键即静默丢持仓(正是本 bug 根因)。外层 cash/frozen/fee 走 `str(Decimal)`(稳定标量,worker 可读)。

## 范围(3 文件)

- `src/ginkgo/trading/bases/portfolio_base.py` — `snapshot_state`/`restore_state` 改 Position 实体
- `src/ginkgo/data/services/portfolio_service.py` — `persist`/`load` DB 边界转换 + `get_positions` docstring 去陈旧行号引用
- `tests/unit/data/services/test_portfolio_service_mock.py` — `_make_state` 改造真实 Position 实体;新增 `test_load_returns_position_entities`

## 验证

- `py_compile` 2 src 文件过
- 核心 41 passed(0.47s):`test_position_mapper` + `test_position_crud_mock` + `test_portfolio_service_positions` + `TestPersistState`(含新 `test_load_returns_position_entities`)
- worker replay `-k replay`:2 passed + 1 既有 hang(`test_replay_drains_queue_before_transition`,memory `project-worker-test-known-failures` 记录的"2 fail + 1 hang"之一,该测试全 mock `_drain`/`_transition`/`_persist_all_portfolios`/`_engine`,**不触及 snapshot/restore/persist/load** → 非本 PR 回归)
- 全链路消费者核查:worker 两处(persist `paper_trading_worker.py:614` / restore `:243`)**只读外层标量**(`has_state`/`cash`/`engine_current_time`),从不碰 positions 元素 → G 全链路自洽,无其他消费者被破坏

## 与 #6890 关系

`/review 6890`(ADR-029 mapper 收敛)评审发现。ADR-029 已退役 `_convert_input_item` 钩子族——无论该钩子对 dict 的行为如何,G 让 CRUD 在快照路径只收 MPosition(model_class),绕开 dict 处理问题。本 PR 从 master 独立修,与 PR #6892(M2 枚举 or -1)同为 #6890 评审的独立跟进,互不依赖。

🤖 Generated with [Claude Code](https://claude.ai/code)