### PR TITLE
fix(models): 补修 #6892 遗漏的 broker_attitude/account_type/execution_mode value-0 吞没

### DIFF
--- a/src/ginkgo/data/models/model_engine.py
+++ b/src/ginkgo/data/models/model_engine.py
@@ -81,7 +81,9 @@ class MEngine(MMysqlBase):
         self.backtest_start_date = backtest_start_date  # 新增时间范围字段赋值
         self.backtest_end_date = backtest_end_date      # 新增时间范围字段赋值
         if broker_attitude is not None:
-            self.broker_attitude = ATTITUDE_TYPES.validate_input(broker_attitude) or 2  # 默认OPTIMISTIC
+            # validate_input 对 OTHER(0) 返 0(合法值);`or 2` 会误吞为 OPTIMISTIC(2) → 仅 None 兜底
+            validated = ATTITUDE_TYPES.validate_input(broker_attitude)
+            self.broker_attitude = validated if validated is not None else 2
         if status is not None:
             # validate_input 对 OTHER(0) 返 0(合法值);`or -1` 会误吞为 -1 → 仅 None 兜底
             validated = ENGINESTATUS_TYPES.validate_input(status)
@@ -117,7 +119,8 @@ class MEngine(MMysqlBase):
             self.source = validated if validated is not None else -1
             del kwargs['source']
         if 'broker_attitude' in kwargs:
-            self.broker_attitude = ATTITUDE_TYPES.validate_input(kwargs['broker_attitude']) or 2
+            validated = ATTITUDE_TYPES.validate_input(kwargs['broker_attitude'])
+            self.broker_attitude = validated if validated is not None else 2
             del kwargs['broker_attitude']
         # 设置其他字段，包括run_count
         for key, value in kwargs.items():

--- a/src/ginkgo/data/models/model_signal_tracker.py
+++ b/src/ginkgo/data/models/model_signal_tracker.py
@@ -87,9 +87,12 @@ class MSignalTracker(MMysqlBase, MBacktestRecordBase):
 
         # 执行模式 - 自动转换枚举
         if execution_mode is not None:
-            self.execution_mode = EXECUTION_MODE.validate_input(execution_mode) or EXECUTION_MODE.PAPER.value
+            # validate_input 对 BACKTEST(0) 返 0(合法值);`or PAPER.value` 会误吞为 PAPER(2) → 仅 None 兜底
+            validated = EXECUTION_MODE.validate_input(execution_mode)
+            self.execution_mode = validated if validated is not None else EXECUTION_MODE.PAPER.value
         if account_type is not None:
-            self.account_type = ACCOUNT_TYPE.validate_input(account_type) or ACCOUNT_TYPE.PAPER.value
+            validated = ACCOUNT_TYPE.validate_input(account_type)
+            self.account_type = validated if validated is not None else ACCOUNT_TYPE.PAPER.value
 
         # 预期执行参数
         if expected_code is not None:
@@ -177,7 +180,9 @@ class MSignalTracker(MMysqlBase, MBacktestRecordBase):
         self.strategy_id = strategy_id
         self.portfolio_id = portfolio_id
         self.execution_mode = EXECUTION_MODE.validate_input(execution_mode) or 0
-        self.account_type = ACCOUNT_TYPE.validate_input(account_type) or 1
+        # account_type: validate_input 对 BACKTEST(0) 返 0(合法值);`or 1` 会误吞为 PAPER(1) → 仅 None 兜底
+        validated = ACCOUNT_TYPE.validate_input(account_type)
+        self.account_type = validated if validated is not None else 1
         
         # 预期参数
         self.expected_code = expected_code
@@ -232,7 +237,8 @@ class MSignalTracker(MMysqlBase, MBacktestRecordBase):
         self.strategy_id = df["strategy_id"]
         self.portfolio_id = df["portfolio_id"]
         self.execution_mode = EXECUTION_MODE.validate_input(df["execution_mode"]) or 0
-        self.account_type = ACCOUNT_TYPE.validate_input(df["account_type"]) or 1
+        validated = ACCOUNT_TYPE.validate_input(df["account_type"])
+        self.account_type = validated if validated is not None else 1
         
         # 预期参数
         self.expected_code = df["expected_code"]

--- a/tests/unit/data/models/test_enum_other_zero_roundtrip.py
+++ b/tests/unit/data/models/test_enum_other_zero_roundtrip.py
@@ -7,6 +7,8 @@ ENGINESTATUS.IDLE=0)返回 0。旧代码 `validate_input(x) or -1` 因 `0 or -1 
 修复(`validated = validate_input(x); x = validated if validated is not None else -1`)
 保留 0、仅对 None(无效输入)兜底 -1。本测试锁住该语义,防再被简化回 `or -1`。
 """
+import datetime
+
 import pytest
 
 from ginkgo.enums import (
@@ -18,8 +20,11 @@ from ginkgo.enums import (
     ORDER_TYPES,
     ORDERSTATUS_TYPES,
     ENGINESTATUS_TYPES,
+    ATTITUDE_TYPES,
+    EXECUTION_MODE,
+    ACCOUNT_TYPE,
 )
-from ginkgo.data.models import MBar, MSignal
+from ginkgo.data.models import MBar, MSignal, MEngine, MSignalTracker
 
 # 受影响 enum 及其 value-0 成员名(均会被旧 `or -1` 误吞)
 VALUE_ZERO = [
@@ -31,6 +36,9 @@ VALUE_ZERO = [
     (ORDER_TYPES, "OTHER"),
     (ORDERSTATUS_TYPES, "OTHER"),
     (ENGINESTATUS_TYPES, "IDLE"),
+    (ATTITUDE_TYPES, "OTHER"),
+    (EXECUTION_MODE, "BACKTEST"),
+    (ACCOUNT_TYPE, "BACKTEST"),
 ]
 
 
@@ -72,3 +80,27 @@ def test_msignal_direction_other_roundtrips():
     """模型层:MSignal(direction=OTHER).direction == 0。"""
     s = MSignal(code="000001.SZ", direction=DIRECTION_TYPES.OTHER)
     assert s.direction == 0
+
+
+def test_mengine_broker_attitude_other_roundtrips():
+    """模型层:MEngine(broker_attitude=OTHER).broker_attitude == 0(非 2)。"""
+    e = MEngine(broker_attitude=ATTITUDE_TYPES.OTHER)
+    assert e.broker_attitude == 0
+
+
+def test_msignal_tracker_backtest_zero_roundtrips():
+    """模型层:execution_mode/account_type 传 BACKTEST(0) 必须存 0,不被 PAPER 吞。"""
+    s = MSignalTracker(
+        signal_id="s1",
+        strategy_id="st1",
+        portfolio_id="p1",
+        execution_mode=EXECUTION_MODE.BACKTEST,
+        account_type=ACCOUNT_TYPE.BACKTEST,
+        expected_code="000001.SZ",
+        expected_direction=DIRECTION_TYPES.LONG,
+        expected_price=10.0,
+        expected_volume=100,
+        expected_timestamp=datetime.datetime(2025, 1, 1),
+    )
+    assert s.execution_mode == 0
+    assert s.account_type == 0


### PR DESCRIPTION
## 背景

#6892 修复 `validate_input(x) or -1` 吞 value-0 枚举成员,但 review 发现其只修了 `or -1` 形态,**遗漏同文件内 `or 默认值` 形态**——后者同样吞 value-0(`validate_input` 对 value-0 返 0,`0 or X == X`)。#6892 已合并,漏修随之进入 master。

## 本 PR 补修(review #6892 指出 + reviewer 漏报补正)

| 文件 | 行 | 字段 | 旧 | 吞掉的 value-0 |
|---|---|---|---|---|
| model_engine.py | L84, L120 | broker_attitude | `or 2` | ATTITUDE.OTHER(0) |
| model_signal_tracker.py | L92 | account_type | `or PAPER.value` | ACCOUNT_TYPE.BACKTEST(0) |
| model_signal_tracker.py | L180, L235 | account_type | `or 1` | ACCOUNT_TYPE.BACKTEST(0) |
| model_signal_tracker.py | L90 | execution_mode | `or PAPER.value` | EXECUTION_MODE.BACKTEST(0) ← reviewer 漏报补正 |

统一改 `validated = validate_input(x); x = validated if validated is not None else 默认`(保留 0、仅 None 兜底),与 #6892 主修复同一惯用法。

## 测试

`VALUE_ZERO` 参数化补 ATTITUDE/EXECUTION/ACCOUNT 三项;新增 `MEngine(broker_attitude=OTHER)` 与 `MSignalTracker(execution_mode=BACKTEST, account_type=BACKTEST)` roundtrip,锁住 model 层存 0。18 passed。同目录 `tests/unit/data/models/` 456 passed,2 failed 为预存(`MOrder.frozen` 属性缺失,stash 验证与本 PR 无关)。

## 范围说明

review 评论另指出 `transfer_mapper.py:40-53` 有 4 处同款 `or -1`(非 #6892 改动文件),本 PR 不含,建议单独处理。
