### PR TITLE
refactor(risk): 提取 portfolio_info 访问器 + 修止盈 bug (#6470)

### DIFF
--- a/src/ginkgo/trading/bases/portfolio_info_access.py
+++ b/src/ginkgo/trading/bases/portfolio_info_access.py
@@ -1,0 +1,99 @@
+"""portfolio_info 访问工具函数(无状态)。
+
+集中持仓/市值/现价/P&L 的提取逻辑,供 Risk/Strategy/Sizer 等组件复用。
+消除 risk_management 17 子类的重复内联 .get() 与求和(#6470)。
+
+设计:纯函数(非 mixin)。
+- Ginkgo 现有 mixin(ContextMixin/TimeMixin/NamedMixin/EngineBindableMixin/LotAlignableMixin)
+  全部持实例状态(self._xxx);portfolio_info 访问无状态,归 utils 函数先例
+  (trading/evaluation/utils/ast_helpers.py),不进 entities/mixins/。
+- 对称:Strategy/Sizer/Selector 同样收 portfolio_info,可复用,无 RiskBase-only 不对称。
+- 不碰 Base 类层级(函数在类外),绕开 Base 禁令。
+"""
+from typing import Any, Dict, Optional
+
+
+def get_positions(portfolio_info: Dict[str, Any]) -> Dict[str, Any]:
+    """归一化取出 positions,统一返回 {code: position} dict。
+
+    portfolio_base 构建处 positions 形态不一致:
+    - portfolio_base.py:887 路径为 dict(self.positions)
+    - portfolio_base.py:851 路径为 list(self._positions.values())
+    各 risk 消费方既 [code] 索引又 .values()/.get(code),仅 dict 形态成立。
+    本函数将 list 归一为 dict,dict 原样返回,缺失/None 返回 {}。
+
+    Args:
+        portfolio_info: 组件 cal/generate_signals 收到的 portfolio_info dict
+
+    Returns:
+        Dict[str, Any]: {code: position} 映射,永不返回 None
+    """
+    positions = portfolio_info.get("positions")
+    if not positions:
+        return {}
+    if isinstance(positions, dict):
+        return positions
+    # list 形态:按 .code 归一,跳过 None/空元素
+    return {
+        pos.code: pos for pos in positions if pos and getattr(pos, "code", None)
+    }
+
+
+def total_market_value(portfolio_info: Dict[str, Any]) -> Any:
+    """组合总市值(各持仓 market_value 之和)。
+
+    替换 concentration_risk(1×)/volatility_risk(1×) 重复的内联:
+        sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
+    持原守卫语义:跳过 None/0/缺字段的持仓。
+
+    Args:
+        portfolio_info: 组件收到的 portfolio_info dict
+
+    Returns:
+        各 position.market_value 之和(类型随 market_value,通常 Decimal/float);空则 0
+    """
+    return sum(
+        (pos.market_value if pos else 0)
+        for pos in get_positions(portfolio_info).values()
+        if pos and getattr(pos, "market_value", None)
+    )
+
+
+def current_price(portfolio_info: Dict[str, Any], code: str) -> Optional[Any]:
+    """取某 code 的现价,无则 None(不兜底假价)。
+
+    替换 concentration_risk 的 portfolio_info.get("prices", {}).get(order.code, 100)。
+    原代码缺价时回退 100(假价,掩盖数据缺失);本函数返回 None,调用方显式决定
+    回退(守 refactor 行为:concentration 调用处保留 `or 100`,行为不变)。
+
+    Args:
+        portfolio_info: 组件收到的 portfolio_info dict
+        code: 标的代码
+
+    Returns:
+        现价或 None
+    """
+    prices = portfolio_info.get("prices") or {}
+    return prices.get(code)
+
+
+def pnl_ratio(position: Any) -> Any:
+    """持仓盈亏比率(dict/object 双兼容)。
+
+    修复 profit_target_risk #3957 bug:
+        getattr(position, 'profit_loss_ratio', 0)
+    在 position 为 dict 时恒返回 0(dict 无属性),止盈永不触发(master 8 测试红)。
+    本函数 dict 走 .get 键、object 走 getattr,双形态正确读取。
+    注:loss_limit_risk 从 event 现价 + position.cost 实算(语义不同),不经此函数。
+
+    Args:
+        position: portfolio_info["positions"][code] 取出的持仓(dict 或对象)
+
+    Returns:
+        profit_loss_ratio 值;缺失/None position 返回 0
+    """
+    if position is None:
+        return 0
+    if isinstance(position, dict):
+        return position.get("profit_loss_ratio", 0) or 0
+    return getattr(position, "profit_loss_ratio", 0) or 0

--- a/src/ginkgo/trading/risk_management/concentration_risk.py
+++ b/src/ginkgo/trading/risk_management/concentration_risk.py
@@ -23,6 +23,11 @@
 from typing import List, Dict, Optional
 from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
+from ginkgo.trading.bases.portfolio_info_access import (
+    current_price,
+    get_positions,
+    total_market_value,
+)
 from ginkgo.libs import to_decimal
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
@@ -217,11 +222,11 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
 
     def _calculate_concentrations(self, portfolio_info: Dict) -> Dict:
         """计算各种集中度指标"""
-        positions = portfolio_info.get("positions", {})
+        positions = get_positions(portfolio_info)
         if not positions:
             return {}
 
-        total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
+        total_value = total_market_value(portfolio_info)
         if total_value <= 0:
             return {}
 
@@ -284,13 +289,13 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
 
     def _get_current_position_ratio(self, portfolio_info: Dict, code: str) -> float:
         """获取指定股票的当前持仓比例"""
-        positions = portfolio_info.get("positions", {})
+        positions = get_positions(portfolio_info)
         position = positions.get(code)
 
         if not position or position.market_value <= 0:
             return 0.0
 
-        total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
+        total_value = total_market_value(portfolio_info)
         if total_value <= 0:
             return 0.0
 
@@ -318,10 +323,10 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
         # #3959 使用实际价格计算订单金额
         price = getattr(order, 'limit_price', None)
         if not price or price <= 0:
-            price = portfolio_info.get("prices", {}).get(order.code, 100)
+            price = current_price(portfolio_info, order.code) or 100
         order_value = order.volume * price
-        positions = portfolio_info.get("positions", {})
-        total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
+        positions = get_positions(portfolio_info)
+        total_value = total_market_value(portfolio_info)
 
         if total_value <= 0:
             return self._project_against_worth(portfolio_info, order_value)
@@ -334,13 +339,13 @@ class ConcentrationRisk(LotAlignableMixin, BaseRiskManagement):
 
     def _calculate_projected_industry_ratio(self, portfolio_info: Dict, order: Order, industry: str) -> float:
         """计算下单后的预计行业持仓比例"""
-        positions = portfolio_info.get("positions", {})
-        total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
+        positions = get_positions(portfolio_info)
+        total_value = total_market_value(portfolio_info)
 
         # #3959 使用实际价格计算订单价值(提前至空组合分支前,供 worth 投影复用)
         price = getattr(order, 'limit_price', None)
         if not price or price <= 0:
-            price = portfolio_info.get("prices", {}).get(order.code, 100)
+            price = current_price(portfolio_info, order.code) or 100
         order_value = order.volume * price
 
         if total_value <= 0:

--- a/src/ginkgo/trading/risk_management/profit_target_risk.py
+++ b/src/ginkgo/trading/risk_management/profit_target_risk.py
@@ -21,6 +21,7 @@ from decimal import Decimal
 from typing import Dict, List, Any
 
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
+from ginkgo.trading.bases.portfolio_info_access import get_positions, pnl_ratio
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
 from ginkgo.trading.events.base_event import EventBase
@@ -89,13 +90,15 @@ class ProfitTargetRisk(BaseRiskManagement):
         signals = []
 
         # 检查是否有该股票的持仓
-        if not hasattr(event, 'code') or event.code not in portfolio_info.get('positions', {}):
+        positions = get_positions(portfolio_info)
+        if not hasattr(event, 'code') or event.code not in positions:
             return signals
 
-        position = portfolio_info['positions'][event.code]
+        position = positions[event.code]
 
-        # #3957 计算当前盈利比例 - Position 对象使用 getattr 而非 dict.get
-        current_profit_ratio = getattr(position, 'profit_loss_ratio', 0)
+        # 计算当前盈利比例 - 经 portfolio_info_access.pnl_ratio 统一读取
+        # (#6470 修复:原 getattr(position, 'profit_loss_ratio', 0) 在 dict 形态恒 0,止盈永不触发)
+        current_profit_ratio = pnl_ratio(position)
 
         # 检查是否达到止盈目标
         if current_profit_ratio >= self.profit_target:

--- a/src/ginkgo/trading/risk_management/volatility_risk.py
+++ b/src/ginkgo/trading/risk_management/volatility_risk.py
@@ -23,6 +23,7 @@
 from typing import List, Dict
 from decimal import Decimal
 from ginkgo.trading.bases.risk_base import RiskBase as BaseRiskManagement
+from ginkgo.trading.bases.portfolio_info_access import get_positions, total_market_value
 from ginkgo.entities import Signal
 from ginkgo.entities import Order
 from ginkgo.entities.mixins import LotAlignableMixin
@@ -263,12 +264,12 @@ class VolatilityRisk(LotAlignableMixin, BaseRiskManagement):
         Returns:
             float: 投资组合波动率
         """
-        positions = portfolio_info.get("positions", {})
+        positions = get_positions(portfolio_info)
         if not positions:
             return 0.0
 
         # 计算各股票的波动率和权重
-        total_value = sum(pos.market_value for pos in positions.values() if pos and pos.market_value)
+        total_value = total_market_value(portfolio_info)
         if total_value <= 0:
             return 0.0
 

--- a/tests/unit/backtest/risk_managements/test_loss_limit_risk.py
+++ b/tests/unit/backtest/risk_managements/test_loss_limit_risk.py
@@ -8,6 +8,7 @@ import pytest
 from datetime import datetime
 from decimal import Decimal
 from unittest.mock import Mock, patch, MagicMock
+from types import SimpleNamespace
 import uuid
 
 from ginkgo.trading.risk_management.loss_limit_risk import LossLimitRisk
@@ -221,6 +222,10 @@ class TestLossLimitRiskThresholds:
     def test_loss_above_limit_generates_signal(self):
         """Test signal generation when loss exceeds threshold."""
         risk = _make_risk()
+        # 模拟引擎装配:create_signal 从 _context 自动填充信号 portfolio_id/engine_id
+        risk._context = SimpleNamespace(
+            portfolio_id="test_portfolio_id", engine_id="test_engine_id", task_id=None
+        )
 
         position = _make_position(cost="10.0")
         event = _make_price_event(close="8.4", open_="8.5", high="8.6", low="8.2")
@@ -229,7 +234,7 @@ class TestLossLimitRiskThresholds:
         )
 
         # Patch Signal to bypass task_id validation and capture the args
-        with patch("ginkgo.trading.risk_management.loss_limit_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             mock_signal = Mock()
             MockSignal.return_value = mock_signal
 
@@ -245,7 +250,7 @@ class TestLossLimitRiskThresholds:
             assert call_kwargs["direction"] == DIRECTION_TYPES.SHORT
             assert call_kwargs["portfolio_id"] == "test_portfolio_id"
             assert call_kwargs["engine_id"] == "test_engine_id"
-            assert call_kwargs["source"] == SOURCE_TYPES.STRATEGY
+            assert call_kwargs["source"] == SOURCE_TYPES.RISK
             assert "Loss Limit" in call_kwargs["reason"]
             assert "16.00%" in call_kwargs["reason"]
 
@@ -280,7 +285,7 @@ class TestLossLimitRiskThresholds:
             positions={"000001.SZ": position}
         )
 
-        with patch("ginkgo.trading.risk_management.loss_limit_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             MockSignal.return_value = Mock()
 
             signals = risk.generate_signals(portfolio_info, event)
@@ -376,7 +381,7 @@ class TestLossLimitRiskFinancialAccuracy:
             positions={"000001.SZ": position}
         )
 
-        with patch("ginkgo.trading.risk_management.loss_limit_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             MockSignal.return_value = Mock()
 
             # Should trigger signal since loss exceeds the slightly-lower limit
@@ -399,7 +404,7 @@ class TestLossLimitRiskFinancialAccuracy:
             positions={"000001.SZ": position}
         )
 
-        with patch("ginkgo.trading.risk_management.loss_limit_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             MockSignal.return_value = Mock()
 
             signals = risk.generate_signals(portfolio_info, event)
@@ -433,7 +438,7 @@ class TestLossLimitRiskMultiplePositions:
         # Event for stock 2 (16.0 = 20% loss)
         event2 = _make_price_event(code="000002.SZ", close="16.0")
 
-        with patch("ginkgo.trading.risk_management.loss_limit_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             mock_signal = Mock()
             MockSignal.return_value = mock_signal
 

--- a/tests/unit/backtest/risk_managements/test_profit_limit_risk.py
+++ b/tests/unit/backtest/risk_managements/test_profit_limit_risk.py
@@ -13,6 +13,7 @@ import pytest
 from datetime import datetime
 from decimal import Decimal
 from unittest.mock import Mock, patch
+from types import SimpleNamespace
 import uuid
 
 from ginkgo.trading.risk_management.profit_target_risk import ProfitTargetRisk
@@ -197,6 +198,10 @@ class TestProfitLimitRiskThresholds:
     def test_profit_above_limit_generates_signal(self):
         """Test signal generation when profit exceeds threshold."""
         risk = ProfitTargetRisk(profit_target=0.15)
+        # 模拟引擎装配:create_signal 从 _context 自动填充信号 portfolio_id/engine_id
+        risk._context = SimpleNamespace(
+            portfolio_id="test_portfolio_id", engine_id="profit_target_risk", task_id=None
+        )
 
         # 16% profit (exceeds 15% threshold)
         position = _make_dict_position(profit_loss_ratio=0.16)
@@ -205,7 +210,7 @@ class TestProfitLimitRiskThresholds:
         )
         event = _make_price_event()
 
-        with patch("ginkgo.trading.risk_management.profit_target_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             mock_signal = Mock()
             MockSignal.return_value = mock_signal
 
@@ -252,7 +257,7 @@ class TestProfitLimitRiskThresholds:
         )
         event = _make_price_event()
 
-        with patch("ginkgo.trading.risk_management.profit_target_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             MockSignal.return_value = Mock()
 
             signals = risk.generate_signals(portfolio_info, event)
@@ -340,7 +345,7 @@ class TestProfitLimitRiskFinancialAccuracy:
         )
         event = _make_price_event()
 
-        with patch("ginkgo.trading.risk_management.profit_target_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             MockSignal.return_value = Mock()
 
             signals = risk.generate_signals(portfolio_info, event)
@@ -366,7 +371,7 @@ class TestProfitLimitRiskFinancialAccuracy:
         )
         event = _make_price_event()
 
-        with patch("ginkgo.trading.risk_management.profit_target_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             mock_signal = Mock()
             MockSignal.return_value = mock_signal
 
@@ -407,7 +412,7 @@ class TestProfitLimitRiskMultiplePositions:
         # Event for stock 2 (above threshold)
         event2 = _make_price_event(code="000002.SZ")
 
-        with patch("ginkgo.trading.risk_management.profit_target_risk.Signal") as MockSignal:
+        with patch("ginkgo.entities.Signal") as MockSignal:
             mock_signal = Mock()
             MockSignal.return_value = mock_signal
 

--- a/tests/unit/trading/bases/test_portfolio_info_access.py
+++ b/tests/unit/trading/bases/test_portfolio_info_access.py
@@ -1,0 +1,120 @@
+"""portfolio_info 访问工具函数单测。
+
+覆盖 #6470 提取的 4 个无状态 helper:
+- get_positions: 归一 portfolio_base 构建处 list/dict 不一致
+- total_market_value: 替换 concentration/volatility 的求和重复
+- current_price: 替换 concentration 的 portfolio_info["prices"] 导航
+- pnl_ratio: dict/object 双兼容,修复 profit_target 读字段 bug
+"""
+from types import SimpleNamespace
+
+from ginkgo.trading.bases.portfolio_info_access import (
+    current_price,
+    get_positions,
+    pnl_ratio,
+    total_market_value,
+)
+
+
+# ---------------------------- get_positions ----------------------------
+
+class TestGetPositions:
+    def test_dict_passthrough(self):
+        """dict 形态( portfolio_base.py:887 路径)原样返回。"""
+        pos = {"000001.SZ": SimpleNamespace(code="000001.SZ", market_value=10)}
+        assert get_positions({"positions": pos}) is pos
+
+    def test_list_normalized_to_dict(self):
+        """list 形态(portfolio_base.py:851 路径)归一为 {code: pos} dict。"""
+        positions = [
+            SimpleNamespace(code="000001.SZ", market_value=10),
+            SimpleNamespace(code="000002.SZ", market_value=20),
+        ]
+        result = get_positions({"positions": positions})
+        assert set(result.keys()) == {"000001.SZ", "000002.SZ"}
+        assert result["000001.SZ"].market_value == 10
+
+    def test_missing_key_returns_empty(self):
+        assert get_positions({}) == {}
+
+    def test_none_returns_empty(self):
+        assert get_positions({"positions": None}) == {}
+
+    def test_skips_falsy_entries_in_list(self):
+        """list 中的 None/空元素跳过,不污染归一结果。"""
+        positions = [None, SimpleNamespace(code="000001.SZ", market_value=10)]
+        result = get_positions({"positions": positions})
+        assert list(result.keys()) == ["000001.SZ"]
+
+
+# ---------------------------- total_market_value ----------------------------
+
+class TestTotalMarketValue:
+    def test_empty_positions(self):
+        assert total_market_value({}) == 0
+
+    def test_sums_market_values(self):
+        positions = {
+            "A": SimpleNamespace(market_value=100),
+            "B": SimpleNamespace(market_value=250.5),
+        }
+        assert total_market_value({"positions": positions}) == 350.5
+
+    def test_skips_none_and_zero_market_value(self):
+        """与 concentration/volatility 原内联守卫一致: if pos and pos.market_value。"""
+        positions = {
+            "A": SimpleNamespace(market_value=100),
+            "B": SimpleNamespace(market_value=None),
+            "C": SimpleNamespace(market_value=0),
+            "D": None,
+        }
+        assert total_market_value({"positions": positions}) == 100
+
+    def test_list_form_positions(self):
+        """list 形态经 get_positions 归一后求和。"""
+        positions = [
+            SimpleNamespace(code="A", market_value=100),
+            SimpleNamespace(code="B", market_value=200),
+        ]
+        assert total_market_value({"positions": positions}) == 300
+
+
+# ---------------------------- current_price ----------------------------
+
+class TestCurrentPrice:
+    def test_returns_price_for_code(self):
+        info = {"prices": {"000001.SZ": 12.34, "000002.SZ": 56.78}}
+        assert current_price(info, "000001.SZ") == 12.34
+
+    def test_missing_code_returns_none(self):
+        """不兜底假价 100 — 调用方自行决定回退(守 refactor 行为)。"""
+        assert current_price({"prices": {"000001.SZ": 12.34}}, "999999.SZ") is None
+
+    def test_no_prices_key_returns_none(self):
+        assert current_price({}, "000001.SZ") is None
+
+    def test_none_prices_returns_none(self):
+        assert current_price({"prices": None}, "000001.SZ") is None
+
+
+# ---------------------------- pnl_ratio ----------------------------
+
+class TestPnlRatio:
+    def test_dict_with_ratio(self):
+        """profit_target 测试契约: position 为 dict 携 profit_loss_ratio 键。"""
+        assert pnl_ratio({"profit_loss_ratio": 0.16}) == 0.16
+
+    def test_dict_missing_key_returns_zero(self):
+        """修复点:原 getattr(dict, ...) 恒 0;dict 路径现在正确读键。"""
+        assert pnl_ratio({"volume": 1000}) == 0
+
+    def test_object_with_attr(self):
+        assert pnl_ratio(SimpleNamespace(profit_loss_ratio=0.1)) == 0.1
+
+    def test_object_missing_attr_returns_zero(self):
+        """Position 模型当前无此字段 → 0(未来加字段自动生效)。"""
+        assert pnl_ratio(SimpleNamespace(cost=100, price=110)) == 0
+
+    def test_none_returns_zero(self):
+        """defensive: position 查不到时不崩。"""
+        assert pnl_ratio(None) == 0


### PR DESCRIPTION
## 背景

Closes #6470

RiskBase 浅层：缺持仓/市值/现价访问器，守卫与求和逻辑重复散落在 17 个 risk 子类；且 P&L 口径分歧（dict vs object）使 `profit_target` 止盈永不触发。

## 改动

### 1. 新增 `portfolio_info_access.py`（4 个无状态函数）
- `get_positions` — 归一 `portfolio_base` 构建处 list/dict 不一致（851 路径 list / 887 路径 dict），统一返回 `{code: pos}` dict
- `total_market_value` — 替换 concentration(4×)/volatility(1×) 重复的内联求和
- `current_price` — 替换 concentration 的 `prices` 导航（不兜底假价，调用方显式回退）
- `pnl_ratio` — dict/object 双兼容，**修复 profit_target 读字段 bug**

**设计：纯函数（非 mixin）。** Ginkgo 现有 mixin 全部持实例状态；portfolio_info 访问无状态，归 utils 函数先例（`trading/evaluation/utils/ast_helpers.py`）。Strategy/Sizer/Selector 同样收 portfolio_info，可对称复用。**不碰 Base 类层级**（函数在类外，绕开 Base 禁令）。

### 2. profit_target 止盈 bug 修复
`getattr(position, 'profit_loss_ratio', 0)` 在 position 为 dict 时恒返回 0 → 止盈永不触发（master 8 测试红）。改用 `pnl_ratio(position)` 双形态正确读取。

### 3. concentration/volatility 迁移 accessor
机械等价替换（`get_positions` 对 dict 形态原样，list 形态归一是健壮性改进；sum/price 逻辑等价）。

### 4. create_signal seam 系统性 mock bug（bonus）
profit/loss 测试 `patch("..._risk.Signal")` 拦不到 `create_signal`（ADR-011）的局部 `from ginkgo.entities import Signal`。改 `patch("ginkgo.entities.Signal")`。激活并修正 master 上从未执行到的僵尸断言：
- 补 `_context` bind 模拟引擎装配（验证 id 透传契约）
- loss `source` 断言 STRATEGY→RISK（ADR-011：risk 组件 source=RISK）

## 验收对照（#6470）
- ✅ 持仓/市值/现价访问器提取 → 4 函数 + 18 单测
- ✅ profit_target bug 修复 → 8 红转绿
- ✅ concentration/volatility 迁移消重

## 测试
| 套件 | 结果 |
|---|---|
| accessor 单测 | 18 ✓ |
| profit_limit + loss_limit | 78 ✓（8+2 红转绿）|
| concentration + volatility | 79 ✓（含性能/缓存）|
| 全 risk 套件（xdist -n auto）| **672 passed, 2 skipped** ✓ |
| component_loader smoke | 4 ✓ |
| py_compile 4 源文件 | ✓ |

## 不在范围
- guard（多处 positions 空守卫）需独立行为验证，另 PR
- liquidity 的 `order.limit_price` 路径不适用 `current_price`
