### PR TITLE
ci(gate): 补权益分析器 smoke 到 #6135 diff-coverage 子集

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,8 @@ jobs:
         # 无 step 级/pytest 级超时 → 任一 hang 即无限占用 runner。
         #   --timeout=300：单测试卡 300s 即失败 + dump 该测试 traceback 定位 hang 点
         #   （pytest-timeout 已是 required_plugin；thread 法，CI 通用）。
+        # #6475 权益分析器 smoke 扩展：worth 口径统一覆盖（8 分析器 + worth_delta +
+        # portfolio_info_access）。纯计算无 DB，单进程安全，与上方 mock 子集并列。
         run: |
           uv run python -m pytest \
             tests/unit/data/crud/test_user_crud_mock.py \
@@ -319,6 +321,16 @@ jobs:
             tests/unit/client/test_backtest_cli_fill_price_policy.py \
             tests/unit/trading/brokers/test_sim_broker_reproducibility.py \
             tests/unit/workers/test_paper_trading_worker_slippage_smoke.py \
+            tests/unit/backtest/analyzers/test_profit.py \
+            tests/unit/backtest/analyzers/test_consecutive_pnl.py \
+            tests/unit/backtest/analyzers/test_sharpe_ratio.py \
+            tests/unit/backtest/analyzers/test_skew_kurtosis.py \
+            tests/unit/backtest/analyzers/test_sortino_ratio.py \
+            tests/unit/backtest/analyzers/test_var_cvar.py \
+            tests/unit/backtest/analyzers/test_volatility.py \
+            tests/unit/backtest/analyzers/test_win_rate.py \
+            tests/unit/trading/analysis/test_worth_delta.py \
+            tests/unit/trading/bases/test_portfolio_info_access.py \
             --cov=src/ginkgo \
             --cov=api \
             --cov-report=json:coverage.json \


### PR DESCRIPTION
## 背景
#6901（#6475 权益分析器 worth 口径统一）已合并 master，但 PR 未改 ci.yml gate 子集。

#6135 diff-coverage gate 的 smoke 子集（ci.yml 274-321）原**零 analyzer 测试**，导致 #6901 的 82 个 worth 重构改动行 diff coverage 仅 **31.71% < 80%** —— 这是 #6901 Smoke 失败的根因（PR 仍被 merge，失败检查留在历史）。本 PR 补齐 gate 子集，消除该覆盖债。

## 修复
把 10 个 analyzer 测试加进 gate smoke 子集：
- 8 权益分析器：`test_profit` / `consecutive_pnl` / `sharpe_ratio` / `skew_kurtosis` / `sortino_ratio` / `var_cvar` / `volatility` / `win_rate`
- `test_worth_delta`（#6475 新增纯函数）
- `test_portfolio_info_access`（含 #6475 新增 `get_worth`）

纯计算无 DB，单进程安全，与上方 mock 子集并列。

## 验证
- 10 个 analyzer 测试：**194 passed**（7s）
- diff coverage：**100% (82/82)**（base = #6901 分叉点 `32ff3721`）
- 全 gate 列表（原 47 + 新 10）：588 passed（1 既有失败 `test_user_cli::test_create_user_missing_name_fails`，client 状态污染 known issue，CI 环境过，非本次引入）
