### PR TITLE
refactor(analyzer): 权益分析器 worth 口径统一 + delta 去重 (#6475)

### DIFF
--- a/src/ginkgo/trading/analysis/analyzers/consecutive_pnl.py
+++ b/src/ginkgo/trading/analysis/analyzers/consecutive_pnl.py
@@ -8,6 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import pandas as pd
 import numpy as np
@@ -45,14 +47,14 @@ class ConsecutivePnL(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算连续盈亏统计，存储当前连续亏损天数"""
-        current_worth = portfolio_info.get("worth", 0)
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
 
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        if delta is None:
             consecutive_losses = 0
         else:
             # 计算日盈亏
-            daily_pnl = current_worth - self._last_worth
+            daily_pnl = delta.pnl
 
             if daily_pnl > 0:
                 # 盈利日
@@ -100,8 +102,8 @@ class ConsecutivePnL(BaseAnalyzer):
 
             # 存储当前连续亏损天数（主要指标）
             consecutive_losses = self._current_loss_streak
-            self._last_worth = current_worth
 
+        self._last_worth = current_worth
         self.add_data(consecutive_losses)
 
     @property

--- a/src/ginkgo/trading/analysis/analyzers/consecutive_pnl.py
+++ b/src/ginkgo/trading/analysis/analyzers/consecutive_pnl.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (ENDDAY stage), DeviationChecker
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, pandas, numpy
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas, numpy
 # Role: 连续盈亏分析器 — 记录最大连续盈利/亏损天数及金额，存储当前连续亏损天数
 
 

--- a/src/ginkgo/trading/analysis/analyzers/profit.py
+++ b/src/ginkgo/trading/analysis/analyzers/profit.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (NEWDAY/ENDDAY stage), BASIC_ANALYZERS, ResultPlot
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, to_decimal, pandas
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas
 # Role: 利润分析器 — 计算每日盈亏（当日资产-前日资产），记录日度利润序列
 
 
@@ -8,7 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
-from ginkgo.libs.data.number import to_decimal
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import pandas as pd
 
@@ -27,14 +28,14 @@ class Profit(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """激活利润计算，计算当日利润"""
-        current_worth = float(to_decimal(portfolio_info.get("worth", 0)))
-        
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
+
+        if delta is None:
             value = 0
         else:
-            value = current_worth - self._last_worth
-            self._last_worth = current_worth
-            
+            value = delta.pnl
+
+        self._last_worth = current_worth
         self.add_data(value)
 

--- a/src/ginkgo/trading/analysis/analyzers/sharpe_ratio.py
+++ b/src/ginkgo/trading/analysis/analyzers/sharpe_ratio.py
@@ -1,10 +1,11 @@
 # Upstream: Portfolio (ENDDAY stage), BASIC_ANALYZERS
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, to_decimal, numpy
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, numpy
 # Role: 夏普比率分析器 — 日收益率标准方法，(mean_excess / std) * sqrt(252)
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
-from ginkgo.libs.data.number import to_decimal
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import numpy as np
 
@@ -39,15 +40,14 @@ class SharpeRatio(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算夏普比率"""
-        current_worth = float(to_decimal(portfolio_info.get("worth", 0)))
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
 
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        if delta is None:
             sharpe_ratio = 0.0
         else:
-            if self._last_worth > 0:
-                daily_return = (current_worth - self._last_worth) / self._last_worth
-                self._returns.append(daily_return)
+            if delta.return_ is not None:
+                self._returns.append(delta.return_)
 
                 if len(self._returns) >= 10:
                     returns_array = np.array(self._returns)
@@ -68,8 +68,7 @@ class SharpeRatio(BaseAnalyzer):
             else:
                 sharpe_ratio = 0.0
 
-            self._last_worth = current_worth
-
+        self._last_worth = current_worth
         self.add_data(sharpe_ratio)
 
     @property

--- a/src/ginkgo/trading/analysis/analyzers/skew_kurtosis.py
+++ b/src/ginkgo/trading/analysis/analyzers/skew_kurtosis.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (ENDDAY stage)
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, pandas, numpy, scipy.stats
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas, numpy, scipy.stats
 # Role: 偏度/峰度分析器 — 滚动窗口计算收益率分布偏度（右/左偏）和峰度（尖峭/平坦）
 
 

--- a/src/ginkgo/trading/analysis/analyzers/skew_kurtosis.py
+++ b/src/ginkgo/trading/analysis/analyzers/skew_kurtosis.py
@@ -8,6 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import numpy as np
 from scipy import stats
@@ -34,21 +36,19 @@ class SkewKurtosis(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算偏度值（存储偏度，峰度通过属性获取）"""
-        current_worth = portfolio_info.get("worth", 0)
-        
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
+
+        if delta is None:
             skewness = 0.0
         else:
-            # 计算日收益率
-            if self._last_worth > 0:
-                daily_return = (current_worth - self._last_worth) / self._last_worth
-                self._returns.append(daily_return)
-                
+            if delta.return_ is not None:
+                self._returns.append(delta.return_)
+
                 # 保持窗口大小
                 if len(self._returns) > self._window:
                     self._returns.pop(0)
-                
+
                 # 计算偏度 (需要至少30个数据点)
                 if len(self._returns) >= 30:
                     returns_array = np.array(self._returns)
@@ -57,9 +57,8 @@ class SkewKurtosis(BaseAnalyzer):
                     skewness = 0.0
             else:
                 skewness = 0.0
-            
-            self._last_worth = current_worth
-        
+
+        self._last_worth = current_worth
         self.add_data(skewness)
 
     @property

--- a/src/ginkgo/trading/analysis/analyzers/sortino_ratio.py
+++ b/src/ginkgo/trading/analysis/analyzers/sortino_ratio.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (ENDDAY stage)
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, to_decimal, pandas, numpy
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas, numpy
 # Role: 索提诺比率分析器 — 仅用下行标准差计算风险调整收益，年化后输出
 
 
@@ -8,7 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
-from ginkgo.libs.data.number import to_decimal
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import numpy as np
 
@@ -34,25 +35,23 @@ class SortinoRatio(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算索提诺比率"""
-        current_worth = float(to_decimal(portfolio_info.get("worth", 0)))
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
 
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        if delta is None:
             sortino_ratio = 0.0
         else:
-            # 计算日收益率
-            if self._last_worth > 0:
-                daily_return = (current_worth - self._last_worth) / self._last_worth
-                self._returns.append(daily_return)
-                
+            if delta.return_ is not None:
+                self._returns.append(delta.return_)
+
                 # 计算索提诺比率 (需要至少10个数据点)
                 if len(self._returns) >= 10:
                     returns_array = np.array(self._returns)
-                    
+
                     # 计算平均超额收益
                     excess_returns = returns_array - self._risk_free_rate
                     mean_excess_return = np.mean(excess_returns)
-                    
+
                     # 计算下行标准差 (只考虑负超额收益)
                     negative_excess_returns = excess_returns[excess_returns < 0]
                     if len(negative_excess_returns) > 0:
@@ -61,16 +60,15 @@ class SortinoRatio(BaseAnalyzer):
                     else:
                         # 没有负收益，设为一个大的正值
                         sortino_ratio = mean_excess_return / 0.0001 if mean_excess_return > 0 else 0
-                    
+
                     # 年化索提诺比率
                     sortino_ratio = sortino_ratio * np.sqrt(252)
                 else:
                     sortino_ratio = 0.0
             else:
                 sortino_ratio = 0.0
-            
-            self._last_worth = current_worth
-        
+
+        self._last_worth = current_worth
         self.add_data(sortino_ratio)
 
     @property

--- a/src/ginkgo/trading/analysis/analyzers/var_cvar.py
+++ b/src/ginkgo/trading/analysis/analyzers/var_cvar.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (ENDDAY stage)
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, pandas, numpy
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas, numpy
 # Role: VaR/CVaR分析器 — 历史模拟法计算风险价值和条件风险价值，年化后输出
 
 

--- a/src/ginkgo/trading/analysis/analyzers/var_cvar.py
+++ b/src/ginkgo/trading/analysis/analyzers/var_cvar.py
@@ -8,6 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import numpy as np
 
@@ -34,38 +36,35 @@ class VarCVar(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算VaR值（存储为负值表示风险）"""
-        current_worth = portfolio_info.get("worth", 0)
-        
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
+
+        if delta is None:
             var_value = 0.0
         else:
-            # 计算日收益率
-            if self._last_worth > 0:
-                daily_return = (current_worth - self._last_worth) / self._last_worth
-                self._returns.append(daily_return)
-                
+            if delta.return_ is not None:
+                self._returns.append(delta.return_)
+
                 # 保持窗口大小
                 if len(self._returns) > self._window:
                     self._returns.pop(0)
-                
+
                 # 计算VaR (需要至少20个数据点)
                 if len(self._returns) >= 20:
                     returns_array = np.array(self._returns)
-                    
+
                     # 计算VaR (历史模拟法)
                     var_percentile = (1 - self._confidence_level) * 100
                     var_value = np.percentile(returns_array, var_percentile)
-                    
+
                     # 年化VaR (存储为负值表示风险)
                     var_value = var_value * np.sqrt(252)
                 else:
                     var_value = 0.0
             else:
                 var_value = 0.0
-            
-            self._last_worth = current_worth
-        
+
+        self._last_worth = current_worth
         self.add_data(var_value)
 
     @property

--- a/src/ginkgo/trading/analysis/analyzers/volatility.py
+++ b/src/ginkgo/trading/analysis/analyzers/volatility.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (ENDDAY stage), BASIC_ANALYZERS
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, to_decimal, pandas, numpy
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas, numpy
 # Role: 波动率分析器 — 滚动窗口计算日收益率样本标准差并年化（sqrt(252)）
 
 
@@ -8,7 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
-from ginkgo.libs.data.number import to_decimal
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 import numpy as np
 
@@ -34,21 +35,19 @@ class Volatility(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算波动率"""
-        current_worth = float(to_decimal(portfolio_info.get("worth", 0)))
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
 
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        if delta is None:
             volatility = 0.0
         else:
-            # 计算日收益率
-            if self._last_worth > 0:
-                daily_return = (current_worth - self._last_worth) / self._last_worth
-                self._returns.append(daily_return)
-                
+            if delta.return_ is not None:
+                self._returns.append(delta.return_)
+
                 # 保持窗口大小
                 if len(self._returns) > self._window:
                     self._returns.pop(0)
-                
+
                 # 计算波动率 (需要至少2个数据点)
                 if len(self._returns) >= 2:
                     returns_array = np.array(self._returns)
@@ -60,9 +59,8 @@ class Volatility(BaseAnalyzer):
                     volatility = 0.0
             else:
                 volatility = 0.0
-            
-            self._last_worth = current_worth
-        
+
+        self._last_worth = current_worth
         self.add_data(volatility)
 
     @property

--- a/src/ginkgo/trading/analysis/analyzers/win_rate.py
+++ b/src/ginkgo/trading/analysis/analyzers/win_rate.py
@@ -1,5 +1,5 @@
 # Upstream: Portfolio (ENDDAY stage), BASIC_ANALYZERS
-# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, to_decimal, pandas, numpy
+# Downstream: BaseAnalyzer, RECORDSTAGE_TYPES, worth_delta, get_worth, pandas, numpy
 # Role: 胜率分析器 — 统计盈利日占比（胜率）和平均盈利/平均亏损比（盈亏比）
 
 
@@ -8,7 +8,8 @@
 
 
 from ginkgo.trading.analysis.analyzers.base_analyzer import BaseAnalyzer
-from ginkgo.libs.data.number import to_decimal
+from ginkgo.trading.analysis.worth_delta import worth_delta
+from ginkgo.trading.bases.portfolio_info_access import get_worth
 from ginkgo.enums import RECORDSTAGE_TYPES
 
 
@@ -34,17 +35,15 @@ class WinRate(BaseAnalyzer):
 
     def _do_activate(self, stage: RECORDSTAGE_TYPES, portfolio_info: dict, *args, **kwargs) -> None:
         """计算胜率"""
-        current_worth = float(to_decimal(portfolio_info.get("worth", 0)))
+        current_worth = get_worth(portfolio_info)
+        delta = worth_delta(current_worth, self._last_worth)
 
-        if self._last_worth is None:
-            self._last_worth = current_worth
+        if delta is None:
             win_rate = 0.0
         else:
-            # 计算日收益
-            if self._last_worth > 0:
-                daily_pnl = current_worth - self._last_worth
-                daily_return = daily_pnl / self._last_worth
-                self._returns.append(daily_return)
+            if delta.return_ is not None:
+                self._returns.append(delta.return_)
+                daily_pnl = delta.pnl
 
                 # 统计盈亏
                 if daily_pnl > 0:
@@ -53,7 +52,7 @@ class WinRate(BaseAnalyzer):
                 elif daily_pnl < 0:
                     self._loss_count += 1
                     self._total_loss += abs(daily_pnl)
-                
+
                 # 计算胜率
                 total_trades = self._win_count + self._loss_count
                 if total_trades > 0:
@@ -62,9 +61,8 @@ class WinRate(BaseAnalyzer):
                     win_rate = 0.0
             else:
                 win_rate = 0.0
-            
-            self._last_worth = current_worth
-        
+
+        self._last_worth = current_worth
         self.add_data(win_rate)
 
     @property

--- a/src/ginkgo/trading/analysis/worth_delta.py
+++ b/src/ginkgo/trading/analysis/worth_delta.py
@@ -1,0 +1,44 @@
+"""权益序列相邻差分(纯函数,无状态)。
+
+替换 8 个权益分析器重复的 _last_worth 差分逻辑:
+    pnl = current - last              # 绝对盈亏(profit/consecutive_pnl/win_rate)
+    return = (current - last) / last   # 相对收益(sharpe/sortino/skew/volatility/var_cvar/win_rate)
+
+设计:
+- 纯函数,无状态。_last_worth 状态仍归各 analyzer(行为等价,零风险)。
+- 入参 float 化(analyzer 喂 numpy 要 float;worth 经 get_worth 取出为 Decimal 原生)。
+- last<=0 时 return_ 为 None(除零守卫,与原 `if _last_worth > 0` 一致);pnl 仍算。
+- last is None(首次调用)返回 None(无差分),调用方据此 init。
+
+# Upstream: portfolio_info_access.get_worth (Decimal 原生 worth)
+# Downstream: 8 个权益分析器(sharpe/sortino/skew_kurtosis/volatility/var_cvar/profit/consecutive_pnl/win_rate)
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class WorthDelta:
+    """权益相邻差分结果。"""
+
+    pnl: float  # 绝对盈亏 (current - last)
+    return_: Optional[float]  # 相对收益;last<=0 时 None(除零守卫)
+
+
+def worth_delta(current, last) -> Optional[WorthDelta]:
+    """权益序列相邻差分。
+
+    Args:
+        current: 本期 worth(Decimal/float/int,内部 float 化)
+        last: 上期 worth;None 表示首次调用,返回 None
+
+    Returns:
+        WorthDelta 或 None(首次)。last<=0 时 return_ 为 None,pnl 仍算。
+    """
+    if last is None:
+        return None
+    cur = float(current)
+    lst = float(last)
+    pnl = cur - lst
+    ret = (pnl / lst) if lst > 0 else None
+    return WorthDelta(pnl=pnl, return_=ret)

--- a/src/ginkgo/trading/bases/portfolio_info_access.py
+++ b/src/ginkgo/trading/bases/portfolio_info_access.py
@@ -97,3 +97,22 @@ def pnl_ratio(position: Any) -> Any:
     if isinstance(position, dict):
         return position.get("profit_loss_ratio", 0) or 0
     return getattr(position, "profit_loss_ratio", 0) or 0
+
+
+def get_worth(portfolio_info: Dict[str, Any]) -> Any:
+    """归一取出 worth(组合净值),保留原生类型。
+
+    替换 8 个权益分析器重复的 worth 读取(口径分歧):
+        float(to_decimal(portfolio_info.get("worth", 0)))   # 包装口径
+        portfolio_info.get("worth", 0)                       # 裸读口径
+    统一为单点读取,保留 worth 原生类型(Decimal,与 total_market_value 一致);
+    分析器需 float 时由 worth_delta 入参 float 化,不在本函数转。
+
+    Args:
+        portfolio_info: 组件收到的 portfolio_info dict
+
+    Returns:
+        worth 值(通常 Decimal);缺失/None 返回 0,永不 None
+    """
+    worth = portfolio_info.get("worth", 0)
+    return worth if worth is not None else 0

--- a/tests/unit/backtest/analyzers/test_profit.py
+++ b/tests/unit/backtest/analyzers/test_profit.py
@@ -1,0 +1,89 @@
+"""
+角色: Profit 分析器 characterization test（#6475：日度盈亏 = 当日 worth - 前日 worth）。
+覆盖：首次归零、逐日盈/亏/平、Decimal worth 原生口径（get_worth 保留原生 + worth_delta float 化）、
+      worth 缺失归零。refactor 前后均应绿（行为等价锚点）。
+注：BaseAnalyzer.data 是 DataFrame（columns=['timestamp','value']），取值经 data["value"]。
+"""
+
+import unittest
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+from ginkgo.trading.analysis.analyzers.profit import Profit
+from ginkgo.enums import RECORDSTAGE_TYPES
+from ginkgo.trading.time.providers import LogicalTimeProvider
+
+
+class TestProfit(unittest.TestCase):
+    """测试利润分析器（日度盈亏序列）"""
+
+    def setUp(self):
+        self.analyzer = Profit("test_profit")
+        self.test_time = datetime(2024, 1, 1, 9, 30, 0)
+        self.analyzer.set_time_provider(LogicalTimeProvider(initial_time=self.test_time))
+        self.analyzer.advance_time(self.test_time)
+        self.analyzer.set_analyzer_id("test_profit_001")
+        self.analyzer.set_portfolio_id("test_portfolio_001")
+
+    def _values(self, worths):
+        """喂入 worth 序列（每日 ENDDAY activate），返回 value 列（float 化）。"""
+        for i, w in enumerate(worths):
+            self.analyzer.advance_time(self.test_time + timedelta(days=i))
+            self.analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": w})
+        return [float(v) for v in self.analyzer.data["value"]]
+
+    def test_init(self):
+        """初始化：默认 name、激活 NEWDAY+ENDDAY、record ENDDAY、_last_worth=None"""
+        a = Profit()
+        self.assertEqual(a._name, "ProfitAna")
+        self.assertIn(RECORDSTAGE_TYPES.NEWDAY, a.active_stage)
+        self.assertIn(RECORDSTAGE_TYPES.ENDDAY, a.active_stage)
+        self.assertEqual(a.record_stage, RECORDSTAGE_TYPES.ENDDAY)
+        self.assertIsNone(a._last_worth)
+
+    def test_first_call_zero(self):
+        """首次无前日，盈亏为 0"""
+        self.assertEqual(self._values([10000]), [0.0])
+
+    def test_daily_profit(self):
+        """逐日等额盈利：+100, +100"""
+        self.assertEqual(self._values([10000, 10100, 10200]), [0.0, 100.0, 100.0])
+
+    def test_daily_loss(self):
+        """逐日等额亏损：-100, -100"""
+        self.assertEqual(self._values([10000, 9900, 9800]), [0.0, -100.0, -100.0])
+
+    def test_mixed_pnl(self):
+        """盈亏交替：+100, -50"""
+        self.assertEqual(self._values([10000, 10100, 10050]), [0.0, 100.0, -50.0])
+
+    def test_no_change(self):
+        """worth 不变：盈亏 0"""
+        self.assertEqual(self._values([10000, 10000]), [0.0, 0.0])
+
+    def test_decimal_worth_native(self):
+        """worth 为 Decimal 原生：口径统一后仍正确（#6475 核心）。
+        get_worth 保留 Decimal，worth_delta 内部 float 化，结果与 int/float 一致。"""
+        data = self._values([Decimal("10000"), Decimal("10100"), Decimal("10050")])
+        self.assertEqual(data, [0.0, 100.0, -50.0])
+
+    def test_float_worth_native(self):
+        """worth 为 float：与 Decimal/int 等价"""
+        data = self._values([10000.0, 10100.5, 10050.25])
+        self.assertEqual(len(data), 3)
+        self.assertAlmostEqual(data[0], 0.0, places=2)
+        self.assertAlmostEqual(data[1], 100.5, places=2)
+        self.assertAlmostEqual(data[2], -50.25, places=2)
+
+    def test_missing_worth_treated_as_zero(self):
+        """worth 缺失：get_worth 返回 0，盈亏 = 0 - 前日"""
+        self.analyzer.advance_time(self.test_time)
+        self.analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {"worth": 10000})
+        self.analyzer.advance_time(self.test_time + timedelta(days=1))
+        self.analyzer.activate(RECORDSTAGE_TYPES.ENDDAY, {})
+        last = float(self.analyzer.data["value"].iloc[-1])
+        self.assertAlmostEqual(last, -10000.0, places=2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/trading/analysis/test_worth_delta.py
+++ b/tests/unit/trading/analysis/test_worth_delta.py
@@ -1,0 +1,55 @@
+"""worth_delta 单测:8 个分析器重复差分逻辑的收敛点。"""
+from decimal import Decimal
+
+import pytest
+
+from ginkgo.trading.analysis.worth_delta import WorthDelta, worth_delta
+
+
+class TestWorthDelta:
+    def test_first_call_returns_none(self):
+        """首次(last=None)无差分,调用方据此 init _last_worth。"""
+        assert worth_delta(10000, None) is None
+
+    def test_normal_positive_delta(self):
+        """正常上涨:pnl 绝对 + return 相对。"""
+        d = worth_delta(11000, 10000)
+        assert d.pnl == pytest.approx(1000.0)
+        assert d.return_ == pytest.approx(0.1)
+
+    def test_negative_delta(self):
+        """下跌:负 pnl + 负 return。"""
+        d = worth_delta(9000, 10000)
+        assert d.pnl == pytest.approx(-1000.0)
+        assert d.return_ == pytest.approx(-0.1)
+
+    def test_zero_change(self):
+        """worth 不变:pnl=0,return=0。"""
+        d = worth_delta(10000, 10000)
+        assert d.pnl == 0.0
+        assert d.return_ == 0.0
+
+    def test_zero_last_return_none(self):
+        """last=0 除零守卫:return_ None,pnl 仍算(与原 `if _last_worth>0` 一致)。"""
+        d = worth_delta(1000, 0)
+        assert d.pnl == pytest.approx(1000.0)
+        assert d.return_ is None
+
+    def test_negative_last_return_none(self):
+        """last<0(异常状态)同样守卫,不爆。"""
+        d = worth_delta(1000, -100)
+        assert d.pnl == pytest.approx(1100.0)
+        assert d.return_ is None
+
+    def test_decimal_inputs_float_normalized(self):
+        """Decimal 入参(经 get_worth)内部 float 化,返回 float(analyzer 喂 numpy)。"""
+        d = worth_delta(Decimal("11000"), Decimal("10000"))
+        assert isinstance(d.pnl, float)
+        assert d.pnl == pytest.approx(1000.0)
+        assert d.return_ == pytest.approx(0.1)
+
+    def test_int_inputs(self):
+        """int 入参同样工作,返回 float。"""
+        d = worth_delta(11000, 10000)
+        assert d.pnl == 1000.0
+        assert isinstance(d.pnl, float)

--- a/tests/unit/trading/bases/test_portfolio_info_access.py
+++ b/tests/unit/trading/bases/test_portfolio_info_access.py
@@ -6,11 +6,13 @@
 - current_price: 替换 concentration 的 portfolio_info["prices"] 导航
 - pnl_ratio: dict/object 双兼容,修复 profit_target 读字段 bug
 """
+from decimal import Decimal
 from types import SimpleNamespace
 
 from ginkgo.trading.bases.portfolio_info_access import (
     current_price,
     get_positions,
+    get_worth,
     pnl_ratio,
     total_market_value,
 )
@@ -118,3 +120,27 @@ class TestPnlRatio:
     def test_none_returns_zero(self):
         """defensive: position 查不到时不崩。"""
         assert pnl_ratio(None) == 0
+
+
+# ---------------------------- get_worth ----------------------------
+
+class TestGetWorth:
+    def test_returns_decimal_native(self):
+        """worth 原生 Decimal 保留(与 total_market_value 一致),分析器按需 float 化。"""
+        assert get_worth({"worth": Decimal("10000")}) == Decimal("10000")
+
+    def test_returns_float_native(self):
+        assert get_worth({"worth": 10000.0}) == 10000.0
+
+    def test_missing_returns_zero(self):
+        """缺 worth 键返回 0(与原 .get('worth', 0) 一致)。"""
+        assert get_worth({}) == 0
+
+    def test_none_returns_zero(self):
+        """worth=None 兜 0(原裸读会拿到 None,后续浮点化会崩)。"""
+        assert get_worth({"worth": None}) == 0
+
+    def test_zero_preserved(self):
+        """worth=0 合法(空组合),原样保留不抖类型。"""
+        assert get_worth({"worth": 0}) == 0
+        assert get_worth({"worth": Decimal("0")}) == Decimal("0")


### PR DESCRIPTION
## 问题 (#6475)

`BaseAnalyzer` 计算层过浅:8 个权益曲线分析器各自重复 `_last_worth` 差分逻辑,且 worth 读取口径分歧:

| 口径 | 分析器 |
|---|---|
| `float(to_decimal(portfolio_info.get("worth", 0)))` 包装 | sharpe / sortino / volatility / profit / win_rate |
| `portfolio_info.get("worth", 0)` 裸读 | skew / var_cvar / consecutive_pnl |

重复 + 口径不一致 = 改一处要改 8 处,且行为可能漂移。

## 方案:两个纯函数收敛

- **`get_worth(portfolio_info)`** (扩展 `portfolio_info_access.py`):统一 worth 读取,保留 Decimal 原生(与 `total_market_value` 一致);缺失/None 返回 0。
- **`worth_delta(current, last)`** (新建 `analysis/worth_delta.py`):纯函数差分,返回 `WorthDelta(pnl, return_)`;入参 float 化(分析器喂 numpy 要 float);`last<=0` 时 `return_=None`(除零守卫),`pnl` 仍算。

## 三派适配

| 派系 | 分析器 | 用 |
|---|---|---|
| 返回派 | sharpe / sortino / volatility / skew / var_cvar | `delta.return_` |
| 盈亏派 | profit / consecutive_pnl | `delta.pnl` |
| 混合派 | win_rate | `return_` + `pnl` |

## 行为等价论证

- `delta.return_ is not None` ⟺ 原 `self._last_worth > 0` 守卫(返回派阈值分支)
- `delta is None` ⟺ 原 `self._last_worth is None` 首次初始化分支
- `delta.pnl` 无守卫永算(与盈亏派原 `current - last` 一致,任意 last 都算)
- `_last_worth` 状态仍归各 analyzer(纯函数无状态,零风险迁移);类型从 float→Decimal 原生,但 `worth_delta` 入参 float 化,无行为影响
- sharpe 的 #5973 退化守卫块(rf=0 std 下界 + |mean|>=rf)原样保留

## 测试

- 8 analyzer + `get_worth` + `worth_delta` 共 **194 绿**
- `analyzers/` 全目录 **221 绿**无回归(含未改的 max_drawdown/signal_count 等)
- `profit` 原无测试,补 characterization test(refactor 前后均绿,锁定行为)

Closes #6475

🤖 Generated with [Claude Code](https://claude.com/claude-code)