### PR TITLE
docs(adr): 补 002/003/006/009 反向指针同步后续 ADR

### DIFF
--- a/docs/adrs/ADR-002-layered-architecture.md
+++ b/docs/adrs/ADR-002-layered-architecture.md
@@ -1,7 +1,9 @@
 # ADR-002: 分层架构 API/CLI → Service → CRUD → DB
 
-**Status:** Accepted
+**Status:** Accepted（CRUD 返回类型条款 §3 修订 by [ADR-029](ADR-029-basecrud-hook-retirement.md)）
 **Date:** 2026-06-13
+
+> **演进说明（ADR-029，2026-08-02）**：§3 "CRUD 返回 `ModelList`" 条款已修订——`ModelList` 退役，CRUD 改返 `list[Model]`，DataFrame 转换走独立 `models_to_dataframe`。本 ADR 的四层单向分层不变，仅 CRUD 出口类型更新。详见 [ADR-029](ADR-029-basecrud-hook-retirement.md) §D9。
 
 ## Context
 
@@ -19,13 +21,13 @@ API / CLI → Service → CRUD → DB
 
 1. **API 禁止直接调 CRUD**，必须通过 Service。
 2. **Service 禁止暴露 CRUD 实例**，只返回业务结果或数据传输对象。
-3. **CRUD 返回 `ModelList`**（ORM 模型集合），由调用方按需转换；不在 CRUD 层做 DTO 序列化。
+3. ~~**CRUD 返回 `ModelList`**~~（⟵ ADR-029 修订：退役为 `list[Model]`，DF 走 `models_to_dataframe`）——ORM 模型集合由调用方按需转换；不在 CRUD 层做 DTO 序列化。
 
 ## Rationale
 
 - 业务规则集中在 Service 层，API / CLI / Web-UI 三种入口共享同一套规则。
 - CRUD 实例不外泄，DB session 生命周期完全由 CRUD 内部管理。
-- CRUD 返回 `ModelList` 保持数据层"纯读写"，转换职责上推，避免 CRUD 被各种 DTO 形态污染。
+- CRUD 返回 ORM `list[Model]`（ADR-029 起，原 `ModelList` 退役）保持数据层"纯读写"，转换职责上推，避免 CRUD 被各种 DTO 形态污染。
 
 ## Consequences
 

--- a/docs/adrs/ADR-003-engine-two-mode.md
+++ b/docs/adrs/ADR-003-engine-two-mode.md
@@ -13,7 +13,7 @@
 
 - PAPER 与 LIVE 的差异（模拟成交 vs 真实下单）属于 **Broker / Gateway 层**，不进引擎。
 - `EXECUTION_MODE` 枚举**保持四态不变**——PAPER / PAPER_MANUAL 在 Broker/Gateway 层仍有意义。
-- 旧 `LiveEngine` 已废弃，统一为 `TimeControlledEventEngine(mode=EXECUTION_MODE.LIVE)`。
+- 旧 `LiveEngine` 已废弃，统一为 `TimeControlledEventEngine(mode=EXECUTION_MODE.LIVE)`。（⟵ [ADR-039](ADR-039-liveengine-removal-distributed-live.md) 进一步：正式放弃"mode=LIVE 接管实盘"目标，实盘走 ExecutionNode 分布式；本条仅保留"引擎层 LIVE 与 PAPER 等价"语义，不承诺实盘跑在事件引擎上。）
 
 ## Rationale
 
@@ -24,4 +24,4 @@
 
 - 引擎代码中新增逻辑时，用 `if BACKTEST / else`，不要引入 `elif PAPER` 分支。
 - 若未来确需引擎层区分 PAPER/LIVE，**说明关注点放错了层级**，应下沉到 Broker/Gateway。
-- 详见 `src/ginkgo/trading/engines/time_controlled_engine.py` 与废弃的 `src/ginkgo/livecore/live_engine.py`。
+- 详见 `src/ginkgo/trading/engines/time_controlled_engine.py`；`livecore/live_engine.py` 已由 [ADR-039](ADR-039-liveengine-removal-distributed-live.md) 清理移除。

--- a/docs/adrs/ADR-006-db-role-separation.md
+++ b/docs/adrs/ADR-006-db-role-separation.md
@@ -14,7 +14,7 @@ Ginkgo 同时处理海量时序行情、关系型实体、热缓存、非结构�
 | 数据库 | 角色 | 存什么 |
 |---|---|---|
 | ClickHouse | 时序 | K线、Tick、行情、回测逐笔 |
-| MySQL | 关系 | Portfolio、组件、回测记录、用户配置 |
+| MySQL | 关系 | Portfolio、组件、回测记录、用户配置（注：`MOrder`/`MSignalTracker` 活状态写入当前休眠，见 [ADR-032](ADR-032-persistence-model-basesplit.md)/[034](ADR-034-signal-cross-store-namesake.md)） |
 | Redis | 缓存 | 热数据、会话、跨进程快取 |
 | MongoDB | 文档 | 非结构化/半结构化文档 |
 

--- a/docs/adrs/ADR-009-global-service-hub.md
+++ b/docs/adrs/ADR-009-global-service-hub.md
@@ -26,3 +26,7 @@
 - 获取全局服务统一走 `services` 或 `service_hub`，不直接 `import` 服务实现类的模块级实例。
 - 新增全局服务时，注册到对应域的 `service_hub` 分层下，并在 `services` 公共接口按需导出。
 - 重构时禁止擅自修改 Base 类（BaseCRUD / BaseService），在具体实现层处理。
+  - **已授权例外（须 HITL 背书，见对应 ADR）**：
+    - [ADR-029](ADR-029-basecrud-hook-retirement.md)：BaseCRUD 转换钩子族 + `ModelList` 退役（line 28 立下以来的首次例外）。
+    - [ADR-031](ADR-031-enum-mapping-field-info-sink.md)：`_conversion._get_enum_mappings` 默认实现改为反射 `__table__.columns`。
+  - 新增例外须先立 ADR 并获 HITL 背书，不得默认沿用。


### PR DESCRIPTION
## 背景
全量 ADR(39 篇)冲突审查结论:**无逻辑硬冲突**——所有实质张力均已显式仲裁(supersede/互补/交叉引用)。唯一问题是**文档同步债**:旧 ADR 正文未反向标注取代它的后续决策,单读者会拿到过期规则。

本次仅加反向指针,**不改任何决策实质**。

## 改动(4 篇 7 处)
- **ADR-002**:Status + 演进 blockquote + §3/Rationale 行内注 → CRUD 返回 `ModelList` 退役为 `list[Model]`(ADR-029)
- **ADR-009**:L28「禁改 Base」补**已授权例外清单**(ADR-029 钩子族+ModelList / ADR-031 enum 反射),并声明「新例外须先立 ADR + HITL 背书」
- **ADR-003**:L16 加 039 指针(放弃 mode=LIVE 接管实盘,走 ExecutionNode)+ L27 标注 `live_engine.py` 已移除
- **ADR-006**:MySQL 角色行加休眠注脚(`MOrder`/`MSignalTracker`,见 ADR-032/034)

**ADR-004 经核验已达标**(supersede 链接 + 演进 blockquote + 删除线齐备),未改动。

## 未含(超出本次范畴)
- **P1 跨 ADR 待决项**:MySQL 活态表「重接线 vs 废弃」、实盘下单闭环未焊 —— 需业务决策,非文档修复
- **P2 方法论张力**:011/019 mixin 判定标准、010 rationale 自洽 —— 建议另起小 ADR

## 验证
grep 确认 4 篇 7 处反向指针落地,markdown 链接格式完整无破损。

🤖 Generated with [Claude Code](https://claude.com/claude-code)