### PR TITLE
refactor(assembly): 移除 component_loader 的 ginkgo.data 兼容桩

### DIFF
--- a/src/ginkgo/trading/services/_assembly/component_loader.py
+++ b/src/ginkgo/trading/services/_assembly/component_loader.py
@@ -220,18 +220,6 @@ class ComponentLoader:
                     self._logger.DEBUG(f"Temp file created: {temp_file_path}")
 
                     try:
-                        # 为兼容性添加get_bars函数到模块的全局命名空间
-                        import sys
-                        from ginkgo.data.containers import container as data_container
-
-                        def get_bars_stub(*args, **kwargs):
-                            bar_service = data_container.bar_service()
-                            return bar_service.get(*args, **kwargs)
-
-                        sys.modules["ginkgo.data"] = type(sys)("ginkgo.data")
-                        sys.modules["ginkgo.data"].get_bars = get_bars_stub
-                        sys.modules["ginkgo.data"].container = data_container
-
                         # 动态导入模块
                         self._logger.DEBUG(f"Importing module from {temp_file_path}")
                         spec = importlib.util.spec_from_file_location("dynamic_component", temp_file_path)


### PR DESCRIPTION
## 背景

`component_loader.py` 动态装配 DB 用户组件时,往 `sys.modules` 注入伪造的 `ginkgo.data` 模块,为旧式 `from ginkgo.data import get_bars` 写法垫兼容入口:

```python
sys.modules["ginkgo.data"] = type(sys)("ginkgo.data")
sys.modules["ginkgo.data"].get_bars = get_bars_stub   # 转发 container.bar_service().get(...)
sys.modules["ginkgo.data"].container = data_container
```

## 问题

1. **进程级永久污染**:`finally` 只删临时文件、不恢复 `sys.modules`。真实 `ginkgo.data` 包暴露 `container/services/crud/models/seeding/get_crud...`,被替换成只剩 `get_bars+container` 的裸 module。长驻进程(API/worker)装配任一 DB 组件后,同进程后续 `from ginkgo.data.services import ...` / `ginkgo.data.get_crud` 全部 ImportError。
2. **为废弃路径兜底**:`ginkgo.data.get_bars` 顶层函数本就不存在,`ForbiddenDirectDataAccessRule`(AST 规则)已禁止 `from ginkgo.data import get_bars` 这种直接取数。桩与设计意图相悖。

## 改动

移除 `component_loader.py:222-234` 的桩注入块(12 行),保留 `try:` + 动态导入逻辑。

## 影响评估

- **源码内置组件**:零依赖。全仓 grep 无 `ginkgo.data.get_bars` 顶层真实调用方;内置 strategy/selector/sizer/risk 取数走 DataFeeder / `container.bar_service().get(...)`,与桩无关。
- **DB 用户脚本**:若用旧式 `from ginkgo.data import get_bars`,装配时 ImportError → 触发既有的 source fallback(`component_loader:289`)。属预期行为(对齐 `ForbiddenDirectDataAccessRule`)。

## 验证

- `py_compile` ✅
- component_loader 测试套(detect_class / source_fallback / param_resolution / smoke) **35 passed** ✅
- 无残留引用(`get_bars` / `sys.modules` / `data_container`)✅

## 关联

- 不属于 epic #6698(强制分层消除越层直连),独立提交
- 对齐 `ForbiddenDirectDataAccessRule` 禁止直接取数的设计

🤖 Generated with [Claude Code](https://claude.com/claude-code)
