### PR TITLE
test(adr029): 补 Mapper 收敛覆盖债 smoke (diff-coverage 34.97%→80%)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,21 @@ jobs:
           uv run python -m pytest \
             tests/unit/features/test_factor_service_smoke.py \
             -q -o "addopts=" --no-header --tb=short
+      - name: ADR-029 enum/service coverage smoke (#6890 覆盖债)
+        # ADR-029 Task 1-9 改动的 model enum 分支（validate_input or -1 吞 0 的
+        # if-not-None fix）+ _df 新模块（§Decision 9 DF 出口）+ order/signal service
+        # 写路径（upsert/add + get_df）被 containers import 链触达但 smoke 不调方法体
+        # → diff coverage gate 红。本 smoke 调起方法体补覆盖信号，并锁定 enum 0（OTHER/NEUTRAL）
+        # 不被 ``or`` 吞的核心契约。独立 step 使 push→master 时也跑（gate 仅 PR 触发），
+        # 同时纳入下方 gate 合集采集 coverage。
+        run: |
+          uv run python -m pytest \
+            tests/unit/data/mappers/test_df_mapper.py \
+            tests/unit/data/models/test_model_order_enum.py \
+            tests/unit/data/models/test_model_enum_branches.py \
+            tests/unit/data/services/test_order_service_adr029_smoke.py \
+            tests/unit/data/services/test_signal_service_adr029_smoke.py \
+            -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
         env:
@@ -274,6 +289,15 @@ jobs:
             tests/unit/trading/portfolios/test_t1backtest.py \
             tests/unit/features/test_factor_service_smoke.py \
             tests/unit/trading/feeders/test_backtest_feeder_fetch_smoke.py \
+            tests/unit/data/mappers/test_df_mapper.py \
+            tests/unit/data/models/test_model_order_enum.py \
+            tests/unit/data/models/test_model_enum_branches.py \
+            tests/unit/data/services/test_order_service_adr029_smoke.py \
+            tests/unit/data/services/test_signal_service_adr029_smoke.py \
+            tests/unit/data/mappers/test_signal_mapper_adr029_smoke.py \
+            tests/unit/data/services/test_position_service_adr029_smoke.py \
+            tests/unit/data/services/test_result_service_adr029_smoke.py \
+            tests/unit/trading/test_backtest_result_aggregator_get_df.py \
             tests/unit/interfaces/test_message_mapper.py \
             tests/unit/data/test_signal_order_df_mapper_parity.py \
             tests/unit/data/test_source_enum_reflection_c6.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,8 +235,9 @@ jobs:
             -q -o "addopts=" --no-header --tb=short
       - name: ADR-029 enum/service coverage smoke (#6890 覆盖债)
         # ADR-029 Task 1-9 改动的 model enum 分支（validate_input or -1 吞 0 的
-        # if-not-None fix）+ _df 新模块（§Decision 9 DF 出口）+ order/signal service
-        # 写路径（upsert/add + get_df）被 containers import 链触达但 smoke 不调方法体
+        # if-not-None fix）+ _df 新模块（§Decision 9 DF 出口）+ service 写路径
+        # （order/signal 的 upsert/add + get_df；bar/portfolio/stockinfo/trade_day 的
+        # batch sync 写路径）被 containers import 链触达但 smoke 不调方法体
         # → diff coverage gate 红。本 smoke 调起方法体补覆盖信号，并锁定 enum 0（OTHER/NEUTRAL）
         # 不被 ``or`` 吞的核心契约。独立 step 使 push→master 时也跑（gate 仅 PR 触发），
         # 同时纳入下方 gate 合集采集 coverage。
@@ -247,6 +248,10 @@ jobs:
             tests/unit/data/models/test_model_enum_branches.py \
             tests/unit/data/services/test_order_service_adr029_smoke.py \
             tests/unit/data/services/test_signal_service_adr029_smoke.py \
+            tests/unit/data/services/test_bar_service_adr029_smoke.py \
+            tests/unit/data/services/test_portfolio_service_adr029_smoke.py \
+            tests/unit/data/services/test_stockinfo_service_adr029_smoke.py \
+            tests/unit/data/services/test_trade_day_service_adr029_smoke.py \
             -q -o "addopts=" --no-header --tb=short
       - name: Diff coverage gate (#6135)
         if: github.event_name == 'pull_request'
@@ -294,6 +299,10 @@ jobs:
             tests/unit/data/models/test_model_enum_branches.py \
             tests/unit/data/services/test_order_service_adr029_smoke.py \
             tests/unit/data/services/test_signal_service_adr029_smoke.py \
+            tests/unit/data/services/test_bar_service_adr029_smoke.py \
+            tests/unit/data/services/test_portfolio_service_adr029_smoke.py \
+            tests/unit/data/services/test_stockinfo_service_adr029_smoke.py \
+            tests/unit/data/services/test_trade_day_service_adr029_smoke.py \
             tests/unit/data/mappers/test_signal_mapper_adr029_smoke.py \
             tests/unit/data/services/test_position_service_adr029_smoke.py \
             tests/unit/data/services/test_result_service_adr029_smoke.py \

--- a/tests/unit/data/mappers/test_df_mapper.py
+++ b/tests/unit/data/mappers/test_df_mapper.py
@@ -58,6 +58,8 @@ def test_enum_reflection_converts_frequency():
     assert "frequency" in mappings
     df = models_to_dataframe([model])
     assert "frequency" in df.columns
+    # 锁 in-place 转 enum(L70-81):删转换块则 frequency 列存 int64(非 enum),断言 FAIL。
+    assert isinstance(df.iloc[0]["frequency"], FREQUENCY_TYPES)
 
 
 def test_get_enum_mappings_object_without_table():

--- a/tests/unit/data/mappers/test_df_mapper.py
+++ b/tests/unit/data/mappers/test_df_mapper.py
@@ -1,0 +1,117 @@
+"""``_df.models_to_dataframe`` 单测（ADR-029 §Decision 9 DF 出口）。
+
+覆盖 ``src/ginkgo/data/mappers/_df.py`` 全部可执行行：
+- ``models_to_dataframe``：空列表 / 有 enum 的 model / 无 enum / ``_sa_instance_state``
+  剔除 / 只读 enum 字段 setattr 跳过
+- ``_get_enum_mappings_from_model``：反射 enum 映射 / 无 ``__table__`` 对象
+- ``_safe_enum_convert``：None / 有效值 / 无效值
+"""
+from types import SimpleNamespace
+
+import pandas as pd
+
+from ginkgo.entities import Bar
+from ginkgo.enums import FREQUENCY_TYPES
+from ginkgo.data.mappers.bar_mapper import BarMapper
+from ginkgo.data.mappers._df import (
+    models_to_dataframe,
+    _get_enum_mappings_from_model,
+    _safe_enum_convert,
+)
+
+
+def _make_model():
+    return BarMapper.entity_to_model(
+        Bar(
+            code="000001.SZ",
+            open=10,
+            high=11,
+            low=9,
+            close=10.5,
+            volume=1000,
+            amount=10500,
+            frequency=FREQUENCY_TYPES.DAY,
+            timestamp="2025-01-02",
+        )
+    )
+
+
+def test_empty_list_returns_empty_dataframe():
+    """空列表 → ``pd.DataFrame()``（L63-64）。"""
+    result = models_to_dataframe([])
+    assert result.empty
+
+
+def test_basic_conversion_strips_sa_instance_state():
+    """普通 model → DataFrame，``_sa_instance_state`` 必被 pop（L84-88）。"""
+    df = models_to_dataframe([_make_model()])
+    assert not df.empty
+    assert "code" in df.columns
+    assert df.iloc[0]["code"] == "000001.SZ"
+    assert "_sa_instance_state" not in df.columns
+
+
+def test_enum_reflection_converts_frequency():
+    """``MBar.frequency`` 是 enum 字段；反射映射后 in-place 转 enum（L67-81）。"""
+    model = _make_model()
+    mappings = _get_enum_mappings_from_model(model)
+    assert "frequency" in mappings
+    df = models_to_dataframe([model])
+    assert "frequency" in df.columns
+
+
+def test_get_enum_mappings_object_without_table():
+    """无 ``__table__`` 的普通对象 → ``{}``（L26-28）。"""
+    class Plain:
+        pass
+
+    assert _get_enum_mappings_from_model(Plain()) == {}
+
+
+def test_safe_enum_convert_none_valid_invalid():
+    """None→None；有效值→enum；无效值→原样返回（except 分支 L43-44）。"""
+    assert _safe_enum_convert(None, FREQUENCY_TYPES) is None
+    assert _safe_enum_convert(FREQUENCY_TYPES.DAY.value, FREQUENCY_TYPES) == FREQUENCY_TYPES.DAY
+    assert _safe_enum_convert(-9999, FREQUENCY_TYPES) == -9999
+
+
+def test_readonly_enum_attribute_skipped():
+    """只读 enum 字段 ``setattr`` 抛 ``AttributeError`` → 跳过（L77-81）。
+
+    ``__table__.columns`` 反射到 frequency→enum 映射，但实例的 ``frequency`` 是
+    只读 property（无 setter），in-place ``setattr`` 触发 ``AttributeError`` 被 except 吞掉。
+    """
+    table = SimpleNamespace(
+        columns=[SimpleNamespace(name="frequency", info={"enum": FREQUENCY_TYPES})]
+    )
+
+    class ReadonlyEnumModel:
+        __table__ = table
+
+        def __init__(self):
+            self.code = "x"
+            self._sa_instance_state = object()
+
+        @property
+        def frequency(self):  # 只读 property（无 setter）→ setattr 抛 AttributeError
+            return 1
+
+    df = models_to_dataframe([ReadonlyEnumModel()])
+    # 只读字段被跳过，不抛异常；code 仍在
+    assert "code" in df.columns
+    assert df.iloc[0]["code"] == "x"
+
+
+def test_no_enum_mappings_short_circuits_loop():
+    """``enum_mappings`` 为空 → 跳过 enum 循环（L70）。"""
+    table = SimpleNamespace(columns=[SimpleNamespace(name="code", info=None)])
+
+    class NoEnumModel:
+        __table__ = table
+
+        def __init__(self):
+            self.code = "y"
+            self._sa_instance_state = object()
+
+    df = models_to_dataframe([NoEnumModel()])
+    assert df.iloc[0]["code"] == "y"

--- a/tests/unit/data/mappers/test_position_mapper.py
+++ b/tests/unit/data/mappers/test_position_mapper.py
@@ -112,6 +112,14 @@ class TestPositionMapperRoundtrip:
         back = PositionMapper.model_to_entity(model)
         assert back._settlement_queue == []
 
+    def test_from_model_restores_business_timestamp(self):
+        """model_to_entity：business_timestamp 非 None 时经 TimeMixin kwarg 还原（ADR-029 L105）。"""
+        entity = _make_position()
+        model = PositionMapper.entity_to_model(entity)
+        model.business_timestamp = datetime.datetime(2025, 1, 2, 9, 30)
+        back = PositionMapper.model_to_entity(model)
+        assert back.business_timestamp == datetime.datetime(2025, 1, 2, 9, 30)
+
 
 class TestPositionMapperFromModelGuard:
     def test_from_model_rejects_non_mposition(self):

--- a/tests/unit/data/mappers/test_signal_mapper_adr029_smoke.py
+++ b/tests/unit/data/mappers/test_signal_mapper_adr029_smoke.py
@@ -1,0 +1,46 @@
+"""SignalMapper.model_to_entity 反向映射 smoke（ADR-029 Task 6）。
+
+``model_to_entity``（ORM→Entity：uuid 还原 + business_timestamp 还原，L73/89/90/91）
+被 containers import 链触达但 smoke 不调方法体 → diff coverage gate 红。本 smoke
+直调 model_to_entity 补覆盖信号，并锁定 ADR-029 新增的 business_timestamp 还原分支。
+"""
+import datetime
+
+from ginkgo.data.mappers.signal_mapper import SignalMapper
+from ginkgo.data.models.model_signal import MSignal
+
+
+def _make_msignal() -> MSignal:
+    """构造字段齐全的 MSignal（Signal entity 构造要求 code/strength/volume 等非 None）。"""
+    m = MSignal()
+    for k, v in dict(
+        portfolio_id="p",
+        engine_id="e",
+        task_id="t",
+        code="000001",
+        direction=1,
+        source=1,
+        reason="r",
+        uuid="u",
+        volume=100,
+        weight=1.0,
+        strength=0.5,
+        confidence=0.5,
+    ).items():
+        setattr(m, k, v)
+    return m
+
+
+def test_model_to_entity_restores_uuid():
+    """ORM→Entity：uuid 还原（ADR-029 Task 6 补丢 uuid bug，L73/89/91）。"""
+    m = _make_msignal()
+    ent = SignalMapper.model_to_entity(m)
+    assert ent.uuid == "u"
+
+
+def test_model_to_entity_restores_business_timestamp():
+    """business_timestamp 非 None → entity_kwargs 消费分支（L89-91）。"""
+    m = _make_msignal()
+    m.business_timestamp = datetime.datetime(2025, 1, 2)
+    ent = SignalMapper.model_to_entity(m)
+    assert ent.business_timestamp == datetime.datetime(2025, 1, 2)

--- a/tests/unit/data/models/test_model_enum_branches.py
+++ b/tests/unit/data/models/test_model_enum_branches.py
@@ -118,6 +118,20 @@ def test_stock_info_update_str_enum_branches():
     assert si.source == SOURCE_TYPES.MANUAL.value
 
 
+def test_stock_info_update_str_other_zero_not_swallowed():
+    """currency/market/source=OTHER(0) 保真（旧 ``or -1`` 会吞成 -1）。
+
+    MStockInfo 是 4 个 enum model 里此前唯一无 0 值锚点的；补此锁使
+    tick/signal/stockinfo 对称。回退 I-2 fix（``validated or -1``）则
+    0 被 falsy 吞成 -1，三断言 FAIL。
+    """
+    si = MStockInfo("000001")
+    si.update("000001", currency=0, market=0, source=0)
+    assert si.currency == 0
+    assert si.market == 0
+    assert si.source == 0
+
+
 def test_stock_info_update_series_enum_branches():
     """update(pd.Series)：currency/market 必填 + source 可选分支。"""
     si = MStockInfo("000001")

--- a/tests/unit/data/models/test_model_enum_branches.py
+++ b/tests/unit/data/models/test_model_enum_branches.py
@@ -1,0 +1,139 @@
+"""MTick / MSignal / MStockInfo enum ``if not None`` 分支覆盖（ADR-029 Task 2/3/6）。
+
+``validate_input(x) or -1`` 在 x=OTHER(0)/NEUTRAL(0) 时被 falsy 吞，
+改为 ``_v if _v is not None else -1``。本测覆盖三 model 的 ``update(str)`` /
+``update(pd.Series)`` enum 字段分支：
+- 合法 enum → 保真 ``.value``
+- 非法值 → validate 返 None → -1
+- 0（NEUTRAL/OTHER）→ 保真 0（核心 fix，不被 ``or`` 吞）
+"""
+import pandas as pd
+
+from ginkgo.data.models.model_tick import MTick
+from ginkgo.data.models.model_signal import MSignal
+from ginkgo.data.models.model_stock_info import MStockInfo
+from ginkgo.enums import (
+    TICKDIRECTION_TYPES,
+    DIRECTION_TYPES,
+    SOURCE_TYPES,
+    CURRENCY_TYPES,
+    MARKET_TYPES,
+)
+
+
+# ---------------- MTick ----------------
+def test_tick_update_str_enum_branches():
+    """update(str)：合法保真；非法 str→-1；NEUTRAL(0) 保真不被吞。"""
+    t = MTick()
+    t.update(
+        "000001",
+        price=10,
+        volume=100,
+        direction=TICKDIRECTION_TYPES.ACTIVEBUY,   # 合法
+        source="bogus_source",               # 非法 str → -1
+    )
+    assert t.direction == TICKDIRECTION_TYPES.ACTIVEBUY.value
+    assert t.source == -1
+
+
+def test_tick_update_str_other_zero_not_swallowed():
+    """direction=NEUTRAL(0) 保真（旧 ``or -1`` 会吞成 -1）。"""
+    t = MTick()
+    t.update("000001", direction=0, source=0)  # 0 是合法值
+    assert t.direction == 0
+    assert t.source == 0
+
+
+def test_tick_update_series_enum_branches():
+    """update(pd.Series)：direction 必填分支 + source 可选分支。"""
+    t = MTick()
+    s = pd.Series(
+        {
+            "code": "000001",
+            "price": 10,
+            "volume": 100,
+            "direction": TICKDIRECTION_TYPES.ACTIVESELL.value,
+            "timestamp": "2025-01-02",
+            "source": SOURCE_TYPES.MANUAL.value,
+        }
+    )
+    t.update(s)
+    assert t.direction == TICKDIRECTION_TYPES.ACTIVESELL.value
+    assert t.source == SOURCE_TYPES.MANUAL.value
+
+
+# ---------------- MSignal ----------------
+def test_signal_update_str_enum_branches():
+    """update(str)：合法保真；非法 str→-1；OTHER(0) 保真不被吞。"""
+    s = MSignal()
+    s.update(
+        "p",
+        "e",
+        direction=DIRECTION_TYPES.LONG,   # 合法
+        source="bogus_source",            # 非法 → -1
+    )
+    assert s.direction == DIRECTION_TYPES.LONG.value
+    assert s.source == -1
+
+
+def test_signal_update_str_other_zero_not_swallowed():
+    """direction=OTHER(0) 保真（旧 ``or -1`` 会吞成 -1）。"""
+    s = MSignal()
+    s.update("p", "e", direction=0, source=0)
+    assert s.direction == 0
+    assert s.source == 0
+
+
+def test_signal_update_series_enum_branches():
+    """update(pd.Series)：direction 必填 + source 可选分支。"""
+    s = MSignal()
+    df = pd.Series(
+        {
+            "portfolio_id": "p",
+            "engine_id": "e",
+            "timestamp": "2025-01-02",
+            "code": "000001",
+            "direction": DIRECTION_TYPES.SHORT.value,
+            "reason": "r",
+            "source": SOURCE_TYPES.TUSHARE.value,
+        }
+    )
+    s.update(df)
+    assert s.direction == DIRECTION_TYPES.SHORT.value
+    assert s.source == SOURCE_TYPES.TUSHARE.value
+
+
+# ---------------- MStockInfo ----------------
+def test_stock_info_update_str_enum_branches():
+    """update(str)：currency/market/source 合法保真 + 非法→-1。"""
+    si = MStockInfo("000001")
+    si.update(
+        "000001",
+        currency="bogus_currency",          # 非法 → -1
+        market=MARKET_TYPES.CHINA,          # 合法
+        source=SOURCE_TYPES.MANUAL,         # 合法
+    )
+    assert si.currency == -1
+    assert si.market == MARKET_TYPES.CHINA.value
+    assert si.source == SOURCE_TYPES.MANUAL.value
+
+
+def test_stock_info_update_series_enum_branches():
+    """update(pd.Series)：currency/market 必填 + source 可选分支。"""
+    si = MStockInfo("000001")
+    df = pd.Series(
+        {
+            "code": "000001",
+            "code_name": "test",
+            "industry": "tech",
+            "currency": CURRENCY_TYPES.CNY.value,
+            "market": MARKET_TYPES.CHINA.value,
+            "list_date": "2025-01-02",
+            "delist_date": None,
+            "source": SOURCE_TYPES.TUSHARE.value,
+        }
+    )
+    si.update(df)
+    assert si.currency == CURRENCY_TYPES.CNY.value
+    assert si.market == MARKET_TYPES.CHINA.value
+    assert si.source == SOURCE_TYPES.TUSHARE.value

--- a/tests/unit/data/models/test_model_order_enum.py
+++ b/tests/unit/data/models/test_model_order_enum.py
@@ -1,0 +1,101 @@
+"""MOrder enum ``if not None`` 分支覆盖（ADR-029 Task 7 I-2 fix）。
+
+``validate_input(x) or DEFAULT`` 在 x=OTHER(0) 时被 falsy 吞（0 or 7 → 7），
+改为 ``_v if _v is not None else DEFAULT``。本测覆盖 ``__init__`` /
+``update(str)`` / ``update(pd.Series)`` 三方法的 enum 字段：
+- 合法 enum → 保真 ``.value``
+- 非法值（str / 越界 int）→ validate 返 None → DEFAULT（__init__ 用类型默认；update 用 -1）
+- OTHER(0) → 保真 0（核心 fix，不被 ``or`` 吞）
+"""
+import pandas as pd
+
+from ginkgo.data.models.model_order import MOrder
+from ginkgo.enums import (
+    DIRECTION_TYPES,
+    ORDER_TYPES,
+    ORDERSTATUS_TYPES,
+    SOURCE_TYPES,
+)
+
+
+def test_init_valid_invalid_and_other_zero():
+    """__init__：合法 enum 保真；非法 str→DEFAULT；OTHER(0) 保真不被吞。"""
+    o = MOrder(
+        portfolio_id="p",
+        engine_id="e",
+        direction=DIRECTION_TYPES.LONG,   # 合法 → LONG.value
+        order_type="bogus_order_type",    # 非法 str → DEFAULT(LIMITORDER)
+        status=ORDERSTATUS_TYPES.NEW,     # 合法 → NEW.value
+        source=0,                          # OTHER(0) → 保真 0（旧 `or TUSHARE` 会吞成 7）
+    )
+    assert o.direction == DIRECTION_TYPES.LONG.value
+    assert o.order_type == ORDER_TYPES.LIMITORDER.value
+    assert o.status == ORDERSTATUS_TYPES.NEW.value
+    assert o.source == 0
+
+
+def test_init_other_zero_direction_not_swallowed():
+    """direction=OTHER(0) 保真（不被 ``or LONG`` 吞成 1）。"""
+    o = MOrder(portfolio_id="p", engine_id="e", direction=0)
+    assert o.direction == 0
+
+
+def test_init_invalid_int_falls_back_default():
+    """越界 int（validate ValueError→None）→ DEFAULT。"""
+    o = MOrder(portfolio_id="p", engine_id="e", status=9999)
+    assert o.status == ORDERSTATUS_TYPES.NEW.value
+
+
+def test_update_str_enum_branches():
+    """update(str)：合法保真；非法 str→-1（update 的 DEFAULT）。"""
+    o = MOrder(portfolio_id="p", engine_id="e")
+    o.update(
+        "p2",
+        "e2",
+        direction=DIRECTION_TYPES.SHORT,  # 合法 → SHORT.value
+        status="bogus_status",             # 非法 → -1
+        source=SOURCE_TYPES.MANUAL,        # 合法 → MANUAL.value
+    )
+    assert o.direction == DIRECTION_TYPES.SHORT.value
+    assert o.status == -1
+    assert o.source == SOURCE_TYPES.MANUAL.value
+
+
+def test_update_str_order_type_branch():
+    """update(str)：order_type 分支（L156-157）。合法保真；非法 str→-1。"""
+    o = MOrder(portfolio_id="p", engine_id="e")
+    o.update("p2", "e2", order_type=ORDER_TYPES.MARKETORDER)  # 合法 → MARKETORDER.value
+    assert o.order_type == ORDER_TYPES.MARKETORDER.value
+    o.update("p2", "e2", order_type="bogus_order_type")  # 非法 → -1
+    assert o.order_type == -1
+
+
+def test_update_series_enum_branches():
+    """update(pd.Series)：合法保真；source 可选分支（``if "source" in df``）。"""
+    o = MOrder(portfolio_id="p", engine_id="e")
+    s = pd.Series(
+        {
+            "code": "000001",
+            "direction": DIRECTION_TYPES.LONG.value,
+            "order_type": ORDER_TYPES.LIMITORDER.value,
+            "status": ORDERSTATUS_TYPES.NEW.value,
+            "volume": 100,
+            "limit_price": 10,
+            "frozen_money": 0,
+            "frozen_volume": 0,
+            "transaction_price": 0,
+            "transaction_volume": 0,
+            "remain": 0,
+            "fee": 0,
+            "timestamp": "2025-01-02",
+            "uuid": "u",
+            "portfolio_id": "p",
+            "engine_id": "e",
+            "source": SOURCE_TYPES.TUSHARE.value,
+        }
+    )
+    o.update(s)
+    assert o.direction == DIRECTION_TYPES.LONG.value
+    assert o.order_type == ORDER_TYPES.LIMITORDER.value
+    assert o.status == ORDERSTATUS_TYPES.NEW.value
+    assert o.source == SOURCE_TYPES.TUSHARE.value

--- a/tests/unit/data/services/test_bar_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_bar_service_adr029_smoke.py
@@ -1,0 +1,52 @@
+"""BarService ADR-029 §Decision 1 batch 收敛 smoke（sync_range）。
+
+F3/F4 锁 signal/position/order 的 **add path**（单 entity → crud.add）；
+bar.sync_range 的 **batch path**（L198：list[Bar] → BarMapper.entity_to_model →
+crud.add_batch，生产注释"ADR-029 Task 1：入站前置 mapper.entity_to_model，
+不再依赖 CRUD hook 隐式转"）是兄弟盲区。本 smoke 补锁，走全入站链
+（dataframe_to_bar_entities → _filter_existing_data → BarMapper → add_batch）。
+"""
+import datetime
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from ginkgo.enums import FREQUENCY_TYPES
+from ginkgo.data.models.model_bar import MBar
+from ginkgo.data.services.bar_service import BarService
+
+
+def test_bar_sync_range_batch_via_mapper():
+    """sync_range：fetch daybar → Bar entities → BarMapper.entity_to_model → crud.add_batch
+    （L198,ADR-029 Task 1 收敛）。
+
+    锁 batch path mapper 收敛（F8b,F3 add-path 同形）：mock data_source 返 1 行合法
+    OHLC（high>=max(open,close)、low<=min、正价，过 _validate_bar_data），mock
+    stockinfo.exists→True，mock crud.find→[]（无 existing → _filter_existing_data 全保留）。
+    回退 L198（跳过 mapper，裸 Bar 直送 add_batch）则 isinstance(MBar) FAIL。
+    """
+    data_source = MagicMock()
+    data_source.fetch_cn_stock_daybar.return_value = pd.DataFrame(
+        [{"trade_date": "20250102", "open": 10, "high": 11, "low": 9,
+          "close": 10.5, "vol": 100, "amount": 0}]  # 含 amount 列(L134 r["amount"] 求值在 pd.notna 前)
+    )
+    stockinfo_svc = MagicMock()
+    stockinfo_svc.exists.return_value = True
+    crud = MagicMock()
+    crud.find.return_value = []  # 无 existing → final_entities = 全 bar_entities
+
+    svc = BarService(
+        crud_repo=crud, data_source=data_source, stockinfo_service=stockinfo_svc
+    )
+    res = svc.sync_range(
+        "000001",
+        datetime.datetime(2025, 1, 1),
+        datetime.datetime(2025, 1, 10),
+        FREQUENCY_TYPES.DAY,
+    )
+
+    assert res.success, f"sync_range failed: {getattr(res, 'message', res)}"
+    crud.add_batch.assert_called_once()
+    batch_arg = crud.add_batch.call_args[0][0]
+    assert len(batch_arg) == 1
+    assert isinstance(batch_arg[0], MBar)  # 锁 mapper.entity_to_model 收敛(非裸 entity)

--- a/tests/unit/data/services/test_order_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_order_service_adr029_smoke.py
@@ -46,6 +46,7 @@ def test_upsert_insert_path():
     assert res.success
     assert res.data["action"] == "insert"
     assert len(crud.added) == 1
+    assert isinstance(crud.added[0], MOrder)  # 锁 mapper.entity_to_model 收敛(F3 同形,非裸 entity)
 
 
 def test_upsert_update_path():

--- a/tests/unit/data/services/test_order_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_order_service_adr029_smoke.py
@@ -101,11 +101,14 @@ def test_create_order_record_delegates_to_crud():
 
 # ---------------- get_orders_df ----------------
 def test_get_orders_df_returns_dataframe():
-    """find→list → models_to_dataframe（L122）。"""
+    """find→[MOrder] → models_to_dataframe（L122）产非空 DF。补 ``assert not empty``
+    锁住出口真调了转换——回退/跳过 L122（→ else pd.DataFrame() 空 DF）则断言 FAIL
+    （silent-pass 防护，与 result/signal/position DF 出口同形）。"""
     svc = OrderService(crud_repo=_FakeCrud())
     res = svc.get_orders_df(portfolio_id="p")
     assert res.success
     assert isinstance(res.data, pd.DataFrame)
+    assert not res.data.empty  # 锁 L122 真产非空 DF(回退→空 DF→FAIL)
 
 
 # ---------------- except 分支（覆盖 L283-285 / L317-319）----------------

--- a/tests/unit/data/services/test_order_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_order_service_adr029_smoke.py
@@ -1,0 +1,136 @@
+"""OrderService ADR-029 Task 7/8 写路径 smoke（upsert + create_record + get_df）。
+
+``upsert_order``（存在判断 ``get_by_uuid`` → modify/insert 双语义，``status_override``
+事件后状态覆盖）+ ``create_order_record``（懒 import OrderRecordCRUD 写 MOrderRecord）+
+``get_orders_df``（出口① DataFrame）被 containers import 链触达但 smoke 不调方法体
+→ diff coverage gate 红。本 smoke mock crud 调起方法体补覆盖信号，并锁定 ADR-029 新契约。
+"""
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+
+from ginkgo.entities import Order
+from ginkgo.enums import ORDERSTATUS_TYPES
+from ginkgo.data.models.model_order import MOrder
+from ginkgo.data.services.order_service import OrderService
+
+
+class _FakeCrud:
+    """最小 crud mock：记录 add/modify 调用，get_by_uuid 可注入存在性。"""
+
+    def __init__(self, existing=None):
+        self._existing = existing
+        self.added = []
+        self.modified = []
+
+    def get_by_uuid(self, uuid):
+        return self._existing
+
+    def add(self, model):
+        self.added.append(model)
+
+    def modify(self, filters, updates):
+        self.modified.append((filters, updates))
+
+    def find(self, filters=None, page=None, page_size=None, order_by=None, desc_order=None):
+        return [MOrder(portfolio_id="p", engine_id="e")]
+
+
+# ---------------- upsert_order ----------------
+def test_upsert_insert_path():
+    """get_by_uuid→None：Order Entity→mapper→crud.add，action=insert（L274-285）。"""
+    crud = _FakeCrud(existing=None)
+    svc = OrderService(crud_repo=crud)
+    order = Order(uuid="u1", portfolio_id="p", engine_id="e", code="000001", volume=100)
+    res = svc.upsert_order(order)
+    assert res.success
+    assert res.data["action"] == "insert"
+    assert len(crud.added) == 1
+
+
+def test_upsert_update_path():
+    """get_by_uuid→<obj>：modify 语义，action=update（L256-272）。"""
+    crud = _FakeCrud(existing=MagicMock(uuid="u1"))
+    svc = OrderService(crud_repo=crud)
+    order = Order(uuid="u1", portfolio_id="p", engine_id="e", code="000001", volume=100,
+                  status=ORDERSTATUS_TYPES.NEW, fee=5)
+    res = svc.upsert_order(order)
+    assert res.success
+    assert res.data["action"] == "update"
+    assert len(crud.modified) == 1
+
+
+def test_upsert_status_override():
+    """status_override 覆盖 order.status（事件后状态，L249-261）。"""
+    crud = _FakeCrud(existing=MagicMock(uuid="u1"))
+    svc = OrderService(crud_repo=crud)
+    order = Order(uuid="u1", portfolio_id="p", engine_id="e", code="000001", volume=100,
+                  status=ORDERSTATUS_TYPES.NEW)
+    res = svc.upsert_order(order, status_override=ORDERSTATUS_TYPES.FILLED)
+    assert res.success
+    _filters, updates = crud.modified[0]
+    assert updates["status"] == ORDERSTATUS_TYPES.FILLED
+
+
+def test_upsert_no_uuid_returns_error():
+    """order 无 uuid → ServiceResult.error（L246-247）。Order Entity 自动生成 uuid，
+    用无 uuid 的裸对象触发缺失守卫。"""
+    svc = OrderService(crud_repo=_FakeCrud())
+
+    class NoUuid:
+        pass
+
+    res = svc.upsert_order(NoUuid())  # getattr(order, "uuid", None) → None
+    assert not res.success
+
+
+# ---------------- create_order_record ----------------
+def test_create_order_record_delegates_to_crud():
+    """懒 import OrderRecordCRUD → create(**kwargs)（L308-319）。"""
+    fake_crud = MagicMock()
+    with patch(
+        "ginkgo.data.crud.order_record_crud.OrderRecordCRUD",
+        return_value=fake_crud,
+    ):
+        svc = OrderService(crud_repo=_FakeCrud())
+        res = svc.create_order_record(code="000001", portfolio_id="p")
+    assert res.success
+    fake_crud.create.assert_called_once_with(code="000001", portfolio_id="p")
+
+
+# ---------------- get_orders_df ----------------
+def test_get_orders_df_returns_dataframe():
+    """find→list → models_to_dataframe（L122）。"""
+    svc = OrderService(crud_repo=_FakeCrud())
+    res = svc.get_orders_df(portfolio_id="p")
+    assert res.success
+    assert isinstance(res.data, pd.DataFrame)
+
+
+# ---------------- except 分支（覆盖 L283-285 / L317-319）----------------
+class _BoomCrud:
+    """crud 抛异常，触发 service except 分支。"""
+
+    def get_by_uuid(self, uuid):
+        raise RuntimeError("db down")
+
+
+def test_upsert_exception_returns_error():
+    """get_by_uuid 抛异常 → except → ServiceResult.error（L283-285）。"""
+    svc = OrderService(crud_repo=_BoomCrud())
+    order = Order(uuid="u1", portfolio_id="p", engine_id="e", code="000001", volume=100)
+    res = svc.upsert_order(order)
+    assert not res.success
+
+
+def test_create_order_record_exception_returns_error():
+    """OrderRecordCRUD.create 抛异常 → except → ServiceResult.error（L317-319）。"""
+    fake_crud = MagicMock()
+    fake_crud.create.side_effect = RuntimeError("db down")
+    with patch(
+        "ginkgo.data.crud.order_record_crud.OrderRecordCRUD",
+        return_value=fake_crud,
+    ):
+        svc = OrderService(crud_repo=_FakeCrud())
+        res = svc.create_order_record(code="000001")
+    assert not res.success

--- a/tests/unit/data/services/test_portfolio_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_portfolio_service_adr029_smoke.py
@@ -1,0 +1,39 @@
+"""PortfolioService ADR-029 §Decision 1 batch 收敛 smoke（persist_portfolio_state）。
+
+F3 已锁 PositionService.save_positions 的 **add path**（单 entity → crud.add）；
+persist_portfolio_state 的 **batch path**（L402：list[Position] → PositionMapper.
+entity_to_model → position_crud.batch_create，注释"Position 实体 → MPosition，ADR-010"）
+是兄弟盲区。本 smoke 补锁，使 §Decision 1 在 portfolio 持仓持久化路径也有锚点。
+"""
+from unittest.mock import MagicMock
+
+from ginkgo.entities import Position
+from ginkgo.data.models.model_position import MPosition
+from ginkgo.data.services.portfolio_service import PortfolioService
+
+
+def test_persist_portfolio_state_batch_via_mapper():
+    """persist_portfolio_state：state['positions'] 各 Position → PositionMapper.
+    entity_to_model → position_crud.batch_create（L402,ADR-010 收敛）。
+
+    锁 batch path mapper 收敛（F8a,F3 add-path 同形）：回退 L402（跳过 mapper，
+    裸 Position 直送 batch_create）则 isinstance(MPosition) FAIL。
+    """
+    main_crud = MagicMock()
+    pos_crud = MagicMock()
+    svc = PortfolioService(
+        crud_repo=main_crud,
+        portfolio_file_mapping_crud=MagicMock(),
+    )
+    svc._get_position_crud = lambda: pos_crud  # 注入 position crud
+
+    pos = Position(portfolio_id="p", engine_id="e", task_id="t", code="000001", volume=100)
+    state = {"cash": "100", "frozen": "0", "fee": "0", "positions": [pos]}
+
+    res = svc.persist_portfolio_state("pid", state)
+    assert res.success
+    pos_crud.delete_by_portfolio.assert_called_once_with("pid")
+    pos_crud.batch_create.assert_called_once()
+    batch_arg = pos_crud.batch_create.call_args[0][0]
+    assert len(batch_arg) == 1
+    assert isinstance(batch_arg[0], MPosition)  # 锁 mapper.entity_to_model 收敛(非裸 entity)

--- a/tests/unit/data/services/test_position_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_position_service_adr029_smoke.py
@@ -44,11 +44,14 @@ def test_save_positions_persists_via_mapper():
 
 
 def test_get_positions_df_returns_dataframe():
-    """get_positions_df：find → models_to_dataframe（L128）。"""
+    """get_positions_df：find→[MPosition] → models_to_dataframe（L128）产非空 DF。
+    补 ``assert not empty`` 锁住出口真调了转换——回退/跳过 L128（→ else pd.DataFrame()
+    空 DF）则断言 FAIL（silent-pass 防护，与 result/signal/order DF 出口同形）。"""
     svc = PositionService(crud_repo=_FakeCrud())
     res = svc.get_positions_df(portfolio_id="p")
     assert res.success
     assert isinstance(res.data, pd.DataFrame)
+    assert not res.data.empty  # 锁 L128 真产非空 DF(回退→空 DF→FAIL)
 
 
 def test_upsert_position_create_branch():

--- a/tests/unit/data/services/test_position_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_position_service_adr029_smoke.py
@@ -1,0 +1,60 @@
+"""PositionService ADR-029 Task 5 写路径 smoke（save / get_df / upsert-create）。
+
+三个方法体被 containers import 链触达但 smoke 不调 → diff coverage gate 红：
+- ``save_positions``（L40：走 mapper.entity_to_model 收敛 + 顺修 add(entity) bug）
+- ``get_positions_df``（L128：find → models_to_dataframe 出口）
+- ``upsert_position`` create 分支（L180：existing=None → mapper.entity_to_model → add）
+本 smoke mock crud 调起方法体补覆盖信号。
+"""
+import pandas as pd
+
+from ginkgo.entities import Position
+from ginkgo.data.models.model_position import MPosition
+from ginkgo.data.services.position_service import PositionService
+
+
+class _FakeCrud:
+    """记录 add 调用；find 返模型列表；get_position 返 None 触发 upsert 创建分支。"""
+
+    def __init__(self):
+        self.added = []
+
+    def add(self, model):
+        self.added.append(model)
+
+    def find(self, filters=None, page=None, page_size=None, order_by=None, desc_order=None):
+        return [MPosition(portfolio_id="p", engine_id="e", code="000001")]
+
+    def get_position(self, portfolio_id=None, code=None):
+        return None  # → upsert else 分支（create）
+
+
+def _make_position() -> Position:
+    return Position(portfolio_id="p", engine_id="e", task_id="t", code="000001", volume=100)
+
+
+def test_save_positions_persists_via_mapper():
+    """save_positions：list 各元素 → PositionMapper.entity_to_model → crud.add（L40）。"""
+    crud = _FakeCrud()
+    svc = PositionService(crud_repo=crud)
+    res = svc.save_positions([_make_position()])
+    assert res.success
+    assert len(crud.added) == 1
+
+
+def test_get_positions_df_returns_dataframe():
+    """get_positions_df：find → models_to_dataframe（L128）。"""
+    svc = PositionService(crud_repo=_FakeCrud())
+    res = svc.get_positions_df(portfolio_id="p")
+    assert res.success
+    assert isinstance(res.data, pd.DataFrame)
+
+
+def test_upsert_position_create_branch():
+    """get_position→None → else 创建分支：mapper.entity_to_model → add（L180）。"""
+    crud = _FakeCrud()
+    svc = PositionService(crud_repo=crud)
+    res = svc.upsert_position(_make_position())
+    assert res.success
+    assert res.data["created"] is True
+    assert len(crud.added) == 1

--- a/tests/unit/data/services/test_position_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_position_service_adr029_smoke.py
@@ -40,6 +40,7 @@ def test_save_positions_persists_via_mapper():
     res = svc.save_positions([_make_position()])
     assert res.success
     assert len(crud.added) == 1
+    assert isinstance(crud.added[0], MPosition)  # 锁 mapper.entity_to_model 收敛(顺修 add(entity) bug)
 
 
 def test_get_positions_df_returns_dataframe():
@@ -58,3 +59,4 @@ def test_upsert_position_create_branch():
     assert res.success
     assert res.data["created"] is True
     assert len(crud.added) == 1
+    assert isinstance(crud.added[0], MPosition)  # 锁创建分支走 mapper.entity_to_model(非裸 entity)

--- a/tests/unit/data/services/test_result_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_result_service_adr029_smoke.py
@@ -22,15 +22,17 @@ class _FakeAnalyzerCrud:
 
 def test_get_analyzer_values_df_returns_dataframe():
     """get_by_task_id 返列表 → models_to_dataframe（L156）。patch models_to_dataframe
-    返 DataFrame 以隔离 ORM 模型构造，专注覆盖 L156 出口分支。"""
+    返 DataFrame 以隔离 ORM 模型构造；补 ``assert_called_once`` 锁住 L156 真调了出口
+    转换——否则回退/跳过 models_to_dataframe（→ else pd.DataFrame()）测试仍绿(silent-pass)。"""
     svc = ResultService(analyzer_crud=_FakeAnalyzerCrud())
     with patch(
         "ginkgo.data.services.result_service.models_to_dataframe",
         return_value=pd.DataFrame(),
-    ):
+    ) as mock_m2df:
         res = svc.get_analyzer_values_df(task_id="t")
     assert res.success
     assert isinstance(res.data, pd.DataFrame)
+    mock_m2df.assert_called_once()  # 锁 L156 真调了 models_to_dataframe(回退跳过→mock 未调→FAIL)
 
 
 def test_create_order_record_delegates_to_container():

--- a/tests/unit/data/services/test_result_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_result_service_adr029_smoke.py
@@ -1,0 +1,45 @@
+"""ResultService ADR-029 读路径 + 记录委托 smoke。
+
+- ``get_analyzer_values_df``（L156：get_by_task_id → models_to_dataframe 出口）
+- ``create_order_record``（L662-663：懒 import container 委托 OrderService）
+被 containers import 链触达但 smoke 不调方法体 → diff coverage gate 红。本 smoke
+补覆盖信号：get 路径 mock crud，委托路径 patch container。
+"""
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+
+from ginkgo.data.services.result_service import ResultService
+from ginkgo.data.services.base_service import ServiceResult
+
+
+class _FakeAnalyzerCrud:
+    """get_by_task_id 返 truthy 列表，触发 models_to_dataframe 分支（L156）。"""
+
+    def get_by_task_id(self, task_id=None, portfolio_id=None, analyzer_name=None, page_size=None):
+        return [MagicMock()]
+
+
+def test_get_analyzer_values_df_returns_dataframe():
+    """get_by_task_id 返列表 → models_to_dataframe（L156）。patch models_to_dataframe
+    返 DataFrame 以隔离 ORM 模型构造，专注覆盖 L156 出口分支。"""
+    svc = ResultService(analyzer_crud=_FakeAnalyzerCrud())
+    with patch(
+        "ginkgo.data.services.result_service.models_to_dataframe",
+        return_value=pd.DataFrame(),
+    ):
+        res = svc.get_analyzer_values_df(task_id="t")
+    assert res.success
+    assert isinstance(res.data, pd.DataFrame)
+
+
+def test_create_order_record_delegates_to_container():
+    """懒 import container → order_service().create_order_record(**kwargs)（L662-663）。"""
+    fake_order_svc = MagicMock()
+    fake_order_svc.create_order_record.return_value = ServiceResult.success()
+    with patch("ginkgo.data.containers.container") as mock_container:
+        mock_container.order_service.return_value = fake_order_svc
+        svc = ResultService(analyzer_crud=_FakeAnalyzerCrud())
+        res = svc.create_order_record(code="000001", portfolio_id="p")
+    assert res.success
+    fake_order_svc.create_order_record.assert_called_once_with(code="000001", portfolio_id="p")

--- a/tests/unit/data/services/test_signal_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_signal_service_adr029_smoke.py
@@ -1,0 +1,84 @@
+"""SignalService ADR-029 Task 6 写路径 smoke（add + get_signals_df）。
+
+``add``（kwargs→Signal entity→SignalMapper→crud.add，退役隐式 _create_from_params
+hook）+ ``get_signals_df``（出口① DataFrame）被 containers import 链触达但 smoke
+不调方法体 → diff coverage gate 红。本 smoke mock crud 调起方法体补覆盖信号。
+"""
+import pandas as pd
+
+from ginkgo.enums import DIRECTION_TYPES
+from ginkgo.data.models.model_signal import MSignal
+from ginkgo.data.services.signal_service import SignalService
+
+
+class _FakeCrud:
+    def __init__(self):
+        self.added = []
+
+    def add(self, model):
+        self.added.append(model)
+
+    def find(self, filters=None, page=None, page_size=None, order_by=None, desc_order=None):
+        return [MSignal()]
+
+
+def test_add_signal_persists_via_mapper():
+    """add：Signal entity → SignalMapper.entity_to_model → crud.add（L66-96）。"""
+    crud = _FakeCrud()
+    svc = SignalService(crud_repo=crud)
+    res = svc.add(
+        portfolio_id="p",
+        engine_id="e",
+        task_id="t",
+        code="000001",
+        direction=DIRECTION_TYPES.LONG,
+        reason="momentum",
+    )
+    assert res.success
+    assert len(crud.added) == 1
+
+
+def test_get_signals_df_returns_dataframe():
+    """get_signals_df：find→list → models_to_dataframe（L216）。"""
+    svc = SignalService(crud_repo=_FakeCrud())
+    res = svc.get_signals_df(engine_id="e")
+    assert res.success
+    assert isinstance(res.data, pd.DataFrame)
+
+
+def test_add_signal_with_explicit_timestamp():
+    """传 timestamp → entity.timestamp 覆盖分支（L84-85）。"""
+    crud = _FakeCrud()
+    svc = SignalService(crud_repo=crud)
+    res = svc.add(
+        portfolio_id="p",
+        engine_id="e",
+        task_id="t",
+        code="000001",
+        direction=DIRECTION_TYPES.LONG,
+        reason="r",
+        timestamp="2025-01-02",
+    )
+    assert res.success
+
+
+class _BoomCrud:
+    def add(self, model):
+        raise RuntimeError("db down")
+
+    def find(self, **kwargs):
+        raise RuntimeError("db down")
+
+
+def test_add_signal_exception_returns_error():
+    """crud.add 抛异常 → except → ServiceResult.error（L94-96）。"""
+    svc = SignalService(crud_repo=_BoomCrud())
+    res = svc.add(
+        portfolio_id="p",
+        engine_id="e",
+        task_id="t",
+        code="000001",
+        direction=DIRECTION_TYPES.LONG,
+        reason="r",
+    )
+    assert not res.success

--- a/tests/unit/data/services/test_signal_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_signal_service_adr029_smoke.py
@@ -42,11 +42,14 @@ def test_add_signal_persists_via_mapper():
 
 
 def test_get_signals_df_returns_dataframe():
-    """get_signals_df：find→list → models_to_dataframe（L216）。"""
+    """get_signals_df：find→[MSignal()] → models_to_dataframe（L216）产非空 DF。
+    补 ``assert not empty`` 锁住出口真调了转换——回退/跳过 L216（→ else pd.DataFrame()
+    空 DF）则断言 FAIL（silent-pass 防护，与 result_service DF 出口同形）。"""
     svc = SignalService(crud_repo=_FakeCrud())
     res = svc.get_signals_df(engine_id="e")
     assert res.success
     assert isinstance(res.data, pd.DataFrame)
+    assert not res.data.empty  # 锁 L216 真产非空 DF(回退→空 DF→FAIL)
 
 
 def test_add_signal_with_explicit_timestamp():

--- a/tests/unit/data/services/test_signal_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_signal_service_adr029_smoke.py
@@ -4,6 +4,8 @@
 hook）+ ``get_signals_df``（出口① DataFrame）被 containers import 链触达但 smoke
 不调方法体 → diff coverage gate 红。本 smoke mock crud 调起方法体补覆盖信号。
 """
+import datetime
+
 import pandas as pd
 
 from ginkgo.enums import DIRECTION_TYPES
@@ -36,6 +38,7 @@ def test_add_signal_persists_via_mapper():
     )
     assert res.success
     assert len(crud.added) == 1
+    assert isinstance(crud.added[0], MSignal)  # 锁 mapper.entity_to_model 收敛(非裸 entity)
 
 
 def test_get_signals_df_returns_dataframe():
@@ -60,6 +63,9 @@ def test_add_signal_with_explicit_timestamp():
         timestamp="2025-01-02",
     )
     assert res.success
+    # 锁 L84-85 覆盖分支:timestamp 经 datetime_normalize 存 datetime(2025,1,2)。
+    # 若删掉该 if,entity.timestamp 回退 TimeMixin 默认(now)→ 此断言失败。
+    assert crud.added[0].timestamp == datetime.datetime(2025, 1, 2)
 
 
 class _BoomCrud:

--- a/tests/unit/data/services/test_stockinfo_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_stockinfo_service_adr029_smoke.py
@@ -1,0 +1,39 @@
+"""StockinfoService ADR-029 §Decision 1 batch 收敛 smoke（sync）。
+
+F3/F4 已锁 signal/position.add/order.upsert 的 **add path**；stockinfo.sync 的
+**batch path**（L227：list[StockInfo] → StockInfoMapper.entity_to_model → crud.add_batch，
+生产注释"ADR-029 Task 3：入站前置 mapper（Entity→Model），CRUD 不再做转换"）是兄弟盲区。
+本 smoke 补锁，使 §Decision 1 在 stockinfo 同步路径也有锚点。
+"""
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from ginkgo.data.models.model_stock_info import MStockInfo
+from ginkgo.data.services.stockinfo_service import StockinfoService
+
+
+def test_stockinfo_sync_batch_via_mapper():
+    """sync：fetch_cn_stockinfo → StockInfo entities → StockInfoMapper.entity_to_model →
+    crud.add_batch（L227,ADR-029 Task 3 收敛）。
+
+    锁 batch path mapper 收敛（F8c,F3 add-path 同形）：mock 数据源返 1 行 stockinfo，
+    mock crud.find 返空（无 existing → 全走 new 段）。回退 L227（跳过 mapper，
+    裸 StockInfo 直送 add_batch）则 isinstance(MStockInfo) FAIL。
+    """
+    data_source = MagicMock()
+    data_source.fetch_cn_stockinfo.return_value = pd.DataFrame(
+        [{"ts_code": "000001.SZ", "name": "test", "industry": "bank",
+          "list_date": "20250102", "delist_date": None}]
+    )
+    crud = MagicMock()
+    crud.find.return_value = []  # 无 existing → 全 new
+
+    svc = StockinfoService(crud_repo=crud, data_source=data_source)
+    res = svc.sync()
+
+    assert res.success, f"sync failed: {getattr(res, 'message', res)}"
+    crud.add_batch.assert_called_once()
+    batch_arg = crud.add_batch.call_args[0][0]
+    assert len(batch_arg) == 1
+    assert isinstance(batch_arg[0], MStockInfo)  # 锁 mapper.entity_to_model 收敛(非裸 entity)

--- a/tests/unit/data/services/test_trade_day_service_adr029_smoke.py
+++ b/tests/unit/data/services/test_trade_day_service_adr029_smoke.py
@@ -1,0 +1,37 @@
+"""TradeDayService ADR-029 §Decision 1 batch 收敛 smoke（sync）。
+
+F3/F4 已锁 signal/position.add/order.upsert 的 **add path**；trade_day.sync 的
+**batch path**（L163：list[TradeDay] → TradeDayMapper.entity_to_model → crud.add_batch，
+生产注释明确"ADR-029 Task 4：不再依赖 CRUD hook 隐式转"）是兄弟盲区。本 smoke 补锁。
+"""
+from unittest.mock import MagicMock
+
+import pandas as pd
+
+from ginkgo.data.models.model_trade_day import MTradeDay
+from ginkgo.data.services.trade_day_service import TradeDayService
+
+
+def test_trade_day_sync_batch_via_mapper():
+    """sync：fetch trade_cal → TradeDay entities → TradeDayMapper.entity_to_model →
+    crud.add_batch（L163,ADR-029 Task 4 收敛）。
+
+    锁 batch path mapper 收敛（F8d,F3 add-path 同形）：mock 数据源返 1 行日历，
+    mock crud.find 返空（无 existing → 全走 new 段）。回退 L163（跳过 mapper，
+    裸 TradeDay 直送 add_batch）则 isinstance(MTradeDay) FAIL。
+    """
+    data_source = MagicMock()
+    data_source.fetch_cn_stock_trade_day.return_value = pd.DataFrame(
+        {"cal_date": ["2025-01-02"], "is_open": [1]}
+    )
+    crud = MagicMock()
+    crud.find.return_value = []  # 无 existing → 全 new
+
+    svc = TradeDayService(crud_repo=crud, data_source=data_source)
+    res = svc.sync()
+
+    assert res.success, f"sync failed: {res.message if hasattr(res, 'message') else res}"
+    crud.add_batch.assert_called_once()
+    batch_arg = crud.add_batch.call_args[0][0]
+    assert len(batch_arg) == 1
+    assert isinstance(batch_arg[0], MTradeDay)  # 锁 mapper.entity_to_model 收敛(非裸 entity)

--- a/tests/unit/trading/test_backtest_result_aggregator_get_df.py
+++ b/tests/unit/trading/test_backtest_result_aggregator_get_df.py
@@ -1,0 +1,44 @@
+"""BacktestResultAggregator._get_dataframe 分支 smoke（ADR-029 Task 11 聚合出口）。
+
+``_get_dataframe``（ServiceResult→DataFrame 出口：error/None→None、DataFrame 直返、
+list→models_to_dataframe、其它→None，L195/207/208）被 containers import 链触达但
+smoke 不调 → diff coverage gate 红。本 smoke 用 dummy self 直调覆盖各分支。
+"""
+import pandas as pd
+
+from ginkgo.trading.analysis.backtest_result_aggregator import BacktestResultAggregator
+from ginkgo.data.services.base_service import ServiceResult
+
+
+def _call(result):
+    """_get_dataframe 方法体不引用 self，用 dummy self 直调。"""
+    return BacktestResultAggregator._get_dataframe(object(), result)
+
+
+def test_get_dataframe_empty_list_returns_dataframe():
+    """success + 空list → models_to_dataframe 假分支 → 空 DataFrame（L195/207/208）。"""
+    out = _call(ServiceResult.success(data=[]))
+    assert isinstance(out, pd.DataFrame)
+    assert out.empty
+
+
+def test_get_dataframe_error_result_returns_none():
+    """error result → not is_success → None。"""
+    assert _call(ServiceResult.error("boom")) is None
+
+
+def test_get_dataframe_none_data_returns_none():
+    """success + data=None → None。"""
+    assert _call(ServiceResult.success(data=None)) is None
+
+
+def test_get_dataframe_dataframe_passthrough():
+    """success + DataFrame → 原样直返。"""
+    df = pd.DataFrame({"a": [1]})
+    out = _call(ServiceResult.success(data=df))
+    pd.testing.assert_frame_equal(out, df)
+
+
+def test_get_dataframe_unsupported_type_returns_none():
+    """success + 非 DataFrame/list → None。"""
+    assert _call(ServiceResult.success(data="not-supported")) is None


### PR DESCRIPTION
## 背景

ADR-029(#6890,Entity↔ORM Mapper 全链路收敛 + 钩子族退役)合并后,其引入的 `check_diff_coverage` 80% gate(ADR-029 自身的 PR 上)在阈值边缘——首跑 **34.97%**(186 未覆盖行)。master CI 当前已绿(gate 仅在 `pull_request` 事件跑)。

本 PR 为 ADR-029 的覆盖债补 smoke,**不修当前红色的 gate**(那个 gate 属于已合并的 #6890)。

## 本 PR 做了什么

补 9 个测试文件(804 行)+ ci.yml gate 合集登记 6 个新文件,覆盖 ADR-029 新增/改写代码的执行路径:

| 覆盖点 | 文件 |
|---|---|
| `SignalMapper.model_to_entity` 反向映射(uuid/business_timestamp 还原) | `test_signal_mapper_adr029_smoke.py` |
| `PositionMapper.model_to_entity` business_timestamp 还原 | `test_position_mapper.py`(扩展) |
| DF↔Entity 双向映射 | `test_df_mapper.py` |
| `PositionService` 写路径(save/get_df/upsert-create) | `test_position_service_adr029_smoke.py` |
| `ResultService` 读出口 + container 委托 | `test_result_service_adr029_smoke.py` |
| `MOrder.order_type` enum 分支(`validate_input` if-not-None 兜底,L156-157) | `test_model_order_enum.py` |
| 各 model enum `__init__`/`update(str)`/`update(Series)` 分支 | `test_model_enum_branches.py` |
| `OrderService` 写路径 | `test_order_service_adr029_smoke.py` |
| `BacktestResultAggregator._get_dataframe` ServiceResult→DataFrame 出口 | `test_backtest_result_aggregator_get_df.py` |

## 质量自证(按 gate 口径复现 ADR-029 diff)

base=`f142a96c`(ADR-029 doc commit), head=`master`, 直 diff:

```
Diff coverage: 236/295 executable changed lines covered (80.00%), threshold 80.00%
0 errors
390 passed in 7.52s (single-process, GINKGO_ALLOW_SINGLE_PROCESS=1, TERM=dumb)
```

## 关于本 PR 的 gate 行为(诚实说明)

本 PR diff 仅含测试文件 + ci.yml,**无 src/api 改动**,故 gate 会 **skip-pass**(无 executable changed lines)。即:本 PR 自身 CI 绿是 trivial 的。

**真正价值**:为未来重触 ADR-029 这些代码行的 PR 预置覆盖,使其能过 80% gate,而非每次大重构都在阈值边缘赌。

## 测试

- 单进程跑 gate 合集 43 文件:390 passed, 7.52s, 无 OOM/污染(均为 mock,无 DB)
- 复跑 `check_diff_coverage.py --base f142a96c --head <master> --threshold 80`:80.00%, 0 errors
